### PR TITLE
docs(module:typhography): add the import in documentation

### DIFF
--- a/components/card/doc/index.en-US.md
+++ b/components/card/doc/index.en-US.md
@@ -18,7 +18,7 @@ import { NzCardModule } from 'ng-zorro-antd/card';
 ## API
 
 ```html
-<nz-card nzTitle="卡片标题">卡片内容</nz-card>
+<nz-card nzTitle="card title">card content</nz-card>
 ```
 
 ### nz-card

--- a/components/typography/doc/index.en-US.md
+++ b/components/typography/doc/index.en-US.md
@@ -12,6 +12,10 @@ Basic text writing, including headings, body text, lists, and more.
 - When need to display title or paragraph contents in Articles/Blogs/Notes.
 - When you need copyable/editable/ellipsis texts.
 
+```ts
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+```
+
 ## API
 
 ### [nz-typography]

--- a/components/typography/doc/index.zh-CN.md
+++ b/components/typography/doc/index.zh-CN.md
@@ -12,6 +12,10 @@ cols: 1
 - 当需要展示标题、段落、列表内容时使用，如文章/博客/日志的文本样式。
 - 当需要一列基于文本的基础操作时，如拷贝/省略/可编辑。
 
+```ts
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+```
+
 ## API
 
 ### [nz-typography]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
in the card english page, there are chinese characters in the documentation.
also, import statement is missing in the typography documentation.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
