### PR TITLE
perf(module:tree): change the collapsed of the treeNode to ngIf

### DIFF
--- a/components/core/animation/collapse.ts
+++ b/components/core/animation/collapse.ts
@@ -18,3 +18,14 @@ export const collapseMotion: AnimationTriggerMetadata = trigger('collapseMotion'
   transition('collapsed => expanded', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
   transition('hidden => expanded', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`))
 ]);
+
+export const treeCollapseMotion: AnimationTriggerMetadata = trigger('treeCollapseMotion', [
+  transition(':leave', [
+    style({ overflow: 'hidden' }),
+    animate(`150ms ${AnimationCurves.EASE_IN_OUT}`, style({ height: 0 }))
+  ]),
+  transition(':enter', [
+    style({ overflow: 'hidden', height: 0 }),
+    animate(`150ms ${AnimationCurves.EASE_IN_OUT}`, style({ overflow: 'hidden', height: '*' }))
+  ])
+]);

--- a/components/tree/nz-tree-node.component.html
+++ b/components/tree/nz-tree-node.component.html
@@ -81,12 +81,13 @@
   </ng-template>
 
   <ul
+    *ngIf="nzTreeNode.isExpanded"
     role="group"
     class="ant-tree-child-tree"
     [class.ant-tree-child-tree-open]="!nzSelectMode || nzTreeNode.isExpanded"
     data-expanded="true"
     [@.disabled]="noAnimation?.nzNoAnimation"
-    [@collapseMotion]="nzTreeNode.isExpanded ? 'expanded' : 'collapsed'">
+    @treeCollapseMotion>
     <nz-tree-node
       *ngFor="let node of nzTreeNode.getChildren()"
       [nzTreeNode]="node"

--- a/components/tree/nz-tree-node.component.ts
+++ b/components/tree/nz-tree-node.component.ts
@@ -27,7 +27,7 @@ import { fromEvent, Observable, Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import {
-  collapseMotion,
+  treeCollapseMotion,
   warnDeprecation,
   InputBoolean,
   NzFormatBeforeDropEvent,
@@ -42,7 +42,7 @@ import {
   templateUrl: './nz-tree-node.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
-  animations: [collapseMotion]
+  animations: [treeCollapseMotion]
 })
 export class NzTreeNodeComponent implements OnInit, OnChanges, OnDestroy {
   @ViewChild('dragElement', { static: false }) dragElement: ElementRef;

--- a/components/tree/style/index.less
+++ b/components/tree/style/index.less
@@ -187,6 +187,9 @@
     }
   }
   &-child-tree {
+    // The overflow of the collapse animation in edge and IE is invalid
+    overflow: hidden;
+
     // https://github.com/ant-design/ant-design/issues/14958
     > li {
       // Provide additional padding between top child node and parent node


### PR DESCRIPTION
Change the collapsed of the treeNode from display: none to *ngIf.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Use `display: none` to collapse treeNode.

## What is the new behavior?

Change the collapsed of the treeNode from `display: none` to `*ngIf`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
