### PR TITLE
fix(module:dropdown): restore escape and hide backdrop when disabled

### DIFF
--- a/components/dropdown/nz-dropdown.directive.spec.ts
+++ b/components/dropdown/nz-dropdown.directive.spec.ts
@@ -1,9 +1,10 @@
+import { ESCAPE } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component, Provider, Type } from '@angular/core';
 import { fakeAsync, inject, tick, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { dispatchFakeEvent } from '../core/testing';
+import { dispatchFakeEvent, dispatchKeyboardEvent } from '../core/testing';
 import { NzMenuModule } from '../menu/nz-menu.module';
 import { NzDropDownDirective } from './nz-dropdown.directive';
 import { NzDropDownModule } from './nz-dropdown.module';
@@ -95,21 +96,76 @@ describe('dropdown', () => {
       );
     }).not.toThrowError();
   }));
-  it('should backdrop be disabled', fakeAsync(() => {
+
+  describe('when nzBackdrop=false', () => {
+    let fixture: ComponentFixture<NzTestDropdownComponent>;
+
+    beforeEach(() => {
+      fixture = createComponent(NzTestDropdownComponent, [], []);
+      fixture.componentInstance.backdrop = false;
+    });
+
+    it('backdrop should be invisible if nzTrigger=click', fakeAsync(() => {
+      fixture.componentInstance.trigger = 'click';
+      fixture.detectChanges();
+
+      expect(() => {
+        const dropdownElement = fixture.debugElement.query(By.directive(NzDropDownDirective)).nativeElement;
+        dispatchFakeEvent(dropdownElement, 'click');
+
+        tick(1000);
+        fixture.detectChanges();
+
+        const backdrop = overlayContainerElement.querySelector('.nz-overlay-transparent-backdrop');
+        expect(backdrop).not.toBeNull();
+      }).not.toThrowError();
+    }));
+
+    it('should disappear if invisible backdrop clicked if nzTrigger=click', fakeAsync(() => {
+      fixture.componentInstance.trigger = 'click';
+      fixture.detectChanges();
+
+      expect(() => {
+        const dropdownElement = fixture.debugElement.query(By.directive(NzDropDownDirective)).nativeElement;
+        dispatchFakeEvent(dropdownElement, 'click');
+
+        tick(1000);
+        fixture.detectChanges();
+
+        const backdrop = overlayContainerElement.querySelector('.nz-overlay-transparent-backdrop');
+        expect(backdrop).not.toBeNull();
+
+        dispatchFakeEvent(backdrop as Element, 'click');
+        tick(1000);
+        fixture.detectChanges();
+
+        const nullBackdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop');
+        expect(nullBackdrop).toBeNull();
+      }).not.toThrowError();
+    }));
+  });
+
+  it('should disappear if Escape pressed', fakeAsync(() => {
     const fixture = createComponent(NzTestDropdownComponent, [], []);
     fixture.componentInstance.trigger = 'click';
-    fixture.componentInstance.backdrop = false;
     fixture.detectChanges();
 
     expect(() => {
       const dropdownElement = fixture.debugElement.query(By.directive(NzDropDownDirective)).nativeElement;
-      dispatchFakeEvent(dropdownElement, 'mouseenter');
-      fixture.detectChanges();
+
+      dispatchFakeEvent(dropdownElement, 'click');
       tick(1000);
       fixture.detectChanges();
 
       const backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop');
-      expect(backdrop).toBeNull();
+      expect(backdrop).not.toBeNull();
+
+      dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+      tick(1000);
+      fixture.detectChanges();
+
+      const nullBackdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop');
+      expect(nullBackdrop).toBeNull();
     }).not.toThrowError();
   }));
   it('should nzOverlayClassName and nzOverlayStyle work', fakeAsync(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
After PR https://github.com/NG-ZORRO/ng-zorro-antd/pull/3769, I noticed that to exit the dropdown, one must click on the backdrop DOM element.  
Being with `nzBackdrop=false` there was no such element, it was not possible to hide the visible dropdown.

## What is the new behavior?
When `nzBackdrop=false`, the backdrop is present, but `opacity` is always set to `0`.  
Also, the `Escape` functionality to hide the dropdown has been restored, as it was lost when the Component has been refactored to a Directive (`cdk-connected-overlay` is no more present).

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
