### PR TITLE
fix(module:modal): change back to FocusTrapFactory

### DIFF
--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ConfigurableFocusTrapFactory, FocusTrap } from '@angular/cdk/a11y';
+import { FocusTrap, FocusTrapFactory } from '@angular/cdk/a11y';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { Overlay, OverlayConfig, OverlayKeyboardDispatcher, OverlayRef } from '@angular/cdk/overlay';
 import { CdkPortalOutlet, ComponentPortal, PortalInjector, TemplatePortal } from '@angular/cdk/portal';
@@ -222,7 +222,7 @@ export class NzDrawerComponent<T = NzSafeAny, R = NzSafeAny, D = NzSafeAny> exte
     private overlay: Overlay,
     private injector: Injector,
     private changeDetectorRef: ChangeDetectorRef,
-    private focusTrapFactory: ConfigurableFocusTrapFactory,
+    private focusTrapFactory: FocusTrapFactory,
     private viewContainerRef: ViewContainerRef,
     private overlayKeyboardDispatcher: OverlayKeyboardDispatcher
   ) {

--- a/components/modal/modal-confirm-container.component.ts
+++ b/components/modal/modal-confirm-container.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
+import { FocusTrapFactory } from '@angular/cdk/a11y';
 import { OverlayRef } from '@angular/cdk/overlay';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
@@ -114,7 +114,7 @@ export class NzModalConfirmContainerComponent extends BaseModalContainerComponen
   constructor(
     private i18n: NzI18nService,
     elementRef: ElementRef,
-    focusTrapFactory: ConfigurableFocusTrapFactory,
+    focusTrapFactory: FocusTrapFactory,
     cdr: ChangeDetectorRef,
     render: Renderer2,
     overlayRef: OverlayRef,

--- a/components/modal/modal-container.component.ts
+++ b/components/modal/modal-container.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
+import { FocusTrapFactory } from '@angular/cdk/a11y';
 import { OverlayRef } from '@angular/cdk/overlay';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
@@ -67,7 +67,7 @@ export class NzModalContainerComponent extends BaseModalContainerComponent {
   @ViewChild('modalElement', { static: true }) modalElementRef!: ElementRef<HTMLDivElement>;
   constructor(
     elementRef: ElementRef,
-    focusTrapFactory: ConfigurableFocusTrapFactory,
+    focusTrapFactory: FocusTrapFactory,
     cdr: ChangeDetectorRef,
     render: Renderer2,
     overlayRef: OverlayRef,

--- a/components/modal/modal-container.ts
+++ b/components/modal/modal-container.ts
@@ -4,7 +4,7 @@
  */
 
 import { AnimationEvent } from '@angular/animations';
-import { ConfigurableFocusTrapFactory, FocusTrap } from '@angular/cdk/a11y';
+import { FocusTrap, FocusTrapFactory } from '@angular/cdk/a11y';
 import { OverlayRef } from '@angular/cdk/overlay';
 import { BasePortalOutlet, CdkPortalOutlet, ComponentPortal, TemplatePortal } from '@angular/cdk/portal';
 import { ChangeDetectorRef, ComponentRef, Directive, ElementRef, EmbeddedViewRef, EventEmitter, OnDestroy, Renderer2 } from '@angular/core';
@@ -57,7 +57,7 @@ export class BaseModalContainerComponent extends BasePortalOutlet implements OnD
 
   constructor(
     protected elementRef: ElementRef,
-    protected focusTrapFactory: ConfigurableFocusTrapFactory,
+    protected focusTrapFactory: FocusTrapFactory,
     public cdr: ChangeDetectorRef,
     protected render: Renderer2,
     protected overlayRef: OverlayRef,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/NG-ZORRO/ng-zorro-antd/issues/5591

the new introduced `ConfigurableFocusTrapFactory` strategy disables clicks outside overlay, which is not compatible with many third-party libraries.

Literally, FocusTrap should only prevent focus event other than click event.

On the other hand, even Angular Material is still using the deprecated `FocusTrapFactory` for now.

Issue Number: 5591


## What is the new behavior?
Change back to `FocusTrapFactory`, which enables clicks outside overlay.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
