### PR TITLE
fix(module:popconfirm): fix icon disappear when nzTitle is a TemplateRef instance

### DIFF
--- a/components/popconfirm/nz-popconfirm.component.html
+++ b/components/popconfirm/nz-popconfirm.component.html
@@ -17,8 +17,8 @@
         <div>
           <div class="ant-popover-inner-content">
             <div class="ant-popover-message">
+              <i nz-icon type="exclamation-circle" theme="fill"></i>
               <ng-container *ngIf="isTitleString; else titleTemplate">
-                <i nz-icon type="exclamation-circle" theme="fill"></i>
                 <div class="ant-popover-message-title">{{ nzTitle }}</div>
               </ng-container>
               <ng-template #titleTemplate>


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Icon disappears when nzTitle is a TemplateRef instance.

Issue Number: N/A


## What is the new behavior?
Icon won't disappear when nzTitle is a TemplateRef instance.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
