### PR TITLE
fix(module:input): fix ng-content [nzAddOnBeforeIcon] content projection

### DIFF
--- a/components/input/nz-input-group.component.html
+++ b/components/input/nz-input-group.component.html
@@ -27,7 +27,9 @@
     <ng-container *nzStringTemplateOutlet="nzSuffix">{{ nzSuffix }}</ng-container>
   </span>
 </ng-template>
-<ng-template [ngIf]="isGroup" *ngTemplateOutlet="contentTemplate"></ng-template>
+<ng-container *ngIf="isGroup">
+  <ng-template *ngTemplateOutlet="contentTemplate"></ng-template>
+</ng-container>
 <ng-template #contentTemplate>
   <ng-content></ng-content>
 </ng-template>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- ~Docs have been added / updated (for bug fixes / features)~ N/A


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Projected content inside of an `<nz-input-group>` disappears when `[nzAddOnBeforeIcon]` is updated.

Issue Number: #3596

## What is the new behavior?
Projected content is displayed, `[nzAddOnBeforeIcon]` behaves correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I attempted to add tests, but I find angular testing difficult and could not come up with something satisfactory for projected content.