### PR TITLE
fix(module:date-picker): missing nzUse12Hours binding

### DIFF
--- a/components/date-picker/lib/popups/inner-popup.component.html
+++ b/components/date-picker/lib/popups/inner-popup.component.html
@@ -23,6 +23,7 @@
     [nzDisabledSeconds]="timeOptions.nzDisabledSeconds"
     [nzHideDisabledOptions]="timeOptions.nzHideDisabledOptions"
     [nzDefaultOpenValue]="timeOptions.nzDefaultOpenValue"
+    [nzUse12Hours]="timeOptions.nzUse12Hours"
     [nzAddOn]="timeOptions.nzAddOn"
   ></nz-time-picker-panel>
 </ng-container>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Binding `nzShowTime` of a date-picker to an object that has `nzUse12Hours` set to `true` has no effect on a time picker, it still uses 24 hour picker.

Issue Number: N/A


## What is the new behavior?
Binding the nzShowTime input of a date-picker to an object that has nzUse12Hours set to true modifies the time picker to use 12 hours format picker as expected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
