### PR TITLE
feat(module:tooltip)auto show tooltip when ellipsis

### DIFF
--- a/components/tooltip/base/nz-tooltip-base.directive.ts
+++ b/components/tooltip/base/nz-tooltip-base.directive.ts
@@ -208,6 +208,7 @@ export abstract class NzTooltipBaseDirective implements OnChanges, OnInit, OnDes
     if (this.tooltipRef) {
       this.tooltipRef.destroy();
     }
+    this.unRegisterTriggers();
   }
 
   show(): void {
@@ -246,6 +247,10 @@ export abstract class NzTooltipBaseDirective implements OnChanges, OnInit, OnDes
     this.tooltip.setOverlayOrigin(this as CdkOverlayOrigin);
     // Update all properties to the component.
     this.updateChangedProperties(this.needProxyProperties);
+  }
+
+  protected unRegisterTriggers(): void {
+    this.triggerUnlisteners.forEach(unlisten => unlisten());
   }
 
   protected registerTriggers(): void {
@@ -299,7 +304,7 @@ export abstract class NzTooltipBaseDirective implements OnChanges, OnInit, OnDes
         if (offsetParam < scrollParam) {
           this.show();
         }
-      })
+      });
       this.triggerUnlisteners.push(listenerEllipsisHoverIn);
       const listenerEllipsisHoverOut = this.renderer.listen(el, 'mouseleave', () => this.hide());
       this.triggerUnlisteners.push(listenerEllipsisHoverOut);

--- a/components/tooltip/base/nz-tooltip-base.directive.ts
+++ b/components/tooltip/base/nz-tooltip-base.directive.ts
@@ -291,6 +291,18 @@ export abstract class NzTooltipBaseDirective implements OnChanges, OnInit, OnDes
           this.show();
         })
       );
+    } else if (trigger === 'ellipsisHover') {
+      // auto display tooltip when text cut by ellipsis
+      const listenerEllipsisHoverIn = this.renderer.listen(el, 'mouseenter', () => {
+        const offsetParam = el[`offsetWidth`];
+        const scrollParam = el[`scrollWidth`];
+        if (offsetParam < scrollParam) {
+          this.show();
+        }
+      })
+      this.triggerUnlisteners.push(listenerEllipsisHoverIn);
+      const listenerEllipsisHoverOut = this.renderer.listen(el, 'mouseleave', () => this.hide());
+      this.triggerUnlisteners.push(listenerEllipsisHoverOut);
     } // Else do nothing because user wants to control the visibility programmatically.
   }
 

--- a/components/tooltip/nz-tooltip.definitions.ts
+++ b/components/tooltip/nz-tooltip.definitions.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-export type NzTooltipTrigger = 'click' | 'focus' | 'hover' | null;
+export type NzTooltipTrigger = 'click' | 'focus' | 'hover' | 'ellipsisHover' | null;

--- a/components/tooltip/nz-tooltip.spec.ts
+++ b/components/tooltip/nz-tooltip.spec.ts
@@ -63,7 +63,21 @@ export class NzTooltipTestDirectiveComponent {
     <nz-tooltip nzTitle="FOCUS" [nzTrigger]="'focus'"><span #focusTrigger nz-tooltip>Show</span></nz-tooltip>
     <nz-tooltip nzTitle="CLICK" nzTrigger="click"><span #clickTrigger nz-tooltip>Show</span></nz-tooltip>
     <nz-tooltip nzTitle="VISIBLE" [(nzVisible)]="visible"><span #visibleTrigger nz-tooltip>Show</span></nz-tooltip>
-  `
+    <nz-tooltip nzTitle="ELLIPSISHOVER" nzTrigger="ellipsisHover"
+      ><span #ellipsisHoverTrigger nz-tooltip class="ellipsis">Ellipsis Hover show</span></nz-tooltip
+    >
+  `,
+  styles: [
+    `
+      .ellipsis {
+        display: inline-block;
+        width: 10px;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+    `
+  ]
 })
 export class NzTooltipTestWrapperComponent {
   @ViewChild('clickTrigger', { static: false }) clickTrigger: ElementRef;
@@ -73,6 +87,7 @@ export class NzTooltipTestWrapperComponent {
   @ViewChild('normalTrigger', { static: false }) normalTrigger: ElementRef;
   @ViewChild('templateTrigger', { static: false }) templateTrigger: ElementRef;
   @ViewChild('visibleTrigger', { static: false }) visibleTrigger: ElementRef;
+  @ViewChild('ellipsisHoverTrigger', { static: false }) ellipsisHoverTrigger: ElementRef;
   visible: boolean;
   visibleTogglingCount = 0;
 
@@ -184,6 +199,27 @@ describe('NzTooltip', () => {
       expect(overlayContainerElement.textContent).toContain(featureKey);
 
       dispatchMouseEvent(overlayContainerElement.querySelector('.cdk-overlay-backdrop')!, 'click');
+      waitingForTooltipToggling(fixture);
+      expect(overlayContainerElement.textContent).not.toContain(featureKey);
+    }));
+
+    it('should show/hide tooltip by ellipsis hover if text too long', fakeAsync(() => {
+      const featureKey = 'ELLIPSISHOVER';
+      const triggerElement = component.ellipsisHoverTrigger.nativeElement;
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling(fixture);
+      expect(overlayContainerElement.textContent).toContain(featureKey);
+
+      dispatchMouseEvent(triggerElement, 'mouseleave');
+      waitingForTooltipToggling(fixture);
+      expect(overlayContainerElement.textContent).not.toContain(featureKey);
+    }));
+
+    it('should not show tooltip by ellipsis hover if text not too long', fakeAsync(() => {
+      const featureKey = 'ELLIPSISHOVER';
+      const triggerElement = component.ellipsisHoverTrigger.nativeElement;
+      triggerElement.style.width = '500px';
+      dispatchMouseEvent(triggerElement, 'mouseenter');
       waitingForTooltipToggling(fixture);
       expect(overlayContainerElement.textContent).not.toContain(featureKey);
     }));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
when we use css property ellipsis to cut text and show '...', we want to show tooltip when hover on 'shyDn...' while do not show tooltip when hover on 'shy'

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
