### PR TITLE
feat(layout:sider): support for custom trigger with nzCollapsedWidth set to 0

### DIFF
--- a/components/layout/demo/custom-trigger.ts
+++ b/components/layout/demo/custom-trigger.ts
@@ -4,7 +4,7 @@ import { Component, TemplateRef, ViewChild } from '@angular/core';
   selector: 'nz-demo-layout-custom-trigger',
   template: `
     <nz-layout>
-      <nz-sider nzCollapsible [(nzCollapsed)]="isCollapsed" [nzTrigger]="triggerTemplate">
+      <nz-sider nzCollapsible [(nzCollapsed)]="isCollapsed" [nzCollapsedWidth]="collapsedWidth" [nzTrigger]="triggerTemplate" [nzZeroTrigger]="zeroTriggerTemplate">
         <div class="logo">
         </div>
         <ul nz-menu [nzTheme]="'dark'" [nzMode]="'inline'" [nzInlineCollapsed]="isCollapsed">
@@ -71,10 +71,18 @@ import { Component, TemplateRef, ViewChild } from '@angular/core';
 export class NzDemoLayoutCustomTriggerComponent {
   isCollapsed = false;
   triggerTemplate = null;
+  zeroTriggerTemplate = null;
+  collapsedWidth = 80;
   @ViewChild('trigger') customTrigger: TemplateRef<void>;
 
   /** custom trigger can be TemplateRef **/
   changeTrigger(): void {
     this.triggerTemplate = this.customTrigger;
+  }
+
+  /** custom trigger can be TemplateRef **/
+  changeZeroWidthTrigger(): void {
+    this.collapsedWidth = 0;
+    this.zeroTriggerTemplate = this.customTrigger;
   }
 }

--- a/components/layout/nz-layout.spec.ts
+++ b/components/layout/nz-layout.spec.ts
@@ -15,7 +15,7 @@ import { NzLayoutComponent } from './nz-layout.component';
 import { NzLayoutModule } from './nz-layout.module';
 import { NzSiderComponent } from './nz-sider.component';
 
-describe('layout', () => {
+fdescribe('layout', () => {
   let testComponent;
   let fixture;
   describe('basic', () => {
@@ -173,6 +173,34 @@ describe('layout', () => {
       expect(trigger).not.toBeNull();
     });
   });
+
+  describe('custom-zero-trigger', () => {
+    let sider;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports     : [ NzLayoutModule ],
+        declarations: [ NzDemoLayoutCustomTriggerComponent ],
+        providers   : [],
+        schemas     : [ NO_ERRORS_SCHEMA ]
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzDemoLayoutCustomTriggerComponent);
+      testComponent = fixture.debugElement.componentInstance;
+      sider = fixture.debugElement.query(By.directive(NzSiderComponent)).injector.get(NzSiderComponent);
+    });
+    it('should display custom zero trigger', () => {
+      testComponent.changeZeroWidthTrigger();
+      testComponent.isCollapsed = true;
+      fixture.detectChanges();
+      const trigger = fixture.debugElement.query(By.css('.ant-layout-sider-zero-width-trigger'));
+      expect(trigger).not.toBeNull();
+      expect(trigger.nativeElement.firstElementChild.classList.contains('anticon-up')).toBe(true);
+    });
+  });
+
   describe('responsive', () => {
     let sider;
 

--- a/components/layout/nz-layout.spec.ts
+++ b/components/layout/nz-layout.spec.ts
@@ -15,7 +15,7 @@ import { NzLayoutComponent } from './nz-layout.component';
 import { NzLayoutModule } from './nz-layout.module';
 import { NzSiderComponent } from './nz-sider.component';
 
-fdescribe('layout', () => {
+describe('layout', () => {
   let testComponent;
   let fixture;
   describe('basic', () => {

--- a/components/layout/nz-sider.component.html
+++ b/components/layout/nz-sider.component.html
@@ -2,7 +2,7 @@
   <ng-content></ng-content>
 </div>
 <span class="ant-layout-sider-zero-width-trigger" *ngIf="isZeroTrigger" (click)="toggleCollapse()">
-  <i class="anticon anticon-bars"></i>
+  <ng-template [ngTemplateOutlet]="nzZeroTrigger"></ng-template>
 </span>
 <div class="ant-layout-sider-trigger" *ngIf="isSiderTrigger" (click)="toggleCollapse()" [style.width.px]="nzCollapsed?nzCollapsedWidth:nzWidth">
   <ng-template [ngTemplateOutlet]="nzTrigger"></ng-template>
@@ -10,4 +10,7 @@
 <ng-template #defaultTrigger>
   <i class="anticon" [class.anticon-left]="!nzCollapsed" [class.anticon-right]="nzCollapsed" *ngIf="!nzReverseArrow"></i>
   <i class="anticon" [class.anticon-left]="nzCollapsed" [class.anticon-right]="!nzCollapsed" *ngIf="nzReverseArrow"></i>
+</ng-template>
+<ng-template #defaultZeroTrigger>
+  <i class="anticon anticon-bars"></i>
 </ng-template>

--- a/components/layout/nz-sider.component.ts
+++ b/components/layout/nz-sider.component.ts
@@ -32,6 +32,7 @@ export class NzSiderComponent implements OnInit, AfterViewInit {
   private _collapsed = false;
   private _collapsible = false;
   @ViewChild('defaultTrigger') _trigger: TemplateRef<void>;
+  @ViewChild('defaultZeroTrigger') _zeroTrigger: TemplateRef<void>;
   private _reverseArrow = false;
   private below = false;
   private isInit = false;
@@ -63,6 +64,15 @@ export class NzSiderComponent implements OnInit, AfterViewInit {
 
   get nzTrigger(): TemplateRef<void> {
     return this._trigger;
+  }
+
+  @Input()
+  set nzZeroTrigger(value: TemplateRef<void>) {
+    this._zeroTrigger = value;
+  }
+
+  get nzZeroTrigger(): TemplateRef<void> {
+    return this._zeroTrigger;
   }
 
   @Input()


### PR DESCRIPTION
closes #1950

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] (*only english docs*) Docs have been added / updated (for bug fixes / features) 


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1950 


## What is the new behavior?

You can now set a custom trigger tof rth trigger shown when you have a nzCollapsedWidth set to 0 on 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
