### PR TITLE
feat(module:layout): layout component supports fullscreen

### DIFF
--- a/src/components/layout/nz-layout.component.ts
+++ b/src/components/layout/nz-layout.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
+import { Component, HostBinding, ViewEncapsulation, Input } from '@angular/core';
 
 @Component({
   selector     : 'nz-layout',
@@ -13,7 +13,14 @@ import { Component, HostBinding, ViewEncapsulation } from '@angular/core';
 })
 
 export class NzLayoutComponent {
+  @Input() isFullscreen = false;
+
   @HostBinding('class.ant-layout-has-sider') hasSider = false;
+
+  @HostBinding('class.ant-layout-is-fullscreen')
+  get fullscreen(){
+    return this.isFullscreen;
+  }
 
   @HostBinding('class.ant-layout') _nzLayout = true;
 }

--- a/src/components/layout/nz-layout.component.ts
+++ b/src/components/layout/nz-layout.component.ts
@@ -13,14 +13,12 @@ import { Component, HostBinding, ViewEncapsulation, Input } from '@angular/core'
 })
 
 export class NzLayoutComponent {
-  @Input() isFullscreen = false;
-
-  @HostBinding('class.ant-layout-has-sider') hasSider = false;
 
   @HostBinding('class.ant-layout-is-fullscreen')
-  get fullscreen(){
-    return this.isFullscreen;
-  }
+  @Input()
+  isFullscreen = false;
+
+  @HostBinding('class.ant-layout-has-sider') hasSider = false;
 
   @HostBinding('class.ant-layout') _nzLayout = true;
 }

--- a/src/components/layout/style/index.less
+++ b/src/components/layout/style/index.less
@@ -17,6 +17,10 @@
     }
   }
 
+  &&-is-fullscreen {
+    height: 100%;
+  }
+
   &-header,
   &-footer {
     flex: 0 0 auto;

--- a/src/showcase/nz-demo-layout/nz-demo-layout-is-fullscreen.component.ts
+++ b/src/showcase/nz-demo-layout/nz-demo-layout-is-fullscreen.component.ts
@@ -1,0 +1,57 @@
+import {Component, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'nz-demo-layout-is-fullscreen',
+  template: `
+    <label>isFullscreen</label>
+    <nz-switch [(ngModel)]="isFullscreen"></nz-switch>
+    <div class="components-layout-demo-is-fullscreen">
+      <nz-layout class="layout" [isFullscreen]="isFullscreen">
+        <nz-header>
+          <div class="logo"></div>
+          <ul nz-menu [nzTheme]="'dark'" [nzMode]="'horizontal'" style="line-height: 64px;">
+            <li nz-menu-item>nav 1</li>
+            <li nz-menu-item>nav 2</li>
+            <li nz-menu-item>nav 3</li>
+          </ul>
+        </nz-header>
+        <nz-content style="padding:0 50px;">
+          <nz-breadcrumb style="margin:12px 0;">
+            <nz-breadcrumb-item>Home</nz-breadcrumb-item>
+            <nz-breadcrumb-item>List</nz-breadcrumb-item>
+            <nz-breadcrumb-item>App</nz-breadcrumb-item>
+          </nz-breadcrumb>
+          <div style="background:#fff; padding: 24px; min-height: 280px;">Content</div>
+        </nz-content>
+        <nz-footer style="text-align: center; background-color:#404040;">Ant Design ©2017 Implement By Angular</nz-footer>
+      </nz-layout>
+    </div>
+  `,
+  styles: [
+      `:host ::ng-deep .logo {
+      width: 120px;
+      height: 31px;
+      background: #333;
+      border-radius: 6px;
+      margin: 16px 24px 16px 0;
+      float: left;
+    }
+
+    .components-layout-demo-is-fullscreen {
+      height: 600px;
+      border: solid 1px #333;
+      margin-top:10px;
+    }
+    `
+
+  ]
+})
+export class NzDemoLayoutIsFullScreenComponent implements OnInit {
+  isFullscreen = true;
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+}

--- a/src/showcase/nz-demo-layout/nz-demo-layout.component.ts
+++ b/src/showcase/nz-demo-layout/nz-demo-layout.component.ts
@@ -16,6 +16,7 @@ export class NzDemoLayoutComponent implements OnInit {
   NzDemoLayoutSideCode = require('!!raw-loader!./nz-demo-layout-side.component');
   NzDemoLayoutTriggerCode = require('!!raw-loader!./nz-demo-layout-trigger.component');
   NzDemoLayoutResponsiveCode = require('!!raw-loader!./nz-demo-layout-responsive.component');
+  NzDemoLayoutIsFullScreenCode = require('!!raw-loader!./nz-demo-layout-is-fullscreen.component');
 
   constructor() {
   }

--- a/src/showcase/nz-demo-layout/nz-demo-layout.html
+++ b/src/showcase/nz-demo-layout/nz-demo-layout.html
@@ -127,6 +127,14 @@
           </p>
         </div>
       </nz-code-box>
+      <nz-code-box [nzTitle]="'全屏布局'" id="components-layout-demo-is-fullscreen" [nzCode]="NzDemoLayoutIsFullScreenCode">
+        <nz-demo-layout-is-fullscreen demo></nz-demo-layout-is-fullscreen>
+        <div intro>
+          <p>nz-layout 支持全屏布局。</p>
+          <p>说明：设置为全屏布局时，layout-footer会靠在容器最下方
+          </p>
+        </div>
+      </nz-code-box>
     </div>
   </div>
   <section class="markdown api-container">

--- a/src/showcase/nz-demo-layout/nz-demo-layout.module.ts
+++ b/src/showcase/nz-demo-layout/nz-demo-layout.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
 import { NzDemoLayoutBasicComponent } from './nz-demo-layout-basic.component';
+import { NzDemoLayoutIsFullScreenComponent } from './nz-demo-layout-is-fullscreen.component';
 import { NzDemoLayoutTopComponent } from './nz-demo-layout-top.component';
 import { NzDemoLayoutTopSideComponent } from './nz-demo-layout-top-side.component';
 import { NzDemoLayoutTopSide2Component } from './nz-demo-layout-top-side-2.component';
@@ -25,6 +26,7 @@ import { NzDemoLayoutRoutingModule } from './nz-demo-layout.routing.module';
   declarations: [
     NzDemoLayoutComponent,
     NzDemoLayoutBasicComponent,
+    NzDemoLayoutIsFullScreenComponent,
     NzDemoLayoutTopComponent,
     NzDemoLayoutTopSide2Component,
     NzDemoLayoutTopSideComponent,


### PR DESCRIPTION
add isFullscreen property to layout component, the footer will dock to bottom with height:100% of layout container

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
if you want to dock the footer to bottom, you need to set the height is 100% in style property of layout component.

Issue Number: N/A


## What is the new behavior?
add isFullscreen property to layout component, the footer will dock to bottom with height:100% of layout container.

more info can be find in the showcase of layout component, 全屏布局 section


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
