### PR TITLE
feat(module: tooltip)auto show tooltip when ellipsis

### DIFF
--- a/components/tooltip/base/nz-tooltip-base.directive.ts
+++ b/components/tooltip/base/nz-tooltip-base.directive.ts
@@ -270,6 +270,18 @@ export abstract class NzTooltipBaseDirective implements OnChanges, OnInit, OnDes
         })
       );
       // Hiding would be triggered by the component itself.
+    } else if (trigger === 'ellipsisHover') {
+      // auto display tooltip when text cut by ellipsis
+      const listenerEllipsisHoverIn = this.renderer.listen(el, 'mouseenter', () => {
+        const offsetParam = el[`offsetWidth`];
+        const scrollParam = el[`scrollWidth`];
+        if (offsetParam < scrollParam) {
+          this.show();
+        }
+      })
+      this.triggerUnlisteners.push(listenerEllipsisHoverIn);
+      const listenerEllipsisHoverOut = this.renderer.listen(el, 'mouseleave', () => this.hide());
+      this.triggerUnlisteners.push(listenerEllipsisHoverOut);
     } // else do nothing because user wants to control the visibility programmatically.
   }
 

--- a/components/tooltip/nz-tooltip.definitions.ts
+++ b/components/tooltip/nz-tooltip.definitions.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-export type NzTooltipTrigger = 'click' | 'focus' | 'hover' | null;
+export type NzTooltipTrigger = 'click' | 'focus' | 'hover' | 'ellipsisHover' | null;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
when we use css property ellipsis to cut text and show '...', we want to show tooltip when hover on 'shyDn...' while do not show tooltip when hover on 'shy'

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
