### PR TITLE
fix(module:avatar): fix avatar text resize when used in list

### DIFF
--- a/components/avatar/nz-avatar.component.ts
+++ b/components/avatar/nz-avatar.component.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   Input,
   OnChanges,
+  OnInit,
   SimpleChanges,
   ViewChild
 } from '@angular/core';
@@ -21,7 +22,7 @@ export type NzAvatarSize = 'small' | 'large' | 'default';
   preserveWhitespaces: false,
   changeDetection    : ChangeDetectionStrategy.OnPush
 })
-export class NzAvatarComponent implements OnChanges {
+export class NzAvatarComponent implements OnChanges, OnInit {
   private el: HTMLElement;
   private prefixCls = 'ant-avatar';
   private sizeMap = { large: 'lg', small: 'sm' };
@@ -90,6 +91,8 @@ export class NzAvatarComponent implements OnChanges {
 
   private notifyCalc(): this {
     // If use ngAfterViewChecked, always demands more computations, so......
+    // Should set a minimum time waiting for DOM to be rendered, otherwise string size would not change when avatar is
+    // used in list.
     setTimeout(() => {
       this.calcStringSize();
     });
@@ -106,5 +109,11 @@ export class NzAvatarComponent implements OnChanges {
     this.hasSrc = !!this.nzSrc;
 
     this.setClass().notifyCalc();
+  }
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.notifyCalc();
+    }, 16);
   }
 }


### PR DESCRIPTION
close #2005

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2005 


## What is the new behavior?

Avatar text would resize correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

When avatar is rendered in list, its DOM is not rendered before `calcStringSize` gets invoked. Need to write a test case for this?
