### PR TITLE
docs: fix icon link

### DIFF
--- a/components/icon/doc/index.en-US.md
+++ b/components/icon/doc/index.en-US.md
@@ -9,7 +9,7 @@ Semantic vector graphics.
 
 ## List of icons
 
-We are still adding icons right now, syncing to [antd](https://ant.design/components/icon-cn/#components-icon-demo-iconfont).
+We are still adding icons right now, syncing to [antd](https://ng.ant.design/components/icon/en#components-icon-demo-iconfont).
 
 ## Import this Component Individually
 


### PR DESCRIPTION
The old link refers to the ant-design react project.
So I change it the the correct one.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The link jumps to the documentation for React Ant Design project(zh_cn).
Issue Number: N/A


## What is the new behavior?
The link now jumps to the documentation for Angular Ant Design project(en).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
