### PR TITLE
fix(module:nz-alert): fix overlap of close button with alert's message

### DIFF
--- a/components/alert/nz-alert.component.ts
+++ b/components/alert/nz-alert.component.ts
@@ -135,7 +135,8 @@ export class NzAlertComponent implements OnInit {
       [ `${this.prefixClass}-${this.nzType}` ]  : true,
       [ `${this.prefixClass}-no-icon` ]         : !this.nzShowIcon,
       [ `${this.prefixClass}-banner` ]          : this.nzBanner,
-      [ `${this.prefixClass}-with-description` ]: !!this.nzDescription
+      [ `${this.prefixClass}-with-description` ]: !!this.nzDescription,
+      [ `${this.prefixClass}-closeable` ]: this.nzCloseable
     };
   }
 

--- a/components/alert/style/index.less
+++ b/components/alert/style/index.less
@@ -121,6 +121,10 @@
     display: block;
   }
 
+  &&-closeable {
+    padding-right: 36px;
+  }
+
   &&-close {
     height: 0 !important;
     margin: 0;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Close button overlaps with alert's text
Issue Number: #1668 


## What is the new behavior?
Close button doesn't overlap with alert's text


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
