### PR TITLE
fix(module:date-picker): disable year and month selection if set nzDi…

### DIFF
--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -12,6 +12,7 @@ import isSameDay from 'date-fns/is_same_day';
 import { dispatchKeyboardEvent, dispatchMouseEvent, NGStyleInterface } from 'ng-zorro-antd/core';
 import en_US from '../i18n/languages/en_US';
 
+import isBefore from 'date-fns/is_before';
 import { NzI18nModule, NzI18nService } from 'ng-zorro-antd/i18n';
 import { NzDatePickerModule } from './date-picker.module';
 
@@ -197,6 +198,38 @@ describe('NzDatePickerComponent', () => {
       fixture.detectChanges();
       const disabledCell = queryFromOverlay('tbody.ant-calendar-tbody td.ant-calendar-disabled-cell');
       expect(disabledCell.textContent!.trim()).toBe('15');
+    }));
+
+    it('should support month disabled by nzDisabledDate', fakeAsync(() => {
+      const compareDate = new Date('2018-11-15 00:00:00');
+      fixtureInstance.nzValue = new Date('2018-11-11 12:12:12');
+      fixtureInstance.nzDisabledDate = (current: Date) => isBefore(current, compareDate);
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(queryFromOverlay('calendar-header .ant-calendar-month-select'), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      const allDisabledCells = overlayContainerElement.querySelectorAll(
+        'tbody.ant-calendar-month-panel-tbody tr td.ant-calendar-month-panel-cell-disabled'
+      );
+      const disabledCell = allDisabledCells[allDisabledCells.length - 1];
+      expect(disabledCell.textContent).toContain('11');
+    }));
+
+    it('should support year disabled by nzDisabledDate', fakeAsync(() => {
+      fixtureInstance.nzValue = new Date('2018-11-11 12:12:12');
+      fixtureInstance.nzDisabledDate = (current: Date) => current.getFullYear() === 2019;
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(queryFromOverlay('calendar-header .ant-calendar-year-select'), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      const disabledCell = overlayContainerElement.querySelector(
+        'tbody.ant-calendar-year-panel-tbody tr td.ant-calendar-year-panel-cell-disabled'
+      )!;
+      expect(disabledCell.textContent).toContain('2019');
     }));
 
     it('should support nzLocale', () => {

--- a/components/date-picker/lib/popups/inner-popup.component.html
+++ b/components/date-picker/lib/popups/inner-popup.component.html
@@ -7,6 +7,8 @@
   [showTimePicker]="showTimePicker"
   [enablePrev]="enablePrev"
   [enableNext]="enableNext"
+  [disabledMonth]="disabledDate"
+  [disabledYear]="disabledDate"
 ></calendar-header>
 
 <ng-container *ngIf="showTimePicker && timeOptions">


### PR DESCRIPTION
…sabledDate property (#3425)

close #3425

* fix(module:date-picker): setting the date after today is not optional, the year and month after today should be disabled

* add test

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 3425


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
