### PR TITLE
fix(module:pagination): replace full-width character with half-width

### DIFF
--- a/components/pagination/nz-pagination.component.html
+++ b/components/pagination/nz-pagination.component.html
@@ -26,7 +26,7 @@
                [value]="nzPageIndex"
                (keydown.enter)="handleKeyDown($event,simplePagerInput,false)"
                size="3">
-        <span class="ant-pagination-slash">／</span>
+        <span class="ant-pagination-slash">/</span>
         {{ lastIndex }}
       </li>
       <li class="ant-pagination-next"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The character used in pagination is changed from '／' with '/'. The full-width one is only used in some Chinese paragraph.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
