### PR TITLE
fix(module:editor): fix destroying error when editor is not initialized

### DIFF
--- a/components/code-editor/nz-code-editor.component.ts
+++ b/components/code-editor/nz-code-editor.component.ts
@@ -99,7 +99,9 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
   }
 
   ngOnDestroy(): void {
-    this.editorInstance.dispose();
+    if (this.editorInstance) {
+      this.editorInstance.dispose();
+    }
 
     this.destroy$.next();
     this.destroy$.complete();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Open code editor's page and quickly switch to another component's page before monaco editor is rendered.

## What is the new behavior?

When the editor is destroying, it checks if `editorInstance` is truthy before calling `dispose` method on it.



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information