### PR TITLE
Please change click to mousedown in nz-option-item

### DIFF
--- a/components/select/option-item.component.ts
+++ b/components/select/option-item.component.ts
@@ -39,7 +39,7 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
     '[class.ant-select-item-option-disabled]': 'disabled',
     '[class.ant-select-item-option-active]': 'activated && !disabled',
     '(mouseenter)': 'onHostMouseEnter()',
-    '(click)': 'onHostClick()'
+    '(mousedown)': 'onHostClick()'
   }
 })
 export class NzOptionItemComponent implements OnChanges {


### PR DESCRIPTION
Blur event happens before click on option
Therefore I suggest changing it to mousedown, so that option selection event('ngModelChange on nz-select') will happen before `nzBlur` event

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
