### PR TITLE
chore: add lint-staged settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "less": "^3.9.0",
     "less-plugin-clean-css": "^1.5.1",
+    "lint-staged": "^8.1.0",
     "marked": "^0.5.1",
     "ng-packagr": "^4.0.0",
     "ngx-color": "^2.0.5",
@@ -103,7 +104,14 @@
   },
   "husky": {
     "hooks": {
+      "pre-commit": "lint-staged",
       "commit-msg": "node ./scripts/git/commit-msg.js -E HUSKY_GIT_PARAMS"
     }
+  },
+  "lint-staged": {
+    "*.ts": [
+      "tslint -c tslint.json --fix --",
+      "git add"
+    ]
   }
 }


### PR DESCRIPTION
Closes #2447

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[x] Other... Please describe:
Dev Infrastructure
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`npm run lint` only lints `components/**/*.ts`, however, there is other TypeScript files in the project left as un-linted.

Issue Number: N/A


## What is the new behavior?
Lint all TypeScript files (it respects `.tslintignore`) in `precommit` git hooks, it will try to fix the rules as much as possible for developers left other rule as-is.

If all rules are fixed (mostly stylistic issues), it will run `git add` and the commit is combined with author change and linter change.

If you are interested, I suggest you checkout this branch, revise some TypeScript files and see what lint-staged can do for you.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I will add more `lint-staged` settings later if approved.

On the verbose `package.json` diff: There is a re-ordering of items in `devDependencies` of package.json that makes diff overly verbose. It is introduced at https://github.com/NG-ZORRO/ng-zorro-antd/commit/3b8f9ea3688ed765a28457e08f9117c13c51fa66#diff-b9cfc7f2cdf78a7f4b91a753d10865a2 where maintainer modified the `package.json` without running `npm install` after that. This process *is* unprofessional and should be avoided in the future.