### PR TITLE
fix(module:select) modified nzPlaceHolder into nzPlaceholder as same as the date component

### DIFF
--- a/components/select/demo/basic.ts
+++ b/components/select/demo/basic.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'nz-demo-select-basic',
   template: `
     <div>
-      <nz-select style="width: 120px;" [(ngModel)]="selectedValue" nzAllowClear nzPlaceHolder="Choose">
+      <nz-select style="width: 120px;" [(ngModel)]="selectedValue" nzAllowClear nzPlaceholder="Choose">
         <nz-option nzValue="jack" nzLabel="Jack"></nz-option>
         <nz-option nzValue="lucy" nzLabel="Lucy"></nz-option>
         <nz-option nzValue="disabled" nzLabel="Disabled" nzDisabled></nz-option>

--- a/components/select/demo/custom-content.ts
+++ b/components/select/demo/custom-content.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'nz-demo-select-custom-content',
   template: `
-    <nz-select style="width: 200px;" nzShowSearch nzAllowClear nzPlaceHolder="Select OS" [(ngModel)]="selectedOS">
+    <nz-select style="width: 200px;" nzShowSearch nzAllowClear nzPlaceholder="Select OS" [(ngModel)]="selectedOS">
       <nz-option nzCustomContent nzLabel="Windows" nzValue="windows"><i class="anticon anticon-windows"></i> Windows</nz-option>
       <nz-option nzCustomContent nzLabel="Mac" nzValue="mac"><i class="anticon anticon-apple"></i> Mac</nz-option>
       <nz-option nzCustomContent nzLabel="Android" nzValue="android"><i class="anticon anticon-android"></i> Android</nz-option>

--- a/components/select/demo/label-in-value.ts
+++ b/components/select/demo/label-in-value.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   template: `
     <p>The selected option's age is {{selectedValue?.age}}</p>
     <br>
-    <nz-select style="width: 120px;" [compareWith]="compareFn" [(ngModel)]="selectedValue" (ngModelChange)="log($event)" nzAllowClear nzPlaceHolder="Choose">
+    <nz-select style="width: 120px;" [compareWith]="compareFn" [(ngModel)]="selectedValue" (ngModelChange)="log($event)" nzAllowClear nzPlaceholder="Choose">
       <nz-option *ngFor="let option of optionList" [nzValue]="option" [nzLabel]="option.label"></nz-option>
     </nz-select>
   `

--- a/components/select/demo/multiple.ts
+++ b/components/select/demo/multiple.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'nz-demo-select-multiple',
   template: `
-    <nz-select [nzMaxMultipleCount]="3" style="width: 100%" nzMode="multiple" nzPlaceHolder="Please select" [(ngModel)]="listOfSelectedValue">
+    <nz-select [nzMaxMultipleCount]="3" style="width: 100%" nzMode="multiple" nzPlaceholder="Please select" [(ngModel)]="listOfSelectedValue">
       <nz-option *ngFor="let option of listOfOption" [nzLabel]="option.label" [nzValue]="option.value"></nz-option>
     </nz-select>
   `

--- a/components/select/demo/optgroup.ts
+++ b/components/select/demo/optgroup.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'nz-demo-select-optgroup',
   template: `
-    <nz-select style="width: 120px;" [(ngModel)]="selectedValue" nzAllowClear nzPlaceHolder="Choose">
+    <nz-select style="width: 120px;" [(ngModel)]="selectedValue" nzAllowClear nzPlaceholder="Choose">
       <nz-option-group nzLabel="Manager">
         <nz-option nzValue="jack" nzLabel="Jack"></nz-option>
         <nz-option nzValue="lucy" nzLabel="Lucy"></nz-option>

--- a/components/select/demo/scroll-load.ts
+++ b/components/select/demo/scroll-load.ts
@@ -6,7 +6,7 @@ import { map } from 'rxjs/operators/map';
 @Component({
   selector: 'nz-demo-select-scroll-load',
   template: `
-    <nz-select style="width: 100%;" [(ngModel)]="selectedUser" (nzScrollToBottom)="loadMore()" nzPlaceHolder="Select users" nzAllowClear>
+    <nz-select style="width: 100%;" [(ngModel)]="selectedUser" (nzScrollToBottom)="loadMore()" nzPlaceholder="Select users" nzAllowClear>
       <nz-option *ngFor="let o of optionList" [nzValue]="o" [nzLabel]="o"></nz-option>
       <nz-option *ngIf="isLoading" nzDisabled nzCustomContent>
         <i class="anticon anticon-loading anticon-spin loading-icon"></i> Loading Data...

--- a/components/select/demo/search.ts
+++ b/components/select/demo/search.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'nz-demo-select-search',
   template: `
-    <nz-select style="width: 200px;" nzShowSearch nzAllowClear nzPlaceHolder="Select a person" [(ngModel)]="selectedValue">
+    <nz-select style="width: 200px;" nzShowSearch nzAllowClear nzPlaceholder="Select a person" [(ngModel)]="selectedValue">
       <nz-option nzLabel="Jack" nzValue="jack"></nz-option>
       <nz-option nzLabel="Lucy" nzValue="lucy"></nz-option>
       <nz-option nzLabel="Tom" nzValue="tom"></nz-option>

--- a/components/select/demo/select-users.ts
+++ b/components/select/demo/select-users.ts
@@ -9,7 +9,7 @@ import { switchMap } from 'rxjs/operators/switchMap';
 @Component({
   selector: 'nz-demo-select-select-users',
   template: `
-    <nz-select style="width: 100%;" nzMode="multiple" [(ngModel)]="selectedUser" nzPlaceHolder="Select users" nzAllowClear nzShowSearch [nzServerSearch]="true" (nzOnSearch)="onSearch($event)">
+    <nz-select style="width: 100%;" nzMode="multiple" [(ngModel)]="selectedUser" nzPlaceholder="Select users" nzAllowClear nzShowSearch [nzServerSearch]="true" (nzOnSearch)="onSearch($event)">
       <ng-container *ngFor="let o of optionList">
         <nz-option *ngIf="!isLoading" [nzValue]="o" [nzLabel]="o"></nz-option>
       </ng-container>

--- a/components/select/demo/size.ts
+++ b/components/select/demo/size.ts
@@ -17,11 +17,11 @@ import { Component, OnInit } from '@angular/core';
       <nz-option *ngFor="let option of listOfOption" [nzLabel]="option.label" [nzValue]="option.value"></nz-option>
     </nz-select>
     <br><br>
-    <nz-select style="width: 100%" [(ngModel)]="multipleValue" [nzSize]="size" nzMode="multiple" nzPlaceHolder="Please select">
+    <nz-select style="width: 100%" [(ngModel)]="multipleValue" [nzSize]="size" nzMode="multiple" nzPlaceholder="Please select">
       <nz-option *ngFor="let option of listOfOption" [nzLabel]="option.label" [nzValue]="option.value"></nz-option>
     </nz-select>
     <br><br>
-    <nz-select style="width: 100%" [(ngModel)]="tagValue" [nzSize]="size" nzMode="tags" nzPlaceHolder="Please select">
+    <nz-select style="width: 100%" [(ngModel)]="tagValue" [nzSize]="size" nzMode="tags" nzPlaceholder="Please select">
       <nz-option *ngFor="let option of listOfOption" [nzLabel]="option.label" [nzValue]="option.value"></nz-option>
     </nz-select>
   `

--- a/components/select/demo/tags.ts
+++ b/components/select/demo/tags.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'nz-demo-select-tags',
   template: `
-    <nz-select nzMode="tags" style="width: 100%;" nzPlaceHolder="Tag Mode" [(ngModel)]="listOfTagOptions">
+    <nz-select nzMode="tags" style="width: 100%;" nzPlaceholder="Tag Mode" [(ngModel)]="listOfTagOptions">
       <nz-option *ngFor="let option of listOfOption" [nzLabel]="option.label" [nzValue]="option.value">
       </nz-option>
     </nz-select>

--- a/components/select/doc/index.zh-CN.md
+++ b/components/select/doc/index.zh-CN.md
@@ -40,7 +40,7 @@ title: Select
 | nzMaxMultipleCount | 最多选中多少个标签| number | Infinity |
 | nzMode | 设置 nz-select 的模式 | 'multiple' 丨 'tags' 丨 'default' | 'default' |
 | nzNotFoundContent | 当下拉列表为空时显示的内容 | string | - |
-| nzPlaceHolder | 选择框默认文字 | string | - |
+| nzPlaceholder | 选择框默认文字 | string | - |
 | nzShowSearch | 使单选模式可搜索 | boolean | false |
 | nzSize | 选择框大小，可选 `large` `small` | string | default |
 | nzScrollToBottom | 下拉列表滚动到底部的回调 | ()=>{} | - |

--- a/components/select/nz-select-top-control.component.ts
+++ b/components/select/nz-select-top-control.component.ts
@@ -41,12 +41,12 @@ import { NzOptionComponent } from './nz-option.component';
         [disabled]="nzDisabled">
     </ng-template>
     <div
-      *ngIf="nzPlaceHolder"
+      *ngIf="nzPlaceholder"
       nz-select-unselectable
       [style.display]="placeHolderDisplay"
       (click)="focusOnInput()"
       class="ant-select-selection__placeholder">
-      {{ nzPlaceHolder }}
+      {{ nzPlaceholder }}
     </div>
     <!--single mode-->
     <ng-container *ngIf="isSingleMode">
@@ -107,7 +107,7 @@ export class NzSelectTopControlComponent {
   @Input() nzShowSearch = false;
   @Input() nzDisabled = false;
 
-  @Input() nzPlaceHolder: string;
+  @Input() nzPlaceholder: string;
   @Input() nzOpen = false;
   // tslint:disable-next-line:no-any
   @Input() compareWith: (o1: any, o2: any) => boolean;

--- a/components/select/nz-select-top-control.spec.ts
+++ b/components/select/nz-select-top-control.spec.ts
@@ -188,7 +188,7 @@ describe('nz-select top control', () => {
       nz-select-top-control
       [nzOpen]="open"
       [compareWith]="compareFn"
-      [nzPlaceHolder]="placeHolder"
+      [nzPlaceholder]="placeHolder"
       [nzDisabled]="disabled"
       [nzMode]="mode"
       [nzListTemplateOfOption]="listOfTemplateOption"
@@ -227,7 +227,7 @@ export class NzTestSelectTopControlMultipleComponent {
       nz-select-top-control
       [nzOpen]="open"
       [compareWith]="compareFn"
-      [nzPlaceHolder]="placeHolder"
+      [nzPlaceholder]="placeHolder"
       [nzDisabled]="disabled"
       [nzMode]="mode"
       [nzShowSearch]="showSearch"

--- a/components/select/nz-select.component.ts
+++ b/components/select/nz-select.component.ts
@@ -101,7 +101,7 @@ import { NzSelectTopControlComponent } from './nz-select-top-control.component';
         nz-select-top-control
         [nzOpen]="nzOpen"
         [compareWith]="compareWith"
-        [nzPlaceHolder]="nzPlaceHolder"
+        [nzPlaceholder]="nzPlaceholder"
         [nzShowSearch]="nzShowSearch"
         [nzDisabled]="nzDisabled"
         [nzMode]="nzMode"
@@ -295,11 +295,11 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   }
 
   @Input()
-  set nzPlaceHolder(value: string) {
+  set nzPlaceholder(value: string) {
     this._placeholder = value;
   }
 
-  get nzPlaceHolder(): string {
+  get nzPlaceholder(): string {
     return this._placeholder;
   }
 

--- a/components/select/nz-select.spec.ts
+++ b/components/select/nz-select.spec.ts
@@ -273,7 +273,7 @@ describe('nz-select component', () => {
       [nzDropdownStyle]="dropdownStyle"
       [nzDropdownClassName]="'test-class'"
       (nzOnSearch)="onSearch($event)"
-      [nzPlaceHolder]="placeholder">
+      [nzPlaceholder]="placeholder">
       <nz-option nzValue="jack" nzLabel="Jack"></nz-option>
       <nz-option nzValue="lucy" nzLabel="Lucy"></nz-option>
       <nz-option nzValue="disabled" nzLabel="Disabled" nzDisabled></nz-option>

--- a/site_scripts/_site/src/app/app.component.html
+++ b/site_scripts/_site/src/app/app.component.html
@@ -1,157 +1,161 @@
 <div class="page-wrapper">
-  <header id="header" class="clearfix">
-    <i class="anticon anticon-menu nav-phone-icon" (click)="toggleHide()"></i>
-    <div nz-row>
-      <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="8" [nzLg]="5" [nzXl]="5" [nzXXl]="4">
-        <a id="logo" href>
-          <img alt="logo" src="./assets/img/logo.svg">
-          <img alt="NG-ZORRO" src="./assets/img/zorro.svg">
-        </a>
-      </div>
-      <div nz-col [nzXs]="0" [nzSm]="0" [nzMd]="16" [nzLg]="19" [nzXl]="19" [nzXXl]="20" class="nav nav-hide">
-        <div id="search-box">
-          <i class="anticon anticon-search"></i>
-          <nz-select [nzPlaceHolder]="language=='zh'?'搜索组件...':'Search Components...'" nzShowSearch [(ngModel)]="searchComponent" (ngModelChange)="navigateToPage($event)">
-            <ng-template [ngForOf]="componentList" ngFor let-component>
-              <nz-option [nzValue]="component.path" [nzLabel]="component.label" nzCustomContent *ngIf="language==component.language">
-                <strong>{{component.label}}</strong>
-                <span class="ant-component-decs">{{component.zh}}</span>
-              </nz-option>
-            </ng-template>
-          </nz-select>
-        </div>
-        <button nz-button nzGhost nzSize="small" class="header-lang-button" (click)="switchLanguage(language==='zh'?'en':'zh')">{{language=='zh'?'English':'中文'}}</button>
-        <nz-select nzSize="small" class="version" style="width: 68px;" [(ngModel)]="currentVersion" (ngModelChange)="navigateToVersion($event)">
-          <nz-option *ngFor="let version of versionList" [nzLabel]="version" [nzValue]="version"></nz-option>
-        </nz-select>
-        <ul nz-menu [nzMode]="'horizontal'" id="nav">
-          <li nz-menu-item nzSelected>
-            <a routerLink="/doc/introduce/zh" *ngIf="language=='zh'"><span>组件</span></a>
-            <a routerLink="/doc/introduce/en" *ngIf="language=='en'"><span>Components</span></a>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </header>
-  <div class="main-wrapper">
-    <div nz-row>
-      <div nz-col [class.hide-menu]="hide" [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="6" [nzXl]="5" [nzXXl]="4" class="main-menu">
-        <ul nz-menu [nzMode]="'inline'" class="aside-container menu-site" nzInlineIndent="40">
-          <li *ngFor="let intro of routerList.intro" nz-menu-item routerLinkActive="ant-menu-item-selected" [hidden]="intro.language!=language">
-            <a routerLink="{{intro.path}}">{{intro.label}}</a>
-          </li>
-          <li nz-submenu nzOpen>
-            <span title><h4>Components</h4></span>
-            <ul>
-              <li nz-menu-group *ngFor="let group of routerList.components">
-                <span title>{{group.name}}</span>
-                <ul>
-                  <li nz-menu-item routerLinkActive="ant-menu-item-selected" *ngFor="let component of group.children" [hidden]="component.language!=language">
-                    <a routerLink="{{component.path}}">
-                      <span>{{component.label}}</span><span class="chinese">{{component.zh}}</span>
-                    </a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-      <div nz-col class="main-container main-container-component" [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="18" [nzXl]="19" [nzXXl]="20">
-        <router-outlet></router-outlet>
-      </div>
-    </div>
-    <div nz-row>
-      <div nz-col [nzXs]="{span:24}" [nzSm]="{span:24}" [nzMd]="{span:24}" [nzLg]="{span:18,offset:6}" [nzXl]="{span:19,offset:5}" [nzXXl]="{span:20,offset:4}">
-        <nz-nav-bottom></nz-nav-bottom>
-      </div>
-    </div>
-  </div>
-  <footer id="footer" class="dark">
-    <div class="footer-wrap">
-      <div nz-row>
-        <div nz-col [nzXs]="24" [nzSm]="24" [nzLg]="6">
-          <div class="footer-center">
-            <h2>Ant Design</h2>
-            <div>
-              <a target="_blank " href="https://github.com/NG-ZORRO/ng-zorro-antd"><span>GitHub</span></a>
-              <span> - </span><span><i class="anticon anticon-github"></i></span>
+    <header id="header" class="clearfix">
+        <i class="anticon anticon-menu nav-phone-icon" (click)="toggleHide()"></i>
+        <div nz-row>
+            <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="8" [nzLg]="5" [nzXl]="5" [nzXXl]="4">
+                <a id="logo" href>
+                    <img alt="logo" src="./assets/img/logo.svg">
+                    <img alt="NG-ZORRO" src="./assets/img/zorro.svg">
+                </a>
             </div>
-            <div>
-              <a href="https://ant.design/docs/react/introduce-cn" target="_blank">Ant Design</a>
-              <span> - </span><span>React</span>
-            </div>
-            <div>
-              <a target="_blank " href="https://github.com/websemantics/awesome-ant-design">
-                <span>Awesome Ant Design</span></a>
-            </div>
-          </div>
-        </div>
-        <div nz-col [nzXs]="24" [nzSm]="24" [nzLg]="6">
-          <div class="footer-center">
-            <h2>{{language==='zh'?'资源链接':'Resources'}}</h2>
-            <div>
-              <a href="https://angular.cn" target="_blank">Angular</a>
-            </div>
-            <div>
-              <a href="https://cli.angular.io/" target="_blank">Angular CLI</a>
-            </div>
-            <div>
-              <a target="_blank" rel="noopener noreferrer" href="http://library.ant.design/">AntD Library</a>
-            </div>
-          </div>
-        </div>
-        <div nz-col [nzXs]="24" [nzSm]="24" [nzLg]="6">
-          <div class="footer-center">
-            <h2>{{language==='zh'?'社区':'Community'}}</h2>
-            <div>
-              <a href="#/changelog"><span>{{language==='zh'?'更新记录':'Change Log'}}</span></a>
-            </div>
-            <div>
-              <a target="_blank" rel="noopener noreferrer" href="http://ng.ant.design/issue-helper/#/new-issue">
-                <span>{{language==='zh'?'报告 Bug':'Bug Report'}}</span>
-              </a>
-            </div>
-          </div>
-
-        </div>
-        <div nz-col [nzXs]="24" [nzSm]="24" [nzLg]="6">
-          <div class="footer-center">
-            <h2>
-              <img class="title-icon" src="https://gw.alipayobjects.com/zos/rmsportal/nBVXkrFdWHxbZlmMbsaH.svg" alt="">
-              <span>{{language==='zh'?'更多产品':'More Products'}}</span>
-            </h2>
-            <div>
-              <a target="_blank" rel="noopener noreferrer" href="https://antv.alipay.com/">AntV</a>
-              <span> - </span><span>{{language==='zh'?'数据可视化':'Data Visualization'}}</span></div>
-            <div>
-              <a target="_blank" rel="noopener noreferrer" href="https://eggjs.org/">Egg</a>
-              <span> - </span><span>{{language==='zh'?'企业级 Node 开发框架':'Enterprise Node Framework'}}</span>
-            </div>
-            <div style="margin-top: 20px;">
-              <nz-popover [nzTrigger]="'click'" nzOverlayClassName="theme-color-content">
-                <div class="theme-color" nz-popover>
-                  <div class="theme-color-value" [ngStyle]="{'background': color}"></div>
+            <div nz-col [nzXs]="0" [nzSm]="0" [nzMd]="16" [nzLg]="19" [nzXl]="19" [nzXXl]="20" class="nav nav-hide">
+                <div id="search-box">
+                    <i class="anticon anticon-search"></i>
+                    <nz-select [nzPlaceholder]="language=='zh'?'搜索组件...':'Search Components...'" nzShowSearch [(ngModel)]="searchComponent" (ngModelChange)="navigateToPage($event)">
+                        <ng-template [ngForOf]="componentList" ngFor let-component>
+                            <nz-option [nzValue]="component.path" [nzLabel]="component.label" nzCustomContent *ngIf="language==component.language">
+                                <strong>{{component.label}}</strong>
+                                <span class="ant-component-decs">{{component.zh}}</span>
+                            </nz-option>
+                        </ng-template>
+                    </nz-select>
                 </div>
-                <ng-template #nzTemplate>
-                  <color-sketch [color]="color" (onChangeComplete)="changeColor($event)"></color-sketch>
-                </ng-template>
-              </nz-popover>
+                <button nz-button nzGhost nzSize="small" class="header-lang-button" (click)="switchLanguage(language==='zh'?'en':'zh')">{{language=='zh'?'English':'中文'}}</button>
+                <nz-select nzSize="small" class="version" style="width: 68px;" [(ngModel)]="currentVersion" (ngModelChange)="navigateToVersion($event)">
+                    <nz-option *ngFor="let version of versionList" [nzLabel]="version" [nzValue]="version"></nz-option>
+                </nz-select>
+                <ul nz-menu [nzMode]="'horizontal'" id="nav">
+                    <li nz-menu-item nzSelected>
+                        <a routerLink="/doc/introduce/zh" *ngIf="language=='zh'"><span>组件</span></a>
+                        <a routerLink="/doc/introduce/en" *ngIf="language=='en'"><span>Components</span></a>
+                    </li>
+                </ul>
             </div>
-          </div>
         </div>
-      </div>
+    </header>
+    <div class="main-wrapper">
+        <div nz-row>
+            <div nz-col [class.hide-menu]="hide" [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="6" [nzXl]="5" [nzXXl]="4" class="main-menu">
+                <ul nz-menu [nzMode]="'inline'" class="aside-container menu-site" nzInlineIndent="40">
+                    <li *ngFor="let intro of routerList.intro" nz-menu-item routerLinkActive="ant-menu-item-selected" [hidden]="intro.language!=language">
+                        <a routerLink="{{intro.path}}">{{intro.label}}</a>
+                    </li>
+                    <li nz-submenu nzOpen>
+                        <span title><h4>Components</h4></span>
+                        <ul>
+                            <li nz-menu-group *ngFor="let group of routerList.components">
+                                <span title>{{group.name}}</span>
+                                <ul>
+                                    <li nz-menu-item routerLinkActive="ant-menu-item-selected" *ngFor="let component of group.children" [hidden]="component.language!=language">
+                                        <a routerLink="{{component.path}}">
+                                            <span>{{component.label}}</span><span class="chinese">{{component.zh}}</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+            <div nz-col class="main-container main-container-component" [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="18" [nzXl]="19" [nzXXl]="20">
+                <router-outlet></router-outlet>
+            </div>
+        </div>
+        <div nz-row>
+            <div nz-col [nzXs]="{span:24}" [nzSm]="{span:24}" [nzMd]="{span:24}" [nzLg]="{span:18,offset:6}" [nzXl]="{span:19,offset:5}" [nzXXl]="{span:20,offset:4}">
+                <nz-nav-bottom></nz-nav-bottom>
+            </div>
+        </div>
     </div>
-    <div nz-row class="bottom-bar">
-      <div nz-col [nzSm]="24" [nzLg]="4"></div>
-      <div nz-col [nzSm]="24" [nzLg]="20">
-        <ng-template [ngIf]="language=='zh'">
-          <span style="line-height: 16px; padding-right: 12px; margin-right: 11px; border-right: 1px solid rgba(255, 255, 255, 0.55);"><a href="https://docs.alipay.com/policies/privacy/antfin" rel="noopener noreferrer" target="_blank"><span>隐私权政策</span></a></span><span style="margin-right: 24px;"><a href="https://render.alipay.com/p/f/fd-izto3cem/index.html" rel="noopener noreferrer" target="_blank"><span>权益保障承诺书</span></a></span><span style="margin-right: 12px;">ICP 证浙 B2-2-100257</span><span style="margin-right: 12px;">Copyright © <span>蚂蚁金融服务集团</span></span>
-        </ng-template>
-        <ng-template [ngIf]="language=='en'">
-          <span style="line-height: 16px; padding-right: 12px; margin-right: 11px; border-right: 1px solid rgba(255, 255, 255, 0.55);"><a href="https://docs.alipay.com/policies/privacy/antfin" rel="noopener noreferrer" target="_blank"><span>Privacy Policy</span></a></span><span style="margin-right: 24px;"><a href="https://render.alipay.com/p/f/fd-izto3cem/index.html" rel="noopener noreferrer" target="_blank"><span>Our Commitment to Customer Protection</span></a></span><span style="margin-right: 12px;">ICP 证浙 B2-2-100257</span><span style="margin-right: 12px;">Copyright © <span>Ant Financial</span></span>
-        </ng-template>
-      </div>
-    </div>
-  </footer>
+    <footer id="footer" class="dark">
+        <div class="footer-wrap">
+            <div nz-row>
+                <div nz-col [nzXs]="24" [nzSm]="24" [nzLg]="6">
+                    <div class="footer-center">
+                        <h2>Ant Design</h2>
+                        <div>
+                            <a target="_blank " href="https://github.com/NG-ZORRO/ng-zorro-antd"><span>GitHub</span></a>
+                            <span> - </span><span><i class="anticon anticon-github"></i></span>
+                        </div>
+                        <div>
+                            <a href="https://ant.design/docs/react/introduce-cn" target="_blank">Ant Design</a>
+                            <span> - </span><span>React</span>
+                        </div>
+                        <div>
+                            <a target="_blank " href="https://github.com/websemantics/awesome-ant-design">
+                                <span>Awesome Ant Design</span></a>
+                        </div>
+                    </div>
+                </div>
+                <div nz-col [nzXs]="24" [nzSm]="24" [nzLg]="6">
+                    <div class="footer-center">
+                        <h2>{{language==='zh'?'资源链接':'Resources'}}</h2>
+                        <div>
+                            <a href="https://angular.cn" target="_blank">Angular</a>
+                        </div>
+                        <div>
+                            <a href="https://cli.angular.io/" target="_blank">Angular CLI</a>
+                        </div>
+                        <div>
+                            <a target="_blank" rel="noopener noreferrer" href="http://library.ant.design/">AntD Library</a>
+                        </div>
+                    </div>
+                </div>
+                <div nz-col [nzXs]="24" [nzSm]="24" [nzLg]="6">
+                    <div class="footer-center">
+                        <h2>{{language==='zh'?'社区':'Community'}}</h2>
+                        <div>
+                            <a href="#/changelog"><span>{{language==='zh'?'更新记录':'Change Log'}}</span></a>
+                        </div>
+                        <div>
+                            <a target="_blank" rel="noopener noreferrer" href="http://ng.ant.design/issue-helper/#/new-issue">
+                                <span>{{language==='zh'?'报告 Bug':'Bug Report'}}</span>
+                            </a>
+                        </div>
+                    </div>
+
+                </div>
+                <div nz-col [nzXs]="24" [nzSm]="24" [nzLg]="6">
+                    <div class="footer-center">
+                        <h2>
+                            <img class="title-icon" src="https://gw.alipayobjects.com/zos/rmsportal/nBVXkrFdWHxbZlmMbsaH.svg" alt="">
+                            <span>{{language==='zh'?'更多产品':'More Products'}}</span>
+                        </h2>
+                        <div>
+                            <a target="_blank" rel="noopener noreferrer" href="https://antv.alipay.com/">AntV</a>
+                            <span> - </span><span>{{language==='zh'?'数据可视化':'Data Visualization'}}</span></div>
+                        <div>
+                            <a target="_blank" rel="noopener noreferrer" href="https://eggjs.org/">Egg</a>
+                            <span> - </span><span>{{language==='zh'?'企业级 Node 开发框架':'Enterprise Node Framework'}}</span>
+                        </div>
+                        <div style="margin-top: 20px;">
+                            <nz-popover [nzTrigger]="'click'" nzOverlayClassName="theme-color-content">
+                                <div class="theme-color" nz-popover>
+                                    <div class="theme-color-value" [ngStyle]="{'background': color}"></div>
+                                </div>
+                                <ng-template #nzTemplate>
+                                    <color-sketch [color]="color" (onChangeComplete)="changeColor($event)"></color-sketch>
+                                </ng-template>
+                            </nz-popover>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div nz-row class="bottom-bar">
+            <div nz-col [nzSm]="24" [nzLg]="4"></div>
+            <div nz-col [nzSm]="24" [nzLg]="20">
+                <ng-template [ngIf]="language=='zh'">
+                    <span style="line-height: 16px; padding-right: 12px; margin-right: 11px; border-right: 1px solid rgba(255, 255, 255, 0.55);"><a href="https://docs.alipay.com/policies/privacy/antfin" rel="noopener noreferrer" target="_blank"><span>隐私权政策</span></a>
+                    </span><span style="margin-right: 24px;"><a href="https://render.alipay.com/p/f/fd-izto3cem/index.html" rel="noopener noreferrer" target="_blank"><span>权益保障承诺书</span></a>
+                    </span><span style="margin-right: 12px;">ICP 证浙 B2-2-100257</span><span style="margin-right: 12px;">Copyright © <span>蚂蚁金融服务集团</span></span>
+                </ng-template>
+                <ng-template [ngIf]="language=='en'">
+                    <span style="line-height: 16px; padding-right: 12px; margin-right: 11px; border-right: 1px solid rgba(255, 255, 255, 0.55);"><a href="https://docs.alipay.com/policies/privacy/antfin" rel="noopener noreferrer" target="_blank"><span>Privacy Policy</span></a>
+                    </span><span style="margin-right: 24px;"><a href="https://render.alipay.com/p/f/fd-izto3cem/index.html" rel="noopener noreferrer" target="_blank"><span>Our Commitment to Customer Protection</span></a>
+                    </span><span style="margin-right: 12px;">ICP 证浙 B2-2-100257</span><span style="margin-right: 12px;">Copyright © <span>Ant Financial</span></span>
+                </ng-template>
+            </div>
+        </div>
+    </footer>
 </div>


### PR DESCRIPTION
modified nzPlaceHolder into nzPlaceholder as same as the date component.

今天升级`0.7.0`版本时看到`nz-select` 和 `datePicker`两个组件的`placeholder`命名规范没有统一。
此PR统一为`nzPlaceholder`，避免使用组件时造成多余的记忆成本

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
