### PR TITLE
chore(module:tree, tree-select): remove deprecated API

### DIFF
--- a/components/tree-select/nz-tree-select.component.ts
+++ b/components/tree-select/nz-tree-select.component.ts
@@ -47,7 +47,6 @@ import {
   NzTreeNode,
   NzTreeNodeOptions,
   slideMotion,
-  warnDeprecation,
   WithConfig,
   zoomMotion
 } from 'ng-zorro-antd/core';
@@ -123,17 +122,6 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
   @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME, 'default') nzSize: NzSizeLDSType;
   @Input() nzPlaceHolder = '';
   @Input() nzDropdownStyle: { [key: string]: string };
-  /**
-   * @deprecated 9.0.0 - use `nzExpandedKeys` instead.
-   */
-  @Input()
-  set nzDefaultExpandedKeys(value: string[]) {
-    warnDeprecation(`'nzDefaultExpandedKeys' would be removed in 9.0.0. Please use 'nzExpandedKeys' instead.`);
-    this.expandedKeys = value;
-  }
-  get nzDefaultExpandedKeys(): string[] {
-    return this.expandedKeys;
-  }
 
   @Input()
   set nzExpandedKeys(value: string[]) {

--- a/components/tree-select/nz-tree-select.spec.ts
+++ b/components/tree-select/nz-tree-select.spec.ts
@@ -494,7 +494,6 @@ describe('tree-select component', () => {
       testComponent.expandKeys = [];
       treeSelect.nativeElement.click();
       fixture.detectChanges();
-      expect(treeSelectComponent.nzDefaultExpandedKeys.length === 0).toBe(true);
       expect(treeSelectComponent.nzExpandedKeys.length === 0).toBe(true);
       expect(treeSelectComponent.nzOpen).toBe(true);
       let targetSwitcher = overlayContainerElement.querySelector('.ant-select-tree-switcher')!;
@@ -503,7 +502,6 @@ describe('tree-select component', () => {
       dispatchMouseEvent(targetSwitcher, 'click');
       fixture.detectChanges();
       expect(targetSwitcher.classList.contains('ant-select-tree-switcher_open')).toBe(true);
-      expect(treeSelectComponent.nzDefaultExpandedKeys[0] === '1001').toBe(true);
       expect(treeSelectComponent.nzExpandedKeys[0] === '1001').toBe(true);
       treeSelect.nativeElement.click();
       fixture.detectChanges();
@@ -513,7 +511,6 @@ describe('tree-select component', () => {
       targetSwitcher = overlayContainerElement.querySelector('.ant-select-tree-switcher')!;
       expect(treeSelectComponent.nzOpen).toBe(true);
       expect(targetSwitcher.classList.contains('ant-select-tree-switcher_open')).toBe(true);
-      expect(treeSelectComponent.nzDefaultExpandedKeys[0] === '1001').toBe(true);
       expect(treeSelectComponent.nzExpandedKeys[0] === '1001').toBe(true);
     });
   });

--- a/components/tree-select/nz-tree-select.spec.ts
+++ b/components/tree-select/nz-tree-select.spec.ts
@@ -633,7 +633,7 @@ export class NzTestTreeSelectBasicComponent {
     <nz-tree-select
       style="width: 250px"
       nzPlaceHolder="Please select"
-      [nzDefaultExpandedKeys]="expandKeys"
+      [nzExpandedKeys]="expandKeys"
       [nzNodes]="nodes"
       [nzShowSearch]="showSearch"
       [nzCheckable]="true"

--- a/components/tree/nz-tree-node.component.ts
+++ b/components/tree/nz-tree-node.component.ts
@@ -32,8 +32,7 @@ import {
   NzNoAnimationDirective,
   NzTreeBaseService,
   NzTreeNode,
-  treeCollapseMotion,
-  warnDeprecation
+  treeCollapseMotion
 } from 'ng-zorro-antd/core';
 
 @Component({
@@ -72,22 +71,6 @@ export class NzTreeNodeComponent implements OnInit, OnChanges, OnDestroy {
 
   get nzDraggable(): boolean {
     return this._nzDraggable;
-  }
-
-  /**
-   * @deprecated use `nzExpandAll` instead.
-   */
-  @Input()
-  set nzDefaultExpandAll(value: boolean) {
-    warnDeprecation(`'nzDefaultExpandAll' is going to be removed in 9.0.0. Please use 'nzExpandAll' instead.`);
-    this._nzExpandAll = value;
-    if (value && this.nzTreeNode && !this.nzTreeNode.isLeaf) {
-      this.nzTreeNode.isExpanded = true;
-    }
-  }
-
-  get nzDefaultExpandAll(): boolean {
-    return this._nzExpandAll;
   }
 
   // default set

--- a/components/tree/nz-tree.component.ts
+++ b/components/tree/nz-tree.component.ts
@@ -39,7 +39,6 @@ import {
   NzTreeBaseService,
   NzTreeHigherOrderServiceToken,
   NzTreeNode,
-  warnDeprecation,
   WithConfig
 } from 'ng-zorro-antd/core';
 
@@ -91,23 +90,6 @@ export class NzTreeComponent extends NzTreeBase implements OnInit, OnDestroy, Co
     return this.nzTreeTemplate || this.nzTreeTemplateChild;
   }
 
-  /**
-   * @deprecated 9.0.0 use `nzExpandAll` instead.
-   */
-  @Input()
-  @InputBoolean()
-  set nzDefaultExpandAll(value: boolean) {
-    warnDeprecation(`'nzDefaultExpandAll' would be removed in 9.0.0. Please use 'nzExpandAll' instead.`);
-    this.nzExpandAll = value;
-    this._nzDefaultExpandAll = value;
-  }
-
-  get nzDefaultExpandAll(): boolean {
-    return this._nzDefaultExpandAll;
-  }
-
-  private _nzDefaultExpandAll = false;
-
   @Input() nzBeforeDrop: (confirm: NzFormatBeforeDropEvent) => Observable<boolean>;
 
   @Input() @InputBoolean() nzMultiple = false;
@@ -116,33 +98,6 @@ export class NzTreeComponent extends NzTreeBase implements OnInit, OnDestroy, Co
   // tslint:disable-next-line:no-any
   set nzData(value: any[]) {
     this.initNzData(value);
-  }
-
-  /**
-   * @deprecated 9.0.0 - use `nzExpandedKeys` instead.
-   */
-  @Input()
-  set nzDefaultExpandedKeys(value: string[]) {
-    warnDeprecation(`'nzDefaultExpandedKeys' would be removed in 9.0.0. Please use 'nzExpandedKeys' instead.`);
-    this.nzDefaultSubject.next({ type: 'nzExpandedKeys', keys: value });
-  }
-
-  /**
-   * @deprecated 9.0.0 - use `nzSelectedKeys` instead.
-   */
-  @Input()
-  set nzDefaultSelectedKeys(value: string[]) {
-    warnDeprecation(`'nzDefaultSelectedKeys' would be removed in 9.0.0. Please use 'nzSelectedKeys' instead.`);
-    this.nzDefaultSubject.next({ type: 'nzSelectedKeys', keys: value });
-  }
-
-  /**
-   * @deprecated 9.0.0 - use `nzCheckedKeys` instead.
-   */
-  @Input()
-  set nzDefaultCheckedKeys(value: string[]) {
-    warnDeprecation(`'nzDefaultCheckedKeys' would be removed in 9.0.0. Please use 'nzCheckedKeys' instead.`);
-    this.nzDefaultSubject.next({ type: 'nzCheckedKeys', keys: value });
   }
 
   @Input()
@@ -166,11 +121,6 @@ export class NzTreeComponent extends NzTreeBase implements OnInit, OnDestroy, Co
     this.nzTreeService.searchExpand(value);
     if (isNotNil(value)) {
       this.nzSearchValueChange.emit(this.nzTreeService.formatEvent('search', null, null));
-      /**
-       * @deprecated 9.0.0 - use `nzOnSearchNode` instead.
-       * Hide warning, need remove next version
-       */
-      this.nzOnSearchNode.emit(this.nzTreeService.formatEvent('search', null, null));
     }
   }
 
@@ -190,11 +140,6 @@ export class NzTreeComponent extends NzTreeBase implements OnInit, OnDestroy, Co
   @Output() readonly nzCheckedKeysChange: EventEmitter<string[]> = new EventEmitter<string[]>();
 
   @Output() readonly nzSearchValueChange = new EventEmitter<NzFormatEmitEvent>();
-
-  /**
-   * @deprecated use `nzSearchValueChange` instead.
-   */
-  @Output() readonly nzOnSearchNode = new EventEmitter<NzFormatEmitEvent>();
 
   @Output() readonly nzClick = new EventEmitter<NzFormatEmitEvent>();
   @Output() readonly nzDblClick = new EventEmitter<NzFormatEmitEvent>();

--- a/components/tree/nz-tree.spec.ts
+++ b/components/tree/nz-tree.spec.ts
@@ -30,7 +30,7 @@ describe('nz-tree', () => {
       treeElement = fixture.debugElement.query(By.directive(NzTreeComponent)).nativeElement;
     }));
 
-    it('should set nzDefaultXXX correctly', fakeAsync(() => {
+    it('should set default property correctly', fakeAsync(() => {
       fixture.detectChanges();
       flush();
       tick(300);
@@ -878,10 +878,10 @@ export class NzTestTreeDraggableComponent {
     <nz-tree
       [(ngModel)]="modelNodes"
       [nzMultiple]="true"
-      [nzDefaultExpandedKeys]="expandKeys"
-      [nzDefaultCheckedKeys]="checkedKeys"
-      [nzDefaultSelectedKeys]="selectedKeys"
-      [nzDefaultExpandAll]="expandDefault"
+      [nzExpandedKeys]="expandKeys"
+      [nzCheckedKeys]="checkedKeys"
+      [nzSelectedKeys]="selectedKeys"
+      [nzExpandAll]="expandDefault"
       (nzExpandChange)="nzEvent()"
     >
     </nz-tree>


### PR DESCRIPTION
 PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

BREAKING CHANGE:

* tree
 - Removed `[nzDefaultExpandAll]` use `[nzExpandAll]` instead.
 - Removed `[nzDefaultExpandedKeys]` use `[nzExpandedKeys]` instead.
 - Removed `[nzDefaultSelectedKeys]` use `[nzSelectedKeys]` instead.
 - Removed `[nzDefaultCheckedKeys]` use `[nzCheckedKeys]` instead.
 - Removed `(nzOnSearchNode)` use `(nzSearchValueChange)` instead.

* tree-select
 - Removed `[nzDefaultExpandedKeys]` use `[nzExpandedKeys]` instead.
