### PR TITLE
feat: support colorful checkable tag

### DIFF
--- a/components/tag/demo/checkable.ts
+++ b/components/tag/demo/checkable.ts
@@ -4,8 +4,17 @@ import { Component } from '@angular/core';
   selector: 'nz-demo-tag-checkable',
   template: `
     <nz-tag nzMode="checkable" [nzChecked]="true" (nzCheckedChange)="checkChange($event)">Tag1</nz-tag>
-    <nz-tag nzMode="checkable" [nzChecked]="true" (nzCheckedChange)="checkChange($event)">Tag2</nz-tag>
-    <nz-tag nzMode="checkable" [nzChecked]="true" (nzCheckedChange)="checkChange($event)">Tag3</nz-tag>
+    <nz-tag
+      nzMode="checkable"
+      [nzChecked]="true"
+      [nzColor]="'#f50'"
+      [nzUncheckedColor]="'#f88'"
+      (nzCheckedChange)="checkChange($event)"
+      >Tag2</nz-tag
+    >
+    <nz-tag nzMode="checkable" [nzChecked]="true" [nzColor]="'magenta'" (nzCheckedChange)="checkChange($event)"
+      >Tag3</nz-tag
+    >
   `
 })
 export class NzDemoTagCheckableComponent {

--- a/components/tag/doc/index.en-US.md
+++ b/components/tag/doc/index.en-US.md
@@ -29,6 +29,7 @@ import { NzTagModule } from 'ng-zorro-antd';
 | `[nzMode]` | Mode of tag | `'closeable'｜'default'｜'checkable'` | `'default'` |
 | `[nzChecked]` | Checked status of Tag, double binding, only works when `nzMode="checkable"` | `boolean` | `false` |
 | `[nzColor]` | Color of the Tag | `string` | - |
+| `[nzUncheckedColor]` | Color of unchecked tag, only works when `nzMode="checkable"` | string | - |
 | `(nzAfterClose)` | Callback executed when close animation is completed, only works when `nzMode="closable"` | `EventEmitter<void>` | - |
 | `(nzOnClose)` | Callback executed when tag is closed, only works when `nzMode="closable"`| `EventEmitter<MouseEvent>` | - |
 | `(nzCheckedChange)` | Checked status change call back, only works when `nzMode="checkable"` | `EventEmitter<boolean>` | - |

--- a/components/tag/doc/index.zh-CN.md
+++ b/components/tag/doc/index.zh-CN.md
@@ -31,6 +31,7 @@ import { NzTagModule } from 'ng-zorro-antd';
 | `[nzMode]` | 设定标签工作的模式 | `'closeable'｜'default'｜'checkable'` | `'default'` |
 | `[nzChecked]` | 设置标签的选中状态，可双向绑定，在 `nzMode="checkable"` 时可用 | `boolean` | `false` |
 | `[nzColor]` | 标签色 | `string` | - |
+| `[nzUncheckedColor]` | 标签未选中时的颜色，默认为透明，仅在 `nzMode="checkable"` 时可用 | string | - |
 | `(nzAfterClose)` | 关闭动画完成后的回调，在 `nzMode="closable"` 时可用 | `EventEmitter<void>` | - |
 | `(nzOnClose)` | 关闭时的回调，在 `nzMode="closable"` 时可用 | `EventEmitter<MouseEvent>` | - |
 | `(nzCheckedChange)` | 设置标签的选中状态的回调，在 `nzMode="checkable"` 时可用 | `EventEmitter<void>` | - |

--- a/components/tag/util.ts
+++ b/components/tag/util.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Alibaba.com All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+const presetColorRE = /^(pink|red|yellow|orange|cyan|green|blue|purple|geekblue|magenta|volcano|gold|lime)(-inverse)?$/;
+
+export function isPresetColor(color: string): boolean {
+  if (!color) {
+    return false;
+  }
+  return presetColorRE.test(color);
+}


### PR DESCRIPTION
close #2045

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2045

Checkable tags are either blue or transparent. 


## What is the new behavior?

Checkable tags can be colorful!

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Pending https://github.com/ant-design/ant-design/pull/16252.
