### PR TITLE
build(module:*): update CDK version to ^8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "integration": "npm run build:lib && bash ./integration-test.sh"
   },
   "dependencies": {
-    "@angular/cdk": "^8.0.0",
+    "@angular/cdk": "^8.1.0",
     "@ant-design/icons-angular": "^8.0.2",
     "date-fns": "^1.30.1"
   },


### PR DESCRIPTION
After PR https://github.com/NG-ZORRO/ng-zorro-antd/pull/3807, one cannot build anymore with CDK < 8.1.0, so it should be forced to "update" both using `npm install` and `npm update`.
@wendzhue this is related to what we were discussing in the other issue.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] <s>Tests for the changes have been added (for bug fixes / features)</s>
- [X] <s>Docs have been added / updated (for bug fixes / features)</s>


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
