### PR TITLE
[draft] fix(module:collapse): fix closed collapse cannot be reopned in some …

### DIFF
--- a/components/core/animation/collapse.ts
+++ b/components/core/animation/collapse.ts
@@ -2,7 +2,7 @@ import { animate, state, style, transition, trigger, AnimationTriggerMetadata } 
 import { AnimationCurves } from './animation';
 
 export const collapseMotion: AnimationTriggerMetadata = trigger('collapseMotion', [
-  state('expanded', style({ height: '*', display: '*' })),
+  state('expanded', style({ height: '*', display: 'block' })),
   state('collapsed', style({ height: 0, overflow: 'hidden' })),
   state('hidden', style({ height: 0, display: 'none' })),
   transition('expanded => collapsed', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),

--- a/components/core/animation/collapse.ts
+++ b/components/core/animation/collapse.ts
@@ -2,9 +2,9 @@ import { animate, state, style, transition, trigger, AnimationTriggerMetadata } 
 import { AnimationCurves } from './animation';
 
 export const collapseMotion: AnimationTriggerMetadata = trigger('collapseMotion', [
-  state('expanded', style({ height: '*', display: 'block' })),
+  state('expanded', style({ height: '*', visibility: 'visible' })),
   state('collapsed', style({ height: 0, overflow: 'hidden' })),
-  state('hidden', style({ height: 0, display: 'none' })),
+  state('hidden', style({ height: 0, visibility: 'hidden' })),
   transition('expanded => collapsed', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
   transition('expanded => hidden', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
   transition('collapsed => expanded', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),

--- a/components/core/animation/collapse.ts
+++ b/components/core/animation/collapse.ts
@@ -2,7 +2,7 @@ import { animate, state, style, transition, trigger, AnimationTriggerMetadata } 
 import { AnimationCurves } from './animation';
 
 export const collapseMotion: AnimationTriggerMetadata = trigger('collapseMotion', [
-  state('expanded', style({ height: '*' })),
+  state('expanded', style({ height: '*', display: '*' })),
   state('collapsed', style({ height: 0, overflow: 'hidden' })),
   state('hidden', style({ height: 0, display: 'none' })),
   transition('expanded => collapsed', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),


### PR DESCRIPTION
…browsers

close #3098

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- ~~[ ] Tests for the changes have been added (for bug fixes / features)~~ Need Safari or IE or Edge to test it.
- ~~[ ] Docs have been added / updated (for bug fixes / features)~~ Not needed.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3098

In browsers like Safari, IE or Edge, closed panels cannot be reopened because `display: none` style is not removed.

## What is the new behavior?

Use CSS `visibility` property instead of `display`. Now on Safari, collapsed panels can be un-collapsed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
