### PR TITLE
docs(showcase): use better syntax in NzModal

### DIFF
--- a/src/showcase/nz-demo-modal/nz-demo-confirm-async.component.ts
+++ b/src/showcase/nz-demo-modal/nz-demo-confirm-async.component.ts
@@ -17,12 +17,12 @@ export class NzDemoConfirmAsyncComponent {
       title  : '您是否确认要删除这项内容',
       content: '点确认 1 秒后关闭',
       showConfirmLoading: true,
-      onOk() {
+      onOk: () => {
         return new Promise((resolve) => {
           setTimeout(resolve, 1000);
         });
       },
-      onCancel() {
+      onCancel: () => {
       }
     });
   }

--- a/src/showcase/nz-demo-modal/nz-demo-confirm-basic.component.ts
+++ b/src/showcase/nz-demo-modal/nz-demo-confirm-basic.component.ts
@@ -16,10 +16,10 @@ export class NzDemoConfirmBasicComponent {
     this.confirmServ.confirm({
       title  : '您是否确认要删除这项内容',
       content: '<b>一些解释</b>',
-      onOk() {
+      onOk: () => {
         console.log('确定');
       },
-      onCancel() {
+      onCancel: () => {
       }
     });
   }

--- a/src/showcase/nz-demo-modal/nz-demo-modal-service.component.ts
+++ b/src/showcase/nz-demo-modal/nz-demo-modal-service.component.ts
@@ -50,12 +50,12 @@ export class NzDemoModalServiceComponent {
       content : '纯文本内容，点确认 1 秒后关闭',
       closable: false,
       showConfirmLoading: true,
-      onOk() {
+      onOk: () => {
         return new Promise((resolve) => {
           setTimeout(resolve, 1000);
         });
       },
-      onCancel() {
+      onCancel: () => {
       }
     });
   }
@@ -66,7 +66,7 @@ export class NzDemoModalServiceComponent {
       content     : contentTpl,
       footer      : footerTpl,
       maskClosable: false,
-      onOk() {
+      onOk: () => {
         console.log('Click ok');
       }
     });
@@ -76,9 +76,9 @@ export class NzDemoModalServiceComponent {
     const subscription = this.modalService.open({
       title          : '对话框标题',
       content        : NzModalCustomizeComponent,
-      onOk() {
+      onOk: () => {
       },
-      onCancel() {
+      onCancel: () => {
         console.log('Click cancel');
       },
       footer         : false,


### PR DESCRIPTION
According to #409, update `nzModal`'s showcase in document with better syntax.
r? @vthinkxie 