### PR TITLE
fix(module:date-picker): make keyboard navigation possible

### DIFF
--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -9,7 +9,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import isSameDay from 'date-fns/is_same_day';
 
-import { dispatchKeyboardEvent, dispatchMouseEvent, NgStyleInterface } from 'ng-zorro-antd/core';
+import { dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent, NgStyleInterface } from 'ng-zorro-antd/core';
 import en_US from '../i18n/languages/en_US';
 
 import { NzI18nModule, NzI18nService } from 'ng-zorro-antd/i18n';
@@ -109,6 +109,24 @@ describe('NzDatePickerComponent', () => {
       tick(500);
       fixture.detectChanges();
       expect(getPickerContainer()).not.toBeNull();
+    }));
+
+    it('should be tabbable back to trigger wrapper', fakeAsync(() => {
+      fixture.detectChanges();
+      dispatchMouseEvent(getPickerTriggerWrapper(), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(getPickerContainer()).not.toBeNull();
+
+      // It is impossible to simulate actual TAB behaviour using events.
+      // This is the next best thing.
+      dispatchFakeEvent(queryFromOverlay('span.nz-tab-catching-span'), 'focus');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(getPickerContainer()).toBeNull();
+      expect(document.activeElement).toEqual(getPickerTrigger());
     }));
 
     it('should support nzAllowClear and work properly', fakeAsync(() => {

--- a/components/date-picker/picker.component.html
+++ b/components/date-picker/picker.component.html
@@ -89,4 +89,5 @@
   > <!-- Compatible for overlay that not support offset dynamically and immediately -->
     <ng-content></ng-content>
   </div>
+  <span tabindex=0 (focus)="onClickBackdrop()" class="nz-tab-catching-span"></span>
 </ng-template>

--- a/components/date-picker/picker.component.ts
+++ b/components/date-picker/picker.component.ts
@@ -107,14 +107,18 @@ export class NzPickerComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     if (this.autoFocus) {
-      if (this.isRange) {
-        const firstInput = (this.pickerInput.nativeElement as HTMLElement).querySelector(
-          'input:first-child'
-        ) as HTMLInputElement;
-        firstInput.focus(); // Focus on the first input
-      } else {
-        this.pickerInput.nativeElement.focus();
-      }
+      this.focus();
+    }
+  }
+
+  focus(): void {
+    if (this.isRange) {
+      const firstInput = (this.pickerInput.nativeElement as HTMLElement).querySelector(
+        'input:first-child'
+      ) as HTMLInputElement;
+      firstInput.focus(); // Focus on the first input
+    } else {
+      this.pickerInput.nativeElement.focus();
     }
   }
 
@@ -135,6 +139,7 @@ export class NzPickerComponent implements OnInit, AfterViewInit {
     if (this.realOpenState) {
       this.overlayOpen = false;
       this.openChange.emit(this.overlayOpen);
+      this.focus();
     }
   }
 


### PR DESCRIPTION
Tabbing away from date-picker overlay was not possible: It wrapped
around and usually ended up in browser's address bar. Also, once you
selected date-picker wrapper span, there was no way to open the overlay
via keyboard.
This fixes this. Tabbing away from overlay now focuses on date-picker
wrapper span. Pressing enter on the wrapper span opens the overlay.

Please also see a similar PR for the time-picker module #3145 .

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Tabbing away from date-picker overlay was not possible: It wrapped
around and usually ended up in browser's address bar. Also, once you
selected date-picker wrapper span, there was no way to open the overlay
via keyboard.

Issue Number: N/A


## What is the new behavior?
This fixes this. Tabbing away from overlay now focuses on date-picker
wrapper span. Pressing enter on the wrapper span opens the overlay.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The behavior (both current and new) can be observed on the main demo page (npm run site:start).