### PR TITLE
revert: table small sticky style

### DIFF
--- a/components/table/style/patch.less
+++ b/components/table/style/patch.less
@@ -153,12 +153,6 @@
           background: @component-background;
         }
       }
-      > .@{table-prefix-cls}-tbody > tr > td {
-        &.@{table-td-left-cls}-sticky,
-        &.@{table-td-right-cls}-sticky {
-          background: @component-background;
-        }
-      }
 
       > .@{table-prefix-cls}-thead > tr > th,
       > .@{table-prefix-cls}-tbody > tr > td {


### PR DESCRIPTION
Reverts NG-ZORRO/ng-zorro-antd#3849
It will cause another issue of small table hover style. Ant design has fixed small sticky style (https://github.com/NG-ZORRO/ng-zorro-antd/commit/0608f4596bce89ad5b59124adfdecf182e8038b5#diff-6f1e26fcf688fcefd89a8725673c03abR78)