### PR TITLE
fix(module:modal): Add option to disable restoring focus after modal …

### DIFF
--- a/components/modal/doc/index.en-US.md
+++ b/components/modal/doc/index.en-US.md
@@ -36,6 +36,7 @@ The dialog is currently divided into 2 modes, `normal mode` and `confirm box mod
 | nzFooter          | Footer content, set as footer=null when you don't need default buttons. <i>1. Only valid in normal mode.<br>2. You can customize the buttons to the maximum extent by passing a `ModalButtonOptions` configuration (see the case or the instructions below).</i> | string<br>TemplateRef<br>ModalButtonOptions | OK and Cancel buttons |
 | nzGetContainer    | The mount node for Modal | HTMLElement / () => HTMLElement| A default container |
 | nzKeyboard        | Whether support press esc to close | `boolean` | `true` |
+| nzRestoreFocus    | Whether to re-focus the element that was focused before opening the modal | `boolean` | `true` |
 | nzMask            | Whether show mask or not. | `boolean` | `true` |
 | nzMaskClosable    | Whether to close the modal dialog when the mask (area outside the modal) is clicked | `boolean` | `true` |
 | nzMaskStyle       | Style for modal's mask element. | `object` | - |

--- a/components/modal/nz-modal.component.ts
+++ b/components/modal/nz-modal.component.ts
@@ -61,7 +61,9 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R>
   @Input() @InputBoolean() nzCancelDisabled: boolean = false;
   @Input() @InputBoolean() nzCancelLoading: boolean = false;
   @Input() @InputBoolean() nzKeyboard: boolean = true;
-  @Input() @InputBoolean() nzNoAnimation = false;
+  @Input() @InputBoolean() nzNoAnimation: boolean = false;
+  @Input() @InputBoolean() nzRestoreFocus: boolean = true;
+
   @Input() nzContent: string | TemplateRef<{}> | Type<T>; // [STATIC] If not specified, will use <ng-content>
   @Input() nzComponentParams: T; // [STATIC] ONLY avaliable when nzContent is a component
   @Input() nzFooter: string | TemplateRef<{}> | Array<ModalButtonOptions<T>> | null; // [STATIC] Default Modal ONLY
@@ -317,7 +319,9 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R>
     if (visible) {
       // Hide scrollbar at the first time when shown up
       this.scrollStrategy.enable();
-      this.savePreviouslyFocusedElement();
+      if (this.nzRestoreFocus) {
+        this.savePreviouslyFocusedElement();
+      }
       this.trapFocus();
     }
 
@@ -463,7 +467,11 @@ export class NzModalComponent<T = any, R = any> extends NzModalRef<T, R>
 
   private restoreFocus(): void {
     // We need the extra check, because IE can set the `activeElement` to null in some cases.
-    if (this.previouslyFocusedElement && typeof this.previouslyFocusedElement.focus === 'function') {
+    if (
+      this.nzRestoreFocus &&
+      this.previouslyFocusedElement &&
+      typeof this.previouslyFocusedElement.focus === 'function'
+    ) {
       this.previouslyFocusedElement.focus();
     }
     if (this.focusTrap) {

--- a/components/modal/nz-modal.type.ts
+++ b/components/modal/nz-modal.type.ts
@@ -31,6 +31,7 @@ export interface ModalOptions<T = any, R = any> {
   nzGetContainer?: HTMLElement | OverlayRef | (() => HTMLElement | OverlayRef); // STATIC
   nzAfterOpen?: EventEmitter<void>;
   nzAfterClose?: EventEmitter<R>;
+  nzRestoreFocus?: boolean;
 
   // --- Predefined OK & Cancel buttons
   nzOkText?: string | null;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After closing a modal, if there if a focused element, this element will always be re-focused.

Issue Number: N/A


## What is the new behavior?

Default behavior is the same.
If preferred, user can pass an `nzRestoreFocus` option to the modal that blocks this behaviour


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
