### PR TITLE
refactor(module:*): refactor the WithConfig decorator

### DIFF
--- a/components/affix/affix.component.ts
+++ b/components/affix/affix.component.ts
@@ -22,7 +22,7 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzScrollService } from 'ng-zorro-antd/core/services';
 import { NgStyleInterface, NumberInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { getStyleAsText, InputNumber, shallowEqual } from 'ng-zorro-antd/core/util';
@@ -33,7 +33,7 @@ import { auditTime, map, takeUntil } from 'rxjs/operators';
 import { AffixRespondEvents } from './respond-events';
 import { getTargetRect, SimpleRect } from './utils';
 
-const NZ_CONFIG_COMPONENT_NAME = 'affix';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'affix';
 const NZ_AFFIX_CLS_PREFIX = 'ant-affix';
 const NZ_AFFIX_DEFAULT_SCROLL_TIME = 20;
 
@@ -49,6 +49,7 @@ const NZ_AFFIX_DEFAULT_SCROLL_TIME = 20;
   encapsulation: ViewEncapsulation.None
 })
 export class NzAffixComponent implements AfterViewInit, OnChanges, OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzOffsetTop: NumberInput;
   static ngAcceptInputType_nzOffsetBottom: NumberInput;
 
@@ -57,12 +58,12 @@ export class NzAffixComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() nzTarget?: string | Element | Window;
 
   @Input()
-  @WithConfig<number | null>(NZ_CONFIG_COMPONENT_NAME)
+  @WithConfig<number | null>()
   @InputNumber(undefined)
   nzOffsetTop?: null | number;
 
   @Input()
-  @WithConfig<number | null>(NZ_CONFIG_COMPONENT_NAME)
+  @WithConfig<number | null>()
   @InputNumber(undefined)
   nzOffsetBottom?: null | number;
 

--- a/components/alert/alert.component.ts
+++ b/components/alert/alert.component.ts
@@ -17,13 +17,13 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { slideAlertMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-const NZ_CONFIG_COMPONENT_NAME = 'alert';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'alert';
 
 @Component({
   selector: 'nz-alert',
@@ -71,6 +71,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'alert';
   preserveWhitespaces: false
 })
 export class NzAlertComponent implements OnChanges, OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzCloseable: BooleanInput;
   static ngAcceptInputType_nzShowIcon: BooleanInput;
   static ngAcceptInputType_nzBanner: BooleanInput;
@@ -81,8 +82,8 @@ export class NzAlertComponent implements OnChanges, OnDestroy {
   @Input() nzMessage: string | TemplateRef<void> | null = null;
   @Input() nzDescription: string | TemplateRef<void> | null = null;
   @Input() nzType: 'success' | 'info' | 'warning' | 'error' = 'info';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzCloseable: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzShowIcon: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzCloseable: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzShowIcon: boolean = false;
   @Input() @InputBoolean() nzBanner = false;
   @Input() @InputBoolean() nzNoAnimation = false;
   @Output() readonly nzOnClose = new EventEmitter<boolean>();
@@ -95,7 +96,7 @@ export class NzAlertComponent implements OnChanges, OnDestroy {
 
   constructor(public nzConfigService: NzConfigService, private cdr: ChangeDetectorRef) {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.cdr.markForCheck();

--- a/components/anchor/anchor.component.ts
+++ b/components/anchor/anchor.component.ts
@@ -23,7 +23,7 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { warnDeprecation } from 'ng-zorro-antd/core/logger';
 import { NzScrollService } from 'ng-zorro-antd/core/services';
 import { BooleanInput, NgStyleInterface, NumberInput, NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -39,7 +39,7 @@ interface Section {
   top: number;
 }
 
-const NZ_CONFIG_COMPONENT_NAME = 'anchor';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'anchor';
 const sharpMatcherRegx = /#([^#]+)$/;
 
 @Component({
@@ -65,6 +65,7 @@ const sharpMatcherRegx = /#([^#]+)$/;
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NzAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzAffix: BooleanInput;
   static ngAcceptInputType_nzShowInkInFixed: BooleanInput;
   static ngAcceptInputType_nzBounds: NumberInput;
@@ -75,18 +76,18 @@ export class NzAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
   @Input() @InputBoolean() nzAffix = true;
 
   @Input()
-  @WithConfig(NZ_CONFIG_COMPONENT_NAME)
+  @WithConfig()
   @InputBoolean()
   nzShowInkInFixed: boolean = false;
 
   @Input()
-  @WithConfig(NZ_CONFIG_COMPONENT_NAME)
+  @WithConfig()
   @InputNumber()
   nzBounds: number = 5;
 
   @Input()
   @InputNumber(undefined)
-  @WithConfig<number>(NZ_CONFIG_COMPONENT_NAME)
+  @WithConfig<number>()
   nzOffsetTop?: number = undefined;
 
   @Input() nzContainer?: string | HTMLElement;

--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -17,10 +17,10 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NgClassInterface, NgStyleInterface, NzShapeSCType, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 
-const NZ_CONFIG_COMPONENT_NAME = 'avatar';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
 
 @Component({
   selector: 'nz-avatar',
@@ -49,8 +49,9 @@ const NZ_CONFIG_COMPONENT_NAME = 'avatar';
   encapsulation: ViewEncapsulation.None
 })
 export class NzAvatarComponent implements OnChanges {
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzShape: NzShapeSCType = 'circle';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzSizeLDSType | number = 'default';
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+  @Input() @WithConfig() nzShape: NzShapeSCType = 'circle';
+  @Input() @WithConfig() nzSize: NzSizeLDSType | number = 'default';
   @Input() nzText?: string;
   @Input() nzSrc?: string;
   @Input() nzSrcSet?: string;

--- a/components/back-top/back-top.component.ts
+++ b/components/back-top/back-top.component.ts
@@ -22,7 +22,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { fadeMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzScrollService } from 'ng-zorro-antd/core/services';
 import { NumberInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputNumber } from 'ng-zorro-antd/core/util';
@@ -30,7 +30,7 @@ import { InputNumber } from 'ng-zorro-antd/core/util';
 import { fromEvent, Subject } from 'rxjs';
 import { takeUntil, throttleTime } from 'rxjs/operators';
 
-const NZ_CONFIG_COMPONENT_NAME = 'backTop';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'backTop';
 
 @Component({
   selector: 'nz-back-top',
@@ -53,6 +53,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'backTop';
   preserveWhitespaces: false
 })
 export class NzBackTopComponent implements OnInit, OnDestroy, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzVisibilityHeight: NumberInput;
 
   private scrollListenerDestroy$ = new Subject();
@@ -61,7 +62,7 @@ export class NzBackTopComponent implements OnInit, OnDestroy, OnChanges {
   visible: boolean = false;
 
   @Input() nzTemplate?: TemplateRef<void>;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputNumber() nzVisibilityHeight: number = 400;
+  @Input() @WithConfig() @InputNumber() nzVisibilityHeight: number = 400;
   @Input() nzTarget?: string | HTMLElement;
   @Output() readonly nzClick: EventEmitter<boolean> = new EventEmitter();
 

--- a/components/badge/badge.component.ts
+++ b/components/badge/badge.component.ts
@@ -22,7 +22,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { zoomBadgeMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, isEmpty } from 'ng-zorro-antd/core/util';
 import { Subject } from 'rxjs';
@@ -31,7 +31,7 @@ import { startWith, take, takeUntil } from 'rxjs/operators';
 import { badgePresetColors } from './preset-colors';
 import { NzBadgeStatusType } from './types';
 
-const NZ_CONFIG_COMPONENT_NAME = 'backTop';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'backTop';
 
 @Component({
   selector: 'nz-badge',
@@ -86,6 +86,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'backTop';
   }
 })
 export class NzBadgeComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzShowZero: BooleanInput;
   static ngAcceptInputType_nzShowDot: BooleanInput;
   static ngAcceptInputType_nzDot: BooleanInput;
@@ -102,8 +103,8 @@ export class NzBadgeComponent implements OnInit, AfterViewInit, OnChanges, OnDes
   @Input() @InputBoolean() nzShowZero: boolean = false;
   @Input() @InputBoolean() nzShowDot = true;
   @Input() @InputBoolean() nzDot = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzOverflowCount: number = 99;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzColor?: string = undefined;
+  @Input() @WithConfig() nzOverflowCount: number = 99;
+  @Input() @WithConfig() nzColor?: string = undefined;
   @Input() nzStyle: { [key: string]: string } | null = null;
   @Input() nzText?: string;
   @Input() nzTitle?: string | null | undefined;

--- a/components/button/button.component.ts
+++ b/components/button/button.component.ts
@@ -18,7 +18,7 @@ import {
   SimpleChanges,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 
@@ -30,7 +30,7 @@ export type NzButtonType = 'primary' | 'default' | 'dashed' | 'danger' | 'link' 
 export type NzButtonShape = 'circle' | 'round' | null;
 export type NzButtonSize = 'large' | 'default' | 'small';
 
-const NZ_CONFIG_COMPONENT_NAME = 'button';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'button';
 
 @Component({
   selector: 'button[nz-button], a[nz-button]',
@@ -64,6 +64,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'button';
   }
 })
 export class NzButtonComponent implements OnDestroy, OnChanges, AfterViewInit, AfterContentInit {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzBlock: BooleanInput;
   static ngAcceptInputType_nzGhost: BooleanInput;
   static ngAcceptInputType_nzSearch: BooleanInput;
@@ -81,7 +82,7 @@ export class NzButtonComponent implements OnDestroy, OnChanges, AfterViewInit, A
   @Input() tabIndex: number | string | null = null;
   @Input() nzType: NzButtonType = null;
   @Input() nzShape: NzButtonShape = null;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzButtonSize = 'default';
+  @Input() @WithConfig() nzSize: NzButtonSize = 'default';
   private destroy$ = new Subject<void>();
   private loading$ = new Subject<boolean>();
 
@@ -121,7 +122,7 @@ export class NzButtonComponent implements OnDestroy, OnChanges, AfterViewInit, A
     public nzConfigService: NzConfigService
   ) {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.cdr.markForCheck();

--- a/components/card/card.component.ts
+++ b/components/card/card.component.ts
@@ -15,7 +15,7 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput, NgStyleInterface, NzSizeDSType } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 import { Subject } from 'rxjs';
@@ -23,7 +23,7 @@ import { takeUntil } from 'rxjs/operators';
 import { NzCardGridDirective } from './card-grid.directive';
 import { NzCardTabComponent } from './card-tab.component';
 
-const NZ_CONFIG_COMPONENT_NAME = 'card';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'card';
 
 @Component({
   selector: 'nz-card',
@@ -74,18 +74,19 @@ const NZ_CONFIG_COMPONENT_NAME = 'card';
   }
 })
 export class NzCardComponent implements OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzBordered: BooleanInput;
   static ngAcceptInputType_nzLoading: BooleanInput;
   static ngAcceptInputType_nzHoverable: BooleanInput;
 
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzBordered: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzBordered: boolean = true;
   @Input() @InputBoolean() nzLoading = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzHoverable: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzHoverable: boolean = false;
   @Input() nzBodyStyle: NgStyleInterface | null = null;
   @Input() nzCover?: TemplateRef<void>;
   @Input() nzActions: Array<TemplateRef<void>> = [];
   @Input() nzType: string | 'inner' | null = null;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzSizeDSType = 'default';
+  @Input() @WithConfig() nzSize: NzSizeDSType = 'default';
   @Input() nzTitle?: string | TemplateRef<void>;
   @Input() nzExtra?: string | TemplateRef<void>;
   @ContentChild(NzCardTabComponent, { static: false }) listOfNzCardTabComponent?: NzCardTabComponent;
@@ -94,7 +95,7 @@ export class NzCardComponent implements OnDestroy {
 
   constructor(public nzConfigService: NzConfigService, private cdr: ChangeDetectorRef) {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.cdr.markForCheck();

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -27,7 +27,7 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzDragService, NzResizeService } from 'ng-zorro-antd/core/services';
 import { BooleanInput, NumberInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, InputNumber } from 'ng-zorro-antd/core/util';
@@ -47,7 +47,7 @@ import {
   PointerVector
 } from './typings';
 
-const NZ_CONFIG_COMPONENT_NAME = 'carousel';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'carousel';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -94,6 +94,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'carousel';
   }
 })
 export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnDestroy, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzEnableSwipe: BooleanInput;
   static ngAcceptInputType_nzDots: BooleanInput;
   static ngAcceptInputType_nzAutoPlay: BooleanInput;
@@ -106,16 +107,16 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
   @ViewChild('slickTrack', { static: false }) slickTrack?: ElementRef;
 
   @Input() nzDotRender?: TemplateRef<{ $implicit: number }>;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzEffect: NzCarouselEffects = 'scrollx';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzEnableSwipe: boolean = true;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzDots: boolean = true;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzAutoPlay: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputNumber() nzAutoPlaySpeed: number = 3000;
+  @Input() @WithConfig() nzEffect: NzCarouselEffects = 'scrollx';
+  @Input() @WithConfig() @InputBoolean() nzEnableSwipe: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzDots: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzAutoPlay: boolean = false;
+  @Input() @WithConfig() @InputNumber() nzAutoPlaySpeed: number = 3000;
   @Input() @InputNumber() nzTransitionSpeed = 500;
 
   @Input()
   // @ts-ignore
-  @WithConfig(NZ_CONFIG_COMPONENT_NAME)
+  @WithConfig()
   set nzDotPosition(value: NzCarouselDotPosition) {
     this._dotPosition = value;
     if (value === 'left' || value === 'right') {

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -28,7 +28,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { slideMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { DEFAULT_CASCADER_POSITIONS } from 'ng-zorro-antd/core/overlay';
 import { BooleanInput, NgClassType, NgStyleInterface, NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -49,7 +49,7 @@ import {
   NzShowSearchOptions
 } from './typings';
 
-const NZ_CONFIG_COMPONENT_NAME = 'cascader';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'cascader';
 const defaultDisplayRender = (labels: string[]) => labels.join(' / ');
 
 @Component({
@@ -93,8 +93,7 @@ const defaultDisplayRender = (labels: string[]) => labels.join(' / ');
           nzType="down"
           class="ant-cascader-picker-arrow"
           [class.ant-cascader-picker-arrow-expand]="menuVisible"
-        >
-        </i>
+        ></i>
         <i *ngIf="isLoading" nz-icon nzType="loading" class="ant-cascader-picker-arrow"></i>
         <span
           class="ant-cascader-picker-label"
@@ -187,6 +186,7 @@ const defaultDisplayRender = (labels: string[]) => labels.join(' / ');
   }
 })
 export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit, OnDestroy, ControlValueAccessor {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzShowInput: BooleanInput;
   static ngAcceptInputType_nzShowArrow: BooleanInput;
   static ngAcceptInputType_nzAllowClear: BooleanInput;
@@ -212,7 +212,7 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
   @Input() nzLabelRender: TemplateRef<void> | null = null;
   @Input() nzLabelProperty = 'label';
   @Input() nzNotFoundContent?: string | TemplateRef<void>;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzCascaderSize = 'default';
+  @Input() @WithConfig() nzSize: NzCascaderSize = 'default';
   @Input() nzShowSearch: boolean | NzShowSearchOptions = false;
   @Input() nzPlaceHolder: string = '';
   @Input() nzMenuClassName?: string;
@@ -368,7 +368,7 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
     });
 
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.cdr.markForCheck();

--- a/components/code-editor/code-editor.service.ts
+++ b/components/code-editor/code-editor.service.ts
@@ -5,7 +5,7 @@
 
 import { DOCUMENT } from '@angular/common';
 import { Inject, Injectable, Optional } from '@angular/core';
-import { NzConfigService } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService } from 'ng-zorro-antd/core/config';
 import { PREFIX, warn, warnDeprecation } from 'ng-zorro-antd/core/logger';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { BehaviorSubject, Observable, of as observableOf, Subject } from 'rxjs';
@@ -14,7 +14,7 @@ import { JoinedEditorOptions, NzCodeEditorConfig, NzCodeEditorLoadingStatus, NZ_
 
 declare const monaco: NzSafeAny;
 
-const NZ_CONFIG_COMPONENT_NAME = 'codeEditor';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'codeEditor';
 
 function tryTriggerFunc(fn?: (...args: NzSafeAny[]) => NzSafeAny): (...args: NzSafeAny) => void {
   return (...args: NzSafeAny[]) => {
@@ -42,7 +42,7 @@ export class NzCodeEditorService {
     @Inject(DOCUMENT) _document: NzSafeAny,
     @Inject(NZ_CODE_EDITOR_CONFIG) @Optional() config?: NzCodeEditorConfig
   ) {
-    const globalConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_COMPONENT_NAME);
+    const globalConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME);
 
     if (config) {
       warnDeprecation(
@@ -54,8 +54,8 @@ export class NzCodeEditorService {
     this.config = { ...config, ...globalConfig };
     this.option = this.config.defaultEditorOption || {};
 
-    this.nzConfigService.getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME).subscribe(() => {
-      const newGlobalConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_COMPONENT_NAME);
+    this.nzConfigService.getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME).subscribe(() => {
+      const newGlobalConfig: NzSafeAny = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME);
       if (newGlobalConfig) {
         this._updateDefaultOption(newGlobalConfig.defaultEditorOption);
       }

--- a/components/collapse/collapse-panel.component.ts
+++ b/components/collapse/collapse-panel.component.ts
@@ -18,7 +18,7 @@ import {
 } from '@angular/core';
 import { collapseMotion } from 'ng-zorro-antd/core/animation';
 
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 import { Subject } from 'rxjs';
@@ -26,7 +26,7 @@ import { takeUntil } from 'rxjs/operators';
 
 import { NzCollapseComponent } from './collapse.component';
 
-const NZ_CONFIG_COMPONENT_NAME = 'collapsePanel';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapsePanel';
 
 @Component({
   selector: 'nz-collapse-panel',
@@ -61,13 +61,14 @@ const NZ_CONFIG_COMPONENT_NAME = 'collapsePanel';
   }
 })
 export class NzCollapsePanelComponent implements OnInit, OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzActive: BooleanInput;
   static ngAcceptInputType_nzDisabled: BooleanInput;
   static ngAcceptInputType_nzShowArrow: BooleanInput;
 
   @Input() @InputBoolean() nzActive = false;
   @Input() @InputBoolean() nzDisabled = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzShowArrow: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzShowArrow: boolean = true;
   @Input() nzExtra?: string | TemplateRef<void>;
   @Input() nzHeader?: string | TemplateRef<void>;
   @Input() nzExpandedIcon?: string | TemplateRef<void>;
@@ -89,7 +90,7 @@ export class NzCollapsePanelComponent implements OnInit, OnDestroy {
     @Host() private nzCollapseComponent: NzCollapseComponent
   ) {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.cdr.markForCheck();

--- a/components/collapse/collapse.component.ts
+++ b/components/collapse/collapse.component.ts
@@ -5,7 +5,7 @@
 
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
 
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 import { Subject } from 'rxjs';
@@ -13,14 +13,16 @@ import { takeUntil } from 'rxjs/operators';
 
 import { NzCollapsePanelComponent } from './collapse-panel.component';
 
-const NZ_CONFIG_COMPONENT_NAME = 'collapse';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapse';
 
 @Component({
   selector: 'nz-collapse',
   exportAs: 'nzCollapse',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  template: ` <ng-content></ng-content> `,
+  template: `
+    <ng-content></ng-content>
+  `,
   host: {
     '[class.ant-collapse]': 'true',
     '[class.ant-collapse-icon-position-left]': `nzExpandIconPosition === 'left'`,
@@ -30,19 +32,20 @@ const NZ_CONFIG_COMPONENT_NAME = 'collapse';
   }
 })
 export class NzCollapseComponent implements OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzAccordion: BooleanInput;
   static ngAcceptInputType_nzBordered: BooleanInput;
   static ngAcceptInputType_nzGhost: BooleanInput;
 
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzAccordion: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzBordered: boolean = true;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzGhost: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzAccordion: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzBordered: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzGhost: boolean = false;
   @Input() nzExpandIconPosition: 'left' | 'right' = 'left';
   private listOfNzCollapsePanelComponent: NzCollapsePanelComponent[] = [];
   private destroy$ = new Subject();
   constructor(public nzConfigService: NzConfigService, private cdr: ChangeDetectorRef) {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.cdr.markForCheck();

--- a/components/core/config/config.service.ts
+++ b/components/core/config/config.service.ts
@@ -52,7 +52,7 @@ export class NzConfigService {
  * config.
  */
 // tslint:disable-next-line:typedef
-export function WithConfig<T>(componentName: NzConfigKey) {
+export function WithConfig<T>() {
   return function ConfigDecorator(target: NzSafeAny, propName: NzSafeAny, originalDescriptor?: TypedPropertyDescriptor<T>): NzSafeAny {
     const privatePropName = `$$__assignedValue__${propName}`;
 
@@ -71,7 +71,7 @@ export function WithConfig<T>(componentName: NzConfigKey) {
           return originalValue;
         }
 
-        const componentConfig = this.nzConfigService.getConfigForComponent(componentName) || {};
+        const componentConfig = this.nzConfigService.getConfigForComponent(this._nzModuleName) || {};
         const configValue = componentConfig[propName];
         const ret = isDefined(configValue) ? configValue : originalValue;
 

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -34,12 +34,12 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { DatePickerService } from './date-picker.service';
 
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzPickerComponent } from './picker.component';
 import { CompatibleDate, DisabledTimeFn, NzDateMode, PresetRanges, SupportTimeOptions } from './standard-types';
 
 const POPUP_STYLE_PATCH = { position: 'relative' }; // Aim to override antd's style to support overlay's position strategy (position:absolute will cause it not working beacuse the overlay can't get the height/width of it's content)
-const NZ_CONFIG_COMPONENT_NAME = 'datePicker';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'datePicker';
 
 /**
  * The base picker for all common APIs
@@ -111,6 +111,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'datePicker';
   ]
 })
 export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, ControlValueAccessor {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzAllowClear: BooleanInput;
   static ngAcceptInputType_nzAutoFocus: BooleanInput;
   static ngAcceptInputType_nzDisabled: BooleanInput;
@@ -157,8 +158,8 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Cont
   @Input() nzMode: NzDateMode | NzDateMode[] = 'date';
   @Input() nzRanges?: PresetRanges;
   @Input() nzDefaultPickerValue: CompatibleDate | null = null;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSeparator?: string = undefined;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSuffixIcon: string | TemplateRef<NzSafeAny> = 'calendar';
+  @Input() @WithConfig() nzSeparator?: string = undefined;
+  @Input() @WithConfig() nzSuffixIcon: string | TemplateRef<NzSafeAny> = 'calendar';
 
   // TODO(@wenqi73) The PanelMode need named for each pickers and export
   @Output() readonly nzOnPanelChange = new EventEmitter<NzDateMode | NzDateMode[] | string | string[]>();

--- a/components/descriptions/descriptions.component.ts
+++ b/components/descriptions/descriptions.component.ts
@@ -17,7 +17,7 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { warn } from 'ng-zorro-antd/core/logger';
 import { gridResponsiveMap, NzBreakpointEnum, NzBreakpointService } from 'ng-zorro-antd/core/services';
 import { BooleanInput } from 'ng-zorro-antd/core/types';
@@ -28,7 +28,7 @@ import { auditTime, startWith, switchMap, takeUntil, tap } from 'rxjs/operators'
 import { NzDescriptionsItemComponent } from './descriptions-item.component';
 import { NzDescriptionsItemRenderProps, NzDescriptionsLayout, NzDescriptionsSize } from './typings';
 
-const NZ_CONFIG_COMPONENT_NAME = 'descriptions';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'descriptions';
 const defaultColumnMap: { [key in NzBreakpointEnum]: number } = {
   xxl: 3,
   xl: 3,
@@ -142,17 +142,18 @@ const defaultColumnMap: { [key in NzBreakpointEnum]: number } = {
   }
 })
 export class NzDescriptionsComponent implements OnChanges, OnDestroy, AfterContentInit {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzBordered: BooleanInput;
   static ngAcceptInputType_nzColon: BooleanInput;
 
   @ContentChildren(NzDescriptionsItemComponent) items!: QueryList<NzDescriptionsItemComponent>;
 
-  @Input() @InputBoolean() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzBordered: boolean = false;
+  @Input() @InputBoolean() @WithConfig() nzBordered: boolean = false;
   @Input() nzLayout: NzDescriptionsLayout = 'horizontal';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzColumn: number | { [key in NzBreakpointEnum]: number } = defaultColumnMap;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzDescriptionsSize = 'default';
+  @Input() @WithConfig() nzColumn: number | { [key in NzBreakpointEnum]: number } = defaultColumnMap;
+  @Input() @WithConfig() nzSize: NzDescriptionsSize = 'default';
   @Input() nzTitle: string | TemplateRef<void> = '';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzColon: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzColon: boolean = true;
 
   itemMatrix: NzDescriptionsItemRenderProps[][] = [];
   realColumn = 3;

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -29,7 +29,7 @@ import {
   ViewChild,
   ViewContainerRef
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput, NgStyleInterface, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, toCssPixel } from 'ng-zorro-antd/core/util';
 
@@ -40,7 +40,7 @@ import { NzDrawerRef } from './drawer-ref';
 
 export const DRAWER_ANIMATE_DURATION = 300;
 
-const NZ_CONFIG_COMPONENT_NAME = 'drawer';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
 
 @Component({
   selector: 'nz-drawer',
@@ -99,6 +99,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'drawer';
 })
 export class NzDrawerComponent<T = NzSafeAny, R = NzSafeAny, D = NzSafeAny> extends NzDrawerRef<T, R>
   implements OnInit, OnDestroy, AfterViewInit, OnChanges, NzDrawerOptionsOfComponent {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzClosable: BooleanInput;
   static ngAcceptInputType_nzMaskClosable: BooleanInput;
   static ngAcceptInputType_nzMask: BooleanInput;
@@ -108,9 +109,9 @@ export class NzDrawerComponent<T = NzSafeAny, R = NzSafeAny, D = NzSafeAny> exte
 
   @Input() nzContent!: TemplateRef<{ $implicit: D; drawerRef: NzDrawerRef<R> }> | Type<T>;
   @Input() @InputBoolean() nzClosable: boolean = true;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzMaskClosable: boolean = true;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzMask: boolean = true;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzCloseOnNavigation: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzMaskClosable: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzMask: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzCloseOnNavigation: boolean = true;
   @Input() @InputBoolean() nzNoAnimation = false;
   @Input() @InputBoolean() nzKeyboard: boolean = true;
   @Input() nzTitle?: string | TemplateRef<{}>;

--- a/components/form/form.directive.ts
+++ b/components/form/form.directive.ts
@@ -5,13 +5,13 @@
 
 import { Directive, ElementRef, Input, OnChanges, OnDestroy, Renderer2, SimpleChange, SimpleChanges } from '@angular/core';
 
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput, InputObservable } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 import { Observable, Subject } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
-const NZ_CONFIG_COMPONENT_NAME = 'form';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'form';
 
 export type NzFormLayoutType = 'horizontal' | 'vertical' | 'inline';
 
@@ -25,12 +25,13 @@ export type NzFormLayoutType = 'horizontal' | 'vertical' | 'inline';
   }
 })
 export class NzFormDirective implements OnChanges, OnDestroy, InputObservable {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzNoColon: BooleanInput;
   static ngAcceptInputType_nzDisableAutoTips: BooleanInput;
 
   @Input() nzLayout: NzFormLayoutType = 'horizontal';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzNoColon: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzAutoTips: Record<string, Record<string, string>> = {};
+  @Input() @WithConfig() @InputBoolean() nzNoColon: boolean = false;
+  @Input() @WithConfig() nzAutoTips: Record<string, Record<string, string>> = {};
   @Input() @InputBoolean() nzDisableAutoTips = false;
 
   destroy$ = new Subject();

--- a/components/modal/modal-config.ts
+++ b/components/modal/modal-config.ts
@@ -3,6 +3,8 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { NzConfigKey } from 'ng-zorro-antd/core/config';
+
 export const ZOOM_CLASS_NAME_MAP = {
   enter: 'zoom-enter',
   enterActive: 'zoom-enter-active',
@@ -18,4 +20,4 @@ export const FADE_CLASS_NAME_MAP = {
 };
 
 export const MODAL_MASK_CLASS_NAME = 'ant-modal-mask';
-export const NZ_CONFIG_COMPONENT_NAME = 'modal';
+export const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'modal';

--- a/components/modal/modal-container.ts
+++ b/components/modal/modal-container.ts
@@ -13,7 +13,7 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { getElementOffset } from 'ng-zorro-antd/core/util';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { FADE_CLASS_NAME_MAP, MODAL_MASK_CLASS_NAME, NZ_CONFIG_COMPONENT_NAME, ZOOM_CLASS_NAME_MAP } from './modal-config';
+import { FADE_CLASS_NAME_MAP, MODAL_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME, ZOOM_CLASS_NAME_MAP } from './modal-config';
 
 import { NzModalRef } from './modal-ref';
 import { ModalOptions } from './modal-types';
@@ -44,13 +44,13 @@ export class BaseModalContainerComponent extends BasePortalOutlet implements OnD
   protected destroy$ = new Subject();
 
   get showMask(): boolean {
-    const defaultConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_COMPONENT_NAME) || {};
+    const defaultConfig: NzSafeAny = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
 
     return !!getValueWithConfig<boolean>(this.config.nzMask, defaultConfig.nzMask, true);
   }
 
   get maskClosable(): boolean {
-    const defaultConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_COMPONENT_NAME) || {};
+    const defaultConfig: NzSafeAny = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
 
     return !!getValueWithConfig<boolean>(this.config.nzMaskClosable, defaultConfig.nzMaskClosable, true);
   }
@@ -71,7 +71,7 @@ export class BaseModalContainerComponent extends BasePortalOutlet implements OnD
     this.isStringContent = typeof config.nzContent === 'string';
     this.setContainer();
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.updateMaskClassname();

--- a/components/modal/modal.service.ts
+++ b/components/modal/modal.service.ts
@@ -13,7 +13,7 @@ import { isNotNil } from 'ng-zorro-antd/core/util';
 import { defer, Observable, Subject } from 'rxjs';
 import { startWith } from 'rxjs/operators';
 
-import { MODAL_MASK_CLASS_NAME, NZ_CONFIG_COMPONENT_NAME } from './modal-config';
+import { MODAL_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME } from './modal-config';
 import { NzModalConfirmContainerComponent } from './modal-confirm-container.component';
 import { BaseModalContainerComponent } from './modal-container';
 import { NzModalContainerComponent } from './modal-container.component';
@@ -123,7 +123,7 @@ export class NzModalService implements OnDestroy {
   }
 
   private createOverlay(config: ModalOptions): OverlayRef {
-    const globalConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_COMPONENT_NAME) || {};
+    const globalConfig: NzSafeAny = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
     const overlayConfig = new OverlayConfig({
       hasBackdrop: true,
       scrollStrategy: this.overlay.scrollStrategies.block(),

--- a/components/notification/notification-container.component.ts
+++ b/components/notification/notification-container.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewEncapsulation } from '@angular/core';
-import { NotificationConfig, NzConfigService } from 'ng-zorro-antd/core/config';
+import { NotificationConfig, NzConfigKey, NzConfigService } from 'ng-zorro-antd/core/config';
 import { warnDeprecation } from 'ng-zorro-antd/core/logger';
 import { toCssPixel } from 'ng-zorro-antd/core/util';
 
@@ -14,7 +14,7 @@ import { takeUntil } from 'rxjs/operators';
 
 import { NzNotificationData, NzNotificationDataOptions } from './typings';
 
-const NZ_CONFIG_COMPONENT_NAME = 'notification';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'notification';
 
 const NZ_NOTIFICATION_DEFAULT_CONFIG: Required<NotificationConfig> = {
   nzTop: '24px',
@@ -110,7 +110,7 @@ export class NzNotificationContainerComponent extends NzMNContainerComponent {
 
   protected subscribeConfigChange(): void {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.updateConfig());
   }
@@ -119,7 +119,7 @@ export class NzNotificationContainerComponent extends NzMNContainerComponent {
     this.config = {
       ...NZ_NOTIFICATION_DEFAULT_CONFIG,
       ...this.config,
-      ...this.nzConfigService.getConfigForComponent(NZ_CONFIG_COMPONENT_NAME)
+      ...this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME)
     };
 
     this.top = toCssPixel(this.config.nzTop!);

--- a/components/page-header/page-header.component.ts
+++ b/components/page-header/page-header.component.ts
@@ -20,14 +20,14 @@ import {
 } from '@angular/core';
 
 import { Location } from '@angular/common';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { PREFIX } from 'ng-zorro-antd/core/logger';
 import { NzResizeObserver } from 'ng-zorro-antd/core/resize-observers';
 import { Subject } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 import { NzPageHeaderBreadcrumbDirective, NzPageHeaderFooterDirective } from './page-header-cells';
 
-const NZ_CONFIG_COMPONENT_NAME = 'pageHeader';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'pageHeader';
 
 @Component({
   selector: 'nz-page-header',
@@ -77,10 +77,12 @@ const NZ_CONFIG_COMPONENT_NAME = 'pageHeader';
   }
 })
 export class NzPageHeaderComponent implements AfterViewInit, OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   @Input() nzBackIcon: string | TemplateRef<void> | null = null;
   @Input() nzTitle?: string | TemplateRef<void>;
   @Input() nzSubtitle?: string | TemplateRef<void>;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzGhost: boolean = true;
+  @Input() @WithConfig() nzGhost: boolean = true;
   @Output() readonly nzBack = new EventEmitter<void>();
 
   @ContentChild(NzPageHeaderFooterDirective, { static: false }) nzPageHeaderFooter?: ElementRef<NzPageHeaderFooterDirective>;

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewEncapsulation } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NgStyleInterface, NumberInput } from 'ng-zorro-antd/core/types';
 import { InputNumber, isNotNil } from 'ng-zorro-antd/core/util';
 import { Subject } from 'rxjs';
@@ -26,7 +26,7 @@ import { handleCircleGradient, handleLinearGradient } from './utils';
 
 let gradientIdSeed = 0;
 
-const NZ_CONFIG_COMPONENT_NAME = 'progress';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'progress';
 const statusIconNameMap = new Map([
   ['success', 'check'],
   ['exception', 'close']
@@ -137,25 +137,27 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
   `
 })
 export class NzProgressComponent implements OnChanges, OnInit, OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzSuccessPercent: NumberInput;
   static ngAcceptInputType_nzPercent: NumberInput;
   static ngAcceptInputType_nzStrokeWidth: NumberInput;
   static ngAcceptInputType_nzGapDegree: NumberInput;
   static ngAcceptInputType_nzSteps: NumberInput;
 
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzShowInfo: boolean = true;
+  @Input() @WithConfig() nzShowInfo: boolean = true;
   @Input() nzWidth = 132;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzStrokeColor?: NzProgressStrokeColorType = undefined;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: 'default' | 'small' = 'default';
+  @Input() @WithConfig() nzStrokeColor?: NzProgressStrokeColorType = undefined;
+  @Input() @WithConfig() nzSize: 'default' | 'small' = 'default';
   @Input() nzFormat?: NzProgressFormatter;
   @Input() @InputNumber() nzSuccessPercent?: number;
   @Input() @InputNumber() nzPercent: number = 0;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputNumber() nzStrokeWidth?: number = undefined;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputNumber() nzGapDegree?: number = undefined;
+  @Input() @WithConfig() @InputNumber() nzStrokeWidth?: number = undefined;
+  @Input() @WithConfig() @InputNumber() nzGapDegree?: number = undefined;
   @Input() nzStatus?: NzProgressStatusType;
   @Input() nzType: NzProgressTypeType = 'line';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzGapPosition: NzProgressGapPositionType = 'top';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzStrokeLinecap: NzProgressStrokeLinecapType = 'round';
+  @Input() @WithConfig() nzGapPosition: NzProgressGapPositionType = 'top';
+  @Input() @WithConfig() nzStrokeLinecap: NzProgressStrokeLinecapType = 'round';
 
   @Input() @InputNumber() nzSteps?: number;
 
@@ -245,7 +247,7 @@ export class NzProgressComponent implements OnChanges, OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.updateIcon();

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -23,14 +23,14 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput, NgClassType } from 'ng-zorro-antd/core/types';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { InputBoolean, InputNumber } from 'ng-zorro-antd/core/util';
 
-const NZ_CONFIG_COMPONENT_NAME = 'rate';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'rate';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -76,6 +76,8 @@ const NZ_CONFIG_COMPONENT_NAME = 'rate';
   ]
 })
 export class NzRateComponent implements OnInit, OnDestroy, ControlValueAccessor, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzAllowClear: BooleanInput;
   static ngAcceptInputType_nzAllowHalf: BooleanInput;
   static ngAcceptInputType_nzDisabled: BooleanInput;
@@ -84,8 +86,8 @@ export class NzRateComponent implements OnInit, OnDestroy, ControlValueAccessor,
 
   @ViewChild('ulElement', { static: false }) private ulElement?: ElementRef;
 
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzAllowClear: boolean = true;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzAllowHalf: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzAllowClear: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzAllowHalf: boolean = false;
   @Input() @InputBoolean() nzDisabled: boolean = false;
   @Input() @InputBoolean() nzAutoFocus: boolean = false;
   @Input() nzCharacter?: TemplateRef<void>;
@@ -145,7 +147,7 @@ export class NzRateComponent implements OnInit, OnDestroy, ControlValueAccessor,
 
   ngOnInit(): void {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.cdr.markForCheck());
   }

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -32,7 +32,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { slideMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { BooleanInput, NzSafeAny, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
@@ -51,7 +51,7 @@ const defaultFilterOption: NzFilterOptionType = (searchValue: string, item: NzSe
   }
 };
 
-const NZ_CONFIG_COMPONENT_NAME = 'select';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'select';
 
 export type NzSelectSizeType = 'large' | 'default' | 'small';
 
@@ -159,6 +159,8 @@ export type NzSelectSizeType = 'large' | 'default' | 'small';
   }
 })
 export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnDestroy, AfterContentInit, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzAllowClear: BooleanInput;
   static ngAcceptInputType_nzBorderless: BooleanInput;
   static ngAcceptInputType_nzShowSearch: BooleanInput;
@@ -181,7 +183,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   @Input() nzDropdownRender: TemplateRef<NzSafeAny> | null = null;
   @Input() nzCustomTemplate: TemplateRef<{ $implicit: NzSelectItemInterface }> | null = null;
   @Input()
-  @WithConfig<TemplateRef<NzSafeAny> | string | null>(NZ_CONFIG_COMPONENT_NAME)
+  @WithConfig<TemplateRef<NzSafeAny> | string | null>()
   nzSuffixIcon: TemplateRef<NzSafeAny> | string | null = null;
   @Input() nzClearIcon: TemplateRef<NzSafeAny> | null = null;
   @Input() nzRemoveIcon: TemplateRef<NzSafeAny> | null = null;
@@ -194,7 +196,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   @Input() nzFilterOption: NzFilterOptionType = defaultFilterOption;
   @Input() compareWith: (o1: NzSafeAny, o2: NzSafeAny) => boolean = (o1: NzSafeAny, o2: NzSafeAny) => o1 === o2;
   @Input() @InputBoolean() nzAllowClear = false;
-  @Input() @WithConfig<boolean>(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzBorderless = false;
+  @Input() @WithConfig<boolean>() @InputBoolean() nzBorderless = false;
   @Input() @InputBoolean() nzShowSearch = false;
   @Input() @InputBoolean() nzLoading = false;
   @Input() @InputBoolean() nzAutoFocus = false;

--- a/components/space/space.component.ts
+++ b/components/space/space.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { AfterViewInit, ChangeDetectionStrategy, Component, ContentChildren, Input, OnChanges, OnDestroy, QueryList } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
@@ -12,13 +12,15 @@ import { startWith, takeUntil } from 'rxjs/operators';
 import { NzSpaceItemComponent } from './space-item.component';
 import { NzSpaceDirection, NzSpaceSize } from './types';
 
-const NZ_CONFIG_COMPONENT_NAME = 'space';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'space';
 
 @Component({
   selector: 'nz-space',
   exportAs: 'NzSpace',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: ` <ng-content></ng-content> `,
+  template: `
+    <ng-content></ng-content>
+  `,
   host: {
     class: 'ant-space',
     '[class.ant-space-horizontal]': 'nzDirection === "horizontal"',
@@ -26,8 +28,10 @@ const NZ_CONFIG_COMPONENT_NAME = 'space';
   }
 })
 export class NzSpaceComponent implements OnChanges, OnDestroy, AfterViewInit {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   @Input() nzDirection: NzSpaceDirection = 'horizontal';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: number | NzSpaceSize = 'small';
+  @Input() @WithConfig() nzSize: number | NzSpaceSize = 'small';
 
   @ContentChildren(NzSpaceItemComponent) nzSpaceItemComponents!: QueryList<NzSpaceItemComponent>;
 

--- a/components/spin/spin.component.ts
+++ b/components/spin/spin.component.ts
@@ -14,14 +14,14 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput, NumberInput, NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 import { InputBoolean, InputNumber } from 'ng-zorro-antd/core/util';
 
 import { BehaviorSubject, Subject } from 'rxjs';
 import { debounceTime, flatMap, takeUntil } from 'rxjs/operators';
 
-const NZ_CONFIG_COMPONENT_NAME = 'spin';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'spin';
 
 @Component({
   selector: 'nz-spin',
@@ -58,11 +58,13 @@ const NZ_CONFIG_COMPONENT_NAME = 'spin';
   }
 })
 export class NzSpinComponent implements OnChanges, OnDestroy, OnInit {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzDelay: NumberInput;
   static ngAcceptInputType_nzSimple: BooleanInput;
   static ngAcceptInputType_nzSpinning: BooleanInput;
 
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzIndicator: TemplateRef<NzSafeAny> | null = null;
+  @Input() @WithConfig() nzIndicator: TemplateRef<NzSafeAny> | null = null;
   @Input() nzSize: NzSizeLDSType = 'default';
   @Input() nzTip: string | null = null;
   @Input() @InputNumber() nzDelay = 0;
@@ -92,7 +94,7 @@ export class NzSpinComponent implements OnChanges, OnDestroy, OnInit {
       this.cdr.markForCheck();
     });
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.cdr.markForCheck());
   }

--- a/components/switch/switch.component.ts
+++ b/components/switch/switch.component.ts
@@ -20,11 +20,11 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { BooleanInput, NzSizeDSType, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 
-const NZ_CONFIG_COMPONENT_NAME = 'switch';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'switch';
 
 @Component({
   selector: 'nz-switch',
@@ -72,6 +72,8 @@ const NZ_CONFIG_COMPONENT_NAME = 'switch';
   }
 })
 export class NzSwitchComponent implements ControlValueAccessor, AfterViewInit, OnDestroy {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzLoading: BooleanInput;
   static ngAcceptInputType_nzDisabled: BooleanInput;
   static ngAcceptInputType_nzControl: BooleanInput;
@@ -85,7 +87,7 @@ export class NzSwitchComponent implements ControlValueAccessor, AfterViewInit, O
   @Input() @InputBoolean() nzControl = false;
   @Input() nzCheckedChildren: string | TemplateRef<void> | null = null;
   @Input() nzUnCheckedChildren: string | TemplateRef<void> | null = null;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzSizeDSType = 'default';
+  @Input() @WithConfig() nzSize: NzSizeDSType = 'default';
 
   onHostClick(e: MouseEvent): void {
     e.preventDefault();

--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -23,7 +23,7 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzResizeObserver } from 'ng-zorro-antd/core/resize-observers';
 import { BooleanInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, measureScrollbar } from 'ng-zorro-antd/core/util';
@@ -36,7 +36,7 @@ import { NzTableData, NzTableLayout, NzTablePaginationPosition, NzTableQueryPara
 import { NzTableInnerScrollComponent } from './table-inner-scroll.component';
 import { NzTableVirtualScrollDirective } from './table-virtual-scroll.directive';
 
-const NZ_CONFIG_COMPONENT_NAME = 'table';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
 
 @Component({
   selector: 'nz-table',
@@ -109,8 +109,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'table';
         [nzPageIndex]="nzPageIndex"
         (nzPageSizeChange)="onPageSizeChange($event)"
         (nzPageIndexChange)="onPageIndexChange($event)"
-      >
-      </nz-pagination>
+      ></nz-pagination>
     </ng-template>
     <ng-template #contentTemplate>
       <ng-content></ng-content>
@@ -121,6 +120,8 @@ const NZ_CONFIG_COMPONENT_NAME = 'table';
   }
 })
 export class NzTableComponent<T = NzSafeAny> implements OnInit, OnDestroy, OnChanges, AfterViewInit {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzFrontPagination: BooleanInput;
   static ngAcceptInputType_nzTemplateMode: BooleanInput;
   static ngAcceptInputType_nzShowPagination: BooleanInput;
@@ -154,13 +155,13 @@ export class NzTableComponent<T = NzSafeAny> implements OnInit, OnDestroy, OnCha
   @Input() @InputBoolean() nzTemplateMode = false;
   @Input() @InputBoolean() nzShowPagination = true;
   @Input() @InputBoolean() nzLoading = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzLoadingIndicator: TemplateRef<NzSafeAny> | null = null;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzBordered: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzTableSize = 'default';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzShowSizeChanger: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzHideOnSinglePage: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzShowQuickJumper: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzSimple: boolean = false;
+  @Input() @WithConfig() nzLoadingIndicator: TemplateRef<NzSafeAny> | null = null;
+  @Input() @WithConfig() @InputBoolean() nzBordered: boolean = false;
+  @Input() @WithConfig() nzSize: NzTableSize = 'default';
+  @Input() @WithConfig() @InputBoolean() nzShowSizeChanger: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzHideOnSinglePage: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzShowQuickJumper: boolean = false;
+  @Input() @WithConfig() @InputBoolean() nzSimple: boolean = false;
   @Output() readonly nzPageSizeChange = new EventEmitter<number>();
   @Output() readonly nzPageIndexChange = new EventEmitter<number>();
   @Output() readonly nzQueryParams = new EventEmitter<NzTableQueryParams>();
@@ -200,7 +201,7 @@ export class NzTableComponent<T = NzSafeAny> implements OnInit, OnDestroy, OnCha
     private nzTableDataService: NzTableDataService
   ) {
     this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
+      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.cdr.markForCheck();

--- a/components/tabs/tabset.component.ts
+++ b/components/tabs/tabset.component.ts
@@ -29,7 +29,7 @@ import { NavigationEnd, Router, RouterLink, RouterLinkWithHref } from '@angular/
 import { merge, Observable, of, Subject, Subscription } from 'rxjs';
 import { filter, first, startWith, takeUntil } from 'rxjs/operators';
 
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { PREFIX, warnDeprecation } from 'ng-zorro-antd/core/logger';
 import { BooleanInput, NumberInput, NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 import { InputBoolean, wrapIntoObservable } from 'ng-zorro-antd/core/util';
@@ -46,7 +46,7 @@ import {
 import { NzTabNavBarComponent } from './tab-nav-bar.component';
 import { NzTabComponent, NZ_TAB_SET } from './tab.component';
 
-const NZ_CONFIG_COMPONENT_NAME = 'tabs';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'tabs';
 
 let nextId = 0;
 
@@ -144,6 +144,8 @@ let nextId = 0;
   }
 })
 export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy, AfterContentInit, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzHideAdd: BooleanInput;
   static ngAcceptInputType_nzHideAll: BooleanInput;
   static ngAcceptInputType_nzCentered: BooleanInput;
@@ -168,10 +170,10 @@ export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy
   @Input() nzCanDeactivate: NzTabsCanDeactivateFn | null = null;
   @Input() nzAddIcon: string | TemplateRef<NzSafeAny> = 'plus';
   @Input() nzTabBarStyle: { [key: string]: string } | null = null;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzType: NzTabType = 'line';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzSizeLDSType = 'default';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzAnimated: NzAnimatedInterface | boolean = true;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzTabBarGutter?: number = undefined;
+  @Input() @WithConfig() nzType: NzTabType = 'line';
+  @Input() @WithConfig() nzSize: NzSizeLDSType = 'default';
+  @Input() @WithConfig() nzAnimated: NzAnimatedInterface | boolean = true;
+  @Input() @WithConfig() nzTabBarGutter?: number = undefined;
   @Input() @InputBoolean() nzHideAdd: boolean = false;
   @Input() @InputBoolean() nzCentered: boolean = false;
   @Input() @InputBoolean() nzHideAll = false;

--- a/components/time-picker/time-picker.component.ts
+++ b/components/time-picker/time-picker.component.ts
@@ -24,12 +24,12 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { slideMotion } from 'ng-zorro-antd/core/animation';
 
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { warn } from 'ng-zorro-antd/core/logger';
 import { BooleanInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, isNil } from 'ng-zorro-antd/core/util';
 
-const NZ_CONFIG_COMPONENT_NAME = 'timePicker';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'timePicker';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -93,8 +93,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'timePicker';
               [(ngModel)]="value"
               (ngModelChange)="setValue($event)"
               (closePanel)="close()"
-            >
-            </nz-time-picker-panel>
+            ></nz-time-picker-panel>
           </div>
         </div>
       </div>
@@ -112,6 +111,8 @@ const NZ_CONFIG_COMPONENT_NAME = 'timePicker';
   providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: NzTimePickerComponent, multi: true }]
 })
 export class NzTimePickerComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzUse12Hours: BooleanInput;
   static ngAcceptInputType_nzHideDisabledOptions: BooleanInput;
   static ngAcceptInputType_nzAllowEmpty: BooleanInput;
@@ -137,26 +138,26 @@ export class NzTimePickerComponent implements ControlValueAccessor, OnInit, Afte
 
   @ViewChild('inputElement', { static: true }) inputRef!: ElementRef<HTMLInputElement>;
   @Input() nzSize: string | null = null;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzHourStep: number = 1;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzMinuteStep: number = 1;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSecondStep: number = 1;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzClearText: string = 'clear';
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzPopupClassName: string = '';
+  @Input() @WithConfig() nzHourStep: number = 1;
+  @Input() @WithConfig() nzMinuteStep: number = 1;
+  @Input() @WithConfig() nzSecondStep: number = 1;
+  @Input() @WithConfig() nzClearText: string = 'clear';
+  @Input() @WithConfig() nzPopupClassName: string = '';
   @Input() nzPlaceHolder = '';
   @Input() nzAddOn?: TemplateRef<void>;
   @Input() nzDefaultOpenValue?: Date;
   @Input() nzDisabledHours?: () => number[];
   @Input() nzDisabledMinutes?: (hour: number) => number[];
   @Input() nzDisabledSeconds?: (hour: number, minute: number) => number[];
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzFormat: string = 'HH:mm:ss';
+  @Input() @WithConfig() nzFormat: string = 'HH:mm:ss';
   @Input() nzOpen = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzUse12Hours: boolean = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSuffixIcon: string | TemplateRef<NzSafeAny> = 'clock-circle';
+  @Input() @WithConfig() @InputBoolean() nzUse12Hours: boolean = false;
+  @Input() @WithConfig() nzSuffixIcon: string | TemplateRef<NzSafeAny> = 'clock-circle';
 
   @Output() readonly nzOpenChange = new EventEmitter<boolean>();
 
   @Input() @InputBoolean() nzHideDisabledOptions = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputBoolean() nzAllowEmpty: boolean = true;
+  @Input() @WithConfig() @InputBoolean() nzAllowEmpty: boolean = true;
   @Input() @InputBoolean() nzDisabled = false;
   @Input() @InputBoolean() nzAutoFocus = false;
 

--- a/components/tree-select/tree-select.component.ts
+++ b/components/tree-select/tree-select.component.ts
@@ -28,7 +28,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { slideMotion, zoomMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 
 import {
@@ -53,7 +53,7 @@ export function higherOrderServiceFactory(injector: Injector): NzTreeBaseService
   return injector.get(NzTreeSelectService);
 }
 
-const NZ_CONFIG_COMPONENT_NAME = 'treeSelect';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'treeSelect';
 const TREE_SELECT_DEFAULT_CLASS = 'ant-select-dropdown ant-select-tree-dropdown';
 
 @Component({
@@ -110,8 +110,7 @@ const TREE_SELECT_DEFAULT_CLASS = 'ant-select-dropdown ant-select-tree-dropdown'
           (nzSelectedKeysChange)="updateSelectedNodes()"
           (nzCheckBoxChange)="nzTreeCheckBoxChange.emit($event)"
           (nzSearchValueChange)="setSearchValues($event)"
-        >
-        </nz-tree>
+        ></nz-tree>
         <span *ngIf="nzNodes.length === 0 || isNotFound" class="ant-select-not-found">
           <nz-embed-empty [nzComponentName]="'tree-select'" [specificContent]="nzNotFoundContent"></nz-embed-empty>
         </span>
@@ -155,15 +154,13 @@ const TREE_SELECT_DEFAULT_CLASS = 'ant-select-dropdown ant-select-tree-dropdown'
         [mirrorSync]="isMultiple"
         [disabled]="nzDisabled"
         [showInput]="nzOpen"
-      >
-      </nz-select-search>
+      ></nz-select-search>
 
       <nz-select-placeholder
         *ngIf="nzPlaceHolder && selectedNodes.length === 0"
         [placeholder]="nzPlaceHolder"
         [style.display]="placeHolderDisplay"
-      >
-      </nz-select-placeholder>
+      ></nz-select-placeholder>
 
       <nz-select-item
         *ngIf="!isMultiple && selectedNodes.length === 1"
@@ -205,6 +202,8 @@ const TREE_SELECT_DEFAULT_CLASS = 'ant-select-dropdown ant-select-tree-dropdown'
   }
 })
 export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAccessor, OnInit, OnDestroy, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzAllowClear: BooleanInput;
   static ngAcceptInputType_nzShowExpand: BooleanInput;
   static ngAcceptInputType_nzShowLine: BooleanInput;
@@ -222,10 +221,10 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
   @Input() @InputBoolean() nzAllowClear: boolean = true;
   @Input() @InputBoolean() nzShowExpand: boolean = true;
   @Input() @InputBoolean() nzShowLine: boolean = false;
-  @Input() @InputBoolean() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzDropdownMatchSelectWidth: boolean = true;
+  @Input() @InputBoolean() @WithConfig() nzDropdownMatchSelectWidth: boolean = true;
   @Input() @InputBoolean() nzCheckable: boolean = false;
-  @Input() @InputBoolean() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzHideUnMatched: boolean = false;
-  @Input() @InputBoolean() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzShowIcon: boolean = false;
+  @Input() @InputBoolean() @WithConfig() nzHideUnMatched: boolean = false;
+  @Input() @InputBoolean() @WithConfig() nzShowIcon: boolean = false;
   @Input() @InputBoolean() nzShowSearch: boolean = false;
   @Input() @InputBoolean() nzDisabled = false;
   @Input() @InputBoolean() nzAsyncData = false;
@@ -236,7 +235,7 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
   @Input() nzNotFoundContent?: string;
   @Input() nzNodes: Array<NzTreeNode | NzTreeNodeOptions> = [];
   @Input() nzOpen = false;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzSize: NzSizeLDSType = 'default';
+  @Input() @WithConfig() nzSize: NzSizeLDSType = 'default';
   @Input() nzPlaceHolder = '';
   @Input() nzDropdownStyle: NgStyleInterface | null = null;
   @Input() nzDropdownClassName?: string;

--- a/components/tree/tree.component.ts
+++ b/components/tree/tree.component.ts
@@ -26,7 +26,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { treeCollapseMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import {
   flattenTreeData,
@@ -49,7 +49,7 @@ export function NzTreeServiceFactory(higherOrderService: NzTreeBaseService, tree
   return higherOrderService ? higherOrderService : treeService;
 }
 
-const NZ_CONFIG_COMPONENT_NAME = 'tree';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'tree';
 
 @Component({
   selector: 'nz-tree',
@@ -130,8 +130,7 @@ const NZ_CONFIG_COMPONENT_NAME = 'tree';
         (nzOnDragLeave)="eventTriggerChanged($event)"
         (nzOnDragEnd)="eventTriggerChanged($event)"
         (nzOnDrop)="eventTriggerChanged($event)"
-      >
-      </nz-tree-node>
+      ></nz-tree-node>
     </ng-template>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -161,6 +160,8 @@ const NZ_CONFIG_COMPONENT_NAME = 'tree';
   }
 })
 export class NzTreeComponent extends NzTreeBase implements OnInit, OnDestroy, ControlValueAccessor, OnChanges, AfterViewInit {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzShowIcon: BooleanInput;
   static ngAcceptInputType_nzHideUnMatched: BooleanInput;
   static ngAcceptInputType_nzBlockNode: BooleanInput;
@@ -174,9 +175,9 @@ export class NzTreeComponent extends NzTreeBase implements OnInit, OnDestroy, Co
   static ngAcceptInputType_nzDraggable: BooleanInput;
   static ngAcceptInputType_nzMultiple: BooleanInput;
 
-  @Input() @InputBoolean() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzShowIcon: boolean = false;
-  @Input() @InputBoolean() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzHideUnMatched: boolean = false;
-  @Input() @InputBoolean() @WithConfig(NZ_CONFIG_COMPONENT_NAME) nzBlockNode: boolean = false;
+  @Input() @InputBoolean() @WithConfig() nzShowIcon: boolean = false;
+  @Input() @InputBoolean() @WithConfig() nzHideUnMatched: boolean = false;
+  @Input() @InputBoolean() @WithConfig() nzBlockNode: boolean = false;
   @Input() @InputBoolean() nzExpandAll = false;
   @Input() @InputBoolean() nzSelectMode = false;
   @Input() @InputBoolean() nzCheckStrictly = false;

--- a/components/typography/typography.component.ts
+++ b/components/typography/typography.component.ts
@@ -26,7 +26,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation
 } from '@angular/core';
-import { NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { cancelRequestAnimationFrame, reqAnimFrame } from 'ng-zorro-antd/core/polyfill';
 import { NzResizeService } from 'ng-zorro-antd/core/services';
 import { BooleanInput, NumberInput, NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -40,7 +40,7 @@ import { NzI18nService, NzTextI18nInterface } from 'ng-zorro-antd/i18n';
 import { NzTextCopyComponent } from './text-copy.component';
 import { NzTextEditComponent } from './text-edit.component';
 
-const NZ_CONFIG_COMPONENT_NAME = 'typography';
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'typography';
 const EXPAND_ELEMENT_CLASSNAME = 'ant-typography-expand';
 
 @Component({
@@ -75,8 +75,12 @@ const EXPAND_ELEMENT_CLASSNAME = 'ant-typography-expand';
       </ng-template>
     </ng-container>
 
-    <nz-text-edit *ngIf="nzEditable" [text]="nzContent" (endEditing)="onEndEditing($event)" (startEditing)="onStartEditing()">
-    </nz-text-edit>
+    <nz-text-edit
+      *ngIf="nzEditable"
+      [text]="nzContent"
+      (endEditing)="onEndEditing($event)"
+      (startEditing)="onStartEditing()"
+    ></nz-text-edit>
 
     <nz-text-copy *ngIf="nzCopyable && !editing" [text]="copyText" (textCopy)="onTextCopy($event)"></nz-text-copy>
   `,
@@ -97,6 +101,8 @@ const EXPAND_ELEMENT_CLASSNAME = 'ant-typography-expand';
   }
 })
 export class NzTypographyComponent implements OnInit, AfterViewInit, OnDestroy, OnChanges {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   static ngAcceptInputType_nzCopyable: BooleanInput;
   static ngAcceptInputType_nzEditable: BooleanInput;
   static ngAcceptInputType_nzDisabled: BooleanInput;
@@ -110,7 +116,7 @@ export class NzTypographyComponent implements OnInit, AfterViewInit, OnDestroy, 
   @Input() @InputBoolean() nzExpandable = false;
   @Input() @InputBoolean() nzEllipsis = false;
   @Input() nzContent?: string;
-  @Input() @WithConfig(NZ_CONFIG_COMPONENT_NAME) @InputNumber() nzEllipsisRows: number = 1;
+  @Input() @WithConfig() @InputNumber() nzEllipsisRows: number = 1;
   @Input() nzType: 'secondary' | 'warning' | 'danger' | undefined;
   @Input() nzCopyText: string | undefined;
   @Input() nzSuffix: string | undefined;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

1. 将 `NZ_CONFIG_COMPONENT_NAME` 修改为 `NZ_CONFIG_MODULE_NAME `，因为配置是以 Module 为单位的
2. 调整 WithConfig 的参数
    1.  移除原先传递的 NZ_CONFIG_COMPONENT_NAME，这在大规模使用 WithConfig 时将很有用
    2. 增加 keyAlias 参数，这在 Module 下有多个组件且 Key 重复时将很有用，比如 Button 和 ButtonGroup 都有 `nzSize`
3. 顺带修复了几个 TS 类型推断错误

 
