### PR TITLE
fix(module:slider) Fix initial value for slider in reactive form

### DIFF
--- a/components/slider/nz-slider.component.ts
+++ b/components/slider/nz-slider.component.ts
@@ -198,10 +198,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
       this.valueToOffset(normalizedValue as number);
   }
 
-  writeValue(val: SliderValue): void { // NOTE: writeValue will be called twice when initialized (may BUG? see: https://github.com/angular/angular/issues/14988), here we just ignore the first inited(the first the onValueChange will not registered)
-    if (typeof this.onValueChange !== 'function') {
-      return;
-    } // ignore the first initial call
+  writeValue(val: SliderValue): void {
     this.log(`[ngModel/writeValue]current writing value = `, val);
     this.setValue(val, true);
   }

--- a/components/slider/nz-slider.spec.ts
+++ b/components/slider/nz-slider.spec.ts
@@ -576,17 +576,21 @@ describe('NzSlider', () => {
       sliderControl = testComponent.form.controls.slider;
     });
 
+    it('should have correct initial value', () => {
+      expect(sliderInstance.value).toBe(42);
+    });
+
     it('should not update the control when the value is updated', () => {
-      expect(sliderControl.value).toBe(0);
+      expect(sliderControl.value).toBe(42);
 
       sliderInstance.value = 11;
       fixture.detectChanges();
 
-      expect(sliderControl.value).toBe(0);
+      expect(sliderControl.value).toBe(42);
     });
 
     it('should update the control on click', () => {
-      expect(sliderControl.value).toBe(0);
+      expect(sliderControl.value).toBe(42);
 
       dispatchClickEventSequence(sliderNativeElement, 0.76);
       fixture.detectChanges();
@@ -595,16 +599,16 @@ describe('NzSlider', () => {
     });
 
     it('should update the control on slide', () => {
-      expect(sliderControl.value).toBe(0);
+      expect(sliderControl.value).toBe(42);
 
-      dispatchSlideEventSequence(sliderNativeElement, 0, 0.19);
+      dispatchSlideEventSequence(sliderNativeElement, 0.42, 0.19);
       fixture.detectChanges();
 
       expect(sliderControl.value).toBe(19);
     });
 
     it('should update the value when the control is set', () => {
-      expect(sliderInstance.value).toBe(0);
+      expect(sliderInstance.value).toBe(42);
 
       sliderControl.setValue(7);
       fixture.detectChanges();
@@ -754,7 +758,7 @@ class SliderWithFormControlComponent implements OnInit {
 
   ngOnInit(): void {
     this.form = this.fb.group({
-      slider: [ 0 ]
+      slider: [ 42 ]
     });
   }
 }


### PR DESCRIPTION
Fixes #1529

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
`nz-slider` in reactive form has incorrect initial value (`setValue` is not executed from `wirteValue` during initialization due to optimazation for "template form" case)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1529 


## What is the new behavior?
`nz-slider` in reactive form has correct initial value that matches value from form control

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
