### PR TITLE
fix(form): Template-driven Forms Validation typo

### DIFF
--- a/components/form/demo/validate-static.ts
+++ b/components/form/demo/validate-static.ts
@@ -20,8 +20,8 @@ import { Component } from '@angular/core';
       <nz-form-item>
         <nz-form-label [nzSpan]="5">Validating</nz-form-label>
         <nz-form-control [nzSpan]="12" nzValidateStatus="validating" nzHasFeedback>
-          <input nz-input [ngModel]="'The content is being validating'" name="validating">
-          <nz-form-explain>I'm the content is being validating</nz-form-explain>
+          <input nz-input [ngModel]="'The content is being validated'" name="validating">
+          <nz-form-explain>I'm validating the content</nz-form-explain>
         </nz-form-control>
       </nz-form-item>
       <nz-form-item>


### PR DESCRIPTION
Fix typo in Template-driven Forms Validation text

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The text in field "Validating" in the Template-driven Forms Validation demo says `The content is being validating` and the validation message says `I'm the content is being validating`


## What is the new behavior?
The text should say `The content is being validated` and `I'm validating the content`


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
