### PR TITLE
refactor(module:anchor): remove deprecated APIs for v10

### DIFF
--- a/components/anchor/anchor.component.ts
+++ b/components/anchor/anchor.component.ts
@@ -24,7 +24,6 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
-import { warnDeprecation } from 'ng-zorro-antd/core/logger';
 import { NzScrollService } from 'ng-zorro-antd/core/services';
 import { BooleanInput, NgStyleInterface, NumberInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, InputNumber } from 'ng-zorro-antd/core/util';
@@ -91,7 +90,6 @@ export class NzAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
   nzOffsetTop?: number = undefined;
 
   @Input() nzContainer?: string | HTMLElement;
-  @Input() nzTarget: string | HTMLElement = '';
 
   @Output() readonly nzClick = new EventEmitter<string>();
   @Output() readonly nzScroll = new EventEmitter<NzAnchorLinkComponent>();
@@ -234,19 +232,16 @@ export class NzAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    const { nzOffsetTop, nzTarget, nzContainer } = changes;
+    const { nzOffsetTop, nzContainer } = changes;
     if (nzOffsetTop) {
       this.wrapperStyle = {
         'max-height': `calc(100vh - ${this.nzOffsetTop}px)`
       };
     }
-    if (nzContainer || nzTarget) {
-      const container = this.nzContainer || this.nzTarget;
+    if (nzContainer) {
+      const container = this.nzContainer;
       this.container = typeof container === 'string' ? this.doc.querySelector(container) : container;
       this.registerScrollEvent();
-      if (nzTarget) {
-        warnDeprecation(`'nzTarget' of 'nz-anchor' is deprecated and will be removed in 10.0.0.Please use 'nzContainer' instead.`);
-      }
     }
   }
 }

--- a/components/anchor/anchor.spec.ts
+++ b/components/anchor/anchor.spec.ts
@@ -152,10 +152,10 @@ describe('anchor', () => {
       });
     });
 
-    describe('[nzTarget]', () => {
+    describe('[nzContainer]', () => {
       it('with window', () => {
         spyOn(window, 'addEventListener');
-        context.nzTarget = window;
+        context.nzContainer = window;
         fixture.detectChanges();
         expect(window.addEventListener).toHaveBeenCalled();
       });
@@ -163,7 +163,7 @@ describe('anchor', () => {
         spyOn(context, '_click');
         const el = document.querySelector('#target')!;
         spyOn(el, 'addEventListener');
-        context.nzTarget = '#target';
+        context.nzContainer = '#target';
         fixture.detectChanges();
         expect(el.addEventListener).toHaveBeenCalled();
         page.to('#basic-target');
@@ -235,7 +235,7 @@ describe('anchor', () => {
       [nzBounds]="nzBounds"
       [nzShowInkInFixed]="nzShowInkInFixed"
       [nzOffsetTop]="nzOffsetTop"
-      [nzTarget]="nzTarget"
+      [nzContainer]="nzContainer"
       (nzClick)="_click($event)"
       (nzScroll)="_scroll($event)"
     >
@@ -291,7 +291,7 @@ export class TestComponent {
   nzBounds = 5;
   nzOffsetTop = 0;
   nzShowInkInFixed = false;
-  nzTarget: any = null;
+  nzContainer: any = null;
   _click() {}
   _scroll() {}
 }

--- a/schematics/ng-update/data/input-names.ts
+++ b/schematics/ng-update/data/input-names.ts
@@ -15,6 +15,20 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
       ]
     }
   ],
+  [ TargetVersion.V10 ]: [
+    {
+      pr: 'https://github.com/NG-ZORRO/ng-zorro-antd/pull/5776',
+      changes: [
+        {
+          replace    : 'nzTarget',
+          replaceWith: 'nzContainer',
+          whitelist  : {
+            elements: [ 'nz-anchor' ]
+          }
+        }
+      ]
+    }
+  ],
   [ TargetVersion.V9 ]: [
     {
       pr     : 'https://github.com/NG-ZORRO/ng-zorro-antd/pull/3909',


### PR DESCRIPTION
BREAKING CHANGES:

- `nzTarget` has been removed, use `nzContainer` instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
