### PR TITLE
fix(module:drawer): fix nzZIndex not work with static cdk zindex

### DIFF
--- a/components/style/patch.less
+++ b/components/style/patch.less
@@ -7,7 +7,7 @@
   left: 0;
   height: 100%;
   width: 100%;
-  position: fixed;
+  position: absolute;
   z-index: 1000;
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://github.com/NG-ZORRO/ng-zorro-antd/issues/5450

When the nzzindex property of the drawer component is configured with a value less than 1000, the configuration does not take effect.

Issue Number: 5450

## What is the new behavior?

work normally

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
