### PR TITLE
fix(module:input-number): fix focused style could not be removed after blur

### DIFF
--- a/components/input-number/nz-input-number.component.ts
+++ b/components/input-number/nz-input-number.component.ts
@@ -219,10 +219,16 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   }
 
   down(e: MouseEvent | KeyboardEvent, ratio?: number): void {
+    if (!this.isFocused) {
+      this.focus();
+    }
     this.step('down', e, ratio);
   }
 
   up(e: MouseEvent | KeyboardEvent, ratio?: number): void {
+    if (!this.isFocused) {
+      this.focus();
+    }
     this.step('up', e, ratio);
   }
 

--- a/components/input-number/nz-input-number.spec.ts
+++ b/components/input-number/nz-input-number.spec.ts
@@ -11,7 +11,7 @@ import { NzInputNumberModule } from './nz-input-number.module';
 describe('input number', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [NzInputNumberModule, FormsModule, ReactiveFormsModule],
+      imports     : [NzInputNumberModule, FormsModule, ReactiveFormsModule],
       declarations: [NzTestInputNumberBasicComponent, NzTestInputNumberFormComponent]
     });
     TestBed.compileComponents();
@@ -302,11 +302,11 @@ describe('input number', () => {
     });
     it('should key up and down work with ctrl key', () => {
       const upArrowEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowUp',
+        code   : 'ArrowUp',
         ctrlKey: true
       });
       const downArrowEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowDown',
+        code   : 'ArrowDown',
         ctrlKey: true
       });
       fixture.detectChanges();
@@ -323,11 +323,11 @@ describe('input number', () => {
     });
     it('should key up and down work with meta key', () => {
       const upArrowEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowUp',
+        code   : 'ArrowUp',
         metaKey: true
       });
       const downArrowEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowDown',
+        code   : 'ArrowDown',
         metaKey: true
       });
       fixture.detectChanges();
@@ -346,11 +346,11 @@ describe('input number', () => {
       testComponent.max = 100;
       testComponent.min = -100;
       const upArrowEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowUp',
+        code    : 'ArrowUp',
         shiftKey: true
       });
       const downArrowEvent = new KeyboardEvent('keydown', {
-        code: 'ArrowDown',
+        code    : 'ArrowDown',
         shiftKey: true
       });
       fixture.detectChanges();
@@ -382,14 +382,12 @@ describe('input number', () => {
       expect(inputNumber.nativeElement.classList).toContain('ant-input-number-focused');
       dispatchFakeEvent(inputElement, 'blur');
       fixture.detectChanges();
-      expect(testComponent.isFocused).toBe(false);
       expect(inputNumber.nativeElement.classList).not.toContain('ant-input-number-focused');
       dispatchFakeEvent(downHandler, 'mousedown');
       fixture.detectChanges();
       expect(inputNumber.nativeElement.classList).toContain('ant-input-number-focused');
       dispatchFakeEvent(inputElement, 'blur');
       fixture.detectChanges();
-      expect(testComponent.isFocused).toBe(false);
       expect(inputNumber.nativeElement.classList).not.toContain('ant-input-number-focused');
     }));
   });

--- a/components/input-number/nz-input-number.spec.ts
+++ b/components/input-number/nz-input-number.spec.ts
@@ -11,8 +11,8 @@ import { NzInputNumberModule } from './nz-input-number.module';
 describe('input number', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports     : [ NzInputNumberModule, FormsModule, ReactiveFormsModule ],
-      declarations: [ NzTestInputNumberBasicComponent, NzTestInputNumberFormComponent ]
+      imports: [NzInputNumberModule, FormsModule, ReactiveFormsModule],
+      declarations: [NzTestInputNumberBasicComponent, NzTestInputNumberFormComponent]
     });
     TestBed.compileComponents();
   }));
@@ -302,11 +302,11 @@ describe('input number', () => {
     });
     it('should key up and down work with ctrl key', () => {
       const upArrowEvent = new KeyboardEvent('keydown', {
-        code   : 'ArrowUp',
+        code: 'ArrowUp',
         ctrlKey: true
       });
       const downArrowEvent = new KeyboardEvent('keydown', {
-        code   : 'ArrowDown',
+        code: 'ArrowDown',
         ctrlKey: true
       });
       fixture.detectChanges();
@@ -323,11 +323,11 @@ describe('input number', () => {
     });
     it('should key up and down work with meta key', () => {
       const upArrowEvent = new KeyboardEvent('keydown', {
-        code   : 'ArrowUp',
+        code: 'ArrowUp',
         metaKey: true
       });
       const downArrowEvent = new KeyboardEvent('keydown', {
-        code   : 'ArrowDown',
+        code: 'ArrowDown',
         metaKey: true
       });
       fixture.detectChanges();
@@ -346,11 +346,11 @@ describe('input number', () => {
       testComponent.max = 100;
       testComponent.min = -100;
       const upArrowEvent = new KeyboardEvent('keydown', {
-        code    : 'ArrowUp',
+        code: 'ArrowUp',
         shiftKey: true
       });
       const downArrowEvent = new KeyboardEvent('keydown', {
-        code    : 'ArrowDown',
+        code: 'ArrowDown',
         shiftKey: true
       });
       fixture.detectChanges();
@@ -374,6 +374,23 @@ describe('input number', () => {
       testComponent.formatter = newFormatter;
       fixture.detectChanges();
       expect(inputElement.value).toBe(newFormatter(initValue));
+    }));
+    // #1449
+    it('should up and down focus input', (() => {
+      dispatchFakeEvent(upHandler, 'mousedown');
+      fixture.detectChanges();
+      expect(inputNumber.nativeElement.classList).toContain('ant-input-number-focused');
+      dispatchFakeEvent(inputElement, 'blur');
+      fixture.detectChanges();
+      expect(testComponent.isFocused).toBe(false);
+      expect(inputNumber.nativeElement.classList).not.toContain('ant-input-number-focused');
+      dispatchFakeEvent(downHandler, 'mousedown');
+      fixture.detectChanges();
+      expect(inputNumber.nativeElement.classList).toContain('ant-input-number-focused');
+      dispatchFakeEvent(inputElement, 'blur');
+      fixture.detectChanges();
+      expect(testComponent.isFocused).toBe(false);
+      expect(inputNumber.nativeElement.classList).not.toContain('ant-input-number-focused');
     }));
   });
   describe('input number form', () => {
@@ -466,7 +483,7 @@ export class NzTestInputNumberFormComponent {
 
   constructor(private formBuilder: FormBuilder) {
     this.formGroup = this.formBuilder.group({
-      inputNumber: [ 1 ]
+      inputNumber: [1]
     });
   }
 


### PR DESCRIPTION
fix(module:input-number): fix focused style could not be removed after blur (#1449). The reason was when up/down button is clicked, the input is not focused, so it won't emit blur event to remove focused style. Fixed by manually focusing it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
After clicking the up/down button of a `nz-input-number` without focusing it, clicking outside of the `nz-input-number` would not remove its focused style.

Issue Number: 1449


## What is the new behavior?
After clicking the up/down button of a `nz-input-number` without focusing it, clicking outside of the `nz-input-number` would remove its focused style.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
