### PR TITLE
fix(module:nz-alert): emit close after fade animation is done

### DIFF
--- a/components/alert/nz-alert.component.html
+++ b/components/alert/nz-alert.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="outerClassMap" *ngIf="display" [@fadeAnimation]>
+<div [ngClass]="outerClassMap" *ngIf="display" [@fadeAnimation] (@fadeAnimation.done)="onFadeAnimationDone()">
   <ng-container *ngIf="nzShowIcon">
     <i class="ant-alert-icon" [ngClass]="nzIconType" *ngIf="nzIconType; else iconTemplate"></i>
     <ng-template #iconTemplate>

--- a/components/alert/nz-alert.component.ts
+++ b/components/alert/nz-alert.component.ts
@@ -126,7 +126,12 @@ export class NzAlertComponent implements OnInit {
 
   closeAlert(): void {
     this.display = false;
-    this.nzOnClose.emit(true);
+  }
+
+  onFadeAnimationDone(): void {
+    if (!this.display) {
+      this.nzOnClose.emit(true);
+    }
   }
 
   updateOuterClassMap(): void {


### PR DESCRIPTION
Fixes #1666

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
`nzOnClose` is emitted immediately and as a result, ngIfon alert hides it before the animation is done

Issue Number: #1666

## What is the new behavior?
`nzOnClose` is emitted only when a fade animation is finished, so you will be able to see animation if you are controlling the visibility of alert with ngIf

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
