### PR TITLE
fix(module:select): display IME input completely

### DIFF
--- a/components/select/select-search.component.ts
+++ b/components/select/select-search.component.ts
@@ -18,6 +18,7 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
+import { COMPOSITION_BUFFER_MODE } from '@angular/forms';
 
 @Component({
   selector: 'nz-select-search',
@@ -40,7 +41,8 @@ import {
   `,
   host: {
     '[class.ant-select-selection-search]': 'true'
-  }
+  },
+  providers: [{ provide: COMPOSITION_BUFFER_MODE, useValue: false }]
 })
 export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
   @Input() disabled = false;

--- a/components/select/select-search.component.ts
+++ b/components/select/select-search.component.ts
@@ -61,8 +61,6 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
   }
 
   onValueChange(value: string): void {
-    const inputDOM = this.inputElement.nativeElement;
-    inputDOM.value = value;
     this.value = value;
     this.valueChange.next(value);
     if (this.mirrorSync) {
@@ -71,6 +69,8 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
   }
 
   clearInputValue(): void {
+    const inputDOM = this.inputElement.nativeElement;
+    inputDOM.value = '';
     this.onValueChange('');
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5656

IME input is not displayed in the select box completely.

## What is the new behavior?

IME input is displayed in the select box completely.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The side effect is that a search is performed every time a key is pressed in IME input mode.