### PR TITLE
fix(module:cascader): fix nz-cascader don't refresh when nzOptions binding data changed (#219)

### DIFF
--- a/src/components/cascader/nz-cascader.component.ts
+++ b/src/components/cascader/nz-cascader.component.ts
@@ -442,8 +442,10 @@ export class NzCascaderComponent implements OnInit, OnDestroy, OnChanges, AfterV
 
   /** clear the input box and selected options */
   _clearSelection(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
 
     this._displayLabel = '';
     this._displayLabelIsTemplate = false;
@@ -1029,6 +1031,16 @@ export class NzCascaderComponent implements OnInit, OnDestroy, OnChanges, AfterV
         this._addHostClass(`${this._prefixCls}-picker-disabled`);
       } else {
         this._removeHostClass(`${this._prefixCls}-picker-disabled`);
+      }
+    }
+
+    const nzOptions = changes['nzOptions'];
+    if (nzOptions && !nzOptions.isFirstChange()) {
+      this._nzColumns.splice(0);
+      const newOptions: CascaderOption[] = nzOptions.currentValue;
+      if (newOptions && newOptions.length) {
+        this._nzColumns.push(newOptions);
+        this._clearSelection(null);
       }
     }
   }

--- a/src/showcase/nz-demo-cascader/nz-demo-cascader-basic.component.ts
+++ b/src/showcase/nz-demo-cascader/nz-demo-cascader-basic.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 
-const options = [{
+const init_options = [{
   value: 'zhejiang',
   label: 'Zhejiang',
   children: [{
@@ -26,6 +26,32 @@ const options = [{
   }],
 }];
 
+const other_options = [{
+  value: 'fujian',
+  label: 'Fujian',
+  children: [{
+    value: 'xiamen',
+    label: 'Xiamen',
+    children: [{
+      value: 'Kulangsu',
+      label: 'Kulangsu',
+      isLeaf: true
+    }],
+  }],
+}, {
+  value: 'guangxi',
+  label: 'Guangxi',
+  children: [{
+    value: 'guilin',
+    label: 'Guilin',
+    children: [{
+      value: 'Lijiang',
+      label: 'Li Jiang River',
+      isLeaf: true
+    }],
+  }],
+}];
+
 
 @Component({
   selector: 'nz-demo-cascader-basic',
@@ -36,12 +62,24 @@ const options = [{
       [(ngModel)]="_value"
       (ngModelChange)="_console($event)"
       (nzChange)="_console($event)">
-    </nz-cascader>`,
-  styles  : []
+    </nz-cascader>
+    <a href="javascript:;" (click)="_changeNzOptions()" class="change-options">
+      Change Options
+    </a>
+    `,
+  styles  : [
+    `
+      .change-options {
+        display: inline-block;
+        font-size: 12px;
+        margin-top: 8px;
+      }
+    `
+  ]
 })
 export class NzDemoCascaderBasicComponent implements OnInit {
   /** init data */
-  _options = options;
+  _options = null;
 
   _value: any[] = null;
 
@@ -53,6 +91,18 @@ export class NzDemoCascaderBasicComponent implements OnInit {
   }
 
   ngOnInit() {
+    // let's set nzOptions in a asynchronous  way
+    setTimeout(() => {
+      this._options = init_options;
+    }, 100);
+  }
+
+  _changeNzOptions(): void {
+    if (this._options === init_options) {
+      this._options = other_options;
+    } else {
+      this._options = init_options;
+    }
   }
 }
 


### PR DESCRIPTION
fix(module:cascader): fix nz-cascader don't refresh when nzOptions binding data changed (#219)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 219


## What is the new behavior?
when nzOptions binding data changed, auto rebuild component render

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information