### PR TITLE
feat(module:select): add nzMaxTagTextLength option

### DIFF
--- a/components/select/doc/index.en-US.md
+++ b/components/select/doc/index.en-US.md
@@ -55,6 +55,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 | `[nzTokenSeparators]` | Separator used to tokenize on tag/multiple mode | `string[]` | `[]` |
 | `[nzLoading]` | indicate loading state | `boolean` | false |
 | `[nzMaxTagCount]` | Max tag count to show| `number` | - |
+| `[nzMaxTagTextLength]` | Max tag text length to show | `number` | - |
 | `[nzOptions]` | use nzOptions or `nz-option` to pass options to the select  | `Array<{ label: string \| TemplateRef<any>; value: any; disabled?: boolean; hide?: boolean; groupLabel?: string \| TemplateRef<any>;}>` | - |
 | `[nzMaxTagPlaceholder]` | Placeholder for not showing tags | `TemplateRef<{ $implicit: any[] }>` | - |
 | `[nzOptionHeightPx]` | Each option height inside the dropdown | `number` | `32` |

--- a/components/select/doc/index.zh-CN.md
+++ b/components/select/doc/index.zh-CN.md
@@ -56,6 +56,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 | `[nzTokenSeparators]` | 在 tags 和 multiple 模式下自动分词的分隔符 | `string[]` | `[]` |
 | `[nzLoading]` | 加载中状态 | `boolean` | `false` |
 | `[nzMaxTagCount]` | 最多显示多少个 tag | `number` | - |
+| `[nzMaxTagTextLength]` | 最大显示的 tag 文本长度 | `number` | - |
 | `[nzMaxTagPlaceholder]` | 隐藏 tag 时显示的内容 | `TemplateRef<{ $implicit: any[] }>` | - |
 | `[nzOptions]` | option 列表，可以取代 nz-option，用法参见例子 | `Array<{ label: string \| TemplateRef<any>; value: any; disabled?: boolean; hide?: boolean; groupLabel?: string \| TemplateRef<any>;}>` | - |
 | `[nzOptionHeightPx]` | 下拉菜单中每个 Option 的高度 | `number` | `32` |

--- a/components/select/select-top-control.component.ts
+++ b/components/select/select-top-control.component.ts
@@ -100,6 +100,8 @@ export class NzSelectTopControlComponent implements OnChanges {
   @Input() placeHolder: string | TemplateRef<NzSafeAny> | null = null;
   @Input() open = false;
   @Input() maxTagCount: number = Infinity;
+  @Input() maxTagTextLength: number = Infinity;
+  @Input() tagTextEllipsis: string = '…';
   @Input() autofocus = false;
   @Input() disabled = false;
   @Input() mode: NzSelectModeType = 'default';
@@ -216,14 +218,14 @@ export class NzSelectTopControlComponent implements OnChanges {
   constructor(@Host() @Optional() public noAnimation?: NzNoAnimationDirective) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    const { listOfTopItem, maxTagCount, customTemplate, maxTagPlaceholder } = changes;
+    const { listOfTopItem, maxTagCount, maxTagTextLength, tagTextEllipsis, customTemplate, maxTagPlaceholder } = changes;
     if (listOfTopItem) {
       this.updateTemplateVariable();
     }
-    if (listOfTopItem || maxTagCount || customTemplate || maxTagPlaceholder) {
+    if (listOfTopItem || maxTagCount || customTemplate || maxTagPlaceholder || maxTagTextLength || tagTextEllipsis) {
       const listOfSlicedItem: NzSelectTopControlItemType[] = this.listOfTopItem.slice(0, this.maxTagCount).map(o => {
         return {
-          nzLabel: o.nzLabel,
+          nzLabel: this.getLabelToShow(o.nzLabel),
           nzValue: o.nzValue,
           nzDisabled: o.nzDisabled,
           contentTemplateOutlet: this.customTemplate,
@@ -244,5 +246,11 @@ export class NzSelectTopControlComponent implements OnChanges {
       }
       this.listOfSlicedItem = listOfSlicedItem;
     }
+  }
+  private getLabelToShow(text: string | null): string | null {
+    if (text === null || text.length <= this.maxTagTextLength) {
+      return text;
+    }
+    return `${text.slice(0, this.maxTagTextLength).trim()}${this.tagTextEllipsis}`;
   }
 }

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -85,6 +85,7 @@ export type NzSelectSizeType = 'large' | 'default' | 'small';
       [removeIcon]="nzRemoveIcon"
       [placeHolder]="nzPlaceHolder"
       [maxTagCount]="nzMaxTagCount"
+      [maxTagTextLength]="nzMaxTagTextLength"
       [customTemplate]="nzCustomTemplate"
       [tokenSeparators]="nzTokenSeparators"
       [showSearch]="nzShowSearch"
@@ -180,6 +181,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   @Input() nzNotFoundContent: string | TemplateRef<NzSafeAny> | undefined = undefined;
   @Input() nzPlaceHolder: string | TemplateRef<NzSafeAny> | null = null;
   @Input() nzMaxTagCount = Infinity;
+  @Input() nzMaxTagTextLength = Infinity;
   @Input() nzDropdownRender: TemplateRef<NzSafeAny> | null = null;
   @Input() nzCustomTemplate: TemplateRef<{ $implicit: NzSelectItemInterface }> | null = null;
   @Input()

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -606,6 +606,28 @@ describe('select', () => {
       fixture.detectChanges();
       expect(listOfItem[2].textContent).toBe(' and 2 more selected ');
     }));
+    it('should nzMaxTagTextLength works', fakeAsync(() => {
+      component.listOfOption = [
+        { nzValue: 'test_01', nzLabel: 'oneword' },
+        { nzValue: 'test_02', nzLabel: 'two words' },
+        { nzValue: 'test_03', nzLabel: '3' },
+        { nzValue: 'test_04', nzLabel: 'four' },
+        { nzValue: 'test_05', nzLabel: 'five' }
+      ];
+      component.value = ['test_01', 'test_02', 'test_03', 'test_04', 'test_05'];
+      component.nzMaxTagTextLength = 4;
+      component.nzMaxTagCount = 4;
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const listOfItem = selectElement.querySelectorAll('nz-select-item');
+      expect(listOfItem.length).toBe(5);
+      expect(listOfItem[0].querySelector('.ant-select-selection-item-content')!.textContent).toBe('onew…');
+      expect(listOfItem[1].querySelector('.ant-select-selection-item-content')!.textContent).toBe('two…');
+      expect(listOfItem[2].querySelector('.ant-select-selection-item-content')!.textContent).toBe('3');
+      expect(listOfItem[3].querySelector('.ant-select-selection-item-content')!.textContent).toBe('four');
+      expect(listOfItem[4].querySelector('.ant-select-selection-item-content')!.textContent).toBe('+ 1 ...');
+    }));
   });
   describe('default reactive mode', () => {
     let testBed: ComponentBed<TestSelectReactiveDefaultComponent>;
@@ -1086,6 +1108,28 @@ describe('select', () => {
       fixture.detectChanges();
       expect(listOfItem[2].textContent).toBe(' and 2 more selected ');
     }));
+    it('should nzMaxTagTextLength works', fakeAsync(() => {
+      component.listOfOption = [
+        { value: 'test_01', label: 'oneword' },
+        { value: 'test_02', label: 'two words' },
+        { value: 'test_03', label: '3' },
+        { value: 'test_04', label: 'four' },
+        { value: 'test_05', label: 'five' }
+      ];
+      component.value = ['test_01', 'test_02', 'test_03', 'test_04', 'test_05'];
+      component.nzMaxTagTextLength = 4;
+      component.nzMaxTagCount = 4;
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const listOfItem = selectElement.querySelectorAll('nz-select-item');
+      expect(listOfItem.length).toBe(5);
+      expect(listOfItem[0].querySelector('.ant-select-selection-item-content')!.textContent).toBe('onew…');
+      expect(listOfItem[1].querySelector('.ant-select-selection-item-content')!.textContent).toBe('two…');
+      expect(listOfItem[2].querySelector('.ant-select-selection-item-content')!.textContent).toBe('3');
+      expect(listOfItem[3].querySelector('.ant-select-selection-item-content')!.textContent).toBe('four');
+      expect(listOfItem[4].querySelector('.ant-select-selection-item-content')!.textContent).toBe('+ 1 ...');
+    }));
   });
 });
 
@@ -1222,6 +1266,7 @@ export class TestSelectTemplateMultipleComponent {
       [(ngModel)]="value"
       [nzSize]="nzSize"
       [nzMaxTagCount]="nzMaxTagCount"
+      [nzMaxTagTextLength]="nzMaxTagTextLength"
       [nzTokenSeparators]="nzTokenSeparators"
       [nzMaxTagPlaceholder]="nzMaxTagPlaceholder"
       (ngModelChange)="valueChange($event)"
@@ -1241,6 +1286,7 @@ export class TestSelectTemplateTagsComponent {
   @ViewChild('tagTemplate') tagTemplate: TemplateRef<NzSafeAny>;
   nzSize: NzSelectSizeType = 'default';
   nzMaxTagCount = Infinity;
+  nzMaxTagTextLength = Infinity;
   value: NzSafeAny[] = [];
   listOfOption: NzSelectItemInterface[] = [];
   valueChange = jasmine.createSpy('valueChange');
@@ -1359,6 +1405,7 @@ export class TestSelectReactiveMultipleComponent {
       [nzOptions]="listOfOption"
       [nzSize]="nzSize"
       [nzMaxTagCount]="nzMaxTagCount"
+      [nzMaxTagTextLength]="nzMaxTagTextLength"
       [nzTokenSeparators]="nzTokenSeparators"
       [nzMaxTagPlaceholder]="nzMaxTagPlaceholder"
       (ngModelChange)="valueChange($event)"
@@ -1371,6 +1418,7 @@ export class TestSelectReactiveTagsComponent {
   @ViewChild('tagTemplate') tagTemplate: TemplateRef<NzSafeAny>;
   nzSize: NzSelectSizeType = 'default';
   nzMaxTagCount = Infinity;
+  nzMaxTagTextLength = Infinity;
   value: NzSafeAny[] = [];
   listOfOption: NzSelectOptionInterface[] = [];
   valueChange = jasmine.createSpy('valueChange');


### PR DESCRIPTION
Feature requested in #4204: Add max tag length input to nz-select

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #4204 

## What is the new behavior?

Ability to limit displayed text length of tags in select component.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

It uses `…` as ellipsis char.
