### PR TITLE
fix(module:tabs): prevent focus cause scroll offset

### DIFF
--- a/components/tabs/nz-tabs.spec.ts
+++ b/components/tabs/nz-tabs.spec.ts
@@ -1,6 +1,7 @@
 import { Component, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
-import { fakeAsync, tick, TestBed } from '@angular/core/testing';
+import { fakeAsync, flush, tick, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { dispatchFakeEvent } from '../core/testing';
 
 import { NzTabsModule } from './nz-tabs.module';
 import { NzTabSetComponent } from './nz-tabset.component';
@@ -448,6 +449,17 @@ describe('tabs', () => {
       expect(testComponent.select02).toHaveBeenCalledTimes(0);
       expect(testComponent.deselect02).toHaveBeenCalledTimes(0);
     }));
+    it('should prevent focus scroll', fakeAsync(() => {
+      fixture.detectChanges();
+      expect(tabs.nativeElement.scrollLeft).toBe(0);
+      const input: HTMLInputElement = tabs.nativeElement.querySelector('input');
+      input.focus();
+      expect(tabs.nativeElement.scrollLeft > 0).toBe(true);
+      dispatchFakeEvent(tabs.nativeElement, 'scroll');
+      flush();
+      fixture.detectChanges();
+      expect(tabs.nativeElement.scrollLeft).toBe(0);
+    }));
   });
 });
 
@@ -484,7 +496,7 @@ describe('tabs', () => {
           (nzDeselect)="deselect01()"
           (nzSelect)="select01()"
           (nzClick)="click01()"
-          [nzDisabled]="disabled">Content 2<!----></nz-tab>
+          [nzDisabled]="disabled">Content 2<!----><input></nz-tab>
         <nz-tab
           nzTitle="add"
           *ngIf="add"

--- a/components/tabs/nz-tabset.component.ts
+++ b/components/tabs/nz-tabset.component.ts
@@ -1,13 +1,16 @@
 /** get some code from https://github.com/angular/material2 */
 
+import { DOCUMENT } from '@angular/common';
 import {
   AfterContentChecked,
   AfterViewInit,
   Component,
   ElementRef,
   EventEmitter,
+  Inject,
   Input,
   OnInit,
+  Optional,
   Output,
   Renderer2,
   TemplateRef,
@@ -42,6 +45,9 @@ export type NzTabType = 'line' | 'card';
   preserveWhitespaces: false,
   providers          : [ NzUpdateHostClassService ],
   templateUrl        : './nz-tabset.component.html',
+  host               : {
+    '(scroll)': 'onScroll($event)'
+  },
   styles             : [ `
     :host {
       display: block;
@@ -227,7 +233,20 @@ export class NzTabSetComponent implements AfterContentChecked, OnInit, AfterView
     this.listOfNzTabComponent.splice(this.listOfNzTabComponent.indexOf(value), 1);
   }
 
-  constructor(private renderer: Renderer2, private nzUpdateHostClassService: NzUpdateHostClassService, private elementRef: ElementRef) {
+  // From https://github.com/react-component/tabs/blob/master/src/Tabs.js
+  // Prevent focus to make the Tabs scroll offset
+  onScroll($event: Event): void {
+    const target: Element = $event.target as Element;
+    if (target.scrollLeft > 0) {
+      target.scrollLeft = 0;
+      if (this.document && this.document.activeElement) {
+        (this.document.activeElement as HTMLElement).blur();
+      }
+    }
+  }
+
+  // tslint:disable-next-line:no-any
+  constructor(private renderer: Renderer2, private nzUpdateHostClassService: NzUpdateHostClassService, private elementRef: ElementRef, @Optional() @Inject(DOCUMENT) private document: any) {
     this.el = this.elementRef.nativeElement;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1821


## What is the new behavior?

Reset `scrollLeft` & `document.activeElement` when scroll.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
