### PR TITLE
fix(module:collapse): fix glitch when opening collapse in Angular 7

### DIFF
--- a/components/core/animation/collapse.ts
+++ b/components/core/animation/collapse.ts
@@ -4,7 +4,7 @@ import { AnimationCurves } from './animation';
 export const collapseMotion: AnimationTriggerMetadata = trigger('collapseMotion', [
   state('expanded', style({ height: '*' })),
   state('collapsed', style({ height: 0, overflow: 'hidden' })),
-  state('hidden', style({ height: 0, display: 'none' })),
+  state('hidden', style({ height: 0 })),
   transition('expanded => collapsed', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
   transition('expanded => hidden', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
   transition('collapsed => expanded', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),

--- a/components/core/animation/collapse.ts
+++ b/components/core/animation/collapse.ts
@@ -2,7 +2,9 @@ import { animate, state, style, transition, trigger, AnimationTriggerMetadata } 
 import { AnimationCurves } from './animation';
 
 export const collapseMotion: AnimationTriggerMetadata = trigger('collapseMotion', [
-  state('expanded', style({ height: '*' })),
+  state('expanded', style({ height: '*', display: '*' })),
+  state('collapsed', style({ height: 0, overflow: 'hidden' })),
+  state('hidden', style({ height: 0, display: 'none' })),
   state('collapsed', style({ height: 0, overflow: 'hidden' })),
   state('hidden', style({ height: 0 })),
   transition('expanded => collapsed', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the `collapse` component glitches when opening, it does not glitch when closing. This can be closely observed if a larger text is put into the collapse (Lorum Ipsum for instance). This was not an issue in previous versions of `ng-zorro` (when comparing versions on the documentation website).

Issue Number: N/A


## What is the new behavior?
The new behaviour removes the `display: none` set by the trigger. In Angular 7 having this property causes the glitch issue.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Q: the `collapseMotion` still has a `hidden` state, that I didn't remove right now, but I am wondering why it is there in the first place? Shouldn't there just be a `expanded` and `collapsed` state and that's it?

