### PR TITLE
feat(module:datepicker): support string and number type as value

### DIFF
--- a/src/components/util/nz-date.pipe.ts
+++ b/src/components/util/nz-date.pipe.ts
@@ -3,11 +3,11 @@ import * as moment from 'moment';
 
 @Pipe({ name: 'nzDate' })
 export class NzDatePipe implements PipeTransform {
-  transform(value: Date, formatString: string): string {
-    if (value) {
-      return moment(+value).format(formatString);
+  transform(value: Date | number | string, formatString: string): string {
+    if (moment(value).isValid()) {
+      return moment(value).format(formatString);
     } else {
-      return '';
+      return 'Invalid Date';
     }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

目前，datepicker组件仅仅支持Date类型和数字类型时间戳或字符类型时间戳的输入，其他类型的输入都会被处理成`Invalid date`。


Issue Number: #123 ([feat] about `nzDate` #123), #121 (the value of DatePicker component is only just Date type? #121)


## What is the new behavior?

修改后，该组件可以正确显示字符串类型的ISO 8601时间以及数字类型的时间戳，`momentjs`不支持的类型都会显示为`Invalid Date`，充分利用了`momentjs`的兼容能力，如下图所示。


<img width="410" alt="zorro-datepipe-demo" src="https://user-images.githubusercontent.com/14243906/33052805-9008b7a6-ceab-11e7-8857-b51e1ecbb133.png">



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
