### PR TITLE
docs(spin): fix api table format

### DIFF
--- a/src/showcase/nz-demo-spin/nz-demo-spin.html
+++ b/src/showcase/nz-demo-spin/nz-demo-spin.html
@@ -54,29 +54,29 @@
       <thead>
         <tr>
           <th>参数</th>
+          <th>说明</th>
           <th>类型</th>
           <th>默认值</th>
-          <th>说明</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>nzSize</td>
-          <td>enum</td>
-          <td>default</td>
           <td>spin组件中点的大小，可选值为 small default large</td>
+          <td>Enum</td>
+          <td>default</td>
         </tr>
         <tr>
           <td>nzSpinning</td>
+          <td>用于内嵌其他组件的模式，可以关闭 loading 效果</td>
           <td>Boolean</td>
           <td>true</td>
-          <td>用于内嵌其他组件的模式，可以关闭 loading 效果</td>
         </tr>
         <tr>
           <td>nzTip</td>
+          <td>自定义描述文案</td>
           <td>String</td>
           <td>无</td>
-          <td>自定义描述文案</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the demo of spin, the description column of the API table should after the property column for unification.

## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
About the Enum type, there are three types representation in the docs.
  * String
  * 'blue' | 'red' | 'green'
  * Enum (only in the spin demo)

The first two are common, I suggest to make them uniform and I can do once you make the decision.