### PR TITLE
fix(module:date-picker) fix problem with date-picker after "Esc"

### DIFF
--- a/components/date-picker/picker.component.html
+++ b/components/date-picker/picker.component.html
@@ -65,6 +65,7 @@
   [cdkConnectedOverlayPositions]="overlayPositions"
   (positionChange)="onPositionChange($event)"
   (backdropClick)="onClickBackdrop()"
+  (detach)="onOverlayDetach()"
 >
   <div
     [@dropDownAnimation]="dropdownAnimation"

--- a/components/date-picker/picker.component.ts
+++ b/components/date-picker/picker.component.ts
@@ -113,22 +113,30 @@ export class NzPickerComponent implements OnInit, AfterViewInit {
 
   // Show overlay content
   showOverlay(): void {
-    this.overlayOpen = true;
-    this.openChange.emit(this.overlayOpen);
+    if (!this.overlayOpen) {
+      this.overlayOpen = true;
+      this.openChange.emit(this.overlayOpen);
+    }
   }
 
   hideOverlay(): void {
-    this.overlayOpen = false;
-    this.openChange.emit(this.overlayOpen);
+    if (this.overlayOpen) {
+      this.overlayOpen = false;
+      this.openChange.emit(this.overlayOpen);
+    }
   }
 
   onClickInputBox(): void {
-    if (!this.disabled) {
+    if (!this.disabled && !this.isOpenHandledByUser()) {
       this.showOverlay();
     }
   }
 
   onClickBackdrop(): void {
+    this.hideOverlay();
+  }
+
+  onOverlayDetach(): void {
     this.hideOverlay();
   }
 


### PR DESCRIPTION
Fixes #1539

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- Date picker can't be opened after it was closed by "Escape" key.
- `nzOnOpenChange` is emitted with `true` when `nzOpen` is `false` and a user clicks on the input (date picker is still hidden, but it's expected behavior)
 
Issue Number: #1539 


## What is the new behavior?
- Date picker works fine after closing by "Escape" key.
- `nzOnOpenChange` is not emitted when `nzOpen` is `false` and a user clicks on the input

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I found a related issue, but it can't be fixed right now:
- Given date picker with `nzOpen` equals to `true`
- When a user presses "Escape" key
- Then date picker is closed

In other scenarios (click on a backdrop, select date), we prevent closing of date picker when `nzOpen` equals to `true`, but in this case we can't do it, because there is no option in overlay from `@angular/cdk` to not be closed by "Escape". We can't prevent it right now.

https://github.com/angular/material2/blob/9062640b9a1ff98432218fc8ec59332ff154e781/src/cdk/overlay/overlay-directives.ts#L337-L341