### PR TITLE
fix(module: tab): fix vertical-bar error in docs

### DIFF
--- a/components/tabs/doc/index.zh-CN.md
+++ b/components/tabs/doc/index.zh-CN.md
@@ -27,7 +27,7 @@ Ant Design 依次提供了三级选项卡，分别用于不同的场景。
 | nzSelectedIndex | 当前激活 tab 面板的 序列号，可双向绑定 | number | 无 |
 | nzSelectedIndexChange | 当前激活 tab 面板的 序列号变更回调函数 | (nzSelectedIndex:number)=>{} | 无 |
 | nzSelectChange | 当前激活 tab 面板变更回调函数 | (nzSelectedIndex: number,tab: NzTabComponent)=>{} | 无 |
-| nzAnimated | 是否使用动画切换 Tabs，在 `nzTabPosition=top|bottom` 时有效 | `boolean ｜ {inkBar:boolean, tabPane:boolean} ｜ true`, 当 type="card" 时为 false |
+| nzAnimated | 是否使用动画切换 Tabs，在 nzTabPosition=top丨bottom 时有效 | boolean丨{inkBar:boolean, tabPane:boolean} | true, 当 type="card" 时为 false |
 | nzSize | 大小，提供 `large` `default` 和 `small` 三种大小 | string | 'default' |
 | nzTabBarExtraContent | tab bar 上额外的元素 | `TemplateRef<void>` | 无 |
 | nzTabBarStyle | tab bar 的样式对象 | object | - |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The line about `nzAnimated` is wrong because of conflict between vertical-bar and markdown table.

Issue Number: N/A

## What is the new behavior?
add Chinese vertical bar to fix the bug

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
