### PR TITLE
[POC] refactor: hide internal modules

### DIFF
--- a/components/date-picker/public-api.ts
+++ b/components/date-picker/public-api.ts
@@ -7,10 +7,10 @@
  */
 
 export { PickerResult, PickerResultSingle, PickerResultRange, PresetRanges, PanelMode } from './standard-types';
-
 export { NzDatePickerModule } from './nz-date-picker.module';
-export { NzDatePickerComponent } from './nz-date-picker.component';
-export { NzRangePickerComponent } from './nz-range-picker.component';
-export { NzMonthPickerComponent } from './nz-month-picker.component';
-export { NzWeekPickerComponent } from './nz-week-picker.component';
-export { NzYearPickerComponent } from './nz-year-picker.component';
+
+export { NzDatePickerComponent as θnzDatePickerComponent } from './nz-date-picker.component';
+export { NzRangePickerComponent as θnzRangePickerComponent } from './nz-range-picker.component';
+export { NzMonthPickerComponent as θnzMonthPickerComponent } from './nz-month-picker.component';
+export { NzWeekPickerComponent as θnzWeekPickerComponent } from './nz-week-picker.component';
+export { NzYearPickerComponent as θnzYearPickerComponent } from './nz-year-picker.component';


### PR DESCRIPTION
这个 PR 的意义是测试我们能否隐藏一些内部实现的模块，避免被用户所感知。

在实现二级入口的时候留下了一个问题：

---

重新导出二级入口的内容

在确保二级入口能够正确打包之后，我们还必须确保一级入口能够重新导出（re-export）所有二级入口的内容，以保持对旧的引入方式的兼容。方法是修改 ng-zorro-antd.module.ts 中对组件的导出方式：
```
+ export * from 'ng-zorro-antd/affix';
- export * from './affix/';
```

然而 ng-packagr 的一个 bug 会造成导出同名变量的冲突。原因是，ngc 要求导出一个 module 下所有的 directive component service 和子 module，如果开发者没有在入口文件中显式的导出它们，ngc 就会隐式地导出，例如 date picker 组件的入口文件 ng-zorro-antd-date-picker.d.ts 里就有一些隐式导出的 component 和 module：

```
export * from './public-api';
export { AbstractPickerComponent as ɵp } from './abstract-picker.component';
export { DateRangePickerComponent as ɵo } from './date-range-picker.component';
export { HeaderPickerComponent as ɵr } from './header-picker.component';
export { CalendarFooterComponent as ɵd } from './lib/calendar/calendar-footer.component';
export { CalendarHeaderComponent as ɵb } from './lib/calendar/calendar-header.component';
export { CalendarInputComponent as ɵc } from './lib/calendar/calendar-input.component';
export { OkButtonComponent as ɵe } from './lib/calendar/ok-button.component';
export { TimePickerButtonComponent as ɵf } from './lib/calendar/time-picker-button.component';
export { TodayButtonComponent as ɵg } from './lib/calendar/today-button.component';
export { DateTableComponent as ɵh } from './lib/date/date-table.component';
export { DecadePanelComponent as ɵl } from './lib/decade/decade-panel.component';
export { LibPackerModule as ɵa } from './lib/lib-packer.module';
export { MonthPanelComponent as ɵj } from './lib/month/month-panel.component';
export { MonthTableComponent as ɵk } from './lib/month/month-table.component';
export { DateRangePopupComponent as ɵn } from './lib/popups/date-range-popup.component';
export { InnerPopupComponent as ɵm } from './lib/popups/inner-popup.component';
export { YearPanelComponent as ɵi } from './lib/year/year-panel.component';
export { NzPickerComponent as ɵq } from './picker.component';
```

这在没有二级入口的情况下不会触发 bug，但是如果我们在一级入口重新导出，而且其他 module 也有这种隐式导出的话，就会发生导出重名变量的冲突。解决的办法是显式地导出这些变量。然而这带来了另外一个问题，即一些内部实现的东西也暴露给用户了。

比较合理解决方案是 ng-packagr 给 SEP 起一个有两级结构的 alias，比如 alias as θda 而不是 as θa。我们会在以后尝试修复掉这个瑕疵。

---

原文[在这里](https://zhuanlan.zhihu.com/p/63260991)。

这个 PR 旨在修复该瑕疵，向用户隐藏内部，特别是较为复杂组件的细节。

---

This pull request is to hide some implementation details from users, especially those of complicated components.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
