### PR TITLE
fix(module:carousel):fix carousel scrolls two steps when 'nzAutoPlay'…

### DIFF
--- a/src/components/carousel/nz-carousel.component.ts
+++ b/src/components/carousel/nz-carousel.component.ts
@@ -57,7 +57,6 @@ export class NzCarouselComponent implements AfterViewInit, OnDestroy {
   }
 
   setActive(content, i) {
-    this.clearInterval();
     if (this.nzAutoPlay) {
       this.createInterval();
     }
@@ -114,6 +113,7 @@ export class NzCarouselComponent implements AfterViewInit, OnDestroy {
   }
 
   createInterval() {
+    this.clearInterval();
     this.interval = setInterval(_ => {
       if (this.activeIndex < this.slideContents.length - 1) {
         this.activeIndex++;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
carousel scrolls only one steps when 'nzAutoPlay' is true.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
