### PR TITLE
feat(module:mention): add prefix property to nzOnSearchChange payload

### DIFF
--- a/components/mention/demo/async.ts
+++ b/components/mention/demo/async.ts
@@ -1,4 +1,5 @@
 import { Component, ViewEncapsulation } from '@angular/core';
+import { MentionOnSearchTypes } from 'ng-zorro-antd';
 
 @Component({
   selector     : 'nz-demo-mention-async',
@@ -20,7 +21,7 @@ export class NzDemoMentionAsyncComponent {
   loading = false;
   suggestions = [];
 
-  onSearchChange(value: string): void {
+  onSearchChange({value}: MentionOnSearchTypes): void {
     console.log(`search: ${value}`);
     this.loading = true;
     this.fetchSuggestions(value, (suggestions) => {

--- a/components/mention/demo/multiple-trigger.ts
+++ b/components/mention/demo/multiple-trigger.ts
@@ -1,4 +1,5 @@
 import { Component, ViewEncapsulation } from '@angular/core';
+import { MentionOnSearchTypes } from 'ng-zorro-antd';
 
 @Component({
   selector     : 'nz-demo-mention-multiple-trigger',
@@ -6,6 +7,7 @@ import { Component, ViewEncapsulation } from '@angular/core';
   template     : `
   <nz-mention
     [nzSuggestions]="suggestions"
+    (nzOnSearchChange)="onSearchChange($event)"
     [nzPrefix]="['#', '@']">
     <input
       placeholder="input @ to mention people, # to mention tag"
@@ -17,6 +19,13 @@ import { Component, ViewEncapsulation } from '@angular/core';
 })
 export class NzDemoMentionMultipleTriggerComponent {
   inputValue: string;
-  suggestions = ['afc163', 'benjycui', 'yiminghe', 'RaoHai', '中文', 'にほんご'];
+  suggestions = [];
+  users = ['afc163', 'benjycui', 'yiminghe', 'RaoHai', '中文', 'にほんご'];
+  tags = ['1.0', '2.0', '3.0'];
+
+  onSearchChange({value, prefix}: MentionOnSearchTypes): void {
+    console.log('nzOnSearchChange', value, prefix);
+    this.suggestions = prefix === '@' ? this.users : this.tags;
+  }
 
 }

--- a/components/mention/doc/index.en-US.md
+++ b/components/mention/doc/index.en-US.md
@@ -35,7 +35,7 @@ When need to mention someone or something.
 | nzSuggestions | Suggestion content | `any[]` | `[]` |
 | nzValueWith | Function that maps an suggestion's value  | `(any) => string` | `(value: string) => string` |
 | (nzOnSelect) | Callback function called when select from suggestions | `EventEmitter<any>` | - |
-| (onSearchChange) | Callback function called when search content changes| `EventEmitter<string>` | - |
+| (onSearchChange) | Callback function called when search content changes| `EventEmitter<MentionOnSearchTypes>` | - |
 
 ### Methods
 
@@ -72,3 +72,9 @@ Customize the suggestion template
   </nz-mention>
 ```
 
+### MentionOnSearchTypes
+
+| Property | Description | Type | Default |
+| -------- | ----------- | ---- | ------- |
+| value | Search keyword | string | - |
+| prefix | prefix | string | - |

--- a/components/mention/doc/index.zh-CN.md
+++ b/components/mention/doc/index.zh-CN.md
@@ -36,7 +36,7 @@ title: Mention
 | nzSuggestions | 建议内容 | `any[]` | `[]` |
 | nzValueWith | 建议选项的取值方法  | `(any) => string` | `(value: string) => string` |
 | (nzOnSelect) | 下拉框选择建议时回调 | `EventEmitter<any>` | - |
-| (onSearchChange) | 输入框中 @ 变化时回调 | `EventEmitter<string>` | - |
+| (onSearchChange) | 输入框中 @ 变化时回调 | `EventEmitter<MentionOnSearchTypes>` | - |
 
 ### 方法
 
@@ -72,3 +72,10 @@ title: Mention
     </ng-container>
   </nz-mention>
 ```
+
+### MentionOnSearchTypes
+
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| value | 搜索关键词 | string | - |
+| prefix | 触发前缀 | string | - |

--- a/components/mention/mention.component.ts
+++ b/components/mention/mention.component.ts
@@ -15,6 +15,11 @@ import { getCaretCoordinates } from '../core/util/textarea-caret-position';
 import { NzMentionSuggestionDirective } from './mention-suggestions';
 import { NzMentionTriggerDirective } from './mention-trigger';
 
+export interface MentionOnSearchTypes {
+  value: string;
+  prefix: string;
+}
+
 @Component({
   selector: 'nz-mention',
   templateUrl: './mention.component.html',
@@ -34,7 +39,7 @@ import { NzMentionTriggerDirective } from './mention-trigger';
 export class NzMentionComponent implements OnDestroy, AfterContentInit {
 
   @Output() nzOnSelect: EventEmitter<string | {}> = new EventEmitter();
-  @Output() nzOnSearchChange: EventEmitter<string> = new EventEmitter();
+  @Output() nzOnSearchChange: EventEmitter<MentionOnSearchTypes> = new EventEmitter();
 
   @Input() nzValueWith: (value: any) => string = value => value; // tslint:disable-line:no-any
   @Input() nzPrefix: string | string[] = '@';
@@ -171,12 +176,16 @@ export class NzMentionComponent implements OnDestroy, AfterContentInit {
   }
 
   private suggestionsFilter(value: string, emit: boolean): void {
+    const suggestions = value.substring(1);
     if (this.previousValue === value) { return; }
     this.previousValue = value;
     if (emit) {
-      this.nzOnSearchChange.emit(this.cursorMention);
+      this.nzOnSearchChange.emit({
+        value: this.cursorMention.substring(1),
+        prefix:  this.cursorMention[0]
+      });
     }
-    const searchValue = value.toLowerCase();
+    const searchValue = suggestions.toLowerCase();
     this.filteredSuggestions = this.nzSuggestions
     .filter(suggestion => this.nzValueWith(suggestion).toLowerCase().includes(searchValue));
   }
@@ -188,7 +197,7 @@ export class NzMentionComponent implements OnDestroy, AfterContentInit {
       return;
     }
     this.suggestionsFilter(this.cursorMention, emit);
-    const activeIndex = this.filteredSuggestions.indexOf(this.cursorMention);
+    const activeIndex = this.filteredSuggestions.indexOf(this.cursorMention.substring(1));
     this.activeIndex = activeIndex >= 0 ? activeIndex : 0;
     this.openDropdown();
   }
@@ -227,7 +236,7 @@ export class NzMentionComponent implements OnDestroy, AfterContentInit {
         this.cursorMentionStart =  -1;
         this.cursorMentionEnd =  -1;
       } else {
-        this.cursorMention =  mention.substring(1);
+        this.cursorMention =  mention;
         this.cursorMentionStart =  startPos;
         this.cursorMentionEnd =  endPos;
         return;

--- a/components/mention/mention.spec.ts
+++ b/components/mention/mention.spec.ts
@@ -474,7 +474,6 @@ class NzTestSimpleMentionComponent {
     [nzValueWith]="valueWith"
     [nzPrefix]="prefix"
     [nzPlacement]="'top'"
-    (nzOnSearchChange)="onSearchChange($event)"
     [nzLoading]="loading">
      <textarea
         nz-input


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
```ts
nzOnSearchChange: EventEmitter<string>
```

## What is the new behavior?

```ts
export interface MentionOnSearchTypes {
  value: string;
  prefix: string;
}

nzOnSearchChange: EventEmitter<MentionOnSearchTypes>
```
## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

类似 Github 的提及，`@` 和 `#` 会请求不同的接口获取数据。需要在事件中带上触发的前缀才能识别。
