### PR TITLE
refactor(module: resizable): change cursor styles

### DIFF
--- a/components/resizable/nz-resizable.directive.ts
+++ b/components/resizable/nz-resizable.directive.ts
@@ -178,11 +178,11 @@ export class NzResizableDirective implements AfterViewInit, OnDestroy {
     switch (this.currentHandleEvent!.direction) {
       case 'left':
       case 'right':
-        this.renderer.setStyle(document.body, 'cursor', 'col-resize');
+        this.renderer.setStyle(document.body, 'cursor', 'ew-resize');
         break;
       case 'top':
       case 'bottom':
-        this.renderer.setStyle(document.body, 'cursor', 'row-resize');
+        this.renderer.setStyle(document.body, 'cursor', 'ns-resize');
         break;
       case 'topLeft':
       case 'bottomRight':

--- a/components/resizable/style/index.less
+++ b/components/resizable/style/index.less
@@ -69,10 +69,10 @@
   &:not(.@{resizable-prefix-cls}-resizing) {
     .@{resizable-prefix-cls}-handle {
       &-top, &-bottom {
-        cursor: row-resize;
+        cursor: ns-resize;
       }
       &-right, &-left {
-        cursor: col-resize;
+        cursor: ew-resize;
       }
       &-bottomRight, &-topLeft {
         cursor: nwse-resize;


### PR DESCRIPTION
In order to keep the style consistent, the cursors for col-resize should be changed to ew-resize (row-resize to ns-resize).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

* Cursors for [Resizable](https://ng.ant.design/experimental/resizable/en) are now using different styles between `[col/row]` and `[ew/ns]`, which make the UI style inconsistent (e.g., on Windows).
  + Because there are events to add these cursor styles to `<body>` element during MouseDown, it's hard to make a local patch using CSS only.
<img src="https://i.imgur.com/O7UD6Vn.png" width="500px"/> 
Issue Number: N/A


## What is the new behavior?
As screenshot above (both col-resize and row-resize are change to ew- and ns- like styles)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
