### PR TITLE
feat(module:radio): add solid button style

### DIFF
--- a/components/radio/doc/index.en-US.md
+++ b/components/radio/doc/index.en-US.md
@@ -34,6 +34,7 @@ radio group，wrap a group of `nz-radio`。
 | `[nzDisabled]` | Disable all radio buttons | boolean |  false |
 | `[nzSize]` | Size, only on radio style | `large` `default` `small` | `default` |
 | `(ngModelChange)` | the callback function when current selected `nz-radio` value change | `EventEmitter<string>` | - |
+| `[nzButtonStyle]` | style type of radio button | `outline` 丨 `solid` | `outline` |
 
 ## Methods
 

--- a/components/radio/doc/index.zh-CN.md
+++ b/components/radio/doc/index.zh-CN.md
@@ -36,6 +36,7 @@ title: Radio
 | `[nzDisabled]` | 设定所有 `nz-radio` disable 状态 | boolean | false |
 | `[nzSize]` | 大小，只对按钮样式生效 | `large` ｜ `default` ｜ `small` | `default` |
 | `(ngModelChange)` | 选中变化时回调 | `EventEmitter<boolean>` | - |
+| `[nzButtonStyle]` | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` 丨 `solid` | `outline` |
 
 ## 方法
 

--- a/components/radio/nz-radio-group.component.ts
+++ b/components/radio/nz-radio-group.component.ts
@@ -11,6 +11,7 @@ import { isNotNil } from '../core/util/check';
 import { toBoolean } from '../core/util/convert';
 
 export type NzRadioGroupSizeType = 'large' | 'default' | 'small';
+export type NzRadioButtonStyle = 'outline' | 'solid';
 
 import { NzRadioButtonComponent } from './nz-radio-button.component';
 import { NzRadioComponent } from './nz-radio.component';
@@ -72,6 +73,8 @@ export class NzRadioGroupComponent implements AfterContentInit, ControlValueAcce
     return this._name;
   }
 
+  @Input() nzButtonStyle: NzRadioButtonStyle = 'outline';
+
   updateDisabledState(): void {
     if (isNotNil(this.nzDisabled)) {
       this.radios.forEach((radio) => {
@@ -102,6 +105,11 @@ export class NzRadioGroupComponent implements AfterContentInit, ControlValueAcce
   @HostBinding('class.ant-radio-group-small')
   get isSmall(): boolean {
     return this.nzSize === 'small';
+  }
+
+  @HostBinding('class.ant-radio-group-solid')
+  get isSolid(): boolean {
+    return this.nzButtonStyle === 'solid';
   }
 
   addRadio(radio: NzRadioComponent | NzRadioButtonComponent): void {

--- a/components/radio/nz-radio.spec.ts
+++ b/components/radio/nz-radio.spec.ts
@@ -194,6 +194,19 @@ describe('radio', () => {
       expect(testComponent.value).toBe('A');
     }));
   });
+  describe('radio group solid', () => {
+    let fixture;
+    let radioGroup;
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzTestRadioGroupSolidComponent);
+      fixture.detectChanges();
+      radioGroup = fixture.debugElement.query(By.directive(NzRadioGroupComponent));
+      it('should support solid css', () => {
+        fixture.detectChanges();
+        expect(radioGroup.nativeElement.classList).toContain('ant-radio-group-solid');
+      });
+    });
+  });
   describe('radio form', () => {
     let fixture;
     let testComponent;
@@ -409,4 +422,19 @@ export class NzTestRadioGroupDisabledFormComponent implements OnInit {
       radio: [ { value: 'B', disabled: true } ]
     });
   }
+}
+
+@Component({
+  selector: 'nz-test-radui-group-solid',
+  template: `
+    <nz-radio-group [(ngModel)]="value" [nzButtonStyle]="'solid'">
+      <label nz-radio-button nzValue="A">A</label>
+      <label nz-radio-button nzValue="B">B</label>
+      <label nz-radio-button nzValue="C" [nzDisabled]="singleDisabled">C</label>
+      <label nz-radio-button nzValue="D">D</label>
+    </nz-radio-group>`
+})
+export class NzTestRadioGroupSolidComponent {
+  value = 'A';
+  singleDisabled = false;
 }

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -177,6 +177,22 @@ span.@{radio-prefix-cls} + * {
     padding: 0 @control-padding-horizontal-sm - 1px;
   }
 
+  .@{radio-group-prefix-cls}-solid &-checked:not(&-disabled) {
+    background: @radio-dot-color;
+    border-color: @radio-dot-color;
+    color: #fff;
+    &:hover {
+      border-color: @radio-button-hover-color;
+      background: @radio-button-hover-color;
+      color: #fff;
+    }
+    &:active {
+      border-color: @radio-button-active-color;
+      background: @radio-button-active-color;
+      color: #fff;
+    }
+  }
+
   &:not(:first-child) {
     &::before {
       content: "";


### PR DESCRIPTION
close #1891

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1891 


## What is the new behavior?

Same as https://ant.design/components/radio/#components-radio-demo-radiobutton-solid.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I temporarily add style in `index.less`.