### PR TITLE
feat(module:date-picker): support parse input value

### DIFF
--- a/components/comment/demo/basic.ts
+++ b/components/comment/demo/basic.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { distanceInWords } from 'date-fns';
+import { formatDistance } from 'date-fns';
 
 @Component({
   selector: 'nz-demo-comment-basic',
@@ -35,7 +35,7 @@ import { distanceInWords } from 'date-fns';
 export class NzDemoCommentBasicComponent {
   likes = 0;
   dislikes = 0;
-  time = distanceInWords(new Date(), new Date());
+  time = formatDistance(new Date(), new Date());
 
   like(): void {
     this.likes = 1;

--- a/components/comment/demo/editor.ts
+++ b/components/comment/demo/editor.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { distanceInWords } from 'date-fns';
+import { formatDistance } from 'date-fns';
 
 @Component({
   selector: 'nz-demo-comment-editor',
@@ -51,12 +51,12 @@ export class NzDemoCommentEditorComponent {
           ...this.user,
           content,
           datetime: new Date(),
-          displayTime: distanceInWords(new Date(), new Date())
+          displayTime: formatDistance(new Date(), new Date())
         }
       ].map(e => {
         return {
           ...e,
-          displayTime: distanceInWords(new Date(), e.datetime)
+          displayTime: formatDistance(new Date(), e.datetime)
         };
       });
     }, 800);

--- a/components/comment/demo/list.ts
+++ b/components/comment/demo/list.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { addDays, distanceInWords } from 'date-fns';
+import { addDays, formatDistance } from 'date-fns';
 
 @Component({
   selector: 'nz-demo-comment-list',
@@ -25,7 +25,7 @@ export class NzDemoCommentListComponent {
       content:
         'We supply a series of design principles, practical patterns and high quality design resources' +
         '(Sketch and Axure), to help people create their product prototypes beautifully and efficiently.',
-      datetime: distanceInWords(new Date(), addDays(new Date(), 1))
+      datetime: formatDistance(new Date(), addDays(new Date(), 1))
     },
     {
       author: 'Han Solo',
@@ -33,7 +33,7 @@ export class NzDemoCommentListComponent {
       content:
         'We supply a series of design principles, practical patterns and high quality design resources' +
         '(Sketch and Axure), to help people create their product prototypes beautifully and efficiently.',
-      datetime: distanceInWords(new Date(), addDays(new Date(), 2))
+      datetime: formatDistance(new Date(), addDays(new Date(), 2))
     }
   ];
 }

--- a/components/core/time/candy-date.ts
+++ b/components/core/time/candy-date.ts
@@ -25,10 +25,11 @@ import {
   startOfMonth,
   startOfWeek
 } from 'date-fns';
-import addMonths from 'date-fns/add_months';
-import addYears from 'date-fns/add_years';
-import setDay from 'date-fns/set_day';
-import setMonth from 'date-fns/set_month';
+import addMonths from 'date-fns/addMonths';
+import addYears from 'date-fns/addYears';
+import setDay from 'date-fns/setDay';
+import setMonth from 'date-fns/setMonth';
+import { WeekDayIndex } from 'ng-zorro-antd/i18n';
 import { warn } from '../logger';
 import { IndexableObject } from '../types';
 
@@ -94,7 +95,7 @@ export class CandyDate implements IndexableObject {
   //   return this;
   // }
 
-  calendarStart(options?: { weekStartsOn: number | undefined }): CandyDate {
+  calendarStart(options?: { weekStartsOn: WeekDayIndex | undefined }): CandyDate {
     return new CandyDate(startOfWeek(startOfMonth(this.nativeDate), options));
   }
 
@@ -168,7 +169,7 @@ export class CandyDate implements IndexableObject {
     return new CandyDate(addMonths(this.nativeDate, amount));
   }
 
-  setDay(day: number, options?: { weekStartsOn: number }): CandyDate {
+  setDay(day: number, options?: { weekStartsOn: WeekDayIndex }): CandyDate {
     return new CandyDate(setDay(this.nativeDate, day, options));
   }
 

--- a/components/core/time/candy-date.ts
+++ b/components/core/time/candy-date.ts
@@ -29,10 +29,10 @@ import addMonths from 'date-fns/addMonths';
 import addYears from 'date-fns/addYears';
 import setDay from 'date-fns/setDay';
 import setMonth from 'date-fns/setMonth';
-import { WeekDayIndex } from 'ng-zorro-antd/i18n';
 import { warn } from '../logger';
 import { IndexableObject } from '../types';
 
+export type WeekDayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 export type CandyDateCompareGrain = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
 export type CandyDateType = CandyDate | Date | null;
 export type SingleValue = CandyDate | null;

--- a/components/date-picker/abstract-picker.component.ts
+++ b/components/date-picker/abstract-picker.component.ts
@@ -150,13 +150,9 @@ export abstract class AbstractPickerComponent implements OnInit, OnChanges, OnDe
     // Default format when it's empty
     if (!this.nzFormat) {
       if (this.showWeek) {
-        this.nzFormat = this.dateHelper.relyOnDatePipe ? 'yyyy-ww' : 'YYYY-WW'; // Format for week
+        this.nzFormat = 'yyyy-ww'; // Format for week
       } else {
-        if (this.dateHelper.relyOnDatePipe) {
-          this.nzFormat = this.nzShowTime ? 'yyyy-MM-dd HH:mm:ss' : 'yyyy-MM-dd';
-        } else {
-          this.nzFormat = this.nzShowTime ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD';
-        }
+        this.nzFormat = this.nzShowTime ? 'yyyy-MM-dd HH:mm:ss' : 'yyyy-MM-dd';
       }
     }
   }

--- a/components/date-picker/calendar-footer.component.ts
+++ b/components/date-picker/calendar-footer.component.ts
@@ -19,7 +19,8 @@ import {
 } from '@angular/core';
 
 import { CandyDate, isNonEmptyString, isTemplateRef } from 'ng-zorro-antd/core';
-import { DateHelperService, NzCalendarI18nInterface, transCompatFormat } from 'ng-zorro-antd/i18n';
+import { DateHelperService, NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
+import { transCompatFormat } from './lib/util';
 import { PREFIX_CLASS } from './name';
 
 @Component({

--- a/components/date-picker/calendar-footer.component.ts
+++ b/components/date-picker/calendar-footer.component.ts
@@ -19,7 +19,7 @@ import {
 } from '@angular/core';
 
 import { CandyDate, isNonEmptyString, isTemplateRef } from 'ng-zorro-antd/core';
-import { DateHelperByDatePipe, DateHelperService, NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
+import { DateHelperService, NzCalendarI18nInterface, transCompatFormat } from 'ng-zorro-antd/i18n';
 import { PREFIX_CLASS } from './name';
 
 @Component({
@@ -102,10 +102,7 @@ export class CalendarFooterComponent implements OnChanges {
     }
     if (changes.locale) {
       // NOTE: Compat for DatePipe formatting rules
-      let dateFormat: string = this.locale.dateFormat;
-      if (this.dateHelper.relyOnDatePipe) {
-        dateFormat = (this.dateHelper as DateHelperByDatePipe).transCompatFormat(dateFormat);
-      }
+      const dateFormat: string = transCompatFormat(this.locale.dateFormat);
       this.todayTitle = this.dateHelper.format(this.now.nativeDate, dateFormat);
     }
   }

--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -218,6 +218,20 @@ describe('NzDatePickerComponent', () => {
       expect(getPickerContainer()).toBeNull();
     }));
 
+    it('should support nzFormat', fakeAsync(() => {
+      fixtureInstance.nzFormat = 'dd.MM.yyyy';
+      fixtureInstance.nzValue = new Date('2020-03-04');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      const input = getPickerInput(fixture.debugElement);
+      expect(input.value).toBe('04.03.2020');
+      dispatchMouseEvent(queryFromOverlay('.ant-picker-cell')!, 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(input.value).toBe('24.02.2020');
+    }));
+
     it('should support nzClassName', () => {
       const className = (fixtureInstance.nzClassName = 'my-test-class');
       fixture.detectChanges();
@@ -855,7 +869,7 @@ describe('date-fns testing', () => {
     fixtureInstance.useSuite = 1;
   });
 
-  it('should nzFormat parse input value by date-fns', fakeAsync(() => {
+  it('should parse input value with nzFormat', fakeAsync(() => {
     const nzOnChange = spyOn(fixtureInstance, 'nzOnChange');
     fixtureInstance.nzFormat = 'dd.MM.yyyy';
     fixture.detectChanges();

--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -7,14 +7,15 @@ import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angu
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import isSameDay from 'date-fns/is_same_day';
+import isSameDay from 'date-fns/isSameDay';
 
 import { dispatchKeyboardEvent, dispatchMouseEvent, NgStyleInterface, typeInElement } from 'ng-zorro-antd/core';
 import en_US from '../i18n/languages/en_US';
 import { PREFIX_CLASS } from './name';
 import { getPicker, getPickerAbstract, getPickerInput } from './testing/util';
 
-import { NzI18nModule, NzI18nService } from 'ng-zorro-antd/i18n';
+import { enUS } from 'date-fns/locale';
+import { NZ_DATE_LOCALE, NzI18nModule, NzI18nService } from 'ng-zorro-antd/i18n';
 import { NzDatePickerModule } from './date-picker.module';
 
 registerLocaleData(zh);
@@ -835,6 +836,46 @@ describe('NzDatePickerComponent', () => {
   }
 });
 
+describe('date-fns testing', () => {
+  let fixture: ComponentFixture<NzTestDatePickerComponent>;
+  let fixtureInstance: NzTestDatePickerComponent;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsModule, NoopAnimationsModule, NzDatePickerModule, NzI18nModule],
+      providers: [{ provide: NZ_DATE_LOCALE, useValue: enUS }],
+      declarations: [NzTestDatePickerComponent]
+    });
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NzTestDatePickerComponent);
+    fixtureInstance = fixture.componentInstance;
+    fixtureInstance.useSuite = 1;
+  });
+
+  it('should nzFormat parse input value by date-fns', fakeAsync(() => {
+    const nzOnChange = spyOn(fixtureInstance, 'nzOnChange');
+    fixtureInstance.nzFormat = 'dd.MM.yyyy';
+    fixture.detectChanges();
+    dispatchMouseEvent(getPickerInput(fixture.debugElement), 'click');
+    fixture.detectChanges();
+    tick(500);
+    fixture.detectChanges();
+    const input = getPickerInput(fixture.debugElement);
+    typeInElement('25.10.2019', input);
+    fixture.detectChanges();
+    input.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+    fixture.detectChanges();
+    flush();
+    const result = (nzOnChange.calls.allArgs()[0] as Date[])[0];
+    expect(result.getFullYear()).toBe(2019);
+    expect(result.getMonth() + 1).toBe(10);
+    expect(result.getDate()).toBe(25);
+  }));
+});
+
 @Component({
   template: `
     <ng-container [ngSwitch]="useSuite">
@@ -846,6 +887,7 @@ describe('NzDatePickerComponent', () => {
         [nzDisabled]="nzDisabled"
         [nzClassName]="nzClassName"
         [nzDisabledDate]="nzDisabledDate"
+        [nzFormat]="nzFormat"
         [nzLocale]="nzLocale"
         [nzPlaceHolder]="nzPlaceHolder"
         [nzPopupStyle]="nzPopupStyle"
@@ -892,6 +934,7 @@ class NzTestDatePickerComponent {
   nzAutoFocus: boolean;
   nzDisabled: boolean;
   nzClassName: string;
+  nzFormat: string;
   nzDisabledDate: (d: Date) => boolean;
   nzLocale: any; // tslint:disable-line:no-any
   nzPlaceHolder: string;

--- a/components/date-picker/demo/basic.ts
+++ b/components/date-picker/demo/basic.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import getISOWeek from 'date-fns/get_iso_week';
+import getISOWeek from 'date-fns/getISOWeek';
 import { en_US, NzI18nService, zh_CN } from 'ng-zorro-antd/i18n';
 
 @Component({

--- a/components/date-picker/demo/disabled-date.ts
+++ b/components/date-picker/demo/disabled-date.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
-import differenceInCalendarDays from 'date-fns/difference_in_calendar_days';
-import setHours from 'date-fns/set_hours';
+import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
+import setHours from 'date-fns/setHours';
 import { DisabledTimeFn, DisabledTimePartial } from 'ng-zorro-antd/date-picker/standard-types';
 
 @Component({

--- a/components/date-picker/demo/presetted-ranges.ts
+++ b/components/date-picker/demo/presetted-ranges.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import endOfMonth from 'date-fns/end_of_month';
+import endOfMonth from 'date-fns/endOfMonth';
 
 @Component({
   selector: 'nz-demo-date-picker-presetted-ranges',

--- a/components/date-picker/lib/abstract-panel-header.html
+++ b/components/date-picker/lib/abstract-panel-header.html
@@ -27,7 +27,7 @@
         role="button"
         type="button"
         title="{{ selector.title || null }}"
-        (click)="selector.onClick ? selector.onClick() : null"
+        (click)="selector.onClick()"
       >
         {{ selector.label }}
       </button>

--- a/components/date-picker/lib/abstract-panel-header.ts
+++ b/components/date-picker/lib/abstract-panel-header.ts
@@ -87,7 +87,7 @@ export abstract class AbstractPanelHeader implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.value) {
+    if (changes.value || changes.locale) {
       this.render();
     }
   }

--- a/components/date-picker/lib/date-header.component.ts
+++ b/components/date-picker/lib/date-header.component.ts
@@ -9,8 +9,9 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { PanelSelector } from './interface';
 
-import { DateHelperService, transCompatFormat } from 'ng-zorro-antd/i18n';
+import { DateHelperService } from 'ng-zorro-antd/i18n';
 import { AbstractPanelHeader } from './abstract-panel-header';
+import { transCompatFormat } from './util';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/components/date-picker/lib/date-header.component.ts
+++ b/components/date-picker/lib/date-header.component.ts
@@ -9,7 +9,7 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { PanelSelector } from './interface';
 
-import { DateHelperByDatePipe, DateHelperService } from 'ng-zorro-antd/i18n';
+import { DateHelperService, transCompatFormat } from 'ng-zorro-antd/i18n';
 import { AbstractPanelHeader } from './abstract-panel-header';
 
 @Component({
@@ -25,16 +25,12 @@ export class DateHeaderComponent extends AbstractPanelHeader {
   }
 
   getSelectors(): PanelSelector[] {
-    let yearFormat: string = this.locale.yearFormat;
-    if (this.dateHelper.relyOnDatePipe) {
-      yearFormat = (this.dateHelper as DateHelperByDatePipe).transCompatFormat(yearFormat);
-    }
     return [
       {
         className: `${this.prefixCls}-year-btn`,
         title: this.locale.yearSelect,
         onClick: () => this.changeMode('year'),
-        label: this.dateHelper.format(this.value.nativeDate, yearFormat)
+        label: this.dateHelper.format(this.value.nativeDate, transCompatFormat(this.locale.yearFormat))
       },
       {
         className: `${this.prefixCls}-month-btn`,

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -20,7 +20,7 @@ import {
 } from '@angular/core';
 
 import { CandyDate, valueFunctionProp } from 'ng-zorro-antd/core';
-import { DateHelperService, NzCalendarI18nInterface, NzI18nService } from 'ng-zorro-antd/i18n';
+import { DateHelperService, NzCalendarI18nInterface, NzI18nService, transCompatFormat } from 'ng-zorro-antd/i18n';
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell, DayCell } from './interface';
 
@@ -134,9 +134,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
 
       for (let day = 0; day < 7; day++) {
         const date = weekStart.addDays(day);
-        const dateFormat = this.dateHelper.relyOnDatePipe
-          ? 'longDate'
-          : this.i18n.getLocaleData('DatePicker.lang.dateFormat', 'YYYY-MM-DD');
+        const dateFormat = transCompatFormat(this.i18n.getLocaleData('DatePicker.lang.dateFormat', 'YYYY-MM-DD'));
         const title = this.dateHelper.format(date.nativeDate, dateFormat);
         const label = this.dateHelper.format(date.nativeDate, 'dd');
 

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -20,9 +20,10 @@ import {
 } from '@angular/core';
 
 import { CandyDate, valueFunctionProp } from 'ng-zorro-antd/core';
-import { DateHelperService, NzCalendarI18nInterface, NzI18nService, transCompatFormat } from 'ng-zorro-antd/i18n';
+import { DateHelperService, NzCalendarI18nInterface, NzI18nService } from 'ng-zorro-antd/i18n';
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell, DayCell } from './interface';
+import { transCompatFormat } from './util';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -99,7 +99,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
       const day = start.addDays(colIndex);
       weekDays.push({
         value: day.nativeDate,
-        title: this.dateHelper.format(day.nativeDate, this.dateHelper.relyOnDatePipe ? 'E' : 'ddd'), // eg. Tue
+        title: this.dateHelper.format(day.nativeDate, 'E'), // eg. Tue
         content: this.dateHelper.format(day.nativeDate, this.getVeryShortWeekFormat()), // eg. Tu,
         isSelected: false,
         isDisabled: false,
@@ -111,15 +111,12 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
   }
 
   private getVeryShortWeekFormat(): string {
-    if (this.dateHelper.relyOnDatePipe) {
-      return this.i18n
-        .getLocaleId()
-        .toLowerCase()
-        .indexOf('zh') === 0
-        ? 'EEEEE'
-        : 'EEEEEE'; // Use extreme short for chinese
-    }
-    return 'dd';
+    return this.i18n
+      .getLocaleId()
+      .toLowerCase()
+      .indexOf('zh') === 0
+      ? 'EEEEE'
+      : 'EEEEEE'; // Use extreme short for chinese
   }
 
   makeBodyRows(): DateBodyRow[] {
@@ -141,7 +138,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
           ? 'longDate'
           : this.i18n.getLocaleData('DatePicker.lang.dateFormat', 'YYYY-MM-DD');
         const title = this.dateHelper.format(date.nativeDate, dateFormat);
-        const label = this.dateHelper.format(date.nativeDate, this.dateHelper.relyOnDatePipe ? 'dd' : 'DD');
+        const label = this.dateHelper.format(date.nativeDate, 'dd');
 
         const cell: DayCell = {
           value: date.nativeDate,

--- a/components/date-picker/lib/decade-header.component.ts
+++ b/components/date-picker/lib/decade-header.component.ts
@@ -42,7 +42,9 @@ export class DecadeHeaderComponent extends AbstractPanelHeader {
       {
         className: `${this.prefixCls}-decade-btn`,
         title: '',
-        onClick: () => null,
+        onClick: () => {
+          // noop
+        },
         label: `${this.startYear}-${this.endYear}`
       }
     ];

--- a/components/date-picker/lib/month-header.component.ts
+++ b/components/date-picker/lib/month-header.component.ts
@@ -9,8 +9,9 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { PanelSelector } from './interface';
 
-import { DateHelperService, transCompatFormat } from 'ng-zorro-antd/i18n';
+import { DateHelperService } from 'ng-zorro-antd/i18n';
 import { AbstractPanelHeader } from './abstract-panel-header';
+import { transCompatFormat } from './util';
 
 @Component({
   encapsulation: ViewEncapsulation.None,

--- a/components/date-picker/lib/month-header.component.ts
+++ b/components/date-picker/lib/month-header.component.ts
@@ -9,7 +9,7 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { PanelSelector } from './interface';
 
-import { DateHelperByDatePipe, DateHelperService } from 'ng-zorro-antd/i18n';
+import { DateHelperService, transCompatFormat } from 'ng-zorro-antd/i18n';
 import { AbstractPanelHeader } from './abstract-panel-header';
 
 @Component({
@@ -25,16 +25,12 @@ export class MonthHeaderComponent extends AbstractPanelHeader {
   }
 
   getSelectors(): PanelSelector[] {
-    let yearFormat: string = this.locale.yearFormat;
-    if (this.dateHelper.relyOnDatePipe) {
-      yearFormat = (this.dateHelper as DateHelperByDatePipe).transCompatFormat(yearFormat);
-    }
     return [
       {
         className: `${this.prefixCls}-month-btn`,
         title: this.locale.yearSelect,
         onClick: () => this.changeMode('year'),
-        label: this.dateHelper.format(this.value.nativeDate, yearFormat)
+        label: this.dateHelper.format(this.value.nativeDate, transCompatFormat(this.locale.yearFormat))
       }
     ];
   }

--- a/components/date-picker/lib/util.ts
+++ b/components/date-picker/lib/util.ts
@@ -70,3 +70,22 @@ export function isAllowedDate(value: CandyDate, disabledDate?: DisabledDateFn, d
   }
   return true;
 }
+
+/**
+ * Compatible translate the moment-like format pattern to angular's pattern
+ * Why? For now, we need to support the existing language formats in AntD, and AntD uses the default temporal syntax.
+ *
+ * TODO: compare and complete all format patterns
+ * Each format docs as below:
+ * @link https://momentjs.com/docs/#/displaying/format/
+ * @link https://angular.io/api/common/DatePipe#description
+ * @param format input format pattern
+ */
+export function transCompatFormat(format: string): string {
+  return (
+    format &&
+    format
+      .replace(/Y/g, 'y') // only support y, yy, yyy, yyyy
+      .replace(/D/g, 'd')
+  ); // d, dd represent of D, DD for momentjs, others are not support
+}

--- a/components/date-picker/month-picker.component.spec.ts
+++ b/components/date-picker/month-picker.component.spec.ts
@@ -6,7 +6,7 @@ import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angu
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import isBefore from 'date-fns/is_before';
+import isBefore from 'date-fns/isBefore';
 
 import { dispatchMouseEvent, NgStyleInterface } from 'ng-zorro-antd/core';
 import { PREFIX_CLASS } from 'ng-zorro-antd/date-picker/name';

--- a/components/date-picker/picker.component.ts
+++ b/components/date-picker/picker.component.ts
@@ -403,7 +403,7 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
 
   private checkValidInputDate(inputTarget: EventTarget): CandyDate | null {
     const input = (inputTarget as HTMLInputElement).value;
-    const date = new CandyDate(input);
+    const date = new CandyDate(this.dateHelper.parseDate(input, this.format));
 
     if (!date.isValid() || input !== this.dateHelper.format(date.nativeDate, this.format)) {
       // Should also match the input format exactly

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -7,8 +7,8 @@ import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angu
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import differenceInDays from 'date-fns/difference_in_days';
-import isSameDay from 'date-fns/is_same_day';
+import differenceInDays from 'date-fns/differenceInDays';
+import isSameDay from 'date-fns/isSameDay';
 
 import { dispatchKeyboardEvent, dispatchMouseEvent, NgStyleInterface, typeInElement } from 'ng-zorro-antd/core';
 import { PREFIX_CLASS } from 'ng-zorro-antd/date-picker/name';

--- a/components/i18n/convert-tokens.ts
+++ b/components/i18n/convert-tokens.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright Alibaba.com All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+// Compatible for date-fns v1 from https://github.com/date-fns/date-fns-upgrade/blob/master/src/v2/convertTokens/index.ts
+
+interface TokensMap {
+  [v1token: string]: string;
+}
+
+const tokensMap: TokensMap = {
+  M: 'L',
+  Mo: 'Mo',
+  MM: 'LL',
+  MMM: 'LLL',
+  MMMM: 'LLLL',
+  Q: 'q',
+  Qo: 'qo',
+  D: 'd',
+  Do: 'do',
+  DD: 'dd',
+  DDD: 'D',
+  DDDo: 'Do',
+  DDDD: 'DDD',
+  d: 'i',
+  do: 'io',
+  dd: 'iiiiii',
+  ddd: 'iii',
+  dddd: 'iiii',
+  A: 'a',
+  a: 'a',
+  aa: 'aaaa',
+  E: 'i',
+  W: 'I',
+  Wo: 'Io',
+  WW: 'II',
+  YY: 'yy',
+  YYYY: 'yyyy',
+  GG: 'RR',
+  GGGG: 'RRRR',
+  H: 'H',
+  HH: 'HH',
+  h: 'h',
+  hh: 'hh',
+  m: 'm',
+  mm: 'mm',
+  s: 's',
+  ss: 'ss',
+  S: 'S',
+  SS: 'SS',
+  SSS: 'SSS',
+  Z: 'xxx',
+  ZZ: 'xx',
+  X: 't',
+  x: 'T'
+};
+
+const v1tokens = Object.keys(tokensMap)
+  .sort()
+  .reverse();
+
+// tslint:disable-next-line:prefer-template
+const tokensRegExp = new RegExp('(\\[[^\\[]*\\])|(\\\\)?' + '(' + v1tokens.join('|') + '|.)', 'g');
+
+interface TokensBuffer {
+  formatBuffer: string[];
+  textBuffer: string[];
+}
+
+export function convertTokens(format: string): string {
+  const tokensCaptures = format.match(tokensRegExp);
+  if (tokensCaptures) {
+    return tokensCaptures
+      .reduce(
+        (acc, tokenString, index) => {
+          const v2token = tokensMap[tokenString];
+
+          if (!v2token) {
+            const escapedCaptures = tokenString.match(/^\[(.+)\]$/);
+            if (escapedCaptures) {
+              acc.textBuffer.push(escapedCaptures[1]);
+            } else {
+              acc.textBuffer.push(tokenString);
+            }
+          }
+
+          const endOfString = index === tokensCaptures.length - 1;
+          if (acc.textBuffer.length && (v2token || endOfString)) {
+            acc.formatBuffer.push(`'${acc.textBuffer.join('')}'`);
+            acc.textBuffer = [];
+          }
+
+          if (v2token) {
+            acc.formatBuffer.push(v2token);
+          }
+
+          return acc;
+        },
+        { formatBuffer: [], textBuffer: [] } as TokensBuffer
+      )
+      .formatBuffer.join('');
+  } else {
+    return format;
+  }
+}

--- a/components/i18n/convert-tokens.ts
+++ b/components/i18n/convert-tokens.ts
@@ -73,7 +73,7 @@ interface TokensBuffer {
 }
 
 export function convertTokens(format: string): string {
-  warnDeprecation(`'NZ_DATE_FNS_COMPATIBLE' is deprecated and will be removed in next minor version. Please update to date-fns v2 format.`);
+  warnDeprecation(`'NZ_DATE_FNS_COMPATIBLE' will be removed in 10.0.0, please update to date-fns v2 format.`);
   const tokensCaptures = format.match(tokensRegExp);
   if (tokensCaptures) {
     return tokensCaptures

--- a/components/i18n/convert-tokens.ts
+++ b/components/i18n/convert-tokens.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
+import { warnDeprecation } from 'ng-zorro-antd/core';
 
 // Compatible for date-fns v1 from https://github.com/date-fns/date-fns-upgrade/blob/master/src/v2/convertTokens/index.ts
 
@@ -72,6 +73,7 @@ interface TokensBuffer {
 }
 
 export function convertTokens(format: string): string {
+  warnDeprecation(`'NZ_DATE_FNS_COMPATIBLE' is deprecated and will be removed in next minor version. Please update to date-fns v2 format.`);
   const tokensCaptures = format.match(tokensRegExp);
   if (tokensCaptures) {
     return tokensCaptures

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -7,8 +7,7 @@
  */
 
 import { InjectionToken } from '@angular/core';
-
-export type WeekDayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+import { WeekDayIndex } from 'ng-zorro-antd/core';
 
 export interface NzDateConfig {
   /** Customize the first day of a week */

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -8,6 +8,13 @@
 
 import { InjectionToken } from '@angular/core';
 
+export type WeekDayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface NzDateConfig {
+  /** Customize the first day of a week */
+  firstDayOfWeek?: WeekDayIndex;
+}
+
 export const NZ_DATE_CONFIG = new InjectionToken<NzDateConfig>('date-config');
 
 export const NZ_DATE_CONFIG_DEFAULT: NzDateConfig = {
@@ -18,7 +25,21 @@ export function mergeDateConfig(config: NzDateConfig): NzDateConfig {
   return { ...NZ_DATE_CONFIG_DEFAULT, ...config };
 }
 
-export interface NzDateConfig {
-  /** Customize the first day of a week */
-  firstDayOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+/**
+ * Compatible translate the moment-like format pattern to angular's pattern
+ * Why? For now, we need to support the existing language formats in AntD, and AntD uses the default temporal syntax.
+ *
+ * TODO: compare and complete all format patterns
+ * Each format docs as below:
+ * @link https://momentjs.com/docs/#/displaying/format/
+ * @link https://angular.io/api/common/DatePipe#description
+ * @param format input format pattern
+ */
+export function transCompatFormat(format: string): string {
+  return (
+    format &&
+    format
+      .replace(/Y/g, 'y') // only support y, yy, yyy, yyyy
+      .replace(/D/g, 'd')
+  ); // d, dd represent of D, DD for momentjs, others are not support
 }

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -20,7 +20,10 @@ export const NZ_DATE_CONFIG_DEFAULT: NzDateConfig = {
   firstDayOfWeek: undefined
 };
 
-export const NZ_DATE_FORMAT_CONVERT = new InjectionToken<boolean>('date-format-convert');
+/**
+ * @deprecated Will be removed in 10.0.0, please update to date-fns v2 format
+ */
+export const NZ_DATE_FNS_COMPATIBLE = new InjectionToken<boolean>('date-format-convert');
 
 export function mergeDateConfig(config: NzDateConfig): NzDateConfig {
   return { ...NZ_DATE_CONFIG_DEFAULT, ...config };

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -12,7 +12,6 @@ import { WeekDayIndex } from 'ng-zorro-antd/core';
 export interface NzDateConfig {
   /** Customize the first day of a week */
   firstDayOfWeek?: WeekDayIndex;
-  dateFnsFormatConvert?: boolean;
 }
 
 export const NZ_DATE_CONFIG = new InjectionToken<NzDateConfig>('date-config');
@@ -20,6 +19,8 @@ export const NZ_DATE_CONFIG = new InjectionToken<NzDateConfig>('date-config');
 export const NZ_DATE_CONFIG_DEFAULT: NzDateConfig = {
   firstDayOfWeek: undefined
 };
+
+export const NZ_DATE_FORMAT_CONVERT = new InjectionToken<boolean>('date-format-convert');
 
 export function mergeDateConfig(config: NzDateConfig): NzDateConfig {
   return { ...NZ_DATE_CONFIG_DEFAULT, ...config };

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -25,22 +25,3 @@ export const NZ_DATE_FORMAT_CONVERT = new InjectionToken<boolean>('date-format-c
 export function mergeDateConfig(config: NzDateConfig): NzDateConfig {
   return { ...NZ_DATE_CONFIG_DEFAULT, ...config };
 }
-
-/**
- * Compatible translate the moment-like format pattern to angular's pattern
- * Why? For now, we need to support the existing language formats in AntD, and AntD uses the default temporal syntax.
- *
- * TODO: compare and complete all format patterns
- * Each format docs as below:
- * @link https://momentjs.com/docs/#/displaying/format/
- * @link https://angular.io/api/common/DatePipe#description
- * @param format input format pattern
- */
-export function transCompatFormat(format: string): string {
-  return (
-    format &&
-    format
-      .replace(/Y/g, 'y') // only support y, yy, yyy, yyyy
-      .replace(/D/g, 'd')
-  ); // d, dd represent of D, DD for momentjs, others are not support
-}

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -13,6 +13,7 @@ export type WeekDayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 export interface NzDateConfig {
   /** Customize the first day of a week */
   firstDayOfWeek?: WeekDayIndex;
+  dateFnsCompat?: boolean;
 }
 
 export const NZ_DATE_CONFIG = new InjectionToken<NzDateConfig>('date-config');

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -12,7 +12,7 @@ import { WeekDayIndex } from 'ng-zorro-antd/core';
 export interface NzDateConfig {
   /** Customize the first day of a week */
   firstDayOfWeek?: WeekDayIndex;
-  dateFnsCompat?: boolean;
+  dateFnsFormatConvert?: boolean;
 }
 
 export const NZ_DATE_CONFIG = new InjectionToken<NzDateConfig>('date-config');

--- a/components/i18n/date-helper.service.spec.ts
+++ b/components/i18n/date-helper.service.spec.ts
@@ -64,7 +64,7 @@ describe('DateHelperService', () => {
         imports: [NzI18nModule],
         providers: [
           { provide: NZ_DATE_LOCALE, useValue: enUS },
-          { provide: NZ_DATE_CONFIG, useValue: { firstDayOfWeek: 4, dateFnsCompat: true } }
+          { provide: NZ_DATE_CONFIG, useValue: { firstDayOfWeek: 4, dateFnsFormatConvert: true } }
         ]
       });
 

--- a/components/i18n/date-helper.service.spec.ts
+++ b/components/i18n/date-helper.service.spec.ts
@@ -1,7 +1,7 @@
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import enDateLocale from 'date-fns/locale/en';
+import enDateLocale from 'date-fns/locale';
 import { NZ_DATE_CONFIG } from './date-config';
 import { DateHelperByDatePipe, DateHelperService } from './date-helper.service';
 import en_US from './languages/en_US';

--- a/components/i18n/date-helper.service.spec.ts
+++ b/components/i18n/date-helper.service.spec.ts
@@ -53,8 +53,8 @@ describe('DateHelperService', () => {
 
     it('should do formatting correctly', () => {
       const date = new Date('2018-12-31 12:11:10');
-      expect(dateHelper.format(date, 'YYYY-MM-DD')).toBe('2018-12-31');
-      expect(dateHelper.format(date, 'WW')).toBe('01'); // ISO week
+      expect(dateHelper.format(date, 'yyyy-MM-dd')).toBe('2018-12-31');
+      expect(dateHelper.format(date, 'II')).toBe('01'); // ISO week
     });
   });
 
@@ -62,7 +62,10 @@ describe('DateHelperService', () => {
     beforeEach(() => {
       injector = TestBed.configureTestingModule({
         imports: [NzI18nModule],
-        providers: [{ provide: NZ_DATE_CONFIG, useValue: { firstDayOfWeek: 4 } }]
+        providers: [
+          { provide: NZ_DATE_LOCALE, useValue: enUS },
+          { provide: NZ_DATE_CONFIG, useValue: { firstDayOfWeek: 4, dateFnsCompat: true } }
+        ]
       });
 
       dateHelper = injector.get(DateHelperService);
@@ -70,6 +73,19 @@ describe('DateHelperService', () => {
 
     it('should set first day of week to 4', () => {
       expect(dateHelper.getFirstDayOfWeek()).toBe(4);
+    });
+
+    it('should do compat formatting correctly', () => {
+      const date = new Date('2018-12-31 12:11:10');
+      expect(dateHelper.format(date, 'YYYY-MM-DD')).toBe('2018-12-31');
+      expect(dateHelper.format(date, 'WW')).toBe('01'); // ISO week
+    });
+
+    it('should do compat parse correctly', () => {
+      const date = dateHelper.parseDate('31.12.2018', 'DD.MM.YYYY');
+      expect(date.getFullYear()).toBe(2018);
+      expect(date.getMonth()).toBe(11);
+      expect(date.getDate()).toBe(31);
     });
   });
 });

--- a/components/i18n/date-helper.service.spec.ts
+++ b/components/i18n/date-helper.service.spec.ts
@@ -2,7 +2,7 @@ import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { enUS } from 'date-fns/locale';
-import { NZ_DATE_CONFIG, NZ_DATE_FORMAT_CONVERT } from './date-config';
+import { NZ_DATE_CONFIG, NZ_DATE_FNS_COMPATIBLE } from './date-config';
 import { DateHelperByDatePipe, DateHelperService } from './date-helper.service';
 import en_US from './languages/en_US';
 import { NzI18nModule } from './nz-i18n.module';
@@ -65,7 +65,7 @@ describe('DateHelperService', () => {
         providers: [
           { provide: NZ_DATE_LOCALE, useValue: enUS },
           { provide: NZ_DATE_CONFIG, useValue: { firstDayOfWeek: 4 } },
-          { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
+          { provide: NZ_DATE_FNS_COMPATIBLE, useValue: true }
         ]
       });
 

--- a/components/i18n/date-helper.service.spec.ts
+++ b/components/i18n/date-helper.service.spec.ts
@@ -2,7 +2,7 @@ import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { enUS } from 'date-fns/locale';
-import { NZ_DATE_CONFIG } from './date-config';
+import { NZ_DATE_CONFIG, NZ_DATE_FORMAT_CONVERT } from './date-config';
 import { DateHelperByDatePipe, DateHelperService } from './date-helper.service';
 import en_US from './languages/en_US';
 import { NzI18nModule } from './nz-i18n.module';
@@ -64,7 +64,8 @@ describe('DateHelperService', () => {
         imports: [NzI18nModule],
         providers: [
           { provide: NZ_DATE_LOCALE, useValue: enUS },
-          { provide: NZ_DATE_CONFIG, useValue: { firstDayOfWeek: 4, dateFnsFormatConvert: true } }
+          { provide: NZ_DATE_CONFIG, useValue: { firstDayOfWeek: 4 } },
+          { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
         ]
       });
 

--- a/components/i18n/date-helper.service.spec.ts
+++ b/components/i18n/date-helper.service.spec.ts
@@ -1,7 +1,7 @@
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import enDateLocale from 'date-fns/locale';
+import { enUS } from 'date-fns/locale';
 import { NZ_DATE_CONFIG } from './date-config';
 import { DateHelperByDatePipe, DateHelperService } from './date-helper.service';
 import en_US from './languages/en_US';
@@ -41,7 +41,7 @@ describe('DateHelperService', () => {
     beforeEach(() => {
       injector = TestBed.configureTestingModule({
         imports: [NzI18nModule],
-        providers: [{ provide: NZ_DATE_LOCALE, useValue: enDateLocale }]
+        providers: [{ provide: NZ_DATE_LOCALE, useValue: enUS }]
       });
 
       dateHelper = injector.get(DateHelperService);

--- a/components/i18n/date-helper.service.ts
+++ b/components/i18n/date-helper.service.ts
@@ -13,8 +13,9 @@ import fnsGetISOWeek from 'date-fns/getISOWeek';
 import fnsParse from 'date-fns/parse';
 
 import parseISO from 'date-fns/parseISO';
+import { WeekDayIndex } from 'ng-zorro-antd/core';
 import { convertTokens } from './convert-tokens';
-import { mergeDateConfig, NZ_DATE_CONFIG, NzDateConfig, WeekDayIndex } from './date-config';
+import { mergeDateConfig, NZ_DATE_CONFIG, NzDateConfig } from './date-config';
 import { NzI18nService } from './nz-i18n.service';
 
 export function DATE_HELPER_SERVICE_FACTORY(injector: Injector, config: NzDateConfig): DateHelperService {

--- a/components/i18n/date-helper.service.ts
+++ b/components/i18n/date-helper.service.ts
@@ -77,12 +77,12 @@ export class DateHelperByDateFns extends DateHelperService {
    * @param formatStr format string
    */
   format(date: Date, formatStr: string): string {
-    const mergedStr = this.config.dateFnsCompat ? convertTokens(formatStr) : formatStr;
+    const mergedStr = this.config.dateFnsFormatConvert ? convertTokens(formatStr) : formatStr;
     return date ? fnsFormat(date, mergedStr, { locale: this.i18n.getDateLocale() }) : '';
   }
 
   parseDate(text: string, formatStr: string): Date {
-    const mergedStr = this.config.dateFnsCompat ? convertTokens(formatStr) : formatStr;
+    const mergedStr = this.config.dateFnsFormatConvert ? convertTokens(formatStr) : formatStr;
     return fnsParse(text, mergedStr, new Date(), {
       locale: this.i18n.getDateLocale(),
       weekStartsOn: this.getFirstDayOfWeek()

--- a/components/i18n/date-helper.service.ts
+++ b/components/i18n/date-helper.service.ts
@@ -15,7 +15,7 @@ import fnsParse from 'date-fns/parse';
 import parseISO from 'date-fns/parseISO';
 import { WeekDayIndex } from 'ng-zorro-antd/core';
 import { convertTokens } from './convert-tokens';
-import { mergeDateConfig, NZ_DATE_CONFIG, NZ_DATE_FORMAT_CONVERT, NzDateConfig } from './date-config';
+import { mergeDateConfig, NZ_DATE_CONFIG, NZ_DATE_FNS_COMPATIBLE, NzDateConfig } from './date-config';
 import { NzI18nService } from './nz-i18n.service';
 
 export function DATE_HELPER_SERVICE_FACTORY(injector: Injector, config: NzDateConfig, convertFormat: boolean): DateHelperService {
@@ -32,13 +32,13 @@ export function DATE_HELPER_SERVICE_FACTORY(injector: Injector, config: NzDateCo
 @Injectable({
   providedIn: 'root',
   useFactory: DATE_HELPER_SERVICE_FACTORY,
-  deps: [Injector, [new Optional(), NZ_DATE_CONFIG], [new Optional(), NZ_DATE_FORMAT_CONVERT]]
+  deps: [Injector, [new Optional(), NZ_DATE_CONFIG], [new Optional(), NZ_DATE_FNS_COMPATIBLE]]
 })
 export abstract class DateHelperService {
   constructor(
     protected i18n: NzI18nService,
     @Optional() @Inject(NZ_DATE_CONFIG) protected config: NzDateConfig,
-    @Optional() @Inject(NZ_DATE_FORMAT_CONVERT) protected convertFormat: boolean
+    @Optional() @Inject(NZ_DATE_FNS_COMPATIBLE) protected convertFormat: boolean
   ) {
     this.config = mergeDateConfig(this.config);
   }

--- a/components/i18n/nz-i18n.interface.ts
+++ b/components/i18n/nz-i18n.interface.ts
@@ -119,5 +119,4 @@ export interface NzI18nInterface {
   };
 }
 
-// tslint:disable-next-line:no-any
-export type DateLocale = Locale; // TODO: Implement this type definition when date-fns is stable
+export type DateLocale = Locale;

--- a/components/i18n/nz-i18n.interface.ts
+++ b/components/i18n/nz-i18n.interface.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
+import { Locale } from 'date-fns';
 
 export interface NzPaginationI18nInterface {
   items_per_page: string;
@@ -119,4 +120,4 @@ export interface NzI18nInterface {
 }
 
 // tslint:disable-next-line:no-any
-export type DateLocale = any; // TODO: Implement this type definition when date-fns is stable
+export type DateLocale = Locale; // TODO: Implement this type definition when date-fns is stable

--- a/components/i18n/public-api.ts
+++ b/components/i18n/public-api.ts
@@ -8,7 +8,7 @@
 
 export { NzI18nModule } from './nz-i18n.module';
 export { NzI18nService } from './nz-i18n.service';
-export { NZ_DATE_CONFIG, NzDateConfig, WeekDayIndex, transCompatFormat } from './date-config';
+export { NZ_DATE_CONFIG, NzDateConfig, transCompatFormat } from './date-config';
 export * from './nz-i18n.interface';
 export * from './nz-i18n.token';
 export * from './date-helper.service';

--- a/components/i18n/public-api.ts
+++ b/components/i18n/public-api.ts
@@ -8,7 +8,7 @@
 
 export { NzI18nModule } from './nz-i18n.module';
 export { NzI18nService } from './nz-i18n.service';
-export { NZ_DATE_CONFIG, NzDateConfig } from './date-config';
+export { NZ_DATE_CONFIG, NzDateConfig, WeekDayIndex, transCompatFormat } from './date-config';
 export * from './nz-i18n.interface';
 export * from './nz-i18n.token';
 export * from './date-helper.service';

--- a/components/i18n/public-api.ts
+++ b/components/i18n/public-api.ts
@@ -8,7 +8,7 @@
 
 export { NzI18nModule } from './nz-i18n.module';
 export { NzI18nService } from './nz-i18n.service';
-export { NZ_DATE_CONFIG, NzDateConfig, transCompatFormat } from './date-config';
+export { NZ_DATE_CONFIG, NzDateConfig } from './date-config';
 export * from './nz-i18n.interface';
 export * from './nz-i18n.token';
 export * from './date-helper.service';

--- a/components/package.json
+++ b/components/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@angular/cdk": "^9.0.0",
     "@ant-design/icons-angular": "^9.0.0",
-    "date-fns": "^1.30.1",
+    "date-fns": "^2.10.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {

--- a/docs/i18n.en-US.md
+++ b/docs/i18n.en-US.md
@@ -43,16 +43,6 @@ The default configuration is as follows:
 }
 ```
 
-### NZ_DATE_FORMAT_CONVERT
-
-We have updated version of `date-fns` to 2.x, **We recommend that users use the new format of `date-fns` 2.x**, and we also provide `NZ_DATE_FORMAT_CONVERT` that `ng-zorro-antd` will convert 1.x format to 2.x format when you set `true`. For a comparison of the old and new formats, refer to [here](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20).
-```js
-providers: [
-  { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
-]
-```
-
-
 ## Service
 
 `ng-zorro-antd` provides the service of  `NzI18nService` to dynamic change the locale text.
@@ -166,3 +156,26 @@ registerLocaleData(en);
 ## Language supported by date-fns
 
 [https://date-fns.org/docs/I18n#supported-languages](https://date-fns.org/docs/I18n#supported-languages)
+
+
+## date-fns update
+
+We have upgraded `date-fns` to v2. When you switch to` date-fns`, some date formats will have a breaking change. Such as:
+
+```html
+<!-- datefns v1 -->
+<nz-date-picker nzFormat="YYYY-MM-DD"></nz-date-picker>
+
+<!-- datefns v2 -->
+<nz-date-picker nzFormat="yyyy-MM-dd"></nz-date-picker>
+```
+
+**We recommend using `date-fns` v2 date format**. If you don't want to use the new date format, you can use `NZ_DATE_FORMAT_CONVERT`. When set to` true`, `ng-zorro-antd` will convert the format of v1 to v2. See the comparison of the old and new formats [here](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20).
+
+```js
+providers: [
+  { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
+]
+```
+
+**But `NZ_DATE_FORMAT_CONVERT` won't be kept for too long, it will be removed until` ng-zorro-antd` v10**, I hope you can update the `date-fns` date format in time. For `date-fns` upgrade guide, see [here](https://github.com/date-fns/date-fns).

--- a/docs/i18n.en-US.md
+++ b/docs/i18n.en-US.md
@@ -170,12 +170,12 @@ We have upgraded `date-fns` to v2. When you switch to` date-fns`, some date form
 <nz-date-picker nzFormat="yyyy-MM-dd"></nz-date-picker>
 ```
 
-**We recommend using `date-fns` v2 date format**. If you don't want to use the new date format, you can use `NZ_DATE_FORMAT_CONVERT`. When set to` true`, `ng-zorro-antd` will convert the format of v1 to v2. See the comparison of the old and new formats [here](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20).
+**We recommend using `date-fns` v2 date format**. If you don't want to use the new date format, you can use `NZ_DATE_FNS_COMPATIBLE`. When set to` true`, `ng-zorro-antd` will convert the format of v1 to v2. See the comparison of the old and new formats [here](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20).
 
 ```js
 providers: [
-  { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
+  { provide: NZ_DATE_FNS_COMPATIBLE, useValue: true }
 ]
 ```
 
-**But `NZ_DATE_FORMAT_CONVERT` won't be kept for too long, it will be removed until` ng-zorro-antd` v10**, I hope you can update the `date-fns` date format in time. For `date-fns` upgrade guide, see [here](https://github.com/date-fns/date-fns).
+**But `NZ_DATE_FNS_COMPATIBLE` won't be kept for too long, we will remove the support for `date-fns` v1 format until ` ng-zorro-antd` v10**, we hope you can update the `date-fns` date format in time. For `date-fns` upgrade guide, see [here](https://github.com/date-fns/date-fns).

--- a/docs/i18n.en-US.md
+++ b/docs/i18n.en-US.md
@@ -39,11 +39,19 @@ The default configuration is as follows:
 ```js
 {
   /** Specify which day is the beginning of the week (null for default, 0 for Sunday, 1 for Monday, and so on) */
-  firstDayOfWeek: null,
-  / ** Whether to convert date-fns date format to 2.x, default is false **/
-  dateFnsFormatConvert: false
+  firstDayOfWeek: null
 }
 ```
+
+### NZ_DATE_FORMAT_CONVERT
+
+We have updated date-fns version to ^2.10.0, **We recommend that users use the new format of date-fns 2.x**, and we also provide this token that NG-ZORRO will convert 1.x format to 2.x format when you set `true`. For a comparison of the old and new formats, refer to [here](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)
+```js
+providers: [
+  { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
+]
+```
+
 
 ## Service
 

--- a/docs/i18n.en-US.md
+++ b/docs/i18n.en-US.md
@@ -39,7 +39,9 @@ The default configuration is as follows:
 ```js
 {
   /** Specify which day is the beginning of the week (null for default, 0 for Sunday, 1 for Monday, and so on) */
-  firstDayOfWeek: null
+  firstDayOfWeek: null,
+  / ** Whether to convert date-fns date format to 2.x, default is false **/
+  dateFnsFormatConvert: false
 }
 ```
 
@@ -125,14 +127,13 @@ So we have a new `date-fns` method ([syntax reference](https://date-fns.org/docs
 
 ```typescript
 import { NzI18nService } from 'ng-zorro-antd/i18n';
-import * as enDateLocale from 'date-fns/locale/en';
-import * as jaDateLocale from 'date-fns/locale/ja';
+import { enUS, ja } from 'date-fns/locale';
 
 @NgModule({
   ...
   providers: [
     // Set the value of NZ_DATE_LOCALE in the application root module to activate date-fns mode
-    { provide: NZ_DATE_LOCALE, useValue: enDateLocale }
+    { provide: NZ_DATE_LOCALE, useValue: enUS }
   ]
 })
 export class AppModule {
@@ -141,7 +142,7 @@ export class AppModule {
   ...
 
   switchLanguage() {
-    this.i18n.setDateLocale(jaDateLocale); // Switch language to Japanese at runtime
+    this.i18n.setDateLocale(ja); // Switch language to Japanese at runtime
   }
 }
 ```

--- a/docs/i18n.en-US.md
+++ b/docs/i18n.en-US.md
@@ -45,7 +45,7 @@ The default configuration is as follows:
 
 ### NZ_DATE_FORMAT_CONVERT
 
-We have updated date-fns version to ^2.10.0, **We recommend that users use the new format of date-fns 2.x**, and we also provide this token that NG-ZORRO will convert 1.x format to 2.x format when you set `true`. For a comparison of the old and new formats, refer to [here](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)
+We have updated version of `date-fns` to 2.x, **We recommend that users use the new format of `date-fns` 2.x**, and we also provide `NZ_DATE_FORMAT_CONVERT` that `ng-zorro-antd` will convert 1.x format to 2.x format when you set `true`. For a comparison of the old and new formats, refer to [here](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20).
 ```js
 providers: [
   { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }

--- a/docs/i18n.zh-CN.md
+++ b/docs/i18n.zh-CN.md
@@ -44,7 +44,7 @@ export class AppModule { }
 
 ### NZ_DATE_FORMAT_CONVERT
 
-目前我们已将 date-fns 升级至 ^2.10.0，**我们推荐用户使用 date-fns 2.x 的新的 format 格式**。同时也提供该 token，当设置为 `true` 时，NG-ZORRO 会把 1.x format 转为 2.x format，新旧 format 的对比参照[这里](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)。
+我们已将 `date-fns` 升级至 2.x，**我们推荐用户使用 `date-fns` 2.x 的日期格式**。同时也提供 `NZ_DATE_FORMAT_CONVERT`，当设置为 `true` 时，`ng-zorro-antd` 会把 1.x 的格式转为 2.x，新旧格式的对比参照[这里](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)。
 ```js
 providers: [
   { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }

--- a/docs/i18n.zh-CN.md
+++ b/docs/i18n.zh-CN.md
@@ -38,10 +38,17 @@ export class AppModule { }
 ```js
 {
   /** 指定哪一天为一周的开始（null表示采用内部默认值，0表示星期日，1表示星期一，以此类推） */
-  firstDayOfWeek: null,
-  / ** 是否将 date-fns 日期格式转换到 2.x, 默认 false **/
-  dateFnsFormatConvert: false
+  firstDayOfWeek: null
 }
+```
+
+### NZ_DATE_FORMAT_CONVERT
+
+目前我们已将 date-fns 升级至 ^2.10.0，**我们推荐用户使用 date-fns 2.x 的新的 format 格式**。同时也提供该 token，当设置为 `true` 时，NG-ZORRO 会把 1.x format 转为 2.x format，新旧 format 的对比参照[这里](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)。
+```js
+providers: [
+  { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
+]
 ```
 
 ## 运行时修改

--- a/docs/i18n.zh-CN.md
+++ b/docs/i18n.zh-CN.md
@@ -167,12 +167,12 @@ registerLocaleData(en);
 <nz-date-picker nzFormat="yyyy-MM-dd"></nz-date-picker>
 ```
 
-**我们推荐使用 `date-fns` v2 的日期格式**。如果你不想使用新日期格式，你可以用 `NZ_DATE_FORMAT_CONVERT` ，当设置为 `true` 时，`ng-zorro-antd` 会把 v1 的格式转为 v2，新旧格式的对比看[这里](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)。
+**我们推荐使用 `date-fns` v2 的日期格式**。如果你不想使用新日期格式，你可以用 `NZ_DATE_FNS_COMPATIBLE` ，当设置为 `true` 时，`ng-zorro-antd` 会把 v1 的格式转为 v2，新旧格式的对比看[这里](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)。
 
 ```js
 providers: [
-  { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
+  { provide: NZ_DATE_FNS_COMPATIBLE, useValue: true }
 ]
 ```
 
-**但 `NZ_DATE_FORMAT_CONVERT` 不会保留太久，到 `ng-zorro-antd` v10 将会被移除**，希望你能及时更新 `date-fns` 日期格式。关于 `date-fns` 升级指南看[这里](https://github.com/date-fns/date-fns)。
+**但 `NZ_DATE_FNS_COMPATIBLE` 不会保留太久，到 `ng-zorro-antd` v10 将会移除对 `date-fns` v1 日期格式的支持**，希望你能及时更新 `date-fns` 日期格式。关于 `date-fns` 升级指南看[这里](https://github.com/date-fns/date-fns)。

--- a/docs/i18n.zh-CN.md
+++ b/docs/i18n.zh-CN.md
@@ -42,15 +42,6 @@ export class AppModule { }
 }
 ```
 
-### NZ_DATE_FORMAT_CONVERT
-
-我们已将 `date-fns` 升级至 2.x，**我们推荐用户使用 `date-fns` 2.x 的日期格式**。同时也提供 `NZ_DATE_FORMAT_CONVERT`，当设置为 `true` 时，`ng-zorro-antd` 会把 1.x 的格式转为 2.x，新旧格式的对比参照[这里](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)。
-```js
-providers: [
-  { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
-]
-```
-
 ## 运行时修改
 
 `ng-zorro-antd` 提供了一个服务 `NzI18nService` 用于动态修改国际化文案。
@@ -129,7 +120,7 @@ switchLanguage() {
 
 对于日期的格式化，我们默认采用Angular的DatePipe（[语法参考](https://angular.io/api/common/DatePipe)来实现（依赖Angular的locale语言包），但由于Angular自带的DatePipe并非按照ISO标准算法实现（[issue #25380](https://github.com/angular/angular/issues/25380)），使用时周数的展示可能与预期不符（相关issue: [#2406](https://github.com/NG-ZORRO/ng-zorro-antd/issues/2406), [#2819](https://github.com/NG-ZORRO/ng-zorro-antd/issues/2819)）。
 
-所以我们新提供了`date-fns`方式（[语法参考](https://date-fns.org/docs/format#description)）来进行标准的日期格式化，您可以通过以下方式切换至`date-fns`（切换后将影响所有日期类组件如Calendar/DatePicker的日期格式化）：
+所以我们新提供了`date-fns`方式（[语法参考](https://date-fns.org/docs/format#description)）来进行标准的日期格式化，您可以通过以下方式切换至 `date-fns`（切换后将影响所有日期类组件如Calendar/DatePicker的日期格式化）：
 ```typescript
 import { NzI18nService } from 'ng-zorro-antd/i18n';
 import { enUS, ja } from 'date-fns/locale';
@@ -163,3 +154,25 @@ registerLocaleData(en);
 ## date-fns 支持语言
 
 [https://date-fns.org/docs/I18n#supported-languages](https://date-fns.org/docs/I18n#supported-languages)
+
+## date-fns 升级
+
+我们已将 `date-fns` 升级至 v2，当你切换至 `date-fns` 时，一些日期格式会有 breaking change。比如：
+
+```html
+<!-- datefns v1 -->
+<nz-date-picker nzFormat="YYYY-MM-DD"></nz-date-picker>
+
+<!-- datefns v2 -->
+<nz-date-picker nzFormat="yyyy-MM-dd"></nz-date-picker>
+```
+
+**我们推荐使用 `date-fns` v2 的日期格式**。如果你不想使用新日期格式，你可以用 `NZ_DATE_FORMAT_CONVERT` ，当设置为 `true` 时，`ng-zorro-antd` 会把 v1 的格式转为 v2，新旧格式的对比看[这里](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)。
+
+```js
+providers: [
+  { provide: NZ_DATE_FORMAT_CONVERT, useValue: true }
+]
+```
+
+**但 `NZ_DATE_FORMAT_CONVERT` 不会保留太久，到 `ng-zorro-antd` v10 将会被移除**，希望你能及时更新 `date-fns` 日期格式。关于 `date-fns` 升级指南看[这里](https://github.com/date-fns/date-fns)。

--- a/docs/i18n.zh-CN.md
+++ b/docs/i18n.zh-CN.md
@@ -38,7 +38,9 @@ export class AppModule { }
 ```js
 {
   /** 指定哪一天为一周的开始（null表示采用内部默认值，0表示星期日，1表示星期一，以此类推） */
-  firstDayOfWeek: null
+  firstDayOfWeek: null,
+  / ** 是否将 date-fns 日期格式转换到 2.x, 默认 false **/
+  dateFnsFormatConvert: false
 }
 ```
 
@@ -123,14 +125,13 @@ switchLanguage() {
 所以我们新提供了`date-fns`方式（[语法参考](https://date-fns.org/docs/format#description)）来进行标准的日期格式化，您可以通过以下方式切换至`date-fns`（切换后将影响所有日期类组件如Calendar/DatePicker的日期格式化）：
 ```typescript
 import { NzI18nService } from 'ng-zorro-antd/i18n';
-import * as enDateLocale from 'date-fns/locale/en';
-import * as jaDateLocale from 'date-fns/locale/ja';
+import { enUS, ja } from 'date-fns/locale';
 
 @NgModule({
   ...
   providers: [
     // 在应用根模块中设置NZ_DATE_LOCALE的值，将激活date-fns方式的日期格式化展示
-    { provide: NZ_DATE_LOCALE, useValue: enDateLocale }
+    { provide: NZ_DATE_LOCALE, useValue: enUS }
   ]
 })
 export class AppModule {
@@ -139,7 +140,7 @@ export class AppModule {
   ...
 
   switchLanguage() {
-    this.i18n.setDateLocale(jaDateLocale); // 运行时切换语言为日语
+    this.i18n.setDateLocale(ja); // 运行时切换语言为日语
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@angular/cdk": "^9.0.0",
     "@ant-design/icons-angular": "^9.0.0",
-    "date-fns": "^1.30.1",
+    "date-fns": "^2.10.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/scripts/site/_site/doc/app/share/nz-codebox/stack-blitz.ts
+++ b/scripts/site/_site/doc/app/share/nz-codebox/stack-blitz.ts
@@ -413,7 +413,7 @@ export class DemoNgZorroAntdModule {
       '@angular/router'                  : 'next',
       '@angular/animations'              : 'next',
       '@ant-design/icons-angular'        : 'next',
-      'date-fns'                         : '^1.30.1',
+      'date-fns'                         : '^2.10.0',
       'ng-zorro-antd':  `^${version}`
     },
     tags        : [ 'stackblitz', 'sdk' ]


### PR DESCRIPTION
Close #4028 
Close #3976
Close #2492
Close #4101

## 新功能
date-fns 1.x 不支持日期的反格式化，相关 issue 有：#4028 #3976 #2492 #4101。
date-fnx 2.x 已支持[该功能](https://date-fns.org/v2.9.0/docs/parse)。

date-fns 1.x does not support date parsing. Related issues are: #4028 #3976 #2492 #4101. date-fnx 2.x already supports [this feature] (https://date-fns.org/v2.9.0/docs/parse)

## 如何实现
由于 angular 的[日期格式](https://angular.io/api/common/DatePipe)与 date-fns 的[日期格式](https://date-fns.org/v2.9.0/docs/parse)并不兼容。因此反格式化功能只有在用户引入了 date-fns 才能使用。

Since [angular's date format](https://angular.io/api/common/DatePipe) and [date-fns' date format](https://date-fns.org/v2.9.0/docs/parse) are not compatible. Therefore, the parsing feature could only be supported when the user provides date-fns.

## Breaking Change
我们推荐用户使用 date-fns 2.x 的新的 format 格式。同时也提供配置项将 1.x format 转为 2.x format，新旧 format 的对比参照[这里](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)。

We recommend that users use the new format of date-fns 2.x, and we also provide configuration items to convert 1.x format to 2.x format. For a comparison of the old and new formats, refer to [here](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20).

```ts
@NgModule({
  ...
  imports     : [ NgZorroAntdModule ],
  providers: [
    { provide: NZ_DATE_LOCALE, useValue: enUS },
    // Set `dateFnsFormatConvert ` to convert format from v1 to v2
    { provide: NZ_DATE_FNS_COMPATIBLE, useValue: true }
  ]
})
export class AppModule { }
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
