### PR TITLE
feat(module:calendar): support only display date of active month

### DIFF
--- a/components/calendar/calendar.component.ts
+++ b/components/calendar/calendar.component.ts
@@ -65,6 +65,7 @@ type NzCalendarDateTemplate = TemplateRef<{ $implicit: Date }>;
         [activeDate]="activeDate"
         [cellRender]="dateCell"
         [fullCellRender]="dateFullCell"
+        [nzMonthScope]="nzMonthScope"
         (valueChange)="onDateSelect($event)"
       ></date-table>
     </ng-template>
@@ -98,6 +99,7 @@ export class NzCalendarComponent implements ControlValueAccessor, OnChanges {
 
   @Input() nzMode: NzCalendarMode = 'month';
   @Input() nzValue: Date;
+  @Input() nzMonthScope = false;
 
   @Output() readonly nzModeChange: EventEmitter<NzCalendarMode> = new EventEmitter();
   @Output() readonly nzPanelChange: EventEmitter<{ date: Date; mode: NzCalendarMode }> = new EventEmitter();

--- a/components/calendar/calendar.spec.ts
+++ b/components/calendar/calendar.spec.ts
@@ -402,6 +402,26 @@ describe('Calendar', () => {
       expect(component.selectChange).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('monthScope', () => {
+    let fixture: ComponentFixture<NzTestCalendarMonthCellComponent>;
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(NzTestCalendarMonthCellComponent);
+    }));
+
+    it('should only show date of active month', () => {
+      fixture.detectChanges();
+
+      const host = fixture.debugElement.queryAll(By.directive(Calendar))[2];
+      const tds = host.queryAll(By.css('td'));
+      expect(tds.length).toEqual(30);
+      const firstTd = tds[0].query(By.css('.ant-picker-calendar-date-value'));
+      expect(firstTd.nativeElement.textContent).toEqual('1');
+      const lastTd = tds[tds.length - 1].query(By.css('.ant-picker-calendar-date-value'));
+      expect(lastTd.nativeElement.textContent).toEqual('30');
+    });
+  });
 });
 
 @Component({
@@ -469,9 +489,12 @@ class NzTestCalendarDateFullCellComponent {}
     <nz-calendar nzMode="year">
       <ng-container *nzMonthCell>Bar</ng-container>
     </nz-calendar>
+    <nz-calendar [(ngModel)]="date" [nzMonthScope]="true"></nz-calendar>
   `
 })
-class NzTestCalendarMonthCellComponent {}
+class NzTestCalendarMonthCellComponent {
+  date = new Date(2020, 9, 17);
+}
 
 @Component({
   template: `

--- a/components/calendar/doc/index.en-US.md
+++ b/components/calendar/doc/index.en-US.md
@@ -52,4 +52,5 @@ registerLocaleData(en);
 | `[nzDateFullCell]` | (Contentable) Customize the display of the date cell, the template content will override the cell | `TemplateRef<Date>` | - |
 | `[nzMonthCell]` | (Contentable) Customize the display of the month cell, the template content will be appended to the cell | `TemplateRef<Date>` | - |
 | `[nzMonthFullCell]` | (Contentable) Customize the display of the month cell, the template content will override the cell | `TemplateRef<Date>` | - |
+| `[nzMonthScope]` | Only display date of the active month | `boolean` | `false` |
 | `(nzPanelChange)` | Callback for when panel changes | `EventEmitter<{ date: Date, mode: 'month' \| 'year' }>` | - |

--- a/components/calendar/doc/index.zh-CN.md
+++ b/components/calendar/doc/index.zh-CN.md
@@ -52,5 +52,6 @@ registerLocaleData(zh);
 | `[nzDateFullCell]` | （可作为内容）自定义渲染日期单元格，模版内容覆盖单元格 | `TemplateRef<Date>` | - |
 | `[nzMonthCell]` | （可作为内容）自定义渲染月单元格，模版内容会被追加到单元格 | `TemplateRef<Date>` | - |
 | `[nzMonthFullCell]` | （可作为内容）自定义渲染月单元格，模版内容覆盖单元格 | `TemplateRef<Date>` | - |
+| `[nzMonthScope]` | 是否只显示当前月份的日期 | `boolean` | `false` |
 | `(nzPanelChange)` | 面板变化的回调 | `EventEmitter<{ date: Date, mode: 'month' \| 'year' }>` | - |
 | `(nzSelectChange)` | 选择日期的回调 | `EventEmitter<Date>` | - |

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -38,6 +38,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
   @Input() locale: NzCalendarI18nInterface;
   @Input() selectedValue: CandyDate[]; // Range ONLY
   @Input() hoverValue: CandyDate[]; // Range ONLY
+  @Input() nzMonthScope = false;
 
   @Output() readonly dayHover = new EventEmitter<CandyDate>(); // Emitted when hover on a day by mouse enter
 
@@ -225,6 +226,16 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
       weekRows.push(row);
     }
 
+    if (this.nzMonthScope) {
+      const allDateCell: DateCell[] = [];
+      weekRows.forEach(row => {
+        const rowCells = row.dateCells.filter(cell => cell.value.getMonth() === this.activeDate.getMonth());
+        allDateCell.push(...rowCells);
+      });
+      weekRows.forEach(v => {
+        v.dateCells = allDateCell.splice(0, 7);
+      });
+    }
     return weekRows;
   }
 

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -235,6 +235,10 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
       weekRows.forEach(v => {
         v.dateCells = allDateCell.splice(0, 7);
       });
+      // delete empty row
+      if (weekRows[weekRows.length - 1].dateCells.length === 0) {
+        weekRows.pop();
+      }
     }
     return weekRows;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4615


## What is the new behavior?
If you enable `nzMonthScope`(default `false`), then calendar only display the date of active month, not display extra date anymore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
