### PR TITLE
docs(module: cascader): optimize the demo for custom render

### DIFF
--- a/components/cascader/demo/custom-render.md
+++ b/components/cascader/demo/custom-render.md
@@ -7,9 +7,9 @@ title:
 
 ## zh-CN
 
-例如给最后一项加上邮编链接。
+例如仅显示最后一级并加上邮编链接。
 
 ## en-US
 
-For instance, add an external link after the selected value.
+For instance, display only the last level, add an external link after the selected value.
 

--- a/components/cascader/demo/custom-render.ts
+++ b/components/cascader/demo/custom-render.ts
@@ -49,16 +49,16 @@ const options = [
 @Component({
   selector: 'nz-demo-cascader-custom-render',
   template: `
-    <nz-cascader [nzLabelRender]="renderTpl" [nzOptions]="nzOptions" [(ngModel)]="values" (ngModelChange)="onChanges($event)">
-    </nz-cascader>
+    <nz-cascader [nzLabelRender]="renderTpl" [nzOptions]="nzOptions" [(ngModel)]="values" (ngModelChange)="onChanges($event)"></nz-cascader>
 
     <ng-template #renderTpl let-labels="labels" let-selectedOptions="selectedOptions">
       <ng-container *ngFor="let label of labels; let i = index; let isLast = last">
-        <span *ngIf="!isLast">{{ label }} / </span>
         <span *ngIf="isLast">
-          {{ label }} (<a href="javascript:;" (click)="handleAreaClick($event, label, selectedOptions[i])">
-            {{ selectedOptions[i].code }} </a
-          >)
+          {{ label }} (
+          <a href="javascript:;" (click)="handleAreaClick($event, label, selectedOptions[i])">
+            {{ selectedOptions[i].code }}
+          </a>
+          )
         </span>
       </ng-container>
     </ng-template>


### PR DESCRIPTION
[the cascader in the demo](https://ng.ant.design/components/cascader/zh#components-cascader-demo-custom-render) is to short to show all the levels, how about changing to show only the last level.And this is a common requirement in development.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
