### PR TITLE
fix(module:avatar): Prioritize icons and text

### DIFF
--- a/components/avatar/avatar.spec.ts
+++ b/components/avatar/avatar.spec.ts
@@ -47,7 +47,8 @@ describe('avatar', () => {
       context.comp.imgError(event);
       tick();
       fixture.detectChanges();
-      expect(getType(dl)).toBe('icon');
+      // Text priority is higher than Icon
+      expect(getType(dl)).toBe('text');
       expect(context.comp.hasSrc).toBe(false);
       context.nzSrc =
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg==';

--- a/components/avatar/nz-avatar.component.ts
+++ b/components/avatar/nz-avatar.component.ts
@@ -90,10 +90,10 @@ export class NzAvatarComponent implements OnChanges {
       this.hasSrc = false;
       this.hasIcon = false;
       this.hasText = false;
-      if (this.nzIcon) {
-        this.hasIcon = true;
-      } else if (this.nzText) {
+      if (this.nzText) {
         this.hasText = true;
+      } else if (this.nzIcon) {
+        this.hasIcon = true;
       }
       this.setClass().notifyCalc();
       this.setSizeStyle();
@@ -104,8 +104,12 @@ export class NzAvatarComponent implements OnChanges {
     if (changes.hasOwnProperty('nzIcon') && changes.nzIcon.currentValue) {
       this.oldAPIIcon = changes.nzIcon.currentValue.indexOf('anticon') > -1;
     }
+    /**
+     * If both text and icon are set, the text should be displayed first.
+     * image > text > icon
+     */
     this.hasText = !this.nzSrc && !!this.nzText;
-    this.hasIcon = !this.nzSrc && !!this.nzIcon;
+    this.hasIcon = !this.nzSrc && !!this.nzIcon && !this.hasText;
     this.hasSrc = !!this.nzSrc;
 
     this.setClass().notifyCalc();

--- a/components/avatar/style/index.less
+++ b/components/avatar/style/index.less
@@ -37,6 +37,7 @@
     display: block;
     width: 100%;
     height: 100%;
+    object-fit: cover;
   }
 }
 

--- a/components/avatar/style/index.less
+++ b/components/avatar/style/index.less
@@ -37,7 +37,6 @@
     display: block;
     width: 100%;
     height: 100%;
-    object-fit: cover;
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1. avatar img 非正方形时会被压缩
2. 同时存在text与icon时，两者都会被显示出来
Issue Number: N/A


## What is the new behavior?
利用 `object-fit: cover` 解决了 `avatar` 图片被压缩的问题
提高了 text 的优先级，同时存在 icon 和 text，会优先显示text

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
