### PR TITLE
fix(module:page-header): has footer or breadcrumb style bug

### DIFF
--- a/components/page-header/nz-page-header.component.ts
+++ b/components/page-header/nz-page-header.component.ts
@@ -21,7 +21,7 @@ import {
 } from '@angular/core';
 
 import { Location } from '@angular/common';
-import { NzPageHeaderFooterDirective } from './nz-page-header-cells';
+import { NzPageHeaderBreadcrumbDirective, NzPageHeaderFooterDirective } from './nz-page-header-cells';
 
 @Component({
   selector: 'nz-page-header',
@@ -32,7 +32,8 @@ import { NzPageHeaderFooterDirective } from './nz-page-header-cells';
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-page-header ant-page-header-ghost',
-    '[class.ant-page-header-has-footer]': 'nzPageHeaderFooter'
+    '[class.has-footer]': 'nzPageHeaderFooter',
+    '[class.has-breadcrumb]': 'nzPageHeaderBreadcrumb'
   },
   styles: [
     `
@@ -57,6 +58,10 @@ export class NzPageHeaderComponent implements OnChanges {
 
   @ContentChild(NzPageHeaderFooterDirective, { static: false }) nzPageHeaderFooter: ElementRef<
     NzPageHeaderFooterDirective
+  >;
+
+  @ContentChild(NzPageHeaderBreadcrumbDirective, { static: false }) nzPageHeaderBreadcrumb: ElementRef<
+    NzPageHeaderBreadcrumbDirective
   >;
 
   constructor(private location: Location) {}

--- a/components/page-header/nz-page-header.spec.ts
+++ b/components/page-header/nz-page-header.spec.ts
@@ -44,6 +44,7 @@ describe('NzPageHeaderComponent', () => {
     const fixture = TestBed.createComponent(NzDemoPageHeaderBreadcrumbComponent);
     const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
     fixture.detectChanges();
+    expect(pageHeader.nativeElement.classList).toContain('has-breadcrumb');
     expect(pageHeader.nativeElement.querySelector('nz-breadcrumb[nz-page-header-breadcrumb]')).toBeTruthy();
   });
 
@@ -80,7 +81,7 @@ describe('NzPageHeaderComponent', () => {
     const fixture = TestBed.createComponent(NzDemoPageHeaderResponsiveComponent);
     const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
     fixture.detectChanges();
-    expect(pageHeader.nativeElement.classList).toContain('ant-page-header-has-footer');
+    expect(pageHeader.nativeElement.classList).toContain('has-footer');
     expect(pageHeader.nativeElement.querySelector('nz-page-header-footer.ant-page-header-footer')).toBeTruthy();
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

 `NzPageHeaderComponent` don't use `.has-breadcrumb`  `.has-footer` style class

## What is the new behavior?

use `.has-breadcrumb`  `.has-footer` style class

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
