### PR TITLE
fix(module:pagination): take minimum of page range and total

### DIFF
--- a/components/pagination/nz-pagination.component.html
+++ b/components/pagination/nz-pagination.component.html
@@ -39,7 +39,7 @@
       <span class="ant-pagination-total-text" *ngIf="nzShowTotal">
         <ng-template
           [ngTemplateOutlet]="nzShowTotal"
-          [ngTemplateOutletContext]="{ $implicit: nzTotal,range:[(nzPageIndex-1)*nzPageSize+1,nzPageIndex*nzPageSize] }">
+          [ngTemplateOutletContext]="{ $implicit: nzTotal,range:[(nzPageIndex-1)*nzPageSize+1, min(nzPageIndex*nzPageSize, nzTotal)] }">
         </ng-template>
       </span>
     <li

--- a/components/pagination/nz-pagination.component.ts
+++ b/components/pagination/nz-pagination.component.ts
@@ -264,6 +264,10 @@ export class NzPaginationComponent implements OnInit, OnDestroy {
     return this.nzPageIndex === this.firstIndex;
   }
 
+  min(val1: number, val2: number): number {
+    return Math.min(val1, val2);
+  }
+
   constructor(private i18n: NzI18nService) {
   }
 

--- a/components/pagination/nz-pagination.spec.ts
+++ b/components/pagination/nz-pagination.spec.ts
@@ -280,6 +280,9 @@ describe('pagination', () => {
       testComponent.pageIndex = 2;
       fixture.detectChanges();
       expect(paginationElement.firstElementChild.innerText).toBe('21-40 of 85 items');
+      testComponent.pageIndex = 5;
+      fixture.detectChanges();
+      expect(paginationElement.firstElementChild.innerText).toBe('81-85 of 85 items');
     });
   });
 


### PR DESCRIPTION
close #2036

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2036 


## What is the new behavior?

When the last page shows up, `range[1]` would be `nzTotal`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
