### PR TITLE
feat(module:select): support open and close panel via keyboard

### DIFF
--- a/components/select/nz-select.component.ts
+++ b/components/select/nz-select.component.ts
@@ -5,6 +5,7 @@ import {
   transition,
   trigger
 } from '@angular/animations';
+import { DOWN_ARROW, SPACE, TAB } from '@angular/cdk/keycodes';
 import { CdkConnectedOverlay, CdkOverlayOrigin, ConnectedOverlayPositionChange } from '@angular/cdk/overlay';
 import {
   forwardRef,
@@ -151,7 +152,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   @Input() nzDropdownStyle: { [ key: string ]: string; };
   @Input() nzNotFoundContent: string;
   /** https://github.com/angular/angular/pull/13349/files **/
-           // tslint:disable-next-line:no-any
+    // tslint:disable-next-line:no-any
   @Input() compareWith = (o1: any, o2: any) => o1 === o2;
 
   @Input()
@@ -254,6 +255,27 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
     if (!this.nzDisabled) {
       this.nzOpen = !this.nzOpen;
       this.nzOpenChange.emit(this.nzOpen);
+    }
+  }
+
+  @HostListener('keydown', [ '$event' ])
+  private _handleKeydown(event: KeyboardEvent): void {
+    if (this._disabled) { return; }
+
+    const keyCode = event.keyCode;
+
+    if (!this._open) {
+      if (keyCode === SPACE || keyCode === DOWN_ARROW) {
+        this.nzOpen = true;
+        this.nzOpenChange.emit(this.nzOpen);
+        event.preventDefault();
+      }
+    } else {
+      if (keyCode === SPACE || keyCode === TAB) {
+        this.nzOpen = false;
+        this.nzOpenChange.emit(this.nzOpen);
+        event.preventDefault();
+      }
     }
   }
 

--- a/components/select/nz-select.spec.ts
+++ b/components/select/nz-select.spec.ts
@@ -1,3 +1,4 @@
+import { DOWN_ARROW, SPACE, TAB } from '@angular/cdk/keycodes';
 import { Component, ViewChild } from '@angular/core';
 import { async, fakeAsync, flush, inject, tick, TestBed } from '@angular/core/testing';
 import { FormsModule, FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -193,17 +194,40 @@ describe('nz-select component', () => {
       expect(testComponent.onSearch).toHaveBeenCalledTimes(1);
     });
     it('should blur after user hits enter key in single mode', () => {
-        const spy = spyOn(testComponent.nzSelectComponent, 'blur');
-        testComponent.showSearch = true;
-        select.nativeElement.click();
-        fixture.detectChanges();
-        dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', 40);
-        fixture.detectChanges();
-        expect(spy).not.toHaveBeenCalled();
-        dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', 13);
-        fixture.detectChanges();
-        expect(spy).toHaveBeenCalled();
+      const spy = spyOn(testComponent.nzSelectComponent, 'blur');
+      testComponent.showSearch = true;
+      select.nativeElement.click();
+      fixture.detectChanges();
+      dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', 40);
+      fixture.detectChanges();
+      expect(spy).not.toHaveBeenCalled();
+      dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', 13);
+      fixture.detectChanges();
+      expect(spy).toHaveBeenCalled();
     });
+    it('should support keydown events to open and close select panel', fakeAsync(() => {
+      fixture.detectChanges();
+      dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', SPACE);
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(testComponent.open).toBe(true);
+      dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', SPACE);
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(testComponent.open).toBe(false);
+      dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(testComponent.open).toBe(true);
+      dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', TAB);
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(testComponent.open).toBe(false);
+    }));
   });
   describe('tags', () => {
     let fixture;

--- a/components/select/nz-select.spec.ts
+++ b/components/select/nz-select.spec.ts
@@ -16,7 +16,7 @@ describe('nz-select component', () => {
   let overlayContainerElement: HTMLElement;
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports     : [ NzSelectModule, NoopAnimationsModule, FormsModule, ReactiveFormsModule ],
+      imports: [ NzSelectModule, NoopAnimationsModule, FormsModule, ReactiveFormsModule ],
       declarations: [ NzTestSelectDefaultComponent, NzTestSelectTagsComponent, NzTestSelectFormComponent ]
     });
     TestBed.compileComponents();
@@ -222,6 +222,13 @@ describe('nz-select component', () => {
       flush();
       fixture.detectChanges();
       expect(testComponent.open).toBe(true);
+      dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', TAB);
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(testComponent.open).toBe(false);
+      testComponent.disabled = true;
+      fixture.detectChanges();
       dispatchKeyboardEvent(select.nativeElement.querySelector('.ant-select-selection'), 'keydown', TAB);
       fixture.detectChanges();
       flush();


### PR DESCRIPTION
close #1909

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1909 


## What is the new behavior?

User can open and close select panel when select component has focus.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Other components may lack of this feature. Maybe we should go through these in next refactor.
