### PR TITLE
Fix wrong tooltip definitions

### DIFF
--- a/components/tooltip/nz-tooltip.definitions.ts
+++ b/components/tooltip/nz-tooltip.definitions.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-export type NzTooltipTrigger = 'click' | 'focus' | 'hover' | null;
+export type NzTooltipTrigger = 'click' | 'focus' | 'hover' | 'null';


### PR DESCRIPTION
The [nzTooltipTrigger] requires a string with the value `'null'` instead of a `null` value. The definition file specifies a `null` primitive

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
``` 