### PR TITLE
feat(module:table): fix scroll bar displays always even unnecessary

### DIFF
--- a/components/table/src/table/table-inner-scroll.component.ts
+++ b/components/table/src/table/table-inner-scroll.component.ts
@@ -127,11 +127,11 @@ export class NzTableInnerScrollComponent implements OnChanges, AfterViewInit, On
       const hasVerticalScrollBar = this.verticalScrollBarWidth !== 0;
       this.headerStyleMap = {
         overflowX: 'hidden',
-        overflowY: this.scrollY && hasVerticalScrollBar ? 'scroll' : 'hidden'
+        overflowY: this.scrollY && hasVerticalScrollBar ? 'auto' : 'hidden'
       };
       this.bodyStyleMap = {
-        overflowY: this.scrollY ? 'scroll' : null,
-        overflowX: this.scrollX ? 'scroll' : null,
+        overflowY: this.scrollY ? 'auto' : null,
+        overflowX: this.scrollX ? 'auto' : null,
         maxHeight: this.scrollY
       };
       this.scroll$.next();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Table scroll bar is always displayed even when it's unnecessary
![image](https://user-images.githubusercontent.com/15620651/84366812-b4280100-ac16-11ea-9aad-fc198fa12e37.png)

Issue Number: N/A


## What is the new behavior?
Only showing scroll bar when needed.
![image](https://user-images.githubusercontent.com/15620651/84366909-d9b50a80-ac16-11ea-8bf5-013fd9890203.png)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
