### PR TITLE
build: add inline step for templateUrl

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ readonly currentDir=$(cd $(dirname $0); pwd)
 cd ${currentDir}
 rm -rf publish
 cp -r src/components src/__gen_components
+node ./inline-template.js
 node ./less.convert.js
 
 echo 'Compiling to es2015 via Angular compiler'

--- a/inline-template.js
+++ b/inline-template.js
@@ -1,0 +1,30 @@
+const fs = require('fs')
+const path = require('path')
+const glob = require('glob').sync
+
+function inlineResourcesForDirectory(folderPath) {
+  glob(path.join(folderPath, '**/*.ts')).forEach(filePath => inlineResources(filePath))
+}
+
+function inlineResources(filePath) {
+  let fileContent = fs.readFileSync(filePath, 'utf-8')
+
+  fileContent = inlineTemplate(fileContent, filePath)
+
+  fs.writeFileSync(filePath, fileContent, 'utf-8')
+}
+
+function inlineTemplate(fileContent, filePath) {
+  return fileContent.replace(/templateUrl\s*:\s*'([^']+?\.html)'/g, (_match, templateUrl) => {
+    const templatePath = path.join(path.dirname(filePath), templateUrl)
+    const templateContent = loadResourceFile(templatePath)
+    return `template: \`${templateContent}\``
+  })
+}
+
+function loadResourceFile(filePath) {
+  return fs.readFileSync(filePath, 'utf-8')
+    .replace(/([\n\r]\s*)+/gm, ' ')
+}
+
+inlineResourcesForDirectory('./src/__gen_components')

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "codelyzer": "~4.0.1",
     "core-js": "^2.4.1",
     "coveralls": "^2.13.1",
+    "glob": "^7.1.2",
     "highlight.js": "^9.12.0",
     "intl": "^1.2.5",
     "jasmine-core": "~2.6.2",

--- a/src/components/button/nz-button.component.html
+++ b/src/components/button/nz-button.component.html
@@ -1,0 +1,2 @@
+<i class="anticon anticon-spin anticon-loading" *ngIf="nzLoading"></i>
+<ng-content></ng-content>

--- a/src/components/button/nz-button.component.ts
+++ b/src/components/button/nz-button.component.ts
@@ -16,10 +16,7 @@ export type NzButtonSize = 'small' | 'large' | 'default' ;
 @Component({
   selector     : '[nz-button]',
   encapsulation: ViewEncapsulation.None,
-  template     : `
-    <i class="anticon anticon-spin anticon-loading" *ngIf="nzLoading"></i>
-    <ng-content></ng-content>
-  `,
+  templateUrl  : './nz-button.component.html',
   styleUrls    : [
     './style/index.less'
   ]


### PR DESCRIPTION
closes #684

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #684 


## What is the new behavior?

Enable using `templateUrl` for components.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Only made change for button here since it's covered by integration tests. Others can be done in follow ups.