### PR TITLE
perf(module:tree): change the collapsed of the treeNode to ngIf

### DIFF
--- a/components/core/animation/collapse.ts
+++ b/components/core/animation/collapse.ts
@@ -18,3 +18,14 @@ export const collapseMotion: AnimationTriggerMetadata = trigger('collapseMotion'
   transition('collapsed => expanded', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`)),
   transition('hidden => expanded', animate(`150ms ${AnimationCurves.EASE_IN_OUT}`))
 ]);
+
+export const treeCollapseMotion: AnimationTriggerMetadata = trigger('treeCollapseMotion', [
+  transition(':leave', [
+    style({ overflow: 'hidden' }),
+    animate(`150ms ${AnimationCurves.EASE_IN_OUT}`, style({ height: 0 }))
+  ]),
+  transition(':enter', [
+    style({ overflow: 'hidden', height: 0 }),
+    animate(`150ms ${AnimationCurves.EASE_IN_OUT}`, style({ overflow: 'hidden', height: '*' }))
+  ])
+]);

--- a/components/tree/nz-tree-node.component.html
+++ b/components/tree/nz-tree-node.component.html
@@ -73,12 +73,13 @@
   </ng-template>
 
   <ul
+    *ngIf="nzTreeNode.isExpanded"
     role="group"
     class="ant-tree-child-tree"
     [class.ant-tree-child-tree-open]="!nzSelectMode || nzTreeNode.isExpanded"
     data-expanded="true"
     [@.disabled]="noAnimation?.nzNoAnimation"
-    [@collapseMotion]="nzTreeNode.isExpanded ? 'expanded' : 'collapsed'">
+    @treeCollapseMotion>
     <nz-tree-node
       *ngFor="let node of nzTreeNode.getChildren()"
       [nzTreeNode]="node"

--- a/components/tree/nz-tree-node.component.ts
+++ b/components/tree/nz-tree-node.component.ts
@@ -27,7 +27,7 @@ import { fromEvent, Observable, Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import {
-  collapseMotion,
+  treeCollapseMotion,
   warnDeprecation,
   InputBoolean,
   NzFormatBeforeDropEvent,
@@ -42,7 +42,7 @@ import {
   templateUrl: './nz-tree-node.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
-  animations: [collapseMotion]
+  animations: [treeCollapseMotion]
 })
 export class NzTreeNodeComponent implements OnInit, OnChanges, OnDestroy {
   @ViewChild('dragElement', { static: false }) dragElement: ElementRef;

--- a/components/tree/nz-tree.spec.ts
+++ b/components/tree/nz-tree.spec.ts
@@ -161,6 +161,9 @@ describe('nz-tree', () => {
 
     it('test click event', fakeAsync(() => {
       fixture.detectChanges();
+      // To avoid *ngIf to hide nodes
+      treeInstance.expandAll = true;
+      fixture.detectChanges();
       const clickSpy = spyOn(treeInstance, 'nzEvent');
       // click 0-0-0 to select
       let targetNode = treeElement.querySelectorAll('nz-tree-node')[1];
@@ -224,6 +227,9 @@ describe('nz-tree', () => {
 
     it('test check event', fakeAsync(() => {
       fixture.detectChanges();
+      // To avoid *ngIf to hide nodes
+      treeInstance.expandAll = true;
+      fixture.detectChanges();
       // uncheck 0-0-0
       let targetNode = treeElement.querySelectorAll('.ant-tree-checkbox')[1];
       expect(fixture.componentInstance.treeComponent.getCheckedNodeList().length).toEqual(1);
@@ -243,6 +249,8 @@ describe('nz-tree', () => {
 
     it('test check event with nzCheckStrictly', fakeAsync(() => {
       fixture.detectChanges();
+      // To avoid *ngIf to hide nodes
+      treeInstance.expandAll = true;
       treeInstance.checkStrictly = true;
       treeInstance.nodes = [
         {
@@ -281,6 +289,9 @@ describe('nz-tree', () => {
 
     it('test contextmenu event', fakeAsync(() => {
       fixture.detectChanges();
+      // To avoid *ngIf to hide nodes
+      treeInstance.expandAll = true;
+      fixture.detectChanges();
       const clickSpy = spyOn(treeInstance, 'nzEvent');
       // contextmenu 0-0-0
       const targetNode = treeElement.querySelectorAll('nz-tree-node')[1];
@@ -290,6 +301,9 @@ describe('nz-tree', () => {
     }));
 
     it('test disabled node check event', fakeAsync(() => {
+      fixture.detectChanges();
+      // To avoid *ngIf to hide nodes
+      treeInstance.expandAll = true;
       fixture.detectChanges();
       const clickSpy = spyOn(treeInstance, 'nzEvent');
       // contextmenu 0-0-0
@@ -315,6 +329,11 @@ describe('nz-tree', () => {
       fixture.detectChanges();
       // matched node's parent node will be expanded
       expect(fixture.componentInstance.treeComponent.getExpandedNodeList().length).toEqual(4);
+
+      // Notice *ngIf, should expand all nodes
+      // To avoid *ngIf to hide nodes
+      treeInstance.expandAll = true;
+      fixture.detectChanges();
       expect(fixture.componentInstance.treeComponent.getMatchedNodeList().length).toEqual(11);
       expect(treeElement.querySelectorAll('.font-highlight').length).toEqual(11);
     }));
@@ -375,6 +394,7 @@ describe('nz-tree', () => {
       fixture.detectChanges();
       expect(treeElement.querySelectorAll("[title='0-0-reset']").length).toEqual(1);
       node.isDisabled = true;
+      fixture.componentInstance.expandAll = true;
       fixture.detectChanges();
       expect(
         treeElement.querySelector('.ant-tree-treenode-disabled')!.querySelectorAll("[title='0-0-reset']").length
@@ -632,6 +652,8 @@ describe('nz-tree', () => {
       // test selectable false and click it
       node = fixture.componentInstance.treeComponent.getTreeNodeByKey('1001');
       node!.isSelectable = false;
+      fixture.detectChanges();
+      fixture.componentInstance.expandDefault = true;
       fixture.detectChanges();
       // add nzTreeNode children to clear loading state, root click will not change
       const targetNode = treeElement.querySelectorAll('li')[0];

--- a/components/tree/style/patch.less
+++ b/components/tree/style/patch.less
@@ -20,5 +20,7 @@
   color: @highlight-color;
 }
 
-
-
+.@{tree-prefix-cls}-child-tree {
+  // The overflow of the collapse animation in edge and IE is invalid
+  overflow: hidden;
+}


### PR DESCRIPTION
Change the collapsed of the treeNode from display: none to *ngIf.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4182 

Use `display: none` to collapse treeNode.

## What is the new behavior?

Change the collapsed of the treeNode from `display: none` to `*ngIf`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
