### PR TITLE
fix(module:affix): set correct style of Affix after trigger resize

### DIFF
--- a/components/affix/nz-affix.component.ts
+++ b/components/affix/nz-affix.component.ts
@@ -199,12 +199,13 @@ export class NzAffixComponent implements OnInit, OnDestroy {
       return ;
     }
     this.placeholderNode.style.cssText = '';
-    const widthObj = { width: this.placeholderNode.offsetWidth };
+    this.placeholderStyle = undefined;
+    const styleObj = { width: this.placeholderNode.offsetWidth, height: this.fixedEl.nativeElement.offsetHeight };
     this.setAffixStyle(e, {
       ...this.affixStyle,
-      ...widthObj
+      ...styleObj
     });
-    this.setPlaceholderStyle(widthObj);
+    this.setPlaceholderStyle(styleObj);
   }
 
   @throttleByAnimationFrameDecorator()


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3040


## What is the new behavior?
After triggering the resize event, the Affix element will not lose height and behave normally.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
