### PR TITLE
feat(module:drawer): add nzExtra property (NG-ZORRO#3276)

### DIFF
--- a/components/drawer/doc/index.en-US.md
+++ b/components/drawer/doc/index.en-US.md
@@ -30,6 +30,7 @@ import { NzDrawerModule } from 'ng-zorro-antd/drawer';
 | `[nzMaskStyle]` | Style for Drawer's mask element. | `object` | `{}` |
 | `[nzBodyStyle]` | Body style for drawer body element. Such as height, padding etc. | `object` | `{}` |
 | `[nzTitle]` | The title for Drawer. | `string \| TemplateRef<void>` | - |
+| `[nzExtra]` | Content to render in the top-right corner of the Drawer. | `string \| TemplateRef<void>` | - |
 | `[nzVisible]` | Whether the Drawer dialog is visible or not. | `boolean` | `false` |
 | `[nzPlacement]` | The placement of the Drawer. | `'top' \| 'right' \| 'bottom' \| 'left'` | `'right'` |
 | `[nzWidth]` | Width of the Drawer dialog, only when placement is `'right'` or `'left'`.  | `number \| string` | `256` |
@@ -60,6 +61,7 @@ import { NzDrawerModule } from 'ng-zorro-antd/drawer';
 | nzMaskStyle | Style for Drawer's mask element. | `object` | `{}` |
 | nzBodyStyle | Body style for modal body element. Such as height, padding etc. | `object` | `{}` |
 | nzTitle | The title for Drawer. | `string \| TemplateRef<void>` | - |
+| nzExtra | Content to render in the top-right corner of the Drawer. | `string \| TemplateRef<void>` | - |
 | nzWidth |  Width of the Drawer dialog.  | `number \| string` | `256` |
 | nzHeight | Height of the Drawer dialog, only when placement is `'top'` or `'bottom'`.  | `number \| string` | `256` |
 | nzWrapClassName | The class name of the container of the Drawer dialog. | `string` | - |

--- a/components/drawer/doc/index.zh-CN.md
+++ b/components/drawer/doc/index.zh-CN.md
@@ -29,6 +29,7 @@ import { NzDrawerModule } from 'ng-zorro-antd/drawer';
 | `[nzKeyboard]` | 是否支持键盘 esc 关闭 | `boolean` | `true` |
 | `[nzBodyStyle]` | Drawer body 样式 | `object` | `{}` |
 | `[nzTitle]` | 标题 | `string \| TemplateRef<void>` | - |
+| `[nzExtra]` | 抽屉右上角的操作区域 | `string \| TemplateRef<void>` | - |
 | `[nzVisible]` | Drawer 是否可见 | `boolean` | - |
 | `[nzPlacement]` | 抽屉的方向 | `'top' \| 'right' \| 'bottom' \| 'left'` | `'right'` |
 | `[nzWidth]` | 宽度, 只在方向为 `'right'`或`'left'` 时生效 | `number \| string` | `256` |
@@ -59,6 +60,7 @@ import { NzDrawerModule } from 'ng-zorro-antd/drawer';
 | nzMaskStyle | 遮罩样式 | `object` | `{}` |
 | nzBodyStyle | Modal body 样式 | `object` | `{}` |
 | nzTitle | 标题 | `string \| TemplateRef<void>` | - |
+| nzExtra | 抽屉右上角的操作区域 | `string \| TemplateRef<void>` | - |
 | nzWidth | 宽度 | `number \| string` | `256` |
 | nzHeight | 高度, 只在方向为 `'top'`或`'bottom'` 时生效 | `number \| string` | `256` |
 | nzWrapClassName | 对话框外层容器的类名 | `string` | - |

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -72,9 +72,16 @@ const NZ_CONFIG_COMPONENT_NAME = 'drawer';
         >
           <div class="ant-drawer-content">
             <div class="ant-drawer-wrapper-body" [style.height]="isLeftOrRight ? '100%' : null">
-              <div *ngIf="nzTitle || nzClosable" [class.ant-drawer-header]="!!nzTitle" [class.ant-drawer-header-no-title]="!nzTitle">
+              <div
+                *ngIf="nzTitle || nzClosable || nzExtra"
+                [class.ant-drawer-header]="!!nzTitle || !!nzExtra"
+                [class.ant-drawer-header-no-title]="!nzTitle && !nzExtra"
+              >
                 <div *ngIf="nzTitle" class="ant-drawer-title">
-                  <ng-container *nzStringTemplateOutlet="nzTitle"><div [innerHTML]="nzTitle"></div></ng-container>
+                  <ng-container *nzStringTemplateOutlet="nzTitle">{{ nzTitle }}</ng-container>
+                </div>
+                <div *ngIf="nzExtra" [class.ant-drawer-extra]="!!nzClosable" [class.ant-drawer-extra-no-close]="!nzClosable">
+                  <ng-container *nzStringTemplateOutlet="nzExtra">{{ nzExtra }}</ng-container>
                 </div>
                 <button *ngIf="nzClosable" (click)="closeClick()" aria-label="Close" class="ant-drawer-close" style="--scroll-bar: 0px;">
                   <i nz-icon nzType="close"></i>
@@ -111,6 +118,7 @@ export class NzDrawerComponent<T = NzSafeAny, R = NzSafeAny, D = NzSafeAny> exte
   @Input() @InputBoolean() nzNoAnimation = false;
   @Input() @InputBoolean() nzKeyboard: boolean = true;
   @Input() nzTitle: string | TemplateRef<{}>;
+  @Input() nzExtra: string | TemplateRef<void>;
   @Input() nzPlacement: NzDrawerPlacement = 'right';
   @Input() nzMaskStyle: object = {};
   @Input() nzBodyStyle: object = {};

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -7,6 +7,7 @@
 
 .@{drawer-prefix-cls} {
   @drawer-header-close-padding: ceil((@drawer-header-close-size - @font-size-lg) / 2);
+  @drawer-header-extra-margin-right: @drawer-header-close-size - @padding-lg;
 
   position: fixed;
   z-index: @zindex-modal;
@@ -144,6 +145,9 @@
     font-weight: 500;
     font-size: @font-size-lg;
     line-height: 22px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   &-content {
@@ -153,6 +157,21 @@
     background-color: @drawer-bg;
     background-clip: padding-box;
     border: 0;
+  }
+
+  &-extra {
+    float: right;
+    margin-left: auto;
+    margin-right: @drawer-header-extra-margin-right;
+    font-weight: normal;
+    font-size: @font-size-base;
+  }
+
+  &-extra-no-close {
+    float: right;
+    margin-left: auto;
+    font-weight: normal;
+    font-size: @font-size-base;
   }
 
   &-close {
@@ -191,6 +210,7 @@
   }
 
   &-header {
+    display: flex;
     position: relative;
     padding: @drawer-header-padding;
     color: @text-color;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3276


## What is the new behavior?
An extra content will be rendered on the top-right corner of the drawer if you set some value for `nzExtra` prop in the `nz-drawer`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
