### PR TITLE
docs(module:page-header): fix typo in event-binding notation

### DIFF
--- a/components/page-header/doc/index.en-US.md
+++ b/components/page-header/doc/index.en-US.md
@@ -31,7 +31,7 @@ import { NzPageHeaderModule } from 'ng-zorro-antd';
 | `[nzTitle]` | title string | `string｜TemplateRef<void>` | - |
 | `[nzSubTitle]` | subTitle string | `string｜TemplateRef<void>` | - |
 | `[nzBackIcon]` | custom back icon | `string｜TemplateRef<void>` | - |
-| `[nzBack]` | back icon click event | `EventEmitter<void>` | - |
+| `(nzBack)` | back icon click event | `EventEmitter<void>` | - |
 
 ### Page header sections
 | Element | Description |

--- a/components/page-header/doc/index.zh-CN.md
+++ b/components/page-header/doc/index.zh-CN.md
@@ -32,7 +32,7 @@ import { NzPageHeaderModule } from 'ng-zorro-antd';
 | `[nzTitle]` | title 文字 | `string｜TemplateRef<void>` | - |
 | `[nzSubTitle]` | subTitle 文字 | `string｜TemplateRef<void>` | - |
 | `[nzBackIcon]` | 自定义 back icon | `string｜TemplateRef<void>` | - |
-| `[nzBack]` | 返回按钮的点击事件 | `EventEmitter<void>` | - |
+| `(nzBack)` | 返回按钮的点击事件 | `EventEmitter<void>` | - |
 
 ### Page header 组成部分
 | 元素 | 说明 |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```
Changed `[]` to `()` for Event Emitter.