### PR TITLE
chore(module:code-editor): update the instance types

### DIFF
--- a/components/code-editor/code-editor.component.ts
+++ b/components/code-editor/code-editor.component.ts
@@ -28,9 +28,9 @@ import { debounceTime, distinctUntilChanged, filter, map, takeUntil } from 'rxjs
 
 import { NzCodeEditorService } from './code-editor.service';
 import { DiffEditorOptions, EditorOptions, JoinedEditorOptions, NzEditorMode } from './typings';
-import IDiffEditor = editor.IDiffEditor;
-import IEditor = editor.IEditor;
 import ITextModel = editor.ITextModel;
+import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
+import IStandaloneDiffEditor = editor.IStandaloneDiffEditor;
 
 declare const monaco: NzSafeAny;
 
@@ -73,7 +73,7 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
     this.editorOption$.next(value);
   }
 
-  @Output() readonly nzEditorInitialized = new EventEmitter<IEditor | IDiffEditor>();
+  @Output() readonly nzEditorInitialized = new EventEmitter<IStandaloneCodeEditor | IStandaloneDiffEditor>();
 
   editorOptionCached: JoinedEditorOptions = {};
 
@@ -81,7 +81,7 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
   private destroy$ = new Subject<void>();
   private resize$ = new Subject<void>();
   private editorOption$ = new BehaviorSubject<JoinedEditorOptions>({});
-  private editorInstance?: IEditor | IDiffEditor;
+  private editorInstance?: IStandaloneCodeEditor | IStandaloneDiffEditor;
   private value = '';
   private modelSet = false;
 
@@ -205,19 +205,19 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
       if (this.modelSet) {
         (this.editorInstance.getModel() as ITextModel).setValue(this.value);
       } else {
-        (this.editorInstance as IEditor).setModel(
+        (this.editorInstance as IStandaloneCodeEditor).setModel(
           monaco.editor.createModel(this.value, (this.editorOptionCached as EditorOptions).language)
         );
         this.modelSet = true;
       }
     } else {
       if (this.modelSet) {
-        const model = (this.editorInstance as IDiffEditor).getModel()!;
+        const model = (this.editorInstance as IStandaloneDiffEditor).getModel()!;
         model.modified.setValue(this.value);
         model.original.setValue(this.nzOriginalText);
       } else {
         const language = (this.editorOptionCached as EditorOptions).language;
-        (this.editorInstance as IDiffEditor).setModel({
+        (this.editorInstance as IStandaloneDiffEditor).setModel({
           original: monaco.editor.createModel(this.nzOriginalText, language),
           modified: monaco.editor.createModel(this.value, language)
         });
@@ -228,8 +228,8 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
 
   private setValueEmitter(): void {
     const model = (this.nzEditorMode === 'normal'
-      ? (this.editorInstance as IEditor).getModel()
-      : (this.editorInstance as IDiffEditor).getModel()!.modified) as ITextModel;
+      ? (this.editorInstance as IStandaloneCodeEditor).getModel()
+      : (this.editorInstance as IStandaloneDiffEditor).getModel()!.modified) as ITextModel;
 
     model.onDidChangeContent(() => {
       this.emitValue(model.getValue());

--- a/components/code-editor/doc/index.en-US.md
+++ b/components/code-editor/doc/index.en-US.md
@@ -75,7 +75,7 @@ If you use static loading, you should not add assets of monaco editor to your pr
 | `[nzFullControl]` | Enable full control mode. User should manage `TextModel` manually in this mode | `boolean` | `false` |
 | `[nzEditorOption]` | [Please refer to the doc of monaco editor](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorconstructionoptions.html) | `IEditorConstructionOptions` | `{}` |
 | `[nzToolkit]` | A placeholder for adding some quick actions | `TemplateRef<void>` | - |
-| `(nzEditorInitialized)` | The event that a code editor is initialized  | `IEditor` \| `IDiffEditor` | - |
+| `(nzEditorInitialized)` | The event that a code editor is initialized  | `IStandaloneCodeEditor` \| `IStandaloneDiffEditor` | - |
 
 #### Methods
 

--- a/components/code-editor/doc/index.zh-CN.md
+++ b/components/code-editor/doc/index.zh-CN.md
@@ -82,7 +82,7 @@ npm install monaco-editor
 | `[nzFullControl]` | 完全控制模式，此模式下组件不会帮助用户处理 `TextModel`，用户应当自行管理 monaco editor 实例 | `boolean` | `false` |
 | `[nzEditorOption]` | 编辑器选项，[参考 monaco editor 的定义](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorconstructionoptions.html) | `IEditorConstructionOptions` | `{}` |
 | `[nzToolkit]` | 暴露快捷操作 | `TemplateRef<void>` | - |
-| `(nzEditorInitialized)` | 当编辑器组件初始化完毕之后派发事件  | `IEditor` \| `IDiffEditor` | - |
+| `(nzEditorInitialized)` | 当编辑器组件初始化完毕之后派发事件  | `IStandaloneCodeEditor` \| `IStandaloneDiffEditor` | - |
 
 #### 方法
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`nzEditorInitialized` return the `IEditor` type, but often uses the methods of the `IStandaloneCodeEditor` type, so many type-assertion need to be written.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

`IEditor` is the base class of `IStandaloneCodeEditor`, there should be no breaking changes.

Also I tried to narrow the type through `NzCodeEditorComponent<T extends NzEditorMode>`, but it was blocked by https://github.com/microsoft/TypeScript/issues/13995, @wendellhu95 but could you try the following code?

```ts
@Component({
  selector: 'nz-code-editor[nzEditorMode="normal"]',
})
class NzCodeEditorComponent {
  editorInstance: IStandaloneCodeEditor;
}

@Component({
  selector: 'nz-code-editor[nzEditorMode="diff"]',
})
class NzDiffCodeEditorComponent {
  editorInstance: IStandaloneDiffEditor;
}
```