### PR TITLE
fix:(module: date-picker): dd.MM.yyyy date format

### DIFF
--- a/components/date-picker/lib/calendar/calendar-input.component.ts
+++ b/components/date-picker/lib/calendar/calendar-input.component.ts
@@ -45,7 +45,15 @@ export class CalendarInputComponent implements OnInit {
 
   private checkValidInputDate(event: Event): CandyDate {
     const input = (event.target as HTMLInputElement).value;
-    const date = new CandyDate(input);
+    const date =
+      this.format === 'dd.MM.yyyy'
+        ? new CandyDate(
+            input
+              .split(/\./)
+              .reverse()
+              .join('.')
+          )
+        : new CandyDate(input);
 
     this.invalidInputClass = '';
     if (date.isInvalid() || input !== this.toReadableInput(date)) { // Should also match the input format exactly


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I want to use the date-picker with the following format [nzFormat]="'dd.MM.yyyy'", when I type the picker`s input, the state does not change, because the javascript date creates Wed Mar 07 2018 00:00:00 GMT+0100 (Central European Standard Time) from this string: "03.07.2018", so the day and mounth is not the correct order for the Date object.

Issue Number: N/A


## What is the new behavior?
[nzFormat]="'dd.MM.yyyy'" works

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
