### PR TITLE
fix(module:input-number): fix display value after formatter changed

### DIFF
--- a/components/input-number/nz-input-number.component.ts
+++ b/components/input-number/nz-input-number.component.ts
@@ -68,6 +68,7 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   private _step = 1;
   private autoStepTimer;
   private _autoFocus = false;
+  private _formatter = (value) => value;
   displayValue: string | number;
   actualValue: string | number;
   isFocused = false;
@@ -82,7 +83,6 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   @Input() nzSize: 'small' | 'default' | 'large' = 'default';
   @Input() nzMin: number = -Infinity;
   @Input() nzMax: number = Infinity;
-  @Input() nzFormatter = (value) => value;
   @Input() nzParser = (value) => value;
   @Input() nzPrecision: number;
 
@@ -123,6 +123,17 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
 
   get nzStep(): number {
     return this._step;
+  }
+
+  @Input()
+  set nzFormatter(v: (value: number) => string | number) {
+    this._formatter = v;
+    const value = this.getCurrentValidValue(this.actualValue);
+    this.writeValue(value);
+  }
+
+  get nzFormatter(): (value: number) => string | number {
+    return this._formatter;
   }
 
   updateAutoFocus(): void {

--- a/components/input-number/nz-input-number.spec.ts
+++ b/components/input-number/nz-input-number.spec.ts
@@ -366,6 +366,15 @@ describe('input number', () => {
       fixture.detectChanges();
       expect(testComponent.value).toBe(-10);
     });
+    it('should update value immediatelly after formatter changed', (() => {
+      const newFormatter = v => `${v} %`;
+      const initValue = '1';
+      testComponent.nzInputNumberComponent.onModelChange(initValue);
+      fixture.detectChanges();
+      testComponent.formatter = newFormatter;
+      fixture.detectChanges();
+      expect(inputElement.value).toBe(newFormatter(initValue));
+    }));
   });
   describe('input number form', () => {
     let fixture;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After nzFormatter changed, the text on element will not apply the new formatter, unless changes value or unfocus.

## What is the new behavior?

Text updates immediately if formatter changed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
