### PR TITLE
docs(message): fix error message type

### DIFF
--- a/src/showcase/nz-demo-message/nz-demo-message-icon.component.ts
+++ b/src/showcase/nz-demo-message/nz-demo-message-icon.component.ts
@@ -5,7 +5,7 @@ import {NzMessageService} from '../../../index.showcase';
   selector  : 'nz-demo-message-icon',
   template  : `
     <button nz-button (click)="createMessage('success','成功')">显示成功提示</button>
-    <button nz-button (click)="createMessage('info','报错')">显示报错提示</button>
+    <button nz-button (click)="createMessage('error','报错')">显示报错提示</button>
     <button nz-button (click)="createMessage('warning','警告')">显示警告提示</button>
 `,
   styles    : []


### PR DESCRIPTION
The show error message button should use type `error` rather than `info`.