### PR TITLE
revert(module:collapse): remove extra field

### DIFF
--- a/components/collapse/demo/custom.ts
+++ b/components/collapse/demo/custom.ts
@@ -5,16 +5,13 @@ import { Component } from '@angular/core';
   template: `
     <nz-collapse [nzBordered]="false">
       <nz-collapse-panel #p *ngFor="let panel of panels; let isFirst = first" [nzHeader]="panel.name" [nzActive]="panel.active"
-        [ngStyle]="panel.customStyle" [nzExpandedIcon]="!isFirst && (panel.icon || expandedIcon)" [nzExtra]="isFirst && extraTpl">
+        [ngStyle]="panel.customStyle" [nzExpandedIcon]="!isFirst && (panel.icon || expandedIcon)">
         <p>{{panel.name}} content</p>
         <ng-template #expandedIcon let-active>
           {{ active }}
           <i nz-icon type="caret-right" class="ant-collapse-arrow" [nzRotate]="p.nzActive ? 90 : -90"></i>
         </ng-template>
       </nz-collapse-panel>
-      <ng-template #extraTpl>
-        <i nz-icon [nzType]="'smile'"></i>
-      </ng-template>
     </nz-collapse>
   `,
   styles  : []

--- a/components/collapse/doc/index.en-US.md
+++ b/components/collapse/doc/index.en-US.md
@@ -31,4 +31,3 @@ A content area which can be collapsed and expanded.
 | `[nzActive]` | Active status of panel, double binding | `boolean` | - |
 | `(nzActiveChange)` | Callback function of the active status | `EventEmitter<boolean>` | - |
 | `[nzExpandedIcon]` | Customize an icon for toggle | `string｜TemplateRef<void>` | - |
-| `[nzExtra]` | Extra element in the corner | `string｜TemplateRef<void>` | - |

--- a/components/collapse/doc/index.zh-CN.md
+++ b/components/collapse/doc/index.zh-CN.md
@@ -32,4 +32,3 @@ cols: 1
 | `[nzActive]` | 面板是否展开，可双向绑定 | `boolean` | - |
 | `(nzActiveChange)` | 面板展开回调 | `EventEmitter<boolean>` | - |
 | `[nzExpandedIcon]` | 自定义切换图标 | `string｜TemplateRef<void>` | - |
-| `[nzExtra]` | 自定义渲染每个面板右上角的内容 | `string｜TemplateRef<void>` | - |

--- a/components/collapse/nz-collapse-panel.component.html
+++ b/components/collapse/nz-collapse-panel.component.html
@@ -5,9 +5,9 @@
     </ng-container>
   </ng-container>
   <ng-container *nzStringTemplateOutlet="nzHeader">{{ nzHeader }}</ng-container>
-  <div *ngIf="nzExtra" class="ant-collapse-extra">
+  <!-- <div *ngIf="nzExtra" class="ant-collapse-extra">
     <ng-container *nzStringTemplateOutlet="nzExtra">{{ nzExtra }}</ng-container>
-  </div>
+  </div> -->
 </div>
 <div class="ant-collapse-content"
   [class.ant-collapse-content-active]="nzActive"

--- a/components/collapse/nz-collapse-panel.component.html
+++ b/components/collapse/nz-collapse-panel.component.html
@@ -5,9 +5,6 @@
     </ng-container>
   </ng-container>
   <ng-container *nzStringTemplateOutlet="nzHeader">{{ nzHeader }}</ng-container>
-  <!-- <div *ngIf="nzExtra" class="ant-collapse-extra">
-    <ng-container *nzStringTemplateOutlet="nzExtra">{{ nzExtra }}</ng-container>
-  </div> -->
 </div>
 <div class="ant-collapse-content"
   [class.ant-collapse-content-active]="nzActive"

--- a/components/collapse/nz-collapse-panel.component.ts
+++ b/components/collapse/nz-collapse-panel.component.ts
@@ -36,7 +36,6 @@ export class NzCollapsePanelComponent implements OnInit, OnDestroy {
   @Input() @InputBoolean() nzShowArrow = true;
   @Input() nzHeader: string | TemplateRef<void>;
   @Input() nzExpandedIcon: string | TemplateRef<void>;
-  // @Input() nzExtra: string | TemplateRef<void>;
   @Output() readonly nzActiveChange = new EventEmitter<boolean>();
 
   clickHeader(): void {

--- a/components/collapse/nz-collapse-panel.component.ts
+++ b/components/collapse/nz-collapse-panel.component.ts
@@ -36,7 +36,7 @@ export class NzCollapsePanelComponent implements OnInit, OnDestroy {
   @Input() @InputBoolean() nzShowArrow = true;
   @Input() nzHeader: string | TemplateRef<void>;
   @Input() nzExpandedIcon: string | TemplateRef<void>;
-  @Input() nzExtra: string | TemplateRef<void>;
+  // @Input() nzExtra: string | TemplateRef<void>;
   @Output() readonly nzActiveChange = new EventEmitter<boolean>();
 
   clickHeader(): void {

--- a/components/collapse/nz-collapse.spec.ts
+++ b/components/collapse/nz-collapse.spec.ts
@@ -39,14 +39,6 @@ describe('collapse', () => {
       fixture.detectChanges();
       expect(collapse.nativeElement.firstElementChild.classList).toContain('ant-collapse-borderless');
     });
-    // it('should extra work', () => {
-    //   expect(collapse.nativeElement.querySelector('.ant-collapse-extra')).toBeNull();
-    //   testComponent.showExtra = 'extra';
-    //   fixture.detectChanges();
-    //   const extra = collapse.nativeElement.querySelector('.ant-collapse-extra');
-    //   expect(extra).toBeDefined();
-    //   expect(extra.innerText).toBe('extra');
-    // });
     it('should showArrow work', () => {
       fixture.detectChanges();
       expect(panels[ 0 ].nativeElement.querySelector('.ant-collapse-arrow').firstElementChild).toBeDefined();

--- a/components/collapse/nz-collapse.spec.ts
+++ b/components/collapse/nz-collapse.spec.ts
@@ -39,14 +39,14 @@ describe('collapse', () => {
       fixture.detectChanges();
       expect(collapse.nativeElement.firstElementChild.classList).toContain('ant-collapse-borderless');
     });
-    it('should extra work', () => {
-      expect(collapse.nativeElement.querySelector('.ant-collapse-extra')).toBeNull();
-      testComponent.showExtra = 'extra';
-      fixture.detectChanges();
-      const extra = collapse.nativeElement.querySelector('.ant-collapse-extra');
-      expect(extra).toBeDefined();
-      expect(extra.innerText).toBe('extra');
-    });
+    // it('should extra work', () => {
+    //   expect(collapse.nativeElement.querySelector('.ant-collapse-extra')).toBeNull();
+    //   testComponent.showExtra = 'extra';
+    //   fixture.detectChanges();
+    //   const extra = collapse.nativeElement.querySelector('.ant-collapse-extra');
+    //   expect(extra).toBeDefined();
+    //   expect(extra.innerText).toBe('extra');
+    // });
     it('should showArrow work', () => {
       fixture.detectChanges();
       expect(panels[ 0 ].nativeElement.querySelector('.ant-collapse-arrow').firstElementChild).toBeDefined();
@@ -172,7 +172,7 @@ describe('collapse', () => {
   template: `
     <ng-template #headerTemplate>template</ng-template>
     <nz-collapse [nzAccordion]="accordion" [nzBordered]="bordered">
-      <nz-collapse-panel [(nzActive)]="active01" (nzActiveChange)="active01Change($event)" [nzHeader]="header" [nzShowArrow]="showArrow" [nzExtra]="showExtra">
+      <nz-collapse-panel [(nzActive)]="active01" (nzActiveChange)="active01Change($event)" [nzHeader]="header" [nzShowArrow]="showArrow">
         <p>Panel01</p>
       </nz-collapse-panel>
       <nz-collapse-panel [(nzActive)]="active02" (nzActiveChange)="active02Change($event)" [nzDisabled]="disabled">
@@ -189,7 +189,7 @@ export class NzTestCollapseBasicComponent {
   active01 = false;
   active02 = false;
   showArrow = true;
-  showExtra = '';
+  // showExtra = '';
   header = 'string';
   active01Change = jasmine.createSpy('active01 callback');
   active02Change = jasmine.createSpy('active02 callback');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[x] Other... Please describe: revert support of `nzExtra` of `nz-collapse-header` since it's not officially merged to master branch of ant design.
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No, since it never got released
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
