### PR TITLE
feat(module:root): make nz-root optional

### DIFF
--- a/src/components/ng-zorro-antd.module.spec.ts
+++ b/src/components/ng-zorro-antd.module.spec.ts
@@ -1,0 +1,26 @@
+import { async, TestBed } from '@angular/core/testing';
+import { NgZorroAntdModule, NZ_ROOT_CONFIG, NzRootConfig } from './ng-zorro-antd.module';
+
+describe('NgZorroAntdModule with Angular integration', () => {
+  it('should not provide root config with empty forRoot', async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NgZorroAntdModule.forRoot(),
+      ],
+    }).compileComponents();
+
+    expect(TestBed.get(NZ_ROOT_CONFIG)).not.toBeDefined();
+  }));
+
+  it('should provide root config with params in forRoot', async(() => {
+    const options: NzRootConfig = { extraFontName: '', extraFontUrl: '' };
+
+    TestBed.configureTestingModule({
+      imports: [
+        NgZorroAntdModule.forRoot(options),
+      ],
+    }).compileComponents();
+
+    expect(TestBed.get(NZ_ROOT_CONFIG)).toBeDefined();
+  }));
+});

--- a/src/components/ng-zorro-antd.module.ts
+++ b/src/components/ng-zorro-antd.module.ts
@@ -53,6 +53,9 @@ import { NzMessageService } from './message/nz-message.service';
 import { NzModalService } from './modal/nz-modal.service';
 import { NzModalSubject } from './modal/nz-modal-subject.service';
 
+// Tokens (eg. global services' config)
+import { NZ_ROOT_CONFIG, NzRootConfig } from './root/nz-root-config'
+
 // ---------------------------------------------------------
 // | Exports
 // ---------------------------------------------------------
@@ -108,6 +111,7 @@ export { NzModalSubject } from './modal/nz-modal-subject.service';
 // Tokens (eg. global services' config)
 export { NZ_MESSAGE_CONFIG } from './message/nz-message-config';
 export { NZ_NOTIFICATION_CONFIG } from './notification/nz-notification-config';
+export { NZ_ROOT_CONFIG, NzRootConfig } from './root/nz-root-config';
 
 // ---------------------------------------------------------
 // | Root module
@@ -159,13 +163,14 @@ export { NZ_NOTIFICATION_CONFIG } from './notification/nz-notification-config';
 })
 export class NgZorroAntdModule {
 
-  static forRoot(): ModuleWithProviders {
+  static forRoot(options?: NzRootConfig): ModuleWithProviders {
     return {
       ngModule: NgZorroAntdModule,
       providers: [
         // Services
         NzNotificationService,
-        NzMessageService
+        NzMessageService,
+        { provide: NZ_ROOT_CONFIG, useValue: options },
       ]
     };
   }

--- a/src/components/root/nz-root-config.spec.ts
+++ b/src/components/root/nz-root-config.spec.ts
@@ -1,0 +1,32 @@
+import { createNzRootInitializer, NzRootConfig } from './nz-root-config';
+
+describe('NzRootConfig', () => {
+  let mockDocument: Document;
+  let mockConfig: NzRootConfig;
+  let mockElement: HTMLDivElement;
+
+  beforeEach(() => {
+    mockDocument = { head: { appendChild: () => null }, createElement: () => null } as any;
+    mockConfig = { extraFontName: '', extraFontUrl: '' } as any;
+    mockElement = {} as any;
+
+    spyOn(mockDocument, 'createElement').and.returnValue(mockElement);
+    spyOn(mockDocument.head, 'appendChild');
+  });
+
+  it('should apply extra font style when option provided', () => {
+    const iniliatizer = createNzRootInitializer(mockDocument, mockConfig);
+    iniliatizer();
+
+    expect(mockDocument.createElement).toHaveBeenCalledWith('style');
+    expect(mockDocument.head.appendChild).toHaveBeenCalledWith(mockElement);
+  });
+
+  it('should not apply extra font style when option not provided', () => {
+    const iniliatizer = createNzRootInitializer(mockDocument);
+    iniliatizer();
+
+    expect(mockDocument.createElement).not.toHaveBeenCalled();
+    expect(mockDocument.head.appendChild).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/root/nz-root-config.ts
+++ b/src/components/root/nz-root-config.ts
@@ -1,0 +1,32 @@
+import { InjectionToken } from '@angular/core';
+
+export interface NzRootConfig {
+  extraFontName: string;
+  extraFontUrl: string;
+}
+
+export const NZ_ROOT_CONFIG = new InjectionToken<NzRootConfig>('NzRootConfig');
+
+export function createNzRootInitializer(document: Document, options?: NzRootConfig) {
+  return function nzRootInitializer() {
+    if (options) {
+      const style = document.createElement('style');
+      style.innerHTML = `
+        @font-face {
+          font-family: '${options.extraFontName}';
+          src: url('${options.extraFontUrl}.eot'); /* IE9*/
+          src:
+            /* IE6-IE8 */
+            url('${options.extraFontUrl}.eot?#iefix') format('embedded-opentype'),
+            /* chrome、firefox */
+            url('${options.extraFontUrl}.woff') format('woff'),
+            /* chrome、firefox、opera、Safari, Android, iOS 4.2+*/
+            url('${options.extraFontUrl}.ttf') format('truetype'),
+            /* iOS 4.1- */
+            url('${options.extraFontUrl}.svg#iconfont') format('svg');
+        }
+      `;
+      document.head.appendChild(style);
+    }
+  }
+}

--- a/src/components/root/nz-root-style.component.ts
+++ b/src/components/root/nz-root-style.component.ts
@@ -1,0 +1,11 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  template      : ``,
+  styleUrls     : [
+    '../style/index.less',
+    './style/index.less',
+  ],
+  encapsulation : ViewEncapsulation.None,
+})
+export class NzRootStyleComponent { }

--- a/src/components/root/nz-root.component.spec.ts
+++ b/src/components/root/nz-root.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFactoryResolver, Injector, ComponentRef, ComponentFactory, APP_INITIALIZER } from '@angular/core';
+import { async, inject, TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+import { NzRootComponent } from './nz-root.component';
+import { NZ_ROOT_CONFIG, NzRootConfig } from './nz-root-config';
+
+describe('NzRootComponent', () => {
+  let component: NzRootComponent;
+  let mockDocument: Document;
+  let mockConfig: NzRootConfig;
+  let mockElement: HTMLDivElement;
+
+  beforeEach(() => {
+    mockDocument = { head: { appendChild: () => null }, createElement: () => null } as any;
+    mockConfig = { extraFontName: '', extraFontUrl: '' } as any;
+    mockElement = {} as any;
+
+    spyOn(mockDocument, 'createElement').and.returnValue(mockElement);
+    spyOn(mockDocument.head, 'appendChild');
+  });
+
+  it('should apply extra font style when input being set & option not provided', () => {
+    component = new NzRootComponent(mockDocument, undefined);
+    component.nzExtraFontName = 'some-name';
+    component.nzExtraFontUrl = 'some-url';
+
+    component.ngOnInit();
+
+    expect(mockDocument.createElement).toHaveBeenCalledWith('style');
+    expect(mockDocument.head.appendChild).toHaveBeenCalledWith(mockElement);
+  });
+
+  it('should not apply extra font style when option being provided', () => {
+    component = new NzRootComponent(mockDocument, mockConfig);
+    component.nzExtraFontName = 'some-name';
+    component.nzExtraFontUrl = 'some-url';
+
+    component.ngOnInit();
+
+    expect(mockDocument.createElement).not.toHaveBeenCalled();
+    expect(mockDocument.head.appendChild).not.toHaveBeenCalled();
+  });
+
+  it('should not apply extra font style when option being provided', () => {
+    component = new NzRootComponent(mockDocument, undefined);
+
+    component.ngOnInit();
+
+    expect(mockDocument.createElement).not.toHaveBeenCalled();
+    expect(mockDocument.head.appendChild).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/root/nz-root.component.ts
+++ b/src/components/root/nz-root.component.ts
@@ -1,22 +1,18 @@
 import {
   Component,
   Input,
-  ViewEncapsulation,
   OnInit,
-  Inject
+  Inject,
+  Optional,
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
+import { NZ_ROOT_CONFIG, NzRootConfig, createNzRootInitializer} from './nz-root-config';
 
 @Component({
-  selector     : '[nz-root],nz-root',
-  encapsulation: ViewEncapsulation.None,
-  template     : `
+  selector : '[nz-root],nz-root',
+  template : `
     <ng-content></ng-content>
   `,
-  styleUrls    : [
-    '../style/index.less',
-    './style/index.less',
-  ]
 })
 export class NzRootComponent implements OnInit {
 
@@ -24,27 +20,18 @@ export class NzRootComponent implements OnInit {
   @Input() nzExtraFontName: string;
   @Input() nzExtraFontUrl: string;
 
-  constructor(@Inject(DOCUMENT) private _document: Document) { }
+  constructor(
+    @Inject(DOCUMENT) private _document: Document,
+    // Cannot use type annotation here due to https://github.com/angular/angular-cli/issues/2034
+    // Should be revisited after AOT being made the only option
+    @Inject(NZ_ROOT_CONFIG) @Optional() private options: any | undefined,
+  ) { }
 
   ngOnInit() {
-    if (this.nzExtraFontName && this.nzExtraFontUrl) {
-      const style = this._document.createElement('style');
-      style.innerHTML = `
-        @font-face {
-          font-family: '${this.nzExtraFontName}';
-          src: url('${this.nzExtraFontUrl}.eot'); /* IE9*/
-          src:
-            /* IE6-IE8 */
-            url('${this.nzExtraFontUrl}.eot?#iefix') format('embedded-opentype'),
-            /* chrome、firefox */
-            url('${this.nzExtraFontUrl}.woff') format('woff'),
-            /* chrome、firefox、opera、Safari, Android, iOS 4.2+*/
-            url('${this.nzExtraFontUrl}.ttf') format('truetype'),
-            /* iOS 4.1- */
-            url('${this.nzExtraFontUrl}.svg#iconfont') format('svg');
-        }
-      `;
-      this._document.head.appendChild(style);
+    if (this.nzExtraFontName && this.nzExtraFontUrl && !this.options) {
+      const options: NzRootConfig = { extraFontName: this.nzExtraFontName, extraFontUrl: this.nzExtraFontUrl };
+      const initializer = createNzRootInitializer(this._document, options);
+      initializer();
     }
   }
 }

--- a/src/components/root/nz-root.module.spec.ts
+++ b/src/components/root/nz-root.module.spec.ts
@@ -1,0 +1,58 @@
+import { ComponentFactoryResolver, Injector, ComponentRef, ComponentFactory, APP_INITIALIZER } from '@angular/core';
+import { async, inject, TestBed } from '@angular/core/testing';
+import { NzRootModule } from './nz-root.module';
+import { NzRootStyleComponent } from './nz-root-style.component';
+
+describe('NzRootModule', () => {
+  let ngModule: NzRootModule;
+  let mockDocument: Document;
+  let mockInjector: Injector;
+  let mockFactoryResolver: ComponentFactoryResolver;
+  let mockElement: HTMLDivElement;
+  let mockComponentFactory: ComponentFactory<NzRootStyleComponent>;
+  let mockComponentRef: ComponentRef<NzRootStyleComponent>;
+
+  beforeEach(() => {
+    mockDocument = { createElement: () => null } as any;
+    mockInjector = {} as any;
+    mockFactoryResolver = { resolveComponentFactory: () => null } as any;
+    mockElement = {} as any;
+    mockComponentFactory = { create: () => null } as any;
+    mockComponentRef = { destroy: () => null } as any;
+
+    spyOn(mockDocument, 'createElement').and.returnValue(mockElement);
+    spyOn(mockComponentRef, 'destroy');
+    spyOn(mockComponentFactory, 'create').and.returnValue(mockComponentRef);
+    spyOn(mockFactoryResolver, 'resolveComponentFactory').and.returnValue(mockComponentFactory);
+  });
+
+  beforeEach(() => {
+    ngModule = new NzRootModule(mockDocument, mockInjector, mockFactoryResolver);
+  });
+
+  it('should create style component when start', () => {
+    expect(mockDocument.createElement).toHaveBeenCalledWith('div');
+    expect(mockFactoryResolver.resolveComponentFactory).toHaveBeenCalledWith(NzRootStyleComponent);
+    expect(mockComponentFactory.create).toHaveBeenCalledWith(mockInjector, null, mockElement);
+  });
+
+  it('should destroy style component when terminate', () => {
+    ngModule.ngOnDestroy();
+
+    expect(mockComponentRef.destroy).toHaveBeenCalled();
+  })
+});
+
+describe('NzRootModule with Angular integration', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [NzRootModule],
+      declarations: [],
+      providers: [],
+    }).compileComponents();
+  }));
+
+  it('should provide APP_INITIALIZER', inject([APP_INITIALIZER], (initializers: Function[]) => {
+    expect(initializers.some(x => x.name === 'nzRootInitializer')).toBe(true);
+  }));
+});

--- a/src/components/root/nz-root.module.ts
+++ b/src/components/root/nz-root.module.ts
@@ -1,12 +1,28 @@
-import { NgModule } from '@angular/core';
+import { NgModule, OnDestroy, ComponentRef, ComponentFactoryResolver, Inject, Optional, Injector, APP_INITIALIZER } from '@angular/core';
+import { CommonModule, DOCUMENT } from '@angular/common';
 import { NzRootComponent } from './nz-root.component';
-import { CommonModule } from '@angular/common';
+import { NzRootStyleComponent } from './nz-root-style.component';
+import { NZ_ROOT_CONFIG, createNzRootInitializer } from './nz-root-config';
 
 @NgModule({
-  exports     : [ NzRootComponent ],
-  declarations: [ NzRootComponent ],
-  imports     : [ CommonModule ]
+  exports         : [ NzRootComponent ],
+  declarations    : [ NzRootComponent, NzRootStyleComponent ],
+  imports         : [ CommonModule ],
+  entryComponents : [ NzRootStyleComponent ],
+  providers       : [
+    { provide: APP_INITIALIZER, multi: true, useFactory: createNzRootInitializer, deps: [DOCUMENT, [new Optional(), NZ_ROOT_CONFIG]] },
+  ],
 })
+export class NzRootModule implements OnDestroy {
+  private styleHostComponent: ComponentRef<NzRootStyleComponent>;
 
-export class NzRootModule {
+  constructor(@Inject(DOCUMENT) _document: Document, injector: Injector, resolver: ComponentFactoryResolver) {
+    const componentFactory = resolver.resolveComponentFactory(NzRootStyleComponent);
+    const div = _document.createElement('div');
+    this.styleHostComponent = componentFactory.create(injector, null, div);
+  }
+
+  ngOnDestroy() {
+    this.styleHostComponent.destroy();
+  }
 }

--- a/src/showcase/app.component.html
+++ b/src/showcase/app.component.html
@@ -1,100 +1,98 @@
-<nz-root [nzExtraFontName]="'anticon'" [nzExtraFontUrl]="'./assets/fonts/iconfont'">
-  <div class="page-wrapper">
-    <header id="header" class="clearfix">
-      <div nz-row>
-        <div nz-col [nzXs]="'24'" [nzSm]="'8'" [nzMd]="'8'" [nzLg]="'4'">
-          <a id="logo" href>
-            <img alt="logo" src="./assets/img/zorro.svg">
-            <span>NG-ZORRO</span>
-          </a>
-        </div>
-        <div nz-col [nzXs]="'0'" [nzSm]="'16'" [nzMd]="'16'" [nzLg]="'20'" class="nav nav-hide">
-          <div id="search-box">
-            <nz-select [nzPlaceHolder]="'搜索组件...'" [nzMode]="'combobox'" [(ngModel)]="searchComponent" (ngModelChange)="navigateTo($event)">
-              <nz-option [nzValue]="'components/'+component.label | lowercase" [nzLabel]="component.label+' - '+component.zh" *ngFor="let component of componentList"></nz-option>
-            </nz-select>
-          </div>
-          <ul nz-menu [nzMode]="'horizontal'" id="nav">
-            <li nz-menu-item [nzSelected]="true">
-              <a routerLink="/docs/angular/introduce"><span>组件</span></a>
-            </li>
-          </ul>
-        </div>
+<div class="page-wrapper">
+  <header id="header" class="clearfix">
+    <div nz-row>
+      <div nz-col [nzXs]="'24'" [nzSm]="'8'" [nzMd]="'8'" [nzLg]="'4'">
+        <a id="logo" href>
+          <img alt="logo" src="./assets/img/zorro.svg">
+          <span>NG-ZORRO</span>
+        </a>
       </div>
-    </header>
-    <div class="main-wrapper">
-      <div nz-row>
-        <div nz-col [nzXs]="'24'" [nzSm]="'24'" [nzMd]="'6'" [nzLg]="'4'">
-          <ul nz-menu [nzMode]="'inline'" class="aside-container">
-            <li *ngFor="let intro of routerList.intro" nz-menu-item routerLinkActive="ant-menu-item-selected" style="padding-left: 24px;">
-              <a routerLink="{{intro.path}}">{{intro.label}}</a>
-            </li>
-            <li nz-submenu [nzOpen]="true">
-              <span title><h4>Components</h4></span>
-              <ul>
-                <li nz-menu-group *ngFor="let group of routerList.components">
-                  <span title>{{group.name}}</span>
-                  <ul>
-                    <li nz-menu-item routerLinkActive="ant-menu-item-selected" *ngFor="let component of group.children">
-                      <a routerLink="{{component.path}}">
-                        <span>{{component.label}}</span><span class="chinese">{{component.zh}}</span>
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-          </ul>
+      <div nz-col [nzXs]="'0'" [nzSm]="'16'" [nzMd]="'16'" [nzLg]="'20'" class="nav nav-hide">
+        <div id="search-box">
+          <nz-select [nzPlaceHolder]="'搜索组件...'" [nzMode]="'combobox'" [(ngModel)]="searchComponent" (ngModelChange)="navigateTo($event)">
+            <nz-option [nzValue]="'components/'+component.label | lowercase" [nzLabel]="component.label+' - '+component.zh" *ngFor="let component of componentList"></nz-option>
+          </nz-select>
         </div>
-        <div nz-col class="main-container" [nzXs]="'24'" [nzSm]="'24'" [nzMd]="'18'" [nzLg]="'20'">
-          <router-outlet></router-outlet>
-        </div>
+        <ul nz-menu [nzMode]="'horizontal'" id="nav">
+          <li nz-menu-item [nzSelected]="true">
+            <a routerLink="/docs/angular/introduce"><span>组件</span></a>
+          </li>
+        </ul>
       </div>
     </div>
-    <footer id="footer">
-      <ul>
-        <li><h2><i class="anticon anticon-github"></i> GitHub</h2>
-          <div>
-            <a target="_blank " href="https://github.com/NG-ZORRO/ng-zorro-antd"><span>源码仓库</span></a>
-          </div>
-          <div>
-            <a target="_blank " href="https://github.com/websemantics/awesome-ant-design">
-              <span>Awesome Ant Design</span></a>
-          </div>
-        </li>
-        <li><h2><i class="anticon anticon-link"></i> <span>相关站点</span></h2>
-          <div>
-            <a href="http://www.angular.cn" target="_blank">Angular</a>
-            <span> - </span><span>中文网</span></div>
-          <div>
-            <a href="https://cli.angular.io/" target="_blank">CLI</a>
-            <span> - </span><span>脚手架工具</span></div>
-          <div>
-            <a href="https://ant.design/docs/react/introduce-cn" target="_blank">Ant Design</a>
-            <span> - </span><span>React版本</span></div>
-          <div>
-            <a target="_blank" rel="noopener noreferrer" href="https://antv.alipay.com/">AntV</a>
-            <span> - </span><span>数据可视化</span></div>
-          <div>
-            <a target="_blank" rel="noopener noreferrer" href="http://library.ant.design/">AntD Library</a>
-            <span> - </span><span>Axure 部件库</span></div>
-        <li><h2>
-          <i class="anticon anticon-customer-service"></i> <span>社区</span>
-        </h2>
-          <div>
-            <a href="#/changelog"><span>更新记录</span></a>
-          </div>
-          <div>
-            <a target="_blank" rel="noopener noreferrer" href="https://github.com/NG-ZORRO/ng-zorro-antd/issues">
-              <span>报告 Bug</span></a>
-          </div>
-        </li>
-        <li>
-          <h2>Copyright © 2017</h2>
-          <div><span>计算平台事业部 & 阿里云事业群 </span></div>
-          <div>@NG-ZORRO</div>
-        </li>
-      </ul>
-    </footer>
+  </header>
+  <div class="main-wrapper">
+    <div nz-row>
+      <div nz-col [nzXs]="'24'" [nzSm]="'24'" [nzMd]="'6'" [nzLg]="'4'">
+        <ul nz-menu [nzMode]="'inline'" class="aside-container">
+          <li *ngFor="let intro of routerList.intro" nz-menu-item routerLinkActive="ant-menu-item-selected" style="padding-left: 24px;">
+            <a routerLink="{{intro.path}}">{{intro.label}}</a>
+          </li>
+          <li nz-submenu [nzOpen]="true">
+            <span title><h4>Components</h4></span>
+            <ul>
+              <li nz-menu-group *ngFor="let group of routerList.components">
+                <span title>{{group.name}}</span>
+                <ul>
+                  <li nz-menu-item routerLinkActive="ant-menu-item-selected" *ngFor="let component of group.children">
+                    <a routerLink="{{component.path}}">
+                      <span>{{component.label}}</span><span class="chinese">{{component.zh}}</span>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <div nz-col class="main-container" [nzXs]="'24'" [nzSm]="'24'" [nzMd]="'18'" [nzLg]="'20'">
+        <router-outlet></router-outlet>
+      </div>
+    </div>
   </div>
-</nz-root>
+  <footer id="footer">
+    <ul>
+      <li><h2><i class="anticon anticon-github"></i> GitHub</h2>
+        <div>
+          <a target="_blank " href="https://github.com/NG-ZORRO/ng-zorro-antd"><span>源码仓库</span></a>
+        </div>
+        <div>
+          <a target="_blank " href="https://github.com/websemantics/awesome-ant-design">
+            <span>Awesome Ant Design</span></a>
+        </div>
+      </li>
+      <li><h2><i class="anticon anticon-link"></i> <span>相关站点</span></h2>
+        <div>
+          <a href="http://www.angular.cn" target="_blank">Angular</a>
+          <span> - </span><span>中文网</span></div>
+        <div>
+          <a href="https://cli.angular.io/" target="_blank">CLI</a>
+          <span> - </span><span>脚手架工具</span></div>
+        <div>
+          <a href="https://ant.design/docs/react/introduce-cn" target="_blank">Ant Design</a>
+          <span> - </span><span>React版本</span></div>
+        <div>
+          <a target="_blank" rel="noopener noreferrer" href="https://antv.alipay.com/">AntV</a>
+          <span> - </span><span>数据可视化</span></div>
+        <div>
+          <a target="_blank" rel="noopener noreferrer" href="http://library.ant.design/">AntD Library</a>
+          <span> - </span><span>Axure 部件库</span></div>
+      <li><h2>
+        <i class="anticon anticon-customer-service"></i> <span>社区</span>
+      </h2>
+        <div>
+          <a href="#/changelog"><span>更新记录</span></a>
+        </div>
+        <div>
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/NG-ZORRO/ng-zorro-antd/issues">
+            <span>报告 Bug</span></a>
+        </div>
+      </li>
+      <li>
+        <h2>Copyright © 2017</h2>
+        <div><span>计算平台事业部 & 阿里云事业群 </span></div>
+        <div>@NG-ZORRO</div>
+      </li>
+    </ul>
+  </footer>
+</div>

--- a/src/showcase/app.module.ts
+++ b/src/showcase/app.module.ts
@@ -19,7 +19,7 @@ import { NzHighlightModule } from './share/nz-highlight/nz-highlight.module';
     BrowserAnimationsModule,
     FormsModule,
     HttpModule,
-    NgZorroAntdModule.forRoot(),
+    NgZorroAntdModule.forRoot({ extraFontName: 'anticon', extraFontUrl: './assets/fonts/iconfont' }),
     NzCodeBoxModule,
     NzHighlightModule,
     RouterModule.forRoot(routes, { useHash: true, preloadingStrategy: PreloadAllModules })

--- a/src/showcase/nz-intro-getting-started/README.md
+++ b/src/showcase/nz-intro-getting-started/README.md
@@ -67,18 +67,14 @@ import { AppComponent } from './app.component';
 export class AppModule { }
 
 ```
-这样就成功在全局引入了 ng-zorro-antd
+这样就成功在全局引入了 ng-zorro-antd。
 
+> `NgZorroAntdModule.forRoot()` 方法能够接受一个可选的配置对象，用于引入外部的字体文件，类型为 `{ extraFontName: string, extraFontUrl: string }`。
 
 用下面的代码替换 `/src/app/app.component.html`
 
-> **注意**：务必要引入 `nz-root` 根组件， `nz-root` 必须放置在根component `(app.component.html)` 中，而不是替换 `app-root` ，根组件只能引入一次，所有 ng-zorro组件都应该包裹在下面，否则部分组件将不能正常工作
-
 ```html
-<!--引入根组件-->
-<nz-root>
-  <button nz-button [nzType]="'primary'">测试按钮</button>
-</nz-root>
+<button nz-button [nzType]="'primary'">测试按钮</button>
 ```
 [查看](#/components/button)最简单的Button效果
 


### PR DESCRIPTION
Closes #34 .

### API in detail:

For `NgZorroAntdModule.forRoot()` method, there is an optional parameter in signature `{ extraFontName: string, extraFontUrl: string }`, like:

```typescript
const options = { extraFontName: 'some-name', extraFontUrl: 'some-url' };

imports: [
  NgZorroAntdModule.forRoot(options)
]
```

It would be same as using `<nz-root nzExtraFontName="some-name" nzExtraFontUrl="some-url">`.

Meanwhile, user can manually provide an `NZ_ROOT_CONFIG` if they don't want to import the entire lib.
