### PR TITLE
ci: add `karma-sabarivka-reporter` to ensure correct coverage results

### DIFF
--- a/components/karma.conf.js
+++ b/components/karma.conf.js
@@ -14,6 +14,7 @@ module.exports = function(config) {
       require('karma-chrome-launcher'),
       require('karma-spec-reporter'),
       require('karma-jasmine-html-reporter'),
+      require('karma-sabarivka-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('karma-junit-reporter'),
       require('@angular-devkit/build-angular/plugins/karma'),
@@ -26,12 +27,15 @@ module.exports = function(config) {
       clearContext: true, // leave Jasmine Spec Runner output visible in browser
       ...tags && { args: [tags] }
     },
+    coverageReporter: {
+      include: 'components/**/!(*.spec|*.module|*.conf|environment*|main|test).ts',
+    },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '../coverage-report'),
       reports: ['html', 'lcovonly', 'text-summary', 'cobertura'],
       fixWebpackSourcePaths: true
     },
-    reporters: ['progress', 'kjhtml', 'spec', 'junit'],
+    reporters: ['progress', 'kjhtml', 'spec', 'junit', 'sabarivka'],
     junitReporter: {
       outputDir: '../junit'
     },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.2",
     "karma-junit-reporter": "^2.0.1",
+    "karma-sabarivka-reporter": "^3.2.0",
     "karma-spec-reporter": "0.0.32",
     "karma-viewport": "^1.0.4",
     "less": "^3.10.3",


### PR DESCRIPTION
With `karma` and `istanbul` as reporter, if someone simply forgets to
create `feature.spec.js` file for `feature.js` file - coverage result
won't include `feature.js` source file. This leads to an issue with
"fake" test coverage statistic.

**Note**: `include` property of `coverageReporter` should, probably, be modified to exclude some files which intentionally shouldn't be tested. `include` property also accepts array. I've tried to exclude everything I could think of in context of this project.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

<img width="585" alt="image" src="https://user-images.githubusercontent.com/8749624/79067494-f8069480-7cbf-11ea-8043-2034132a4a87.png">

## What is the new behavior?

<img width="572" alt="image" src="https://user-images.githubusercontent.com/8749624/79067505-0ce32800-7cc0-11ea-86e7-bf851c8984fb.png">

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```