### PR TITLE
fix(module:collapse): hidden before the collapse animation

### DIFF
--- a/components/core/animation/collapse.ts
+++ b/components/core/animation/collapse.ts
@@ -13,8 +13,8 @@ export const collapseMotion: AnimationTriggerMetadata = trigger('collapseMotion'
   state('expanded', style({ height: '*' })),
   state('collapsed', style({ height: 0, overflow: 'hidden' })),
   state('hidden', style({ height: 0, overflow: 'hidden', borderTopWidth: '0' })),
-  transition('expanded => collapsed', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
-  transition('expanded => hidden', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
-  transition('collapsed => expanded', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
-  transition('hidden => expanded', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`))
+  transition('expanded => collapsed', [style({ overflow: 'hidden' }), animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)]),
+  transition('expanded => hidden', [style({ overflow: 'hidden' }), animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)]),
+  transition('collapsed => expanded', [style({ overflow: 'hidden' }), animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)]),
+  transition('hidden => expanded', [style({ overflow: 'hidden' }), animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)])
 ]);


### PR DESCRIPTION
set overflow: hidden before the collapse animation, otherwise the content will overflow.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Content overflow when collapsing animation, animation is fast and not easy to see.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
