### PR TITLE
docs: changed notification title text in demo from "I will be close automatically." to "I will never close automatically." to maintain uniform pattern.

### DIFF
--- a/components/notification/demo/duration.ts
+++ b/components/notification/demo/duration.ts
@@ -11,7 +11,7 @@ export class NzDemoNotificationDurationComponent {
   createBasicNotification(): void {
     this.notification.blank(
       'Notification Title',
-      'I will never close automatically. I will be close automatically. I will never close automatically.',
+      'I will never close automatically. I will never close automatically. I will never close automatically.',
       { nzDuration: 0 }
     );
   }


### PR DESCRIPTION
Changed text from "I will be close automatically." to "I will never close automatically."

## PR Checklist
Please check if your PR fulfills the following requirements:

- [*] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [*] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
The observed pattern for notification content is three repeated sentences.
This PR fixes one instance where the pattern was off. 

<!-- Please check the one that applies to this PR using "x". -->
```

[*] Refactoring (no functional changes, no api changes)
[*] Application (the showcase website) / infrastructure changes
```

## What is the current behavior?
The notification content currently read:
`
I will never close automatically. I will be close automatically. I will never close automatically.
`

## What is the new behavior?
The notification content post PR would read:

`
I will never close automatically. I will never close automatically. I will never close automatically.
`

## Does this PR introduce a breaking change?
```
[ ] Yes
[*] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
