### PR TITLE
fix(module:tabs): hide next and prev buttons

### DIFF
--- a/components/tabs/nz-tabs-nav.component.ts
+++ b/components/tabs/nz-tabs-nav.component.ts
@@ -32,10 +32,7 @@ import { NzTabPositionMode } from './nz-tabset.component';
 @Component({
   selector           : '[nz-tabs-nav]',
   preserveWhitespaces: false,
-  templateUrl        : './nz-tabs-nav.component.html',
-  host               : {
-    '[class.ant-tabs-bar]': 'true'
-  }
+  templateUrl        : './nz-tabs-nav.component.html'
 })
 export class NzTabsNavComponent implements AfterContentChecked, AfterContentInit {
   private _animated = true;

--- a/components/tabs/nz-tabs.spec.ts
+++ b/components/tabs/nz-tabs.spec.ts
@@ -10,7 +10,7 @@ describe('tabs', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports     : [ NzTabsModule ],
-      declarations: [ NzTestTabsBasicComponent ]
+      declarations: [ NzTestTabsBasicComponent, NzTestTabsTabPositionLeftComponent ]
     });
     TestBed.compileComponents();
   }));
@@ -461,6 +461,15 @@ describe('tabs', () => {
       expect(tabs.nativeElement.scrollLeft).toBe(0);
     }));
   });
+
+  describe('init nzTabPosition to left', () => {
+    it('should next and prev buttons display abnormal', () => {
+      const fixture = TestBed.createComponent(NzTestTabsTabPositionLeftComponent);
+      fixture.detectChanges();
+      const tabs = fixture.debugElement.query(By.directive(NzTabSetComponent));
+      expect(tabs.nativeElement.querySelector('.ant-tabs-nav-container').classList).not.toContain('ant-tabs-nav-container-scrolling');
+    });
+  });
 });
 
 @Component({
@@ -540,4 +549,19 @@ export class NzTestTabsBasicComponent {
   select02 = jasmine.createSpy('select02 callback');
   deselect02 = jasmine.createSpy('deselect02 callback');
   array = [];
+}
+
+/** https://github.com/NG-ZORRO/ng-zorro-antd/issues/1964 **/
+@Component({
+  selector: 'nz-test-tabs-tab-position-left',
+  template: `
+    <nz-tabset nzTabPosition="left">
+      <nz-tab *ngFor="let tab of tabs" [nzTitle]="'Tab'+ tab">
+        Content of tab {{ tab }}
+      </nz-tab>
+    </nz-tabset>
+  `
+})
+export class NzTestTabsTabPositionLeftComponent {
+  tabs = [1, 2, 3];
 }

--- a/components/tabs/nz-tabset.component.html
+++ b/components/tabs/nz-tabset.component.html
@@ -1,4 +1,6 @@
-<div nz-tabs-nav
+<div 
+  class="ant-tabs-bar"
+  nz-tabs-nav
   role="tablist"
   tabindex="0"
   [nzType]="nzType"


### PR DESCRIPTION
close #1964

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The class `ant-tabs-bar` which defined in `[nz-tabs-nav]` host is rendered after `ngAfterContentInit` ( this conclusion is only according to my debugging, is there any angular mechanism to point this ? ).
https://github.com/NG-ZORRO/ng-zorro-antd/blob/2d123ebd613aa6900bc8c1552e0b1bd06ea2ee64/components/tabs/nz-tabs-nav.component.ts#L37

`showPaginationControls` will get wrong result because the tabs-nav is not vertical:

![84ef4b05161c246541289bc1ee0953b4](https://user-images.githubusercontent.com/23337087/46428217-fc222f80-c775-11e8-8704-608f35646b6c.jpg)

so define the class in `div` will fix this issue.


