### PR TITLE
docs(module:dropdown): fix component doc footer language & dropdown typo

### DIFF
--- a/components/dropdown/doc/index.en-US.md
+++ b/components/dropdown/doc/index.en-US.md
@@ -37,7 +37,7 @@ You should use [nz-menu](/components/menu/en) in `nz-dropdown`. The menu items a
 
 ### nz-dropdown-menu
 
-Wrap Dropdown Menu and pass to `[nz-dropdown]` 和 `NzContextMenuService`, you can export it via Template Syntax `nzDropdownMenu`
+Wrap Dropdown Menu and pass to `[nz-dropdown]` and `NzContextMenuService`, you can export it via Template Syntax `nzDropdownMenu`
 
 > Note：Every `[nz-dropdown]` should pass independent `nz-dropdown-menu`.
 
@@ -58,5 +58,5 @@ Create dropdown with contextmenu, the detail can be found in the example above
 
 | Property | Description | Arguments | Return Value |
 | --- | --- | --- | --- |
-| create | create dropdown | `($event:MouseEvent | {x:number, y:number}, menu:NzDropdownMenuComponent)` | - |
+| create | create dropdown | `($event:MouseEvent \| {x:number, y:number}, menu:NzDropdownMenuComponent)` | - |
 | close | close dropdown | - | - |

--- a/components/dropdown/doc/index.zh-CN.md
+++ b/components/dropdown/doc/index.zh-CN.md
@@ -59,5 +59,5 @@ import { NzDropDownModule } from 'ng-zorro-antd/dropdown';
 
 | 方法/属性 | 说明 | 参数 | 返回 |
 | --- | --- | --- | --- |
-| create | 创建右键菜单 | `($event:MouseEvent | {x:number, y:number}, menu:NzDropdownMenuComponent)` | - |
+| create | 创建右键菜单 | `($event:MouseEvent \| {x:number, y:number}, menu:NzDropdownMenuComponent)` | - |
 | close | 关闭右键菜单 | - | - |

--- a/scripts/site/_site/doc/app/app.component.html
+++ b/scripts/site/_site/doc/app/app.component.html
@@ -49,7 +49,7 @@
             [language]="language">
           </app-fixed-widgets>
           <nz-nav-bottom></nz-nav-bottom>
-          <app-footer [colorHex]="color" (colorChange)="changeColor($event)"></app-footer>
+          <app-footer [colorHex]="color" [language]="language" (colorChange)="changeColor($event)"></app-footer>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- fix the componet doc footer, language is not passed to the footer component
- fix the typo in dropdown doc

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the documentation site's component section, for English documentation, the footer always appears in Chinese.
Also, fix a couple of typos in the dropdown component documentation. It shows Chinese character one place rather than English. Also, fix the table cell content for NzContextMenuService under dropdown.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
