### PR TITLE
Typo issue on upload component documentation

### DIFF
--- a/components/upload/doc/index.en-US.md
+++ b/components/upload/doc/index.en-US.md
@@ -30,16 +30,16 @@ import { NzUploadModule } from 'ng-zorro-antd/upload';
 | `[nzAccept]` | File types that can be accepted. See [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-accept) | `string` | - |
 | `[nzAction]` | Required. Uploading URL | `string \| ((file: NzUploadFile) => string \| Observable<string>)` | - |
 | `[nzDirectory]` | support upload whole directory ([caniuse](https://caniuse.com/#feat=input-file-directory)) | `boolean` | `false` |
-| `[nzBeforeUpload]` | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a Observable. **Warning：this function is not supported in IE9**. NOTICE: Muse be use `=>` to define the method. | `(file: NzUploadFile, fileList: NzUploadFile[]) => boolean \| Observable<boolean>` | - |
-| `[nzCustomRequest]` | override for the default xhr behavior allowing for additional customization and ability to implement your own XMLHttpRequest. NOTICE: Muse be use `=>` to define the method. | `(item) => Subscription` | - |
-| `[nzData]` | Uploading params or function which can return uploading params. NOTICE: Muse be use `=>` to define the method. | `Object \| ((file: NzUploadFile) => Object \| Observable<{}>)` | - |
+| `[nzBeforeUpload]` | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a Observable. **Warning：this function is not supported in IE9**. NOTICE: Must use `=>` to define the method. | `(file: NzUploadFile, fileList: NzUploadFile[]) => boolean \| Observable<boolean>` | - |
+| `[nzCustomRequest]` | override for the default xhr behavior allowing for additional customization and ability to implement your own XMLHttpRequest. NOTICE: Must use `=>` to define the method. | `(item) => Subscription` | - |
+| `[nzData]` | Uploading params or function which can return uploading params. NOTICE: Must use `=>` to define the method. | `Object \| ((file: NzUploadFile) => Object \| Observable<{}>)` | - |
 | `[nzDisabled]` | disable upload button | `boolean` | `false` |
 | `[nzFileList]` | List of files, two-way data-binding | `NzUploadFile[]` | - |
 | `[nzLimit]` | limit single upload count when `nzMultiple` has opened. `0` unlimited | `number` | `0` |
 | `[nzSize]` | limit file size (KB). `0` unlimited | `number` | `0` |
 | `[nzFileType]` | limit file type, e.g: `image/png,image/jpeg,image/gif,image/bmp` | `string` | - |
 | `[nzFilter]` | Custom filter when choosed file | `UploadFilter[]` | - |
-| `[nzHeaders]` | Set request headers, valid above IE10. NOTICE: Muse be use `=>` to define the method.  | `Object \| ((file: NzUploadFile) => Object \| Observable<{}>)` | - |
+| `[nzHeaders]` | Set request headers, valid above IE10. NOTICE: Must use `=>` to define the method.  | `Object \| ((file: NzUploadFile) => Object \| Observable<{}>)` | - |
 | `[nzListType]` | Built-in stylesheets, support for three types: `text`, `picture` or `picture-card` | `'text' \| 'picture' \| 'picture-card'` | `'text'` |
 | `[nzMultiple]` | Whether to support selected multiple file. `IE10+` supported. You can select multiple files with CTRL holding down while multiple is set to be true | `boolean` | `false` |
 | `[nzName]` | The name of uploading file | `string` | `'file'` |
@@ -47,10 +47,10 @@ import { NzUploadModule } from 'ng-zorro-antd/upload';
 | `[nzShowButton]` | Show upload button | `boolean` | `true` |
 | `[nzWithCredentials]` | ajax upload with cookie sent | `boolean` | `false` |
 | `[nzOpenFileDialogOnClick]` | click open file dialog | `boolean` | `true` |
-| `[nzPreview]` | A callback function, will be executed when file link or preview icon is clicked. NOTICE: Muse be use `=>` to define the method. | `(file: NzUploadFile) => void` | - |
-| `[nzPreviewFile]` | Customize preview file logic. NOTICE: Muse be use `=>` to define the method. | `(file: NzUploadFile) => Observable<dataURL: string>` | - |
-| `[nzPreviewIsImage]` | Customize the preview file is an image, generally used when the image URL is in a non-standard format. NOTICE: Muse be use `=>` to define the method. | `(file: NzUploadFile) => boolean` | - |
-| `[nzRemove]` | A callback function, will be executed when removing file button is clicked, remove event will be prevented when return value is `false` or a Observable. NOTICE: Muse be use `=>` to define the method.  | `(file: NzUploadFile) => boolean \| Observable<boolean>` | - |
+| `[nzPreview]` | A callback function, will be executed when file link or preview icon is clicked. NOTICE: Must use `=>` to define the method. | `(file: NzUploadFile) => void` | - |
+| `[nzPreviewFile]` | Customize preview file logic. NOTICE: Must use `=>` to define the method. | `(file: NzUploadFile) => Observable<dataURL: string>` | - |
+| `[nzPreviewIsImage]` | Customize the preview file is an image, generally used when the image URL is in a non-standard format. NOTICE: Must use `=>` to define the method. | `(file: NzUploadFile) => boolean` | - |
+| `[nzRemove]` | A callback function, will be executed when removing file button is clicked, remove event will be prevented when return value is `false` or a Observable. NOTICE: Must use `=>` to define the method.  | `(file: NzUploadFile) => boolean \| Observable<boolean>` | - |
 | `(nzChange)` | A callback function, can be executed when uploading state is changing | `EventEmitter<NzUploadChangeParam>` | - |
 | `[nzDownload]`   | Click the method to download the file, pass the method to perform the method logic, do not pass the default jump to the new TAB. | `(file: NzUploadFile) => void` | Jump to new TAB |
 | `[nzTransformFile]`   | Customize transform file before request  | `(file: NzUploadFile) => NzUploadTransformFileType` | -  |


### PR DESCRIPTION
 Muse be use => Must use

## PR Checklist
Please check if your PR fulfills the following requirements:

-  [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
-  [X] Tests for the changes have been added (for bug fixes / features)
-  [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It is simple documentation type fix on upload compoment


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
