### PR TITLE
fix(module:drawer): fix nzZIndex not work with static cdk zindex (#5450)

### DIFF
--- a/components/style/patch.less
+++ b/components/style/patch.less
@@ -7,8 +7,8 @@
   left: 0;
   height: 100%;
   width: 100%;
-  position: fixed;
-  z-index: 1000;
+  position: static;
+  z-index: auto;
 }
 
 .cdk-overlay-backdrop {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

https://github.com/NG-ZORRO/ng-zorro-antd/issues/5450

配置组件 drawer 的 nzZIndex 参数小于1000时，实际表现不会生效。

Issue Number: 5450

## What is the new behavior?

配置组件 drawer 的 nzZIndex 参数小于1000时，表现正常。

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
