### PR TITLE
refactor(module:cascader): remove deprecated APIs for v10

### DIFF
--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -11,10 +11,7 @@ export type NzCascaderSize = 'small' | 'large' | 'default';
 export type NzCascaderFilter = (searchValue: string, path: NzCascaderOption[]) => boolean;
 export type NzCascaderSorter = (a: NzCascaderOption[], b: NzCascaderOption[], inputValue: string) => number;
 
-/**
- * @deprecated Use the prefixed version.
- */
-export interface CascaderOption {
+export interface NzCascaderOption {
   value?: NzSafeAny;
   label?: string;
   title?: string;
@@ -27,16 +24,9 @@ export interface CascaderOption {
   [key: string]: NzSafeAny;
 }
 
-export type NzCascaderOption = CascaderOption;
-
-/**
- * @deprecated Use the prefixed version.
- */
-export interface CascaderSearchOption extends NzCascaderOption {
+export interface NzCascaderSearchOption extends NzCascaderOption {
   path: NzCascaderOption[];
 }
-
-export type NzCascaderSearchOption = CascaderSearchOption;
 
 export interface NzShowSearchOptions {
   filter?: NzCascaderFilter;

--- a/schematics/ng-update/data/class-names.ts
+++ b/schematics/ng-update/data/class-names.ts
@@ -13,6 +13,13 @@ export const classNames: VersionChanges<ClassNameUpgradeData> = {
         {replace: 'UploadTransformFileType', replaceWith: 'NzUploadTransformFileType'},
         {replace: 'UploadXHRArgs', replaceWith: 'NzUploadXHRArgs'}
       ]
+    },
+    {
+      pr: 'https://github.com/NG-ZORRO/ng-zorro-antd/pull/5778',
+      changes: [
+        {replace: 'CascaderOption', replaceWith: 'NzCascaderOption'},
+        {replace: 'CascaderSearchOption', replaceWith: 'NzCascaderSearchOption'}
+      ]
     }
   ]
 };


### PR DESCRIPTION
BREAKING CHANGES:

- `CascaderOption` has been removed, use `NzCascaderOption` instead.
- `CascaderSearchOption` has been removed, use `NzCascaderSearchOption` instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
