### PR TITLE
fix(module:input): fix auto-resize directive in dynamic component not work

### DIFF
--- a/components/input/nz-autoresize.directive.ts
+++ b/components/input/nz-autoresize.directive.ts
@@ -10,8 +10,8 @@ import {
   Self
 } from '@angular/core';
 import { NgControl } from '@angular/forms';
-import { fromEvent, Subject } from 'rxjs';
-import { auditTime, takeUntil } from 'rxjs/operators';
+import { fromEvent, merge, Subject } from 'rxjs';
+import { auditTime, take, takeUntil } from 'rxjs/operators';
 
 export interface AutoSizeType {
   minRows?: number;
@@ -175,7 +175,9 @@ export class NzAutoResizeDirective implements AfterViewInit, OnDestroy {
           .pipe(auditTime(16), takeUntil(this.destroy$))
           .subscribe(() => this.resizeToFitContent(true));
         });
-        this.ngControl.control.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => this.resizeToFitContent());
+        merge( this.ngControl.control.valueChanges.pipe(takeUntil(this.destroy$)),
+          this.ngZone.onStable.pipe(take(1)))
+          .subscribe(() => this.resizeToFitContent());
       } else {
         console.warn('nzAutosize must work with ngModel or ReactiveForm');
       }


### PR DESCRIPTION
Trigger the calculate function after ngZone on stable for dynamic component in modal or in any other situation
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2713


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
