### PR TITLE
select option offset (Select option 偏移量,用于显示轻量级树形结构)

### DIFF
--- a/src/components/select/nz-option.component.ts
+++ b/src/components/select/nz-option.component.ts
@@ -21,6 +21,19 @@ export class NzOptionComponent implements OnDestroy, OnInit {
   _value: string;
   _label: string;
   _disabled = false;
+  _offset: number;
+
+  @Input()
+  get nzOffSet(): number {
+    return this._offset;
+  }
+
+  set nzOffSet(value: number) {
+    if (this._offset === value) {
+      return;
+    }
+    this._offset = value;
+  }
 
   @Input()
   get nzValue(): string {

--- a/src/components/select/nz-select.component.ts
+++ b/src/components/select/nz-select.component.ts
@@ -130,6 +130,7 @@ import { TagAnimation } from '../core/animation/tag-animations';
               [class.ant-select-dropdown-menu-item-active]="option.nzValue == _activeFilterOption?.nzValue"
               [class.ant-select-dropdown-menu-item-selected]="(option.nzValue==(_selectedOption?.nzValue))||(isInSet(_selectedOptions,option))"
               class="ant-select-dropdown-menu-item"
+              [style.padding-left.px]="option.nzOffSet"
               (click)="clickOption(option,$event)">
               {{option.nzLabel}}
             </li>

--- a/src/showcase/nz-demo-select/nz-demo-select-option-offset.component.ts
+++ b/src/showcase/nz-demo-select/nz-demo-select-option-offset.component.ts
@@ -1,0 +1,46 @@
+import {Component, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'nz-demo-select-option-class',
+  template: `
+    <nz-select
+      style="width: 400px;"
+      [nzTags]="true"
+      [nzPlaceHolder]="'请选择人员'"
+      [(ngModel)]="selectedMultipleOption"
+      [nzNotFoundContent]="'无法找到'"
+      [nzShowSearch]="true">
+      <nz-option
+        *ngFor="let option of searchOptions"
+        [nzLabel]="option.label"
+        [nzValue]="option"
+        [nzOffSet]="option.offset"
+        >
+      </nz-option>
+    </nz-select>
+  `,
+  styles: [`
+    `]
+})
+export class NzDemoSelectOptionClassComponent implements OnInit {
+  searchOptions = [
+    {value: 'group01', label: '第一小组'},
+    {value: 'lucy', label: '露西', offset: 50},
+    {value: 'tom', label: '汤姆', offset: 50},
+    {value: 'group', label: '第二小组'},
+    {value: 'jack', label: '第二小组第一分组', offset: 50},
+    {value: 'jack', label: '杰克', offset: 100},
+    {value: 'sam', label: '山姆', offset: 50}
+  ];
+  selectedMultipleOption = [this.searchOptions[0]];
+
+  constructor() {
+  }
+
+  ngOnInit() {
+    setTimeout(_ => {
+      this.selectedMultipleOption = [];
+    }, 2000)
+  }
+}
+

--- a/src/showcase/nz-demo-select/nz-demo-select-option-offset.component.ts
+++ b/src/showcase/nz-demo-select/nz-demo-select-option-offset.component.ts
@@ -15,7 +15,7 @@ import {Component, OnInit} from '@angular/core';
         [nzLabel]="option.label"
         [nzValue]="option"
         [nzOffSet]="option.offset"
-        >
+        >  
       </nz-option>
     </nz-select>
   `,

--- a/src/showcase/nz-demo-select/nz-demo-select.component.ts
+++ b/src/showcase/nz-demo-select/nz-demo-select.component.ts
@@ -15,6 +15,7 @@ export class NzDemoSelectComponent implements OnInit {
   NzDemoSelectMultipleChangeCode = require('!!raw-loader!./nz-demo-select-multiple-change.component');
   NzDemoSelectTagCode = require('!!raw-loader!./nz-demo-select-tag.component');
   NzDemoSelectSearchChangeCode = require('!!raw-loader!./nz-demo-select-search-change.component');
+  NzDemoSelectOptionOffSetComponentCode= require('!!raw-loader!./nz-demo-select-option-offset.component');
 
   constructor() {
   }

--- a/src/showcase/nz-demo-select/nz-demo-select.html
+++ b/src/showcase/nz-demo-select/nz-demo-select.html
@@ -54,6 +54,12 @@
           <p>多选搜索框和远程数据结合，注意此时需要保留未列在当前选项中但已被加入多选框中的数据，需要添加 <code>nzKeepUnListOptions</code>属性</p>
         </div>
       </nz-code-box>
+      <nz-code-box [nzTitle]="'Option偏移量'" id="components-nz-demo-select-option-offset" [nzCode]="NzDemoSelectOptionOffSetComponentCode">
+        <nz-demo-select-option-class demo></nz-demo-select-option-class>
+        <div intro>
+          <p>为option项添加偏移量,显示类似分组的效果,其偏移量可根据业务自动计算（可计算出多层级显示，模拟tree）。需要otpion添加<code>nzOffSet</code>属性。</p>
+        </div>
+      </nz-code-box>
     </div>
   </div>
   <section class="markdown api-container">
@@ -184,6 +190,12 @@
           <td>是否禁用</td>
           <td>Boolean</td>
           <td>false</td>
+        </tr>
+        <tr>
+          <td>nzOffSet</td>
+          <td>向右偏移量，可根据实际业务计算（可计算出多层级显示，模拟tree）</td>
+          <td>Number</td>
+          <td>0</td>
         </tr>
       </tbody>
     </table>

--- a/src/showcase/nz-demo-select/nz-demo-select.module.ts
+++ b/src/showcase/nz-demo-select/nz-demo-select.module.ts
@@ -14,11 +14,12 @@ import { NzDemoSelectComponent } from './nz-demo-select.component';
 import { NzCodeBoxModule } from '../share/nz-codebox/nz-codebox.module';
 import { NgZorroAntdModule } from '../../../index.showcase';
 
-import { NzDemoSelectRoutingModule } from './nz-demo-select.routing.module';
+import {NzDemoSelectRoutingModule} from './nz-demo-select.routing.module';
+import {NzDemoSelectOptionClassComponent} from './nz-demo-select-option-offset.component';
 
 @NgModule({
-  imports     : [ NzDemoSelectRoutingModule, CommonModule, NzCodeBoxModule, NgZorroAntdModule, FormsModule, JsonpModule ],
-  declarations: [ NzDemoSelectBasicComponent, NzDemoSelectSizeComponent, NzDemoSelectSearchComponent, NzDemoSelectMultipleComponent, NzDemoSelectTagComponent, NzDemoSelectComponent, NzDemoSelectSearchChangeComponent, NzDemoSelectMultipleChangeComponent ],
+  imports: [NzDemoSelectRoutingModule, CommonModule, NzCodeBoxModule, NgZorroAntdModule, FormsModule, JsonpModule],
+  declarations: [NzDemoSelectBasicComponent, NzDemoSelectSizeComponent, NzDemoSelectSearchComponent, NzDemoSelectMultipleComponent, NzDemoSelectTagComponent, NzDemoSelectComponent, NzDemoSelectSearchChangeComponent, NzDemoSelectMultipleChangeComponent, NzDemoSelectOptionClassComponent],
 })
 
 export class NzDemoSelectModule {


### PR DESCRIPTION
由于很多下拉框实际上是有树形架构的,但又不是将整个路径全部选/显示出来(Cascader 级联选择就没有用了).
例如:简单的分组,分类的需求.可能就一至两层.但实际应用中只是选择项,而不是选分类(可禁用分类).
因此增加这个偏移量,来模拟简单的树形结构数据.增加展现层面上的灵活度.已经按规范编写代码/demo.希望能够采纳.