### PR TITLE
docs: add browser language detection

### DIFF
--- a/scripts/site/_site/doc/app/app.component.ts
+++ b/scripts/site/_site/doc/app/app.component.ts
@@ -14,6 +14,7 @@ import { fromEvent } from 'rxjs';
 import { debounceTime, map, startWith } from 'rxjs/operators';
 import { environment } from '../environments/environment';
 import { ROUTER_LIST } from './router';
+import { path } from '@angular-devkit/core';
 
 declare const docsearch: any;
 
@@ -242,8 +243,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   private detectLanguage(): void {
     const language = navigator.language.toLowerCase();
     const pathname = location.pathname;
-    const hasLanguage = pathname.indexOf('en') > -1 || pathname.indexOf('cn') > -1;
-
+    const hasLanguage = pathname.match(/en$/) || pathname.match(/zh$/);
     if (language === 'zh-cn' && !hasLanguage) {
       this.nzI18nService.setLocale(zh_CN);
       this.router.navigate([ 'docs', 'introduce', 'zh' ]);

--- a/scripts/site/_site/doc/app/app.component.ts
+++ b/scripts/site/_site/doc/app/app.component.ts
@@ -132,14 +132,10 @@ export class AppComponent implements OnInit, AfterViewInit {
           }
         }, 200);
       }
-
-      if (navigator.language === 'zh-CN') {
-        this.nzI18nService.setLocale(this.language === 'en' ? en_US : zh_CN);
-        this.router.navigate([ 'docs', 'introduce', 'zh' ]);
-      }
     });
 
     this.initColor();
+    this.detectLanguage();
   }
 
   ngAfterViewInit(): void {
@@ -241,5 +237,16 @@ export class AppComponent implements OnInit, AfterViewInit {
         }
       });
     });
+  }
+
+  private detectLanguage(): void {
+    const language = navigator.language.toLowerCase();
+    const pathname = location.pathname;
+    const hasLanguage = pathname.indexOf('en') > -1 || pathname.indexOf('cn') > -1;
+
+    if (language === 'zh-cn' && !hasLanguage) {
+      this.nzI18nService.setLocale(zh_CN);
+      this.router.navigate([ 'docs', 'introduce', 'zh' ]);
+    }
   }
 }

--- a/scripts/site/_site/doc/app/app.component.ts
+++ b/scripts/site/_site/doc/app/app.component.ts
@@ -14,7 +14,6 @@ import { fromEvent } from 'rxjs';
 import { debounceTime, map, startWith } from 'rxjs/operators';
 import { environment } from '../environments/environment';
 import { ROUTER_LIST } from './router';
-import { path } from '@angular-devkit/core';
 
 declare const docsearch: any;
 

--- a/scripts/site/_site/doc/app/app.component.ts
+++ b/scripts/site/_site/doc/app/app.component.ts
@@ -95,20 +95,26 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.routerList.components.forEach(group => {
       this.componentList = this.componentList.concat([ ...group.children ]);
     });
+
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
         const currentDemoComponent = this.componentList.find(component => `/${component.path}` === this.router.url);
+
         if (currentDemoComponent) {
           this.title.setTitle(`${currentDemoComponent.zh} ${currentDemoComponent.label} - NG-ZORRO`);
         }
+
         const currentIntroComponent = this.routerList.intro.find(component => `/${component.path}` === this.router.url);
         if (currentIntroComponent) {
           this.title.setTitle(`${currentIntroComponent.label} - NG-ZORRO`);
         }
+
         if (this.router.url !== '/' + this.searchComponent) {
           this.searchComponent = null;
         }
+
         this.language = this.router.url.split('/')[ this.router.url.split('/').length - 1 ].split('#')[ 0 ];
+
         this.nzI18nService.setLocale(this.language === 'en' ? en_US : zh_CN);
 
         if (this.docsearch) {
@@ -118,6 +124,7 @@ export class AppComponent implements OnInit, AfterViewInit {
         if (environment.production) {
           window.scrollTo(0, 0);
         }
+
         setTimeout(() => {
           const toc = this.router.parseUrl(this.router.url).fragment || '';
           if (toc) {
@@ -125,7 +132,13 @@ export class AppComponent implements OnInit, AfterViewInit {
           }
         }, 200);
       }
+
+      if (navigator.language === 'zh-CN') {
+        this.nzI18nService.setLocale(this.language === 'en' ? en_US : zh_CN);
+        this.router.navigate([ 'docs', 'introduce', 'zh' ]);
+      }
     });
+
     this.initColor();
   }
 

--- a/scripts/site/_site/doc/app/app.routing.module.ts
+++ b/scripts/site/_site/doc/app/app.routing.module.ts
@@ -1,9 +1,10 @@
 import { Routes } from '@angular/router';
+
 import { DEMO_ROUTES } from './router';
 import { DEMOComponent } from './_demo/demo.component';
 
 export const routes: Routes = [
-  { path: '', pathMatch: 'full', redirectTo: '/docs/introduce/zh' },
+  { path: '', pathMatch: 'full', redirectTo: '/docs/introduce/en' },
   ...DEMO_ROUTES,
   { 'path': 'docs', 'loadChildren': './docs/index.module#NzDocsModule' },
   { path: 'demo', component: DEMOComponent },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Now the docs site would be in English. Add when the doc site boots up and language is not specified in URL, it would detect visitor's language and redirect to Chinese doc if needed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
