### PR TITLE
fix(module:select): fix option's selected hight-light

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -234,8 +234,5 @@
     "@schematics/angular:directive": {
       "prefix": "app"
     }
-  },
-  "cli": {
-    "analytics": "cdac4125-2526-4241-b76d-0ed9b18a8670"
   }
 }

--- a/angular.json
+++ b/angular.json
@@ -234,5 +234,8 @@
     "@schematics/angular:directive": {
       "prefix": "app"
     }
+  },
+  "cli": {
+    "analytics": "cdac4125-2526-4241-b76d-0ed9b18a8670"
   }
 }

--- a/components/select/nz-option-li.component.ts
+++ b/components/select/nz-option-li.component.ts
@@ -35,7 +35,6 @@ import { NzSelectService } from './nz-select.service';
   host: {
     '[class.ant-select-dropdown-menu-item-selected]': 'selected && !nzOption.nzDisabled',
     '[class.ant-select-dropdown-menu-item-disabled]': 'nzOption.nzDisabled',
-    '[class.ant-select-dropdown-menu-item-active]': 'active && !nzOption.nzDisabled',
     '[attr.unselectable]': '"unselectable"',
     '[style.user-select]': '"none"',
     '(click)': 'clickOption()',
@@ -45,7 +44,6 @@ import { NzSelectService } from './nz-select.service';
 export class NzOptionLiComponent implements OnInit, OnDestroy {
   el: HTMLElement = this.elementRef.nativeElement;
   selected = false;
-  active = false;
   destroy$ = new Subject();
   @Input() nzOption: NzOptionComponent;
   @Input() nzMenuItemSelectedIcon: TemplateRef<void>;
@@ -68,12 +66,7 @@ export class NzOptionLiComponent implements OnInit, OnDestroy {
       this.selected = isNotNil(list.find(v => this.nzSelectService.compareWith(v, this.nzOption.nzValue)));
       this.cdr.markForCheck();
     });
-    this.nzSelectService.activatedOption$.pipe(takeUntil(this.destroy$)).subscribe(option => {
-      if (option) {
-        this.active = this.nzSelectService.compareWith(option.nzValue, this.nzOption.nzValue);
-      } else {
-        this.active = false;
-      }
+    this.nzSelectService.activatedOption$.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.cdr.markForCheck();
     });
   }

--- a/components/select/nz-option-li.spec.ts
+++ b/components/select/nz-option-li.spec.ts
@@ -50,19 +50,6 @@ describe('select option li', () => {
       fixture.detectChanges();
       expect(liComponent.selected).toBe(false);
     });
-    it('should active work', () => {
-      fixture.detectChanges();
-      expect(liComponent.active).toBe(false);
-      const option01 = new NzOptionComponent();
-      option01.nzLabel = '01_label';
-      option01.nzValue = '01_value';
-      nzSelectService.activatedOption$.next(option01);
-      fixture.detectChanges();
-      expect(liComponent.active).toBe(true);
-      nzSelectService.activatedOption$.next(null);
-      fixture.detectChanges();
-      expect(liComponent.active).toBe(false);
-    });
     it('should destroy piped', () => {
       fixture.detectChanges();
       // @ts-ignore


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The rule of Select option is different from antd design's . The question is that highlight doesn't disappear when mouse leave the option selected.
Issue Number: N/A


## What is the new behavior?
Hightlight will disappear as expected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
