### PR TITLE
fix(module:cascader): search correctly when a root node is a leaf node

### DIFF
--- a/components/cascader/nz-cascader.component.ts
+++ b/components/cascader/nz-cascader.component.ts
@@ -1227,7 +1227,7 @@ export class NzCascaderComponent implements OnInit, OnDestroy, ControlValueAcces
         if (!sNode.isLeaf) {
           loopParent(sNode, disabled);
         }
-        if (sNode.isLeaf || !sNode.children) {
+        if (sNode.isLeaf || !sNode.children || !sNode.children.length) {
           loopChild(sNode, disabled);
         }
       });
@@ -1248,7 +1248,7 @@ export class NzCascaderComponent implements OnInit, OnDestroy, ControlValueAcces
       path.pop();
     };
 
-    this.oldColumnsHolder[ 0 ].forEach(node => loopParent(node));
+    this.oldColumnsHolder[ 0 ].forEach(node => (node.isLeaf || !node.children || !node.children.length) ? loopChild(node) : loopParent(node));
     if (sorter) {
       results.sort((a, b) => sorter(a.path, b.path, this._inputValue));
     }

--- a/components/cascader/nz-cascader.spec.ts
+++ b/components/cascader/nz-cascader.spec.ts
@@ -1441,6 +1441,30 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
     });
+    it('should support search a root node have no children ', (done) => {
+      fixture.detectChanges();
+      testComponent.nzShowSearch = true;
+      testComponent.nzOptions = options5;
+      fixture.detectChanges();
+      const spy = spyOn(testComponent.cascader, 'focus');
+      cascader.nativeElement.click();
+      fixture.detectChanges();
+      expect(spy).toHaveBeenCalled();
+      testComponent.cascader.inputValue = 'Roo';
+      testComponent.cascader.setMenuVisible(true);
+      fixture.detectChanges();
+      const itemEl1 = overlayContainerElement.querySelector('.ant-cascader-menu:nth-child(1) .ant-cascader-menu-item:nth-child(1)') as HTMLElement;
+      expect(testComponent.cascader.inSearch).toBe(true);
+      expect(itemEl1.innerText).toBe('Root');
+      itemEl1.click();
+      fixture.whenStable().then(() => {
+        expect(testComponent.cascader.inSearch).toBe(false);
+        expect(testComponent.cascader.menuVisible).toBe(false);
+        expect(testComponent.cascader.inputValue).toBe('');
+        expect(testComponent.values.join(',')).toBe('root');
+        done();
+      });
+    });
   });
 
   describe('load data lazily', () => {
@@ -1730,6 +1754,40 @@ const options4 = [ {
       isLeaf: true
     } ]
   } ]
+} ];
+
+const options5 = [ {
+  value   : 'zhejiang',
+  label   : 'Zhejiang',
+  children: [ {
+    value   : 'hangzhou',
+    label   : 'Hangzhou',
+    children: [ {
+      value : 'xihu',
+      label : 'West Lake',
+      isLeaf: true
+    } ]
+  }, {
+    value : 'ningbo',
+    label : 'Ningbo',
+    isLeaf: true
+  } ]
+}, {
+  value   : 'jiangsu',
+  label   : 'Jiangsu',
+  children: [ {
+    value   : 'nanjing',
+    label   : 'Nanjing',
+    children: [ {
+      value : 'zhonghuamen',
+      label : 'Zhong Hua Men',
+      isLeaf: true
+    } ]
+  } ]
+}, {
+  value   : 'root',
+  label   : 'Root',
+  isLeaf: true
 } ];
 @Component({
   selector: 'nz-demo-cascader-default',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2104 


## What is the new behavior?
If a root node is also a leaf node, it can also be searched and highlighted correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
