### PR TITLE
fix(module:alert): padding for overlapping close button

### DIFF
--- a/components/alert/style/index.less
+++ b/components/alert/style/index.less
@@ -111,6 +111,11 @@
     font-size: @font-size-base;
   }
 
+  &-message {
+    display: block;
+    padding-right: 16px;
+  }
+
   &-with-description &-message {
     font-size: @font-size-lg;
     color: @alert-message-color;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[x] Code style update (formatting, local variables)
```

## What is the current behavior?

Issue Number: [#1668](https://github.com/NG-ZORRO/ng-zorro-antd/issues/1668)

## What is the new behavior?

Close button doesn't overlap alert's content anymore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```