### PR TITLE
feat(module:table): fix selector error

### DIFF
--- a/components/table/nz-td.component.ts
+++ b/components/table/nz-td.component.ts
@@ -12,7 +12,7 @@ import { toBoolean } from '../core/util/convert';
 
 @Component({
   // tslint:disable-next-line:component-selector
-  selector   : 'td:not(.custom-tag)',
+  selector   : 'td:not(.nz-disable-td)',
   templateUrl: './nz-td.component.html'
 })
 export class NzTdComponent {

--- a/components/table/nz-td.component.ts
+++ b/components/table/nz-td.component.ts
@@ -12,7 +12,7 @@ import { toBoolean } from '../core/util/convert';
 
 @Component({
   // tslint:disable-next-line:component-selector
-  selector   : 'td',
+  selector   : 'td:not(.custom-tag)',
   templateUrl: './nz-td.component.html'
 })
 export class NzTdComponent {

--- a/components/table/nz-td.spec.ts
+++ b/components/table/nz-td.spec.ts
@@ -123,6 +123,13 @@ describe('nz-td', () => {
       expect(td.nativeElement.classList).toContain('ant-table-td-right-sticky');
       expect(td.nativeElement.style.right).toBe('20px');
     });
+    it('should be throw error when use specific class name', () => {
+      expect(() => {
+        TestBed.configureTestingModule({
+          declarations: [ NzTestDisableTdComponent ]
+        }).createComponent(NzTestDisableTdComponent);
+      }).toThrow();
+    });
   });
 });
 
@@ -155,3 +162,11 @@ export class NzTestTdComponent {
   left;
   right;
 }
+
+@Component({
+  selector: 'nz-disable-td',
+  template: `
+    <td class="nz-disable-td" [nzShowCheckbox]="true"></td>
+  `
+})
+export class NzTestDisableTdComponent {}

--- a/components/table/nz-th.component.ts
+++ b/components/table/nz-th.component.ts
@@ -26,7 +26,7 @@ export interface NzThItemInterface {
 
 @Component({
   // tslint:disable-next-line:component-selector
-  selector           : 'th',
+  selector           : 'th:not(.custom-tag)',
   preserveWhitespaces: false,
   templateUrl        : './nz-th.component.html'
 })

--- a/components/table/nz-th.component.ts
+++ b/components/table/nz-th.component.ts
@@ -26,7 +26,7 @@ export interface NzThItemInterface {
 
 @Component({
   // tslint:disable-next-line:component-selector
-  selector           : 'th:not(.custom-tag)',
+  selector           : 'th:not(.nz-disable-th)',
   preserveWhitespaces: false,
   templateUrl        : './nz-th.component.html'
 })

--- a/components/table/nz-th.spec.ts
+++ b/components/table/nz-th.spec.ts
@@ -248,6 +248,13 @@ describe('nz-th', () => {
       fixture.detectChanges();
       expect(th.nativeElement.classList).toContain('ant-table-expand-icon-th');
     });
+    it('should be throw error when use specific class name', () => {
+      expect(() => {
+        TestBed.configureTestingModule({
+          declarations: [ NzTestDisableThComponent ]
+        }).createComponent(NzTestDisableThComponent);
+      }).toThrow();
+    });
   });
 });
 
@@ -306,3 +313,11 @@ export class NzThTestNzTableComponent {
   filterMultiple = true;
   expand = false;
 }
+
+@Component({
+  selector: 'nz-disable-th',
+  template: `
+    <th class="nz-disable-th" [nzShowCheckbox]="true"></th>
+  `
+})
+export class NzTestDisableThComponent {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

"td" and "th" selector will conflict with user custom component and throw Template parse error: "More than one component matched on this element..."
Issue Number: [#1736](https://github.com/NG-ZORRO/ng-zorro-antd/issues/1736)


## What is the new behavior?

"td" and "th" selector will not conflict with user custom component by use “not:(.custom-tag)” in selector

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
