### PR TITLE
fix(module:carousel): fix index value passed to afterchange callback

### DIFF
--- a/components/carousel/nz-carousel.component.ts
+++ b/components/carousel/nz-carousel.component.ts
@@ -238,7 +238,7 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
       this.nzBeforeChange.emit({ from, to });
       this.strategy.switch(this.activeIndex, index).subscribe(() => {
         this.scheduleNextTransition();
-        this.nzAfterChange.emit(index);
+        this.nzAfterChange.emit(to);
         this.isTransiting = false;
       });
       this.markContentActive(to);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Index value emitted by afterChange output property when we go from either last item to first item or first item to last item is wrong.
ex: 
arr = [1,2,3,4].
- when we go from 4th element to 1st element in a circular swipe manner, the index value emitted is 4 instead of 0
-  when we go from 1st element to 4th element in a reverse circular swipe manner, the index value emitted is -1 instead of 3
Below is the demo of the issue where active index value show the value emitted by afterChange output property
https://angular-aacqoq.stackblitz.io
Below is the editor to play with for the same issue
https://stackblitz.com/edit/angular-aacqoq


## What is the new behavior?
ex: 
arr = [1,2,3,4].
- when we go from 4th element to 1st element in a circular swipe manner, the index value emitted is 0 instead of 4
-  when we go from 1st element to 4th element in a reverse circular swipe manner, the index value emitted is 3 instead of -1

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
No existing test cases to modify for this change