### PR TITLE
feat(module:upload): add `nzPreviewIsImage` property

### DIFF
--- a/components/upload/doc/index.en-US.md
+++ b/components/upload/doc/index.en-US.md
@@ -48,6 +48,7 @@ import { NzUploadModule } from 'ng-zorro-antd/upload';
 | `[nzOpenFileDialogOnClick]` | click open file dialog | `boolean` | `true` |
 | `[nzPreview]` | A callback function, will be executed when file link or preview icon is clicked. NOTICE: Muse be use `=>` to define the method. | `(file: NzUploadFile) => void` | - |
 | `[nzPreviewFile]` | Customize preview file logic. NOTICE: Muse be use `=>` to define the method. | `(file: NzUploadFile) => Observable<dataURL: string>` | - |
+| `[nzPreviewIsImage]` | Customize the preview file is an image, generally used when the image URL is in a non-standard format. NOTICE: Muse be use `=>` to define the method. | `(file: NzUploadFile) => boolean` | - |
 | `[nzRemove]` | A callback function, will be executed when removing file button is clicked, remove event will be prevented when return value is `false` or a Observable. NOTICE: Muse be use `=>` to define the method.  | `(file: NzUploadFile) => boolean \| Observable<boolean>` | - |
 | `(nzChange)` | A callback function, can be executed when uploading state is changing | `EventEmitter<NzUploadChangeParam>` | - |
 | `[nzDownload]`   | Click the method to download the file, pass the method to perform the method logic, do not pass the default jump to the new TAB. | `(file: NzUploadFile) => void` | Jump to new TAB |

--- a/components/upload/doc/index.zh-CN.md
+++ b/components/upload/doc/index.zh-CN.md
@@ -49,6 +49,7 @@ import { NzUploadModule } from 'ng-zorro-antd/upload';
 | `[nzOpenFileDialogOnClick]` | 点击打开文件对话框 | `boolean` | `true` |
 | `[nzPreview]` | 点击文件链接或预览图标时的回调；注意：务必使用 `=>` 定义处理方法。 | `(file: NzUploadFile) => void` | - |
 | `[nzPreviewFile]` | 自定义文件预览逻辑；注意：务必使用 `=>` 定义处理方法。 | `(file: NzUploadFile) => Observable<dataURL: string>` | - |
+| `[nzPreviewIsImage]` | 自定义预览文件是否有效图像，一般用于图像URL为非标准格式；注意：务必使用 `=>` 定义处理方法。 | `(file: NzUploadFile) => boolean` | - |
 | `[nzRemove]` | 点击移除文件时的回调，返回值为 false 时不移除。支持返回 `Observable` 对象；注意：务必使用 `=>` 定义处理方法。 | `(file: NzUploadFile) => boolean \| Observable<boolean>` | - |
 | `(nzChange)` | 上传文件改变时的状态 | `EventEmitter<NzUploadChangeParam>` | - |
 | `[nzDownload]`   | 点击下载文件时的回调，如果没有指定，则默认跳转到文件 url 对应的标签页 | `(file: NzUploadFile) => void` | 跳转新标签页 |

--- a/components/upload/upload-list.component.ts
+++ b/components/upload/upload-list.component.ts
@@ -74,6 +74,7 @@ export class NzUploadListComponent implements OnChanges {
   @Input() onRemove!: (file: NzUploadFile) => void;
   @Input() onDownload?: (file: NzUploadFile) => void;
   @Input() previewFile?: (file: NzUploadFile) => Observable<string>;
+  @Input() previewIsImage?: (file: NzUploadFile) => boolean;
   @Input() iconRender: TemplateRef<NzSafeAny> | null = null;
 
   private genErr(file: NzUploadFile): string {
@@ -202,7 +203,7 @@ export class NzUploadListComponent implements OnChanges {
       file.isUploading = file.status === 'uploading';
       file.message = this.genErr(file);
       file.linkProps = typeof file.linkProps === 'string' ? JSON.parse(file.linkProps) : file.linkProps;
-      file.isImageUrl = this.isImageUrl(file);
+      file.isImageUrl = this.previewIsImage ? this.previewIsImage(file) : this.isImageUrl(file);
       file.iconType = this.getIconType(file);
       file.listItemNameCls = this.listItemNameCls(file);
       file.showDownload = this.showDownload(file);

--- a/components/upload/upload.component.html
+++ b/components/upload/upload.component.html
@@ -1,6 +1,6 @@
 <ng-template #list>
   <nz-upload-list
-    *ngIf="!nzFileListRender"
+    *ngIf="locale && !nzFileListRender"
     #listComp
     [style.display]="nzShowUploadList ? '' : 'none'"
     [locale]="locale"
@@ -9,6 +9,7 @@
     [icons]="$any(nzShowUploadList)"
     [iconRender]="nzIconRender"
     [previewFile]="nzPreviewFile"
+    [previewIsImage]="nzPreviewIsImage"
     [onPreview]="nzPreview"
     [onRemove]="onRemove"
     [onDownload]="nzDownload"

--- a/components/upload/upload.component.ts
+++ b/components/upload/upload.component.ts
@@ -105,6 +105,7 @@ export class NzUploadComponent implements OnInit, OnChanges, OnDestroy {
   @Input() nzRemove?: (file: NzUploadFile) => boolean | Observable<boolean>;
   @Input() nzPreview?: (file: NzUploadFile) => void;
   @Input() nzPreviewFile?: (file: NzUploadFile) => Observable<string>;
+  @Input() nzPreviewIsImage?: (file: NzUploadFile) => boolean;
   @Input() nzTransformFile?: (file: NzUploadFile) => NzUploadTransformFileType;
   @Input() nzDownload?: (file: NzUploadFile) => void;
   @Input() nzIconRender: TemplateRef<NzSafeAny> | null = null;

--- a/components/upload/upload.spec.ts
+++ b/components/upload/upload.spec.ts
@@ -922,6 +922,14 @@ describe('upload', () => {
           });
         });
       });
+      it('#previewIsImage', fakeAsync(() => {
+        instance.previewIsImage = () => true;
+        instance.listType = 'picture';
+        instance.items = [{}];
+        fixture.detectChanges();
+        tick();
+        expect(instance.items[0].isImageUrl).toBe(true);
+      }));
     });
 
     describe('[genThumb]', () => {
@@ -1429,6 +1437,7 @@ class TestUploadComponent {
       [icons]="icons"
       [onPreview]="onPreview"
       [previewFile]="previewFile"
+      [previewIsImage]="previewIsImage"
       [onRemove]="onRemove"
     ></nz-upload-list>
   `,
@@ -1468,6 +1477,7 @@ class TestUploadListComponent {
     this._onPreview = true;
   };
   previewFile!: (file: NzUploadFile) => Observable<string>;
+  previewIsImage!: (file: NzUploadFile) => boolean;
   _onRemove = false;
   onRemove: any = (): void => {
     this._onRemove = true;


### PR DESCRIPTION
- close #5520
- close #4990

`nzPreviewIsImage` 可以更好的自定义预览文件URL是否有效的图像格式，特别是一些CDN它们本身没有一个很明确的图像资源标识，比如：

- https://a.com/1.jpg 一种标准图像路径
- https://a.com/key?w=800&force_format=jpg 也算是一个有效的图像路径

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
