### PR TITLE
docs: correct grammar within English docs

### DIFF
--- a/components/table/demo/ajax.md
+++ b/components/table/demo/ajax.md
@@ -15,6 +15,6 @@ title:
 
 This example shows how to fetch and present data from remote server, and how to implement filtering and sorting in server side by sending related parameters to server.
 
-**Note, this example use [Mock API](https://randomuser.me) that you can look up in Network Console.**
+**Note, this example uses a [Mock API](https://randomuser.me) that you can look up in Network Console.**
 
 


### PR DESCRIPTION
Possible corrections for "this example use mock api..." are "This example makes use of a Mock api..." and "This  example uses a Mock api...."

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

 [X] Documentation only content changes

## Does this PR introduce a breaking change?
```
[ ] Yes
[*] No
```

This PR corrects the usage of grammar within the docs. 

The correct usage for proposed changes : "this example use mock api..." are "This example makes use of a Mock api..." and "This  example uses a Mock api...."

The PR proposes we change the usage to match common English language usage patterns