### PR TITLE
build(packaging): fix conflict version of angular

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,15 +33,16 @@
   "dependencies": {
     "moment": "^2.18.1",
     "@angular/cdk": "^2.0.0-beta.8",
-    "@angular/animations": "^4.0.0",
+    "@angular/animations": "^4.0.0"
+  },
+  "devDependencies": {
     "@angular/common": "^4.0.0",
     "@angular/core": "^4.0.0",
     "@angular/forms": "^4.0.0",
     "@angular/platform-browser": "^4.0.0",
     "rxjs": "^5.0.1",
-    "zone.js": "^0.8.14"
-  },
-  "devDependencies": {
+    "zone.js": "^0.8.14",
+
     "@angular/cli": "1.3.0",
     "@angular/compiler": "^4.0.0",
     "@angular/compiler-cli": "^4.0.0",
@@ -76,6 +77,7 @@
   "peerDependencies": {
     "moment": "^2.18.1",
     "@angular/cdk": "^2.0.0-beta.8",
+    "@angular/animations": "^4.0.0",
     "@angular/core": "^4.0.0",
     "@angular/common": "^4.0.0",
     "@angular/forms": "^4.0.0"


### PR DESCRIPTION
Move the angular core packages out of dependencies to rely on user's installing

Close #23