### PR TITLE
feat(module:input): support nzAutosize property

### DIFF
--- a/src/components/input/nz-input.directive.component.ts
+++ b/src/components/input/nz-input.directive.component.ts
@@ -6,6 +6,7 @@ import {
   ElementRef,
   Input
 } from '@angular/core';
+import { AutoSizeType } from './nz-input.component';
 
 @Component({
   selector     : '[nz-input]',
@@ -19,6 +20,7 @@ export class NzInputDirectiveComponent {
   size = 'default';
   nativeElement: HTMLElement;
   _readonly = false;
+  _autosize: boolean | AutoSizeType = false;
   @HostBinding(`class.ant-input-disabled`) _disabled = false;
 
   @Input()
@@ -56,6 +58,25 @@ export class NzInputDirectiveComponent {
       this._render.removeAttribute(this.nativeElement, 'readonly');
     }
     this._readonly = value;
+  }
+
+  @Input()
+  get nzAutosize() {
+    return this._autosize;
+  }
+
+  set nzAutosize(value: string | boolean | AutoSizeType) {
+    if (value === '') {
+      this._autosize = true;
+    } else {
+      this._autosize = value;
+    }
+
+    if (this._autosize) {
+      this._render.setAttribute(this.nativeElement, 'autosize', '');
+    } else {
+      this._render.removeAttribute(this.nativeElement, 'autosize');
+    }
   }
 
   @HostBinding(`class.ant-input`) _nzInput = true;

--- a/src/components/util/calculate-node-height.ts
+++ b/src/components/util/calculate-node-height.ts
@@ -1,0 +1,151 @@
+const HIDDEN_TEXTAREA_STYLE = `
+  min-height:0 !important;
+  max-height:none !important;
+  height:0 !important;
+  visibility:hidden !important;
+  overflow:hidden !important;
+  position:absolute !important;
+  z-index:-1000 !important;
+  top:0 !important;
+  right:0 !important
+`;
+
+const SIZING_STYLE = [
+  'letter-spacing',
+  'line-height',
+  'padding-top',
+  'padding-bottom',
+  'font-family',
+  'font-weight',
+  'font-size',
+  'text-rendering',
+  'text-transform',
+  'width',
+  'text-indent',
+  'padding-left',
+  'padding-right',
+  'border-width',
+  'box-sizing',
+];
+
+const computedStyleCache = {};
+let hiddenTextarea;
+
+function calculateNodeStyling(node, useCache = false) {
+  const nodeRef = (
+    node.getAttribute('id') ||
+    node.getAttribute('data-reactid') ||
+    node.getAttribute('name')
+  );
+
+  if (useCache && computedStyleCache[nodeRef]) {
+    return computedStyleCache[nodeRef];
+  }
+
+  const style = window.getComputedStyle(node);
+
+  const boxSizing = (
+    style.getPropertyValue('box-sizing') ||
+    style.getPropertyValue('-moz-box-sizing') ||
+    style.getPropertyValue('-webkit-box-sizing')
+  );
+
+  const paddingSize = (
+    parseFloat(style.getPropertyValue('padding-bottom')) +
+    parseFloat(style.getPropertyValue('padding-top'))
+  );
+
+  const borderSize = (
+    parseFloat(style.getPropertyValue('border-bottom-width')) +
+    parseFloat(style.getPropertyValue('border-top-width'))
+  );
+
+  const sizingStyle = SIZING_STYLE
+  .map(name => `${name}:${style.getPropertyValue(name)}`)
+  .join(';');
+
+  const nodeInfo = {
+    sizingStyle,
+    paddingSize,
+    borderSize,
+    boxSizing,
+  };
+
+  if (useCache && nodeRef) {
+    computedStyleCache[nodeRef] = nodeInfo;
+  }
+
+  return nodeInfo;
+}
+
+export default function calculateNodeHeight(
+  uiTextNode,
+  useCache = false,
+  minRows: number | null = null,
+  maxRows: number | null = null,
+) {
+  if (!hiddenTextarea) {
+    hiddenTextarea = document.createElement('textarea');
+    document.body.appendChild(hiddenTextarea);
+  }
+
+  // Fix wrap="off" issue
+  // https://github.com/ant-design/ant-design/issues/6577
+  if (uiTextNode.getAttribute('wrap')) {
+    hiddenTextarea.setAttribute('wrap', uiTextNode.getAttribute('wrap'));
+  } else {
+    hiddenTextarea.removeAttribute('wrap');
+  }
+
+  // Copy all CSS properties that have an impact on the height of the content in
+  // the textbox
+  const {
+    paddingSize, borderSize,
+    boxSizing, sizingStyle,
+  } = calculateNodeStyling(uiTextNode, useCache);
+
+  // Need to have the overflow attribute to hide the scrollbar otherwise
+  // text-lines will not calculated properly as the shadow will technically be
+  // narrower for content
+  hiddenTextarea.setAttribute('style', `${sizingStyle};${HIDDEN_TEXTAREA_STYLE}`);
+  hiddenTextarea.value = uiTextNode.value || uiTextNode.placeholder || '';
+
+  let minHeight = -Infinity;
+  let maxHeight = Infinity;
+  let height = hiddenTextarea.scrollHeight;
+  let overflowY;
+
+  if (boxSizing === 'border-box') {
+    // border-box: add border, since height = content + padding + border
+    height = height + borderSize;
+  } else if (boxSizing === 'content-box') {
+    // remove padding, since height = content
+    height = height - paddingSize;
+  }
+
+  if (minRows !== null || maxRows !== null) {
+    // measure height of a textarea with a single row
+    hiddenTextarea.value = '';
+    const singleRowHeight = hiddenTextarea.scrollHeight - paddingSize;
+    if (minRows !== null) {
+      minHeight = singleRowHeight * minRows;
+      if (boxSizing === 'border-box') {
+        minHeight = minHeight + paddingSize + borderSize;
+      }
+      height = Math.max(minHeight, height);
+    }
+    if (maxRows !== null) {
+      maxHeight = singleRowHeight * maxRows;
+      if (boxSizing === 'border-box') {
+        maxHeight = maxHeight + paddingSize + borderSize;
+      }
+      overflowY = height > maxHeight ? '' : 'hidden';
+      height = Math.min(maxHeight, height);
+    }
+  }
+  // Remove scroll bar flash when autosize without maxRows
+  if (!maxRows) {
+    overflowY = 'hidden';
+  }
+  return { height, minHeight, maxHeight, overflowY };
+}

--- a/src/showcase/nz-demo-input/nz-demo-input-textarea-auot-size.component.ts
+++ b/src/showcase/nz-demo-input/nz-demo-input-textarea-auot-size.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'nz-demo-input-textarea-auot-size',
+  template: `
+    <nz-input [(ngModel)]="inputValueOne" nzType="textarea" nzAutosize nzPlaceHolder="Autosize height based on content lines"></nz-input>
+    <div style="margin-top: 16px;">
+      <nz-input [(ngModel)]="inputValueTwo" nzType="textarea" [nzAutosize]="autosize" nzPlaceHolder="Autosize height with minimum and maximum number of lines"></nz-input>
+    </div>
+  `,
+  styles  : []
+})
+export class NzDemoInputTextareaAutoSizeComponent implements OnInit {
+  inputValueOne: string;
+  inputValueTwo: string;
+  autosize = {
+    minRows: 2,
+    maxRows: 6
+  };
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+}
+

--- a/src/showcase/nz-demo-input/nz-demo-input.component.ts
+++ b/src/showcase/nz-demo-input/nz-demo-input.component.ts
@@ -16,6 +16,7 @@ export class NzDemoInputComponent implements OnInit {
   NzDemoInputGroupCode = require('!!raw-loader!./nz-demo-input-group.component');
   NzDemoInputSearchCode = require('!!raw-loader!./nz-demo-input-search.component');
   NzDemoInputTextareaCode = require('!!raw-loader!./nz-demo-input-textarea.component');
+  NzDemoInputTextareaAutoSizeCode = require('!!raw-loader!./nz-demo-input-textarea-auot-size.component');
   NzDemoInputAffixCode = require('!!raw-loader!./nz-demo-input-affix.component');
 
   constructor() {

--- a/src/showcase/nz-demo-input/nz-demo-input.html
+++ b/src/showcase/nz-demo-input/nz-demo-input.html
@@ -31,6 +31,12 @@
           <p>带有搜索按钮的输入框。</p>
         </div>
       </nz-code-box>
+      <nz-code-box [nzTitle]="'适应文本高度的文本域'" id="components-input-demo-textarea-auot-size" [nzCode]="NzDemoInputTextareaAutoSizeCode">
+        <nz-demo-input-textarea-auot-size demo></nz-demo-input-textarea-auot-size>
+        <div intro>
+          <p><code>nzAutosize</code> 属性适用于 <code>textarea</code> 节点，并且只有高度会自动变化。另外 <code>nzAutosize</code>  可以设定为一个对象，指定最小行数和最大行数。</p>
+        </div>
+      </nz-code-box>
       <nz-code-box [nzTitle]="'前缀与后缀'" id="components-input-demo-affix" [nzCode]="NzDemoInputAffixCode">
         <nz-demo-input-affix demo></nz-demo-input-affix>
         <div intro>
@@ -144,6 +150,28 @@
           <td>ng-template</td>
           <td>-</td>
         </tr>
+      </tbody>
+    </table>
+    <h4 id="Input.TextArea"><span>nz-input[type=textarea]</span>
+      <!-- <a class="anchor">#</a> -->
+    </h4>
+    <p>当 <code>nzType="textarea"</code> 时，特有的API</p>
+    <table>
+      <thead>
+      <tr>
+        <th>参数</th>
+        <th>说明</th>
+        <th>类型</th>
+        <th>默认值</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>nzAutosize</td>
+        <td>自适应内容高度，可设置为 true|false 或对象：<code>{{'{ minRows: 2, maxRows: 6 }'}}</code></td>
+        <td>Boolean|Object</td>
+        <td><code>false</code></td>
+      </tr>
       </tbody>
     </table>
     <h4 id="Input.Group"><span>nz-input-group</span>

--- a/src/showcase/nz-demo-input/nz-demo-input.module.ts
+++ b/src/showcase/nz-demo-input/nz-demo-input.module.ts
@@ -8,6 +8,7 @@ import { NzDemoInputAddOnComponent } from './nz-demo-input-add-on.component';
 import { NzDemoInputGroupComponent } from './nz-demo-input-group.component';
 import { NzDemoInputSearchComponent } from './nz-demo-input-search.component';
 import { NzDemoInputTextareaComponent } from './nz-demo-input-textarea.component';
+import { NzDemoInputTextareaAutoSizeComponent } from './nz-demo-input-textarea-auot-size.component';
 import { NzDemoInputAffixComponent } from './nz-demo-input-affix.component';
 import { NzDemoInputComponent } from './nz-demo-input.component';
 import { NzCodeBoxModule } from '../share/nz-codebox/nz-codebox.module';
@@ -18,7 +19,7 @@ import { NzDemoInputRoutingModule } from './nz-demo-input.routing.module';
 
 @NgModule({
   imports     : [ NzDemoInputRoutingModule, CommonModule, NzCodeBoxModule, NgZorroAntdModule, FormsModule ],
-  declarations: [ NzDemoInputComponent, NzDemoInputBasicComponent, NzDemoInputSizeComponent, NzDemoInputAddOnComponent, NzDemoInputGroupComponent, NzDemoInputSearchComponent, NzDemoInputTextareaComponent, NzDemoInputAffixComponent ]
+  declarations: [ NzDemoInputComponent, NzDemoInputBasicComponent, NzDemoInputSizeComponent, NzDemoInputAddOnComponent, NzDemoInputGroupComponent, NzDemoInputSearchComponent, NzDemoInputTextareaComponent, NzDemoInputTextareaAutoSizeComponent, NzDemoInputAffixComponent ]
 })
 
 export class NzDemoInputModule {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #252 

## What is the new behavior?

Autosizing the height to fit the content, like https://ant.design/components/input/

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
