### PR TITLE
fix(module:select): option item not selected with falsy value

### DIFF
--- a/components/select/option-item.component.ts
+++ b/components/select/option-item.component.ts
@@ -71,7 +71,7 @@ export class NzOptionItemComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     const { value, activatedValue, listOfSelectedValue } = changes;
     if (value || listOfSelectedValue) {
-      this.selected = this.listOfSelectedValue.find(v => this.compareWith(v, this.value));
+      this.selected = this.listOfSelectedValue.some(v => this.compareWith(v, this.value));
     }
     if (value || activatedValue) {
       this.activated = this.compareWith(this.activatedValue, this.value);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
nz-select selected falsy value (eg.0) doesn't have the selected class
[https://stackblitz.com/edit/angular-8iudzt](https://stackblitz.com/edit/angular-8iudzt)

Issue Number: N/A


## What is the new behavior?
Selected falsy value should have the selected class

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
