### PR TITLE
fix(input-number): NzAutoFocus doesn't work or work as expected

### DIFF
--- a/components/input-number/nz-input-number.component.ts
+++ b/components/input-number/nz-input-number.component.ts
@@ -104,12 +104,10 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   }
 
   updateAutoFocus(): void {
-    if (this.isInit) {
-      if (this.nzAutoFocus) {
-        this.renderer.setAttribute(this.inputElement.nativeElement, 'autofocus', 'autofocus');
-      } else {
-        this.renderer.removeAttribute(this.inputElement.nativeElement, 'autofocus');
-      }
+    if (this.nzAutoFocus) {
+      this.renderer.setAttribute(this.inputElement.nativeElement, 'autofocus', 'autofocus');
+    } else {
+      this.renderer.removeAttribute(this.inputElement.nativeElement, 'autofocus');
     }
   }
 
@@ -365,5 +363,8 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
 
   ngAfterViewInit(): void {
     this.isInit = true;
+    if (this._autoFocus) {
+      this.focus();
+    }
   }
 }

--- a/components/input-number/nz-input-number.spec.ts
+++ b/components/input-number/nz-input-number.spec.ts
@@ -57,7 +57,10 @@ describe('input number', () => {
     it('should autofocus work', () => {
       fixture.detectChanges();
       testComponent.autofocus = true;
+      testComponent.nzInputNumberComponent._autoFocus = true;
+      testComponent.nzInputNumberComponent.ngAfterViewInit();
       fixture.detectChanges();
+      expect(inputElement === document.activeElement).toBe(true);
       expect(inputElement.attributes.getNamedItem('autofocus').name).toBe('autofocus');
       testComponent.autofocus = false;
       fixture.detectChanges();


### PR DESCRIPTION
close #1706

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1706 


## What is the new behavior?
HTML `autofocus` attribute now would work in Chrome.

Instead of using HTML `autofocus`, I manually invoke `focus` method. So `input-number` would focus whenever it get rendered, which may be what users want. See discussions in the issue.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
