### PR TITLE
feat(module:modal): support set `nzOkDisabled` and `nzCancelDisabled`

### DIFF
--- a/components/modal/doc/index.en-US.md
+++ b/components/modal/doc/index.en-US.md
@@ -43,6 +43,8 @@ The dialog is currently divided into 2 modes, `normal mode` and `confirm box mod
 | nzClosable        | Whether a close (x) button is visible on top right of the modal dialog or not. <i>Invalid value in confirm box mode (default will be hidden)</i> | `boolean` | `true` |
 | nzOkLoading       | Whether to apply loading visual effect for OK button or not | `boolean` | `false` |
 | nzCancelLoading   | Whether to apply loading visual effect for Cancel button or not | `boolean` | `false` |
+| nzOkDisabled      | Whether to disable Ok button or not | `boolean` | `false` |
+| nzCancelDisabled  | Whether to disable Cancel button or not | `boolean` | `false` |
 | nzFooter          | Footer content, set as footer=null when you don't need default buttons. <i>1. Only valid in normal mode.<br>2. You can customize the buttons to the maximum extent by passing a `ModalButtonOptions` configuration (see the case or the instructions below).</i> | string<br>TemplateRef<br>ModalButtonOptions | OK and Cancel buttons |
 | nzGetContainer    | The mount node for Modal | HTMLElement / () => HTMLElement| A default container |
 | nzKeyboard        | Whether support press esc to close | `boolean` | `true` |

--- a/components/modal/doc/index.zh-CN.md
+++ b/components/modal/doc/index.zh-CN.md
@@ -44,8 +44,8 @@ title: Modal
 | nzClosable        | 是否显示右上角的关闭按钮。<i>确认框模式下该值无效（默认会被隐藏）</i> | `boolean` | `true` |
 | nzOkLoading       | 确定按钮 loading | `boolean` | `false` |
 | nzCancelLoading   | 取消按钮 loading | `boolean` | `false` |
-| nzOkDisabled      | 确定按钮 是否可用  | `boolean` | `false` |
-| nzCancelDisabled  | 取消按钮 是否可用  | `boolean` | `false` |
+| nzOkDisabled      | 是否禁用确定按钮 | `boolean` | `false` |
+| nzCancelDisabled  | 是否禁用取消按钮 | `boolean` | `false` |
 | nzFooter          | 底部内容。<i>1. 仅在普通模式下有效。<br>2. 可通过传入 ModalButtonOptions 来最大程度自定义按钮（详见案例或下方说明）。<br>3. 当不需要底部时，可以设为 null</i> | string<br>TemplateRef<br>ModalButtonOptions | 默认的确定取消按钮 |
 | nzGetContainer    | 指定 Modal 挂载的 HTML 节点 | HTMLElement<br>() => HTMLElement| 默认容器 |
 | nzKeyboard        | 是否支持键盘esc关闭 | `boolean` | `true` |

--- a/components/modal/doc/index.zh-CN.md
+++ b/components/modal/doc/index.zh-CN.md
@@ -44,6 +44,8 @@ title: Modal
 | nzClosable        | 是否显示右上角的关闭按钮。<i>确认框模式下该值无效（默认会被隐藏）</i> | `boolean` | `true` |
 | nzOkLoading       | 确定按钮 loading | `boolean` | `false` |
 | nzCancelLoading   | 取消按钮 loading | `boolean` | `false` |
+| nzOkDisabled      | 确定按钮 是否可用  | `boolean` | `false` |
+| nzCancelDisabled  | 取消按钮 是否可用  | `boolean` | `false` |
 | nzFooter          | 底部内容。<i>1. 仅在普通模式下有效。<br>2. 可通过传入 ModalButtonOptions 来最大程度自定义按钮（详见案例或下方说明）。<br>3. 当不需要底部时，可以设为 null</i> | string<br>TemplateRef<br>ModalButtonOptions | 默认的确定取消按钮 |
 | nzGetContainer    | 指定 Modal 挂载的 HTML 节点 | HTMLElement<br>() => HTMLElement| 默认容器 |
 | nzKeyboard        | 是否支持键盘esc关闭 | `boolean` | `true` |

--- a/components/modal/nz-modal.component.html
+++ b/components/modal/nz-modal.component.html
@@ -76,10 +76,10 @@
         >{{ button.label }}</button>
       </ng-container>
       <ng-container *ngSwitchDefault>
-        <button *ngIf="nzCancelText!==null" nz-button (click)="onClickOkCancel('cancel')" [nzLoading]="nzCancelLoading">
+        <button *ngIf="nzCancelText!==null" nz-button (click)="onClickOkCancel('cancel')" [nzLoading]="nzCancelLoading" [disabled]="nzCancelDisabled">
           {{ cancelText }}
         </button>
-        <button *ngIf="nzOkText!==null" nz-button [nzType]="nzOkType" (click)="onClickOkCancel('ok')" [nzLoading]="nzOkLoading">
+        <button *ngIf="nzOkText!==null" nz-button [nzType]="nzOkType" (click)="onClickOkCancel('ok')" [nzLoading]="nzOkLoading" [disabled]="nzOkDisabled">
           {{ okText }}
         </button>
       </ng-container>

--- a/components/modal/nz-modal.component.ts
+++ b/components/modal/nz-modal.component.ts
@@ -103,7 +103,8 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R> impleme
   get cancelText(): string {
     return this.nzCancelText || this.locale.cancelText;
   }
-
+  @Input() nzOkDisabled: boolean = false;
+  @Input() nzCancelDisabled: boolean = false;
   @Input() @InputBoolean() nzCancelLoading: boolean = false;
   @Input() @Output() readonly nzOnCancel: EventEmitter<T> | OnClickCallback<T> = new EventEmitter<T>();
   @ViewChild('modalContainer') modalContainer: ElementRef;

--- a/components/modal/nz-modal.component.ts
+++ b/components/modal/nz-modal.component.ts
@@ -103,8 +103,8 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R> impleme
   get cancelText(): string {
     return this.nzCancelText || this.locale.cancelText;
   }
-  @Input() nzOkDisabled = false;
-  @Input() nzCancelDisabled = false;
+  @Input() @InputBoolean() nzOkDisabled: boolean = false;
+  @Input() @InputBoolean() nzCancelDisabled: boolean = false;
   @Input() @InputBoolean() nzCancelLoading: boolean = false;
   @Input() @Output() readonly nzOnCancel: EventEmitter<T> | OnClickCallback<T> = new EventEmitter<T>();
   @ViewChild('modalContainer') modalContainer: ElementRef;

--- a/components/modal/nz-modal.component.ts
+++ b/components/modal/nz-modal.component.ts
@@ -103,8 +103,8 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R> impleme
   get cancelText(): string {
     return this.nzCancelText || this.locale.cancelText;
   }
-  @Input() nzOkDisabled: boolean = false;
-  @Input() nzCancelDisabled: boolean = false;
+  @Input() nzOkDisabled = false;
+  @Input() nzCancelDisabled = false;
   @Input() @InputBoolean() nzCancelLoading: boolean = false;
   @Input() @Output() readonly nzOnCancel: EventEmitter<T> | OnClickCallback<T> = new EventEmitter<T>();
   @ViewChild('modalContainer') modalContainer: ElementRef;

--- a/components/modal/nz-modal.spec.ts
+++ b/components/modal/nz-modal.spec.ts
@@ -161,6 +161,8 @@ describe('modal testing (legacy)', () => {
       expect(isButtonLoading(getButtonCancel(modalElement))).not.toBeFalsy();
       expect(modalElement.querySelector('.ant-modal-close')).toBeFalsy();
       expect(modalElement.querySelector('.ant-modal-mask')).toBeFalsy();
+      expect(getButtonOk(modalElement).disabled).toBeTruthy();
+      expect(getButtonCancel(modalElement).disabled).toBeTruthy();
 
       // click ok button
       getButtonOk(modalElement).click();
@@ -690,6 +692,8 @@ class TestBasicServiceComponent {
       nzOkText: 'custom ok',
       nzOkType: 'success',
       nzOkLoading: false,
+      nzOkDisabled: true,
+      nzCancelDisabled: true,
       nzOnOk: () => { console.log('click ok'); return false; },
       nzCancelText: 'custom cancel',
       nzCancelLoading: true,

--- a/components/modal/nz-modal.spec.ts
+++ b/components/modal/nz-modal.spec.ts
@@ -161,8 +161,8 @@ describe('modal testing (legacy)', () => {
       expect(isButtonLoading(getButtonCancel(modalElement))).not.toBeFalsy();
       expect(modalElement.querySelector('.ant-modal-close')).toBeFalsy();
       expect(modalElement.querySelector('.ant-modal-mask')).toBeFalsy();
-      expect(getButtonOk(modalElement).disabled).toBeTruthy();
-      expect(getButtonCancel(modalElement).disabled).toBeTruthy();
+      expect(getButtonOk(modalElement).disabled).toBeFalsy();
+      expect(getButtonCancel(modalElement).disabled).toBeFalsy();
 
       // click ok button
       getButtonOk(modalElement).click();
@@ -692,8 +692,8 @@ class TestBasicServiceComponent {
       nzOkText: 'custom ok',
       nzOkType: 'success',
       nzOkLoading: false,
-      nzOkDisabled: true,
-      nzCancelDisabled: true,
+      nzOkDisabled: false,
+      nzCancelDisabled: false,
       nzOnOk: () => { console.log('click ok'); return false; },
       nzCancelText: 'custom cancel',
       nzCancelLoading: true,

--- a/components/modal/nz-modal.type.ts
+++ b/components/modal/nz-modal.type.ts
@@ -35,6 +35,8 @@ export interface ModalOptions<T = any, R = any> { // tslint:disable-line:no-any
   nzOkText?: string;
   nzOkType?: string;
   nzOkLoading?: boolean;
+  nzOkDisabled?: boolean;
+  nzCancelDisabled?: boolean;
   nzOnOk?: EventEmitter<T> | OnClickCallback<T>; // Mixed using ng's Input/Output (Should care of "this" when using OnClickCallback)
   nzCancelText?: string;
   nzCancelLoading?: boolean;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Modal doesn't support set `nzOkDisabled` and `nzCancelDisabled`

Issue Number: #1838


## What is the new behavior?
Modal support set `nzOkDisabled` and `nzCancelDisabled`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
