### PR TITLE
refactor:(module:all): use takeUntil to manage unsubscribe and update deprecations

### DIFF
--- a/components/carousel/nz-carousel.component.ts
+++ b/components/carousel/nz-carousel.component.ts
@@ -13,7 +13,10 @@ import {
   Renderer2,
   ViewChild
 } from '@angular/core';
-import { Subscription } from 'rxjs';
+
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
 import { toBoolean } from '../core/util/convert';
 
 import { NzCarouselContentDirective } from './nz-carousel-content.directive';
@@ -56,7 +59,8 @@ export class NzCarouselComponent implements AfterViewInit, OnDestroy, AfterConte
   private _dots = true;
   private _vertical = false;
   private _effect = 'scrollx';
-  slideContentsSubscription: Subscription;
+  private unsubscribe$ = new Subject<void>();
+
   activeIndex = 0;
   transform = 'translate3d(0px, 0px, 0px)';
   timeout;
@@ -226,17 +230,17 @@ export class NzCarouselComponent implements AfterViewInit, OnDestroy, AfterConte
   }
 
   ngAfterViewInit(): void {
-    this.slideContentsSubscription = this.slideContents.changes.subscribe(() => {
+    this.slideContents.changes
+    .pipe(takeUntil(this.unsubscribe$))
+    .subscribe(() => {
       this.renderContent();
     });
     this.renderContent();
   }
 
   ngOnDestroy(): void {
-    if (this.slideContentsSubscription) {
-      this.slideContentsSubscription.unsubscribe();
-      this.slideContentsSubscription = null;
-    }
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
     this.clearTimeout();
   }
 

--- a/components/modal/nz-modal.component.ts
+++ b/components/modal/nz-modal.component.ts
@@ -21,7 +21,10 @@ import {
   ViewChild,
   ViewContainerRef
 } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
+
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
 import { NzMeasureScrollbarService } from '../core/services/nz-measure-scrollbar.service';
 
 import { InputBoolean } from '../core/util/convert';
@@ -47,7 +50,8 @@ type AnimationState = 'enter' | 'leave' | null;
 
 // tslint:disable-next-line:no-any
 export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R> implements OnInit, OnChanges, AfterViewInit, OnDestroy, ModalOptions {
-  private i18n$: Subscription;
+  private unsubscribe$ = new Subject<void>();
+
   // tslint:disable-next-line:no-any
   locale: any = {};
   @Input() nzModalType: ModalType = 'default';
@@ -130,7 +134,7 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R> impleme
   }
 
   ngOnInit(): void {
-    this.i18n$ = this.i18n.localeChange.subscribe(() => this.locale = this.i18n.getLocaleData('Modal'));
+    this.i18n.localeChange.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this.locale = this.i18n.getLocaleData('Modal'));
 
     if (this.isComponent(this.nzContent)) {
       this.createDynamicComponent(this.nzContent as Type<T>); // Create component along without View
@@ -177,7 +181,8 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R> impleme
     if (this.container instanceof OverlayRef) {
       this.container.dispose();
     }
-    this.i18n$.unsubscribe();
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 
   open(): void {

--- a/components/pagination/nz-pagination.component.ts
+++ b/components/pagination/nz-pagination.component.ts
@@ -9,7 +9,9 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
 import { isInteger } from '../core/util/check';
 import { toBoolean } from '../core/util/convert';
 import { NzI18nService } from '../i18n/nz-i18n.service';
@@ -20,7 +22,7 @@ import { NzI18nService } from '../i18n/nz-i18n.service';
   templateUrl        : './nz-pagination.component.html'
 })
 export class NzPaginationComponent implements OnInit, OnDestroy {
-  private i18n$: Subscription;
+  private unsubscribe$ = new Subject<void>();
   // tslint:disable-next-line:no-any
   locale: any = {};
   @ViewChild('renderItemTemplate') private _itemRender: TemplateRef<{ $implicit: 'page' | 'prev' | 'next', page: number }>;
@@ -266,10 +268,11 @@ export class NzPaginationComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.i18n$ = this.i18n.localeChange.subscribe(() => this.locale = this.i18n.getLocaleData('Pagination'));
+    this.i18n.localeChange.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this.locale = this.i18n.getLocaleData('Pagination'));
   }
 
   ngOnDestroy(): void {
-    this.i18n$.unsubscribe();
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 }

--- a/components/select/nz-option-container.component.ts
+++ b/components/select/nz-option-container.component.ts
@@ -12,8 +12,7 @@ import { isNotNil } from '../core/util/check';
 import { NzOptionGroupComponent } from './nz-option-group.component';
 import { NzOptionComponent } from './nz-option.component';
 
-import { Subject, Subscription } from 'rxjs';
-import { merge } from 'rxjs/operators';
+import { merge, Subject, Subscription } from 'rxjs';
 import { NzOptionLiComponent } from './nz-option-li.component';
 import { defaultFilterOption, NzOptionPipe, TFilterOption } from './nz-option.pipe';
 
@@ -223,9 +222,13 @@ export class NzOptionContainerComponent implements AfterContentInit, OnDestroy {
   /** watch options change in option group **/
   watchSubOptionChanges(): void {
     this.unsubscribeOption();
-    let optionChanges$ = new Subject().asObservable().pipe(merge(this.listOfNzOptionGroupComponent.changes)).pipe(merge(this.listOfNzOptionComponent.changes));
+    let optionChanges$ = merge(
+      new Subject().asObservable(),
+      this.listOfNzOptionGroupComponent.changes,
+      this.listOfNzOptionComponent.changes
+    );
     if (this.listOfNzOptionGroupComponent.length) {
-      this.listOfNzOptionGroupComponent.forEach(group => optionChanges$ = group.listOfNzOptionComponent ? optionChanges$.pipe(merge(group.listOfNzOptionComponent.changes)) : optionChanges$);
+      this.listOfNzOptionGroupComponent.forEach(group => optionChanges$ = group.listOfNzOptionComponent ? merge(group.listOfNzOptionComponent.changes, optionChanges$) : optionChanges$);
     }
     this.optionSubscription = optionChanges$.subscribe(() => this.refreshAllOptionStatus(true));
   }

--- a/components/steps/nz-steps.component.ts
+++ b/components/steps/nz-steps.component.ts
@@ -8,7 +8,9 @@ import {
   QueryList,
   TemplateRef
 } from '@angular/core';
-import { Subscription } from 'rxjs';
+
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { toBoolean } from '../core/util/convert';
 
@@ -28,7 +30,8 @@ export class NzStepsComponent implements OnInit, OnDestroy, AfterContentInit {
   private _current = 0;
   private _size: NzSizeType = 'default';
   private _direction: NzDirectionType = 'horizontal';
-  private stepsSubscription: Subscription;
+  private unsubscribe$ = new Subject<void>();
+
   stepsClassMap: object;
   showProcessDot = false;
   customProcessDotTemplate: TemplateRef<{ $implicit: TemplateRef<void>, status: string, index: number }>;
@@ -118,16 +121,14 @@ export class NzStepsComponent implements OnInit, OnDestroy, AfterContentInit {
   }
 
   ngOnDestroy(): void {
-    if (this.stepsSubscription) {
-      this.stepsSubscription.unsubscribe();
-      this.stepsSubscription = null;
-    }
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 
   ngAfterContentInit(): void {
     Promise.resolve().then(() => this.updateChildrenSteps());
     if (this.steps) {
-      this.stepsSubscription = this.steps.changes.subscribe(this.updateChildrenSteps);
+       this.steps.changes.pipe(takeUntil(this.unsubscribe$)).subscribe(this.updateChildrenSteps);
     }
   }
 }

--- a/components/table/nz-table.component.ts
+++ b/components/table/nz-table.component.ts
@@ -15,7 +15,10 @@ import {
   TemplateRef,
   ViewChild
 } from '@angular/core';
-import { Subscription } from 'rxjs';
+
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
 import { NzMeasureScrollbarService } from '../core/services/nz-measure-scrollbar.service';
 import { isNotNil } from '../core/util/check';
 import { toBoolean } from '../core/util/convert';
@@ -30,7 +33,7 @@ import { NzTheadComponent } from './nz-thead.component';
   templateUrl        : './nz-table.component.html'
 })
 export class NzTableComponent implements OnInit, AfterViewInit, OnDestroy {
-  private i18n$: Subscription;
+  private unsubscribe$ = new Subject<void>();
   private _bordered = false;
   private _showPagination = true;
   private _loading = false;
@@ -324,7 +327,7 @@ export class NzTableComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.i18n$ = this.i18n.localeChange.subscribe(() => this.locale = this.i18n.getLocaleData('Table'));
+    this.i18n.localeChange.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this.locale = this.i18n.getLocaleData('Table'));
     this.fitScrollBar();
     if (this.nzScroll && this.nzScroll.x && this.nzScroll.y) {
       /** magic code to sync scroll **/
@@ -338,7 +341,8 @@ export class NzTableComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.i18n$.unsubscribe();
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 
   constructor(private elementRef: ElementRef, private cdr: ChangeDetectorRef, private overlay: Overlay, private nzMeasureScrollbarService: NzMeasureScrollbarService, private i18n: NzI18nService) {

--- a/components/timeline/nz-timeline.component.ts
+++ b/components/timeline/nz-timeline.component.ts
@@ -9,7 +9,8 @@ import {
   TemplateRef
 } from '@angular/core';
 
-import { Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { NzTimelineItemComponent } from './nz-timeline-item.component';
 
@@ -20,7 +21,7 @@ import { NzTimelineItemComponent } from './nz-timeline-item.component';
 })
 export class NzTimelineComponent implements AfterContentInit, OnDestroy {
   private _pending: string | boolean | TemplateRef<void>;
-  private timeLineSubscription: Subscription;
+  private unsubscribe$ = new Subject<void>();
   isPendingString: boolean;
   isPendingBoolean: boolean = false;
 
@@ -45,16 +46,14 @@ export class NzTimelineComponent implements AfterContentInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if (this.timeLineSubscription) {
-      this.timeLineSubscription.unsubscribe();
-      this.timeLineSubscription = null;
-    }
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 
   ngAfterContentInit(): void {
     this.updateChildrenTimeLine();
     if (this.listOfTimeLine) {
-      this.timeLineSubscription = this.listOfTimeLine.changes.subscribe(() => {
+      this.listOfTimeLine.changes.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
         this.updateChildrenTimeLine();
       });
     }

--- a/components/transfer/nz-transfer.component.ts
+++ b/components/transfer/nz-transfer.component.ts
@@ -10,7 +10,9 @@ import {
   SimpleChanges,
   TemplateRef
 } from '@angular/core';
-import { of, Observable, Subscription } from 'rxjs';
+
+import { of, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { toBoolean } from '../core/util/convert';
 import { NzI18nService } from '../i18n/nz-i18n.service';
@@ -26,7 +28,7 @@ import { TransferCanMove, TransferChange, TransferItem, TransferSearchChange, Tr
   }
 })
 export class NzTransferComponent implements OnInit, OnChanges, OnDestroy {
-  private i18n$: Subscription;
+  private unsubscribe$ = new Subject<void>();
   // tslint:disable-next-line:no-any
   locale: any = {};
   private _showSearch = false;
@@ -156,7 +158,7 @@ export class NzTransferComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.i18n$ = this.i18n.localeChange.subscribe(() => this.locale = this.i18n.getLocaleData('Transfer'));
+    this.i18n.localeChange.pipe(takeUntil(this.unsubscribe$)).subscribe(() => this.locale = this.i18n.getLocaleData('Transfer'));
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -168,6 +170,7 @@ export class NzTransferComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.i18n$.unsubscribe();
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

### merge

```ts
import { merge } from 'rxjs/operators';
a$.pipe(merge(b$, c$));

// becomes

import { merge } from 'rxjs';
merge(a$, b$, c$);
```

### combineLatest

```ts
import { combineLatest } from 'rxjs/operators';
a$.pipe(combineLatest(b$, c$));

// becomes

import { combineLatest } from 'rxjs';
combineLatest(a$, b$, c$);
```

### use takeUntil to manage unsubscribe

```ts
 this.aSubscription = a$.subscribe(...);
 this.bSubscription = b$.subscribe(...);

ngOnDestroy() {
  this.aSubscription.unsubscribe();
  this.bSubscription.unsubscribe();
}

// becomes

a$.pipe(takeUntil(this.unsubscribe$)).subscribe(...);
b$.pipe(takeUntil(this.unsubscribe$)).subscribe(...);

ngOnDestroy() {
  this.unsubscribe$.next();
  this.unsubscribe$.complete();
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
