### PR TITLE
fix(module:pagination): fix nzPageIndexChange event does not emit

### DIFF
--- a/src/components/pagination/nz-pagination.component.ts
+++ b/src/components/pagination/nz-pagination.component.ts
@@ -20,7 +20,7 @@ import {
         <a></a>
       </li>
       <li [attr.title]="_current+'/'+_lastIndex" class="ant-pagination-simple-pager">
-        <input [(ngModel)]="nzPageIndex" size="3"><span class="ant-pagination-slash">／</span>{{_lastIndex}}
+        <input [ngModel]="nzPageIndex" (ngModelChange)="_nzPageIndexChange($event)" size="3"><span class="ant-pagination-slash">／</span>{{_lastIndex}}
       </li>
       <li
         title="下一页"
@@ -103,7 +103,7 @@ import {
         </nz-select>
         <div class="ant-pagination-options-quick-jumper"
           *ngIf="nzShowQuickJumper">
-          跳至<input [(ngModel)]="nzPageIndex">页
+          跳至<input [ngModel]="nzPageIndex" (ngModelChange)="_nzPageIndexChange($event)">页
         </div>
       </div>
     </ul>`,
@@ -242,6 +242,11 @@ export class NzPaginationComponent {
   _pageSizeChange($event) {
     this.nzPageSize = $event;
     this.nzPageSizeChange.emit($event);
+  }
+
+  _nzPageIndexChange($event) {
+    this.nzPageIndex = $event;
+    this.nzPageIndexChange.emit(this.nzPageIndex);
   }
 
   /** generate indexes list */


### PR DESCRIPTION
Fix #171 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #171 


## What is the new behavior?
In the `nzShowQuickJumper` and `nzSimple` model,  `nzPageIndexChange ` event can emit as normal.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
