### PR TITLE
fix(module:tabs): repeat rendering the TabBarExtra when used nested tabs

### DIFF
--- a/src/components/tabs/nz-tabset.component.ts
+++ b/src/components/tabs/nz-tabset.component.ts
@@ -49,7 +49,7 @@ export type NzTabType = 'line' | 'card';
         [nzHideBar]="nzHide"
         [selectedIndex]="nzSelectedIndex">
         <ng-template #tabBarExtraContent>
-          <ng-template [ngTemplateOutlet]="nzTabBarExtraContent"></ng-template>
+          <ng-template [ngTemplateOutlet]="nzTabBarExtraTemplate || nzTabBarExtraContent"></ng-template>
         </ng-template>
         <div
           nz-tab-label
@@ -90,6 +90,7 @@ export class NzTabSetComponent implements AfterContentChecked, OnInit, AfterView
   _selectedIndex: number | null = null;
   _isViewInit = false;
   _tabs: Array<NzTabComponent> = [];
+  @Input() nzTabBarExtraTemplate: TemplateRef<any>;
   @ContentChild('nzTabBarExtraContent') nzTabBarExtraContent: TemplateRef<any>;
   @ViewChild('tabNav') _tabNav: NzTabsNavComponent;
   @ViewChild('tabContent') _tabContent: ElementRef;

--- a/src/showcase/nz-demo-tabs/nz-demo-tabs-extra.component.ts
+++ b/src/showcase/nz-demo-tabs/nz-demo-tabs-extra.component.ts
@@ -3,14 +3,14 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'nz-demo-tabs-extra',
   template: `
-    <nz-tabset>
+    <nz-tabset [nzTabBarExtraTemplate]="tabBarExtraContent">
       <nz-tab *ngFor="let tab of tabs">
         <ng-template #nzTabHeading>
          Tab {{tab.index}}
         </ng-template>
         <span>Content of tab {{tab.index}}</span>
       </nz-tab>
-      <ng-template #nzTabBarExtraContent>
+      <ng-template #tabBarExtraContent>
         <button nz-button>Extra Action</button>
       </ng-template>
     </nz-tabset>`,

--- a/src/showcase/nz-demo-tabs/nz-demo-tabs.html
+++ b/src/showcase/nz-demo-tabs/nz-demo-tabs.html
@@ -116,6 +116,12 @@
           <td>true</td>
         </tr>
         <tr>
+          <td>nzTabBarExtraTemplate</td>
+          <td>用于指定 tab bar 上特定的额外的元素</td>
+          <td>TemplateRef</td>
+          <td>无</td>
+        </tr>
+        <tr>
           <td>#nzTabBarExtraContent</td>
           <td>tab bar 上额外的元素</td>
           <td>ng-template</td>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #452


## What is the new behavior?
added `[nzTabBarExtraTemplate] ` property to make `#nzTabBarExtraContent` optional

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
