### PR TITLE
fix(module:table): fix table filter not change after click the checkbox

### DIFF
--- a/components/table/nz-th.component.html
+++ b/components/table/nz-th.component.html
@@ -1,10 +1,10 @@
 <ng-template #checkboxTemplate>
   <label nz-checkbox
-    [class.ant-table-selection-select-all-custom]="nzShowRowSelection"
-    [(ngModel)]="nzChecked"
-    [nzDisabled]="nzDisabled"
-    [nzIndeterminate]="nzIndeterminate"
-    (ngModelChange)="nzCheckedChange.emit($event)">
+         [class.ant-table-selection-select-all-custom]="nzShowRowSelection"
+         [(ngModel)]="nzChecked"
+         [nzDisabled]="nzDisabled"
+         [nzIndeterminate]="nzIndeterminate"
+         (ngModelChange)="nzCheckedChange.emit($event)">
   </label>
 </ng-template>
 <div [class.ant-table-column-sorters]="nzShowSort" (click)="updateSortValue()">
@@ -27,23 +27,26 @@
   <ng-content></ng-content>
   <div class="ant-table-column-sorter" *ngIf="nzShowSort">
     <i nz-icon
-      type="caret-up"
-      class="ant-table-column-sorter-up"
-      [class.on]="nzSort == 'ascend'"
-      [class.off]="nzSort != 'ascend'"></i>
+       type="caret-up"
+       class="ant-table-column-sorter-up"
+       [class.on]="nzSort == 'ascend'"
+       [class.off]="nzSort != 'ascend'"></i>
     <i nz-icon
-      type="caret-down"
-      class="ant-table-column-sorter-down"
-      [class.on]="nzSort == 'descend'"
-      [class.off]="nzSort != 'descend'"></i>
+       type="caret-down"
+       class="ant-table-column-sorter-down"
+       [class.on]="nzSort == 'descend'"
+       [class.off]="nzSort != 'descend'"></i>
   </div>
 </div>
-<nz-dropdown nzTrigger="click" *ngIf="nzShowFilter" [nzClickHide]="false" nzTableFilter (nzVisibleChange)="dropDownVisibleChange($event)">
-  <i nz-icon type="filter" theme="fill" [class.ant-table-filter-selected]="hasFilterValue" [class.ant-table-filter-open]="filterVisible" nz-dropdown></i>
+<nz-dropdown nzTrigger="click" *ngIf="nzShowFilter" [nzClickHide]="false" nzTableFilter
+             (nzVisibleChange)="dropDownVisibleChange($event)">
+  <i nz-icon type="filter" theme="fill" [class.ant-table-filter-selected]="hasFilterValue"
+     [class.ant-table-filter-open]="filterVisible" nz-dropdown></i>
   <ul nz-menu>
     <ng-container *ngIf="nzFilterMultiple">
       <li nz-menu-item *ngFor="let filter of multipleFilterList" (click)="checkMultiple(filter)">
-        <label nz-checkbox [ngModel]="filter.checked"></label><span>{{filter.text}}</span>
+        <label nz-checkbox (nzCheckedChange)="checkMultiple(filter)"
+               [ngModel]="filter.checked"></label><span>{{filter.text}}</span>
       </li>
     </ng-container>
     <ng-container *ngIf="!nzFilterMultiple">

--- a/components/table/nz-th.component.html
+++ b/components/table/nz-th.component.html
@@ -1,10 +1,10 @@
 <ng-template #checkboxTemplate>
   <label nz-checkbox
-         [class.ant-table-selection-select-all-custom]="nzShowRowSelection"
-         [(ngModel)]="nzChecked"
-         [nzDisabled]="nzDisabled"
-         [nzIndeterminate]="nzIndeterminate"
-         (ngModelChange)="nzCheckedChange.emit($event)">
+    [class.ant-table-selection-select-all-custom]="nzShowRowSelection"
+    [(ngModel)]="nzChecked"
+    [nzDisabled]="nzDisabled"
+    [nzIndeterminate]="nzIndeterminate"
+    (ngModelChange)="nzCheckedChange.emit($event)">
   </label>
 </ng-template>
 <div [class.ant-table-column-sorters]="nzShowSort" (click)="updateSortValue()">
@@ -27,26 +27,23 @@
   <ng-content></ng-content>
   <div class="ant-table-column-sorter" *ngIf="nzShowSort">
     <i nz-icon
-       type="caret-up"
-       class="ant-table-column-sorter-up"
-       [class.on]="nzSort == 'ascend'"
-       [class.off]="nzSort != 'ascend'"></i>
+      type="caret-up"
+      class="ant-table-column-sorter-up"
+      [class.on]="nzSort == 'ascend'"
+      [class.off]="nzSort != 'ascend'"></i>
     <i nz-icon
-       type="caret-down"
-       class="ant-table-column-sorter-down"
-       [class.on]="nzSort == 'descend'"
-       [class.off]="nzSort != 'descend'"></i>
+      type="caret-down"
+      class="ant-table-column-sorter-down"
+      [class.on]="nzSort == 'descend'"
+      [class.off]="nzSort != 'descend'"></i>
   </div>
 </div>
-<nz-dropdown nzTrigger="click" *ngIf="nzShowFilter" [nzClickHide]="false" nzTableFilter
-             (nzVisibleChange)="dropDownVisibleChange($event)">
-  <i nz-icon type="filter" theme="fill" [class.ant-table-filter-selected]="hasFilterValue"
-     [class.ant-table-filter-open]="filterVisible" nz-dropdown></i>
+<nz-dropdown nzTrigger="click" *ngIf="nzShowFilter" [nzClickHide]="false" nzTableFilter (nzVisibleChange)="dropDownVisibleChange($event)">
+  <i nz-icon type="filter" theme="fill" [class.ant-table-filter-selected]="hasFilterValue" [class.ant-table-filter-open]="filterVisible" nz-dropdown></i>
   <ul nz-menu>
     <ng-container *ngIf="nzFilterMultiple">
       <li nz-menu-item *ngFor="let filter of multipleFilterList" (click)="checkMultiple(filter)">
-        <label nz-checkbox (nzCheckedChange)="checkMultiple(filter)"
-               [ngModel]="filter.checked"></label><span>{{filter.text}}</span>
+        <label nz-checkbox (nzCheckedChange)="checkMultiple(filter)" [ngModel]="filter.checked"></label><span>{{filter.text}}</span>
       </li>
     </ng-container>
     <ng-container *ngIf="!nzFilterMultiple">

--- a/components/table/nz-th.spec.ts
+++ b/components/table/nz-th.spec.ts
@@ -9,8 +9,8 @@ import { NzThComponent } from './nz-th.component';
 describe('nz-th', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports     : [ NzTableModule, NzIconTestModule ],
-      declarations: [ NzThTestNzTableComponent, NzThTestTableDefaultFilterComponent ]
+      imports: [NzTableModule, NzIconTestModule],
+      declarations: [NzThTestNzTableComponent, NzThTestTableDefaultFilterComponent]
     });
     TestBed.compileComponents();
   }));
@@ -175,22 +175,22 @@ describe('nz-th', () => {
       testComponent.nzThComponent.dropDownVisibleChange(true);
       fixture.detectChanges();
       expect(testComponent.filterChange).toHaveBeenCalledTimes(0);
-      testComponent.nzThComponent.checkMultiple(testComponent.nzThComponent.multipleFilterList[ 0 ]);
+      testComponent.nzThComponent.checkMultiple(testComponent.nzThComponent.multipleFilterList[0]);
       testComponent.nzThComponent.dropDownVisibleChange(false);
       fixture.detectChanges();
       expect(testComponent.nzThComponent.hasFilterValue).toBe(true);
-      expect(testComponent.filterChange).toHaveBeenCalledWith([ '1' ]);
+      expect(testComponent.filterChange).toHaveBeenCalledWith(['1']);
     });
     it('should hasFilter change after filters change with multiple', () => {
       testComponent.showFilter = true;
       fixture.detectChanges();
-      testComponent.nzThComponent.checkMultiple(testComponent.nzThComponent.multipleFilterList[ 0 ]);
+      testComponent.nzThComponent.checkMultiple(testComponent.nzThComponent.multipleFilterList[0]);
       testComponent.nzThComponent.search();
       fixture.detectChanges();
       expect(testComponent.nzThComponent.hasFilterValue).toBe(true);
       testComponent.filters = [
-        { text: 'filter1', value: '4' },
-        { text: 'filter2', value: '3' }
+        {text: 'filter1', value: '4'},
+        {text: 'filter2', value: '3'}
       ];
       fixture.detectChanges();
       expect(testComponent.nzThComponent.hasFilterValue).toBe(false);
@@ -199,13 +199,13 @@ describe('nz-th', () => {
       testComponent.showFilter = true;
       testComponent.filterMultiple = false;
       fixture.detectChanges();
-      testComponent.nzThComponent.checkSingle(testComponent.nzThComponent.singleFilterList[ 0 ]);
+      testComponent.nzThComponent.checkSingle(testComponent.nzThComponent.singleFilterList[0]);
       testComponent.nzThComponent.search();
       fixture.detectChanges();
       expect(testComponent.nzThComponent.hasFilterValue).toBe(true);
       testComponent.filters = [
-        { text: 'filter1', value: '5' },
-        { text: 'filter2', value: '3' }
+        {text: 'filter1', value: '5'},
+        {text: 'filter2', value: '3'}
       ];
       fixture.detectChanges();
       expect(testComponent.nzThComponent.hasFilterValue).toBe(false);
@@ -228,7 +228,7 @@ describe('nz-th', () => {
       testComponent.nzThComponent.dropDownVisibleChange(true);
       fixture.detectChanges();
       expect(testComponent.filterChange).toHaveBeenCalledTimes(0);
-      testComponent.nzThComponent.checkSingle(testComponent.nzThComponent.singleFilterList[ 0 ]);
+      testComponent.nzThComponent.checkSingle(testComponent.nzThComponent.singleFilterList[0]);
       testComponent.nzThComponent.dropDownVisibleChange(false);
       fixture.detectChanges();
       expect(testComponent.filterChange).toHaveBeenCalledWith('1');
@@ -244,9 +244,20 @@ describe('nz-th', () => {
     it('should be throw error when use specific class name', () => {
       expect(() => {
         TestBed.configureTestingModule({
-          declarations: [ NzTestDisableThComponent ]
+          declarations: [NzTestDisableThComponent]
         }).createComponent(NzTestDisableThComponent);
       }).toThrow();
+    });
+    it('should filterChange be called after check the checkbox', () => {
+      testComponent.showFilter = true;
+      fixture.detectChanges();
+      testComponent.nzThComponent.dropDownVisibleChange(true);
+      fixture.detectChanges();
+      expect(testComponent.filterChange).toHaveBeenCalledTimes(0);
+      testComponent.nzThComponent.multipleFilterList[0].checked = !testComponent.nzThComponent.multipleFilterList[0].checked;
+      testComponent.nzThComponent.dropDownVisibleChange(false);
+      fixture.detectChanges();
+      expect(testComponent.filterChange).toHaveBeenCalled();
     });
   });
   describe('nz-th with default filter in nz-table', () => {
@@ -307,13 +318,13 @@ export class NzThTestNzTableComponent {
   showRowSelection = false;
   selections = [
     {
-      text    : 'select one',
+      text: 'select one',
       onSelect: jasmine.createSpy('select change')
     }
   ];
   filters = [
-    { text: 'filter1', value: '1' },
-    { text: 'filter2', value: '2' }
+    {text: 'filter1', value: '1'},
+    {text: 'filter2', value: '2'}
   ];
   filterChange = jasmine.createSpy('filter change');
   showFilter = false;
@@ -326,53 +337,57 @@ export class NzThTestNzTableComponent {
   template: `
     <nz-table #filterTable [nzData]="displayData">
       <thead (nzSortChange)="sort($event)" nzSingleSort>
-        <tr>
-          <th nzShowSort nzSortKey="name" nzShowFilter [nzFilters]="nameList" (nzFilterChange)="filter($event,searchAddress)">Name</th>
-          <th nzShowSort nzSortKey="age">Age</th>
-          <th nzShowSort nzSortKey="address" nzShowFilter [nzFilterMultiple]="false" [nzFilters]="addressList" (nzFilterChange)="filter(listOfSearchName,$event)">Address</th>
-        </tr>
+      <tr>
+        <th nzShowSort nzSortKey="name" nzShowFilter [nzFilters]="nameList"
+            (nzFilterChange)="filter($event,searchAddress)">Name
+        </th>
+        <th nzShowSort nzSortKey="age">Age</th>
+        <th nzShowSort nzSortKey="address" nzShowFilter [nzFilterMultiple]="false" [nzFilters]="addressList"
+            (nzFilterChange)="filter(listOfSearchName,$event)">Address
+        </th>
+      </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let data of filterTable.data">
-          <td>{{data.name}}</td>
-          <td>{{data.age}}</td>
-          <td>{{data.address}}</td>
-        </tr>
+      <tr *ngFor="let data of filterTable.data">
+        <td>{{data.name}}</td>
+        <td>{{data.age}}</td>
+        <td>{{data.address}}</td>
+      </tr>
       </tbody>
     </nz-table>`
 })
 export class NzThTestTableDefaultFilterComponent {
   nameList = [
-    { text: 'Joe', value: 'Joe', byDefault: true },
-    { text: 'Jim', value: 'Jim' }
+    {text: 'Joe', value: 'Joe', byDefault: true},
+    {text: 'Jim', value: 'Jim'}
   ];
   addressList = [
-    { text: 'London', value: 'London', byDefault: true },
-    { text: 'Sidney', value: 'Sidney' }
+    {text: 'London', value: 'London', byDefault: true},
+    {text: 'Sidney', value: 'Sidney'}
   ];
   sortName = null;
   sortValue = null;
-  listOfSearchName = [ 'Joe', 'London' ];
+  listOfSearchName = ['Joe', 'London'];
   searchAddress: string;
   data = [
     {
-      name   : 'John Brown',
-      age    : 32,
+      name: 'John Brown',
+      age: 32,
       address: 'New York No. 1 Lake Park'
     },
     {
-      name   : 'Jim Green',
-      age    : 42,
+      name: 'Jim Green',
+      age: 42,
       address: 'London No. 1 Lake Park'
     },
     {
-      name   : 'Joe Black',
-      age    : 32,
+      name: 'Joe Black',
+      age: 32,
       address: 'Sidney No. 1 Lake Park'
     },
     {
-      name   : 'Jim Red',
-      age    : 32,
+      name: 'Jim Red',
+      age: 32,
       address: 'London No. 2 Lake Park'
     }
   ];
@@ -398,7 +413,7 @@ export class NzThTestTableDefaultFilterComponent {
     const data = this.data.filter(item => filterFunc(item));
     /** sort data **/
     if (this.sortName && this.sortValue) {
-      this.displayData = data.sort((a, b) => (this.sortValue === 'ascend') ? (a[ this.sortName ] > b[ this.sortName ] ? 1 : -1) : (b[ this.sortName ] > a[ this.sortName ] ? 1 : -1));
+      this.displayData = data.sort((a, b) => (this.sortValue === 'ascend') ? (a[this.sortName] > b[this.sortName] ? 1 : -1) : (b[this.sortName] > a[this.sortName] ? 1 : -1));
     } else {
       this.displayData = data;
     }


### PR DESCRIPTION
…ox issue#3056

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3056 


## What is the new behavior?
fixed the bug of issue #3056 , now table filter works fine after click the checkbox. the only change is to add < (nzCheckedChange)="checkMultiple(filter)" > to the nz-checkbox of the filter dropdown. Because I 
have followed the code and I found the nz-checkbox.nzCheckedChange method doesn't be called after user click the checkbox. In the current code, the checkMultiple(filter) method be called only when click the li item, so I add the nzCheckedChange to nz-checkbox.

在nz-th.component.html的46-50行，li上有(click)="checkMultiple(filter)，但里面的label(nz-checkbox)在nzCheckedChange时不会触发checkMultiple(filter)方法。所以用户点击checkbox不会触发filter变化，只有点击整个li时才会触发变化

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
