### PR TITLE
docs: fix typo for global config page (en)

### DIFF
--- a/docs/global-config.en-US.md
+++ b/docs/global-config.en-US.md
@@ -105,7 +105,7 @@ export class AppModule {}
 
 ## Dynamically Change Configurations
 
-You can change the global config of a specific component by calling the `set` method of `NzConfigService`. For example, if you want to make all buttons to be barge in size by default, you should:
+You can change the global config of a specific component by calling the `set` method of `NzConfigService`. For example, if you want to make all buttons to be large in size by default, you should:
 
 ```typescript
 import { NzConfigService } from 'ng-zorro-antd/core/config';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There is a small typo on [Global Configuration](https://ng.ant.design/docs/global-config/en) page

![image](https://user-images.githubusercontent.com/6767322/93155901-a912ce80-f739-11ea-9dfb-b0c343044068.png)



## What is the new behavior?

I changed barge to large.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
