### PR TITLE
feat(module:select): add nzAcceptOnBlur property

### DIFF
--- a/components/select/doc/index.en-US.md
+++ b/components/select/doc/index.en-US.md
@@ -47,7 +47,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 | `[nzPlaceHolder]` | Placeholder of select | `string` | - |
 | `[nzShowArrow]` | Whether to show the drop-down arrow | `boolean` | `true` |
 | `[nzShowSearch]` | Whether show search input in single mode. | `boolean` | `false` |
-| `[nzAcceptOnBlur]` | Whether to accept unselected string values on blur. | `boolean` | `false` |
+| `[nzAcceptOnBlur]` | Whether to accept unselected string values on blur. Only applies when `mode` is set to `tags`. | `boolean` | `false` |
 | `[nzSize]` | Size of Select input | `'large' \| 'small' \| 'default'` | `'default'` |
 | `[nzSuffixIcon]` | The custom suffix icon | `TemplateRef<any> \| string` | - |  ✅ |
 | `[nzRemoveIcon]` | The custom remove icon | `TemplateRef<any>` | - |

--- a/components/select/doc/index.en-US.md
+++ b/components/select/doc/index.en-US.md
@@ -47,6 +47,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 | `[nzPlaceHolder]` | Placeholder of select | `string` | - |
 | `[nzShowArrow]` | Whether to show the drop-down arrow | `boolean` | `true` |
 | `[nzShowSearch]` | Whether show search input in single mode. | `boolean` | `false` |
+| `[nzAcceptOnBlur]` | Whether to accept unselected string values on blur. | `boolean` | `false` |
 | `[nzSize]` | Size of Select input | `'large' \| 'small' \| 'default'` | `'default'` |
 | `[nzSuffixIcon]` | The custom suffix icon | `TemplateRef<any> \| string` | - |  ✅ |
 | `[nzRemoveIcon]` | The custom remove icon | `TemplateRef<any>` | - |

--- a/components/select/doc/index.zh-CN.md
+++ b/components/select/doc/index.zh-CN.md
@@ -48,7 +48,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 | `[nzPlaceHolder]` | 选择框默认文字 | `string` | - |
 | `[nzShowArrow]` | 是否显示下拉小箭头 | `boolean` | `true` |
 | `[nzShowSearch]` | 使单选模式可搜索 | `boolean` | `false` |
-| `[nzAcceptOnBlur]` | 是否接受模糊时未选择的字符串值 | `boolean` | `false` |
+| `[nzAcceptOnBlur]` | 是否接受模糊时未选择的字符串值。仅在将模式设置为标签时适用 | `boolean` | `false` |
 | `[nzSize]` | 选择框大小 | `'large' \| 'small' \| 'default'` | `'default'` |
 | `[nzSuffixIcon]` | 自定义的选择框后缀图标 | `TemplateRef<any> \| string` | - | ✅ |
 | `[nzRemoveIcon]` | 自定义的多选框清除图标 | `TemplateRef<any>` | - |

--- a/components/select/doc/index.zh-CN.md
+++ b/components/select/doc/index.zh-CN.md
@@ -48,6 +48,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 | `[nzPlaceHolder]` | 选择框默认文字 | `string` | - |
 | `[nzShowArrow]` | 是否显示下拉小箭头 | `boolean` | `true` |
 | `[nzShowSearch]` | 使单选模式可搜索 | `boolean` | `false` |
+| `[nzAcceptOnBlur]` | 是否接受模糊时未选择的字符串值 | `boolean` | `false` |
 | `[nzSize]` | 选择框大小 | `'large' \| 'small' \| 'default'` | `'default'` |
 | `[nzSuffixIcon]` | 自定义的选择框后缀图标 | `TemplateRef<any> \| string` | - | ✅ |
 | `[nzRemoveIcon]` | 自定义的多选框清除图标 | `TemplateRef<any>` | - |

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -542,7 +542,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
           this.focused = false;
           this.cdr.markForCheck();
           this.nzBlur.emit();
-          if (this.nzAcceptOnBlur && this.searchValue) {
+          if (this.nzMode === 'tags' && this.nzAcceptOnBlur && this.searchValue) {
             this.onItemClick(this.searchValue);
           }
           Promise.resolve().then(() => {

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -168,6 +168,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   static ngAcceptInputType_nzServerSearch: BooleanInput;
   static ngAcceptInputType_nzDisabled: BooleanInput;
   static ngAcceptInputType_nzOpen: BooleanInput;
+  static ngAcceptInputType_nzAcceptOnBlur: BooleanInput;
 
   @Input() nzSize: NzSelectSizeType = 'default';
   @Input() nzOptionHeightPx = 32;
@@ -202,6 +203,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   @Input() @InputBoolean() nzServerSearch = false;
   @Input() @InputBoolean() nzDisabled = false;
   @Input() @InputBoolean() nzOpen = false;
+  @Input() @InputBoolean() nzAcceptOnBlur = false;
   @Input() nzOptions: NzSelectOptionInterface[] = [];
   @Output() readonly nzOnSearch = new EventEmitter<string>();
   @Output() readonly nzScrollToBottom = new EventEmitter<void>();
@@ -540,6 +542,9 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
           this.focused = false;
           this.cdr.markForCheck();
           this.nzBlur.emit();
+          if (this.nzAcceptOnBlur && this.searchValue) {
+            this.onItemClick(this.searchValue);
+          }
           Promise.resolve().then(() => {
             this.onTouched();
           });

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -384,7 +384,7 @@ describe('select', () => {
       flushChanges();
       expect(document.querySelectorAll('nz-option-item.ant-select-item-option-selected').length).toBe(1);
       expect(document.querySelectorAll('nz-option-item.ant-select-item-option-selected')[0].textContent).toBe('Truthy value');
-      ['disabled', undefined, null].forEach((value) => {
+      ['disabled', undefined, null].forEach(value => {
         component.value = value;
         flushChanges();
         expect(document.querySelectorAll('nz-option-item.ant-select-item-option-selected').length).toBe(0);
@@ -634,6 +634,21 @@ describe('select', () => {
       component.nzMaxTagPlaceholder = component.tagTemplate;
       fixture.detectChanges();
       expect(listOfItem[2].textContent).toBe(' and 2 more selected ');
+    }));
+    it('should accept unselected string values on blur with nzAcceptOnBlur', fakeAsync(() => {
+      component.nzAcceptOnBlur = true;
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const inputElement = selectElement.querySelector('input')!;
+      inputElement.value = 'test_01';
+      dispatchFakeEvent(inputElement, 'input');
+      dispatchFakeEvent(inputElement, 'blur');
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(component.value.length).toBe(1);
+      expect(component.value[0]).toBe('test_01');
     }));
   });
   describe('default reactive mode', () => {
@@ -1253,6 +1268,7 @@ export class TestSelectTemplateMultipleComponent {
       [nzMaxTagCount]="nzMaxTagCount"
       [nzTokenSeparators]="nzTokenSeparators"
       [nzMaxTagPlaceholder]="nzMaxTagPlaceholder"
+      [nzAcceptOnBlur]="nzAcceptOnBlur"
       (ngModelChange)="valueChange($event)"
     >
       <nz-option
@@ -1275,6 +1291,7 @@ export class TestSelectTemplateTagsComponent {
   valueChange = jasmine.createSpy('valueChange');
   nzTokenSeparators: string[] = [];
   nzMaxTagPlaceholder!: TemplateRef<{ $implicit: NzSafeAny[] }>;
+  nzAcceptOnBlur = false;
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
On _tag_ mode, when the user enters a value and blurs out the field, the value is discarded.

Issue Number: #5460


## What is the new behavior?
Introduces a  boolean input **nzAcceptOnBlur** which will add the unselected value to the tags array when the field is blurred.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
