### PR TITLE
fix(module:modal): fix multiple nzOnCancel calls

### DIFF
--- a/components/modal/nz-modal.component.ts
+++ b/components/modal/nz-modal.component.ts
@@ -217,7 +217,12 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R> impleme
   }
 
   onClickMask($event: MouseEvent): void {
-    if (this.nzMask && this.nzMaskClosable && ($event.target as HTMLElement).classList.contains('ant-modal-wrap')) {
+    if (
+      this.nzMask &&
+      this.nzMaskClosable &&
+      ($event.target as HTMLElement).classList.contains('ant-modal-wrap') &&
+      this.nzVisible
+    ) {
       this.onClickOkCancel('cancel');
     }
   }
@@ -227,7 +232,9 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R> impleme
   }
 
   private onClickCloseBtn(): void {
-    this.onClickOkCancel('cancel');
+    if (this.nzVisible) {
+      this.onClickOkCancel('cancel');
+    }
   }
 
   private onClickOkCancel(type: 'ok' | 'cancel'): void {

--- a/components/modal/nz-modal.spec.ts
+++ b/components/modal/nz-modal.spec.ts
@@ -172,6 +172,10 @@ describe('modal testing (legacy)', () => {
       modalInstance.nzMaskClosable = true;
       (modalElement.querySelector('.ant-modal-wrap') as HTMLElement).click();
       expect(console.log).toHaveBeenCalledWith('click cancel');
+      // second click on mask should not trigger nzOnCancel
+      (console.log as jasmine.Spy).calls.reset();
+      (modalElement.querySelector('.ant-modal-wrap') as HTMLElement).click();
+      expect(console.log).not.toHaveBeenCalledWith('click cancel');
       flush();
       expectModalDestroyed(tempModalId, true); // should be destroyed
     })); // /basic props


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Double click on cancel button or on "mask" of a modal window causes multiple invocations of `ngOnCancel`.

Issue Number: #958 


## What is the new behavior?
Only first click on cancel button or "mask" invokes `ngOnCancel`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
