### PR TITLE
refactor(module:auto-complete): refactor and fix tests

### DIFF
--- a/components/auto-complete/nz-autocomplete-trigger.directive.ts
+++ b/components/auto-complete/nz-autocomplete-trigger.directive.ts
@@ -122,6 +122,7 @@ export class NzAutocompleteTriggerDirective implements ControlValueAccessor, OnD
   }
 
   openPanel(): void {
+    this.previousValue = this.elementRef.nativeElement.value;
     this.attachOverlay();
   }
 
@@ -178,11 +179,12 @@ export class NzAutocompleteTriggerDirective implements ControlValueAccessor, OnD
   handleInput(event: KeyboardEvent): void {
     const target = event.target as HTMLInputElement;
     let value: number | string | null = target.value;
-    if (target.type === 'number') {
-      value = value === '' ? null : parseFloat(value);
-    }
-    if (this.canOpen() && document.activeElement === event.target && this.previousValue !== value) {
-      this.previousValue = value;
+
+    if (this.canOpen() && document.activeElement === target && this.previousValue !== value) {
+      if (target.type === 'number') {
+        value = value === '' ? null : parseFloat(value);
+      }
+
       this._onChange(value);
       this.openPanel();
     }
@@ -190,7 +192,6 @@ export class NzAutocompleteTriggerDirective implements ControlValueAccessor, OnD
 
   handleFocus(): void {
     if (this.canOpen()) {
-      this.previousValue = this.elementRef.nativeElement.value;
       this.openPanel();
     }
   }


### PR DESCRIPTION
change previousValue setting logics to openPanel

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[x] Other... Please describe: fix tests failed
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
case `should reset the backfilled value display when pressing tabbing` would fail now,
because `previousValue` was not updated when invoking `openPanel`. To solve the problem, we need to change `openPanel` to `handleFocus` in test or put `previousValue` updating logics into `openPanel` in `nz-autocomplete-trigger`'s implemention.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
