### PR TITLE
fix(module:select): arrow icon can be used when not using single-select

### DIFF
--- a/components/select/doc/index.en-US.md
+++ b/components/select/doc/index.en-US.md
@@ -46,7 +46,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 | `[nzMode]` | Set mode of Select | `'multiple' \| 'tags' \| 'default'` | `'default'` |
 | `[nzNotFoundContent]` | Specify content to show when no result matches.. | `string  \|  TemplateRef<void>` | `'Not Found'` |
 | `[nzPlaceHolder]` | Placeholder of select | `string` | - |
-| `[nzShowArrow]` | Whether to show the drop-down arrow | `boolean` | `true` |
+| `[nzShowArrow]` | Whether to show the drop-down arrow | `boolean` | `true`(for single select), `false`(for multiple select) |
 | `[nzShowSearch]` | Whether show search input in single mode. | `boolean` | `false` |
 | `[nzSize]` | Size of Select input | `'large' \| 'small' \| 'default'` | `'default'` |
 | `[nzSuffixIcon]` | The custom suffix icon | `TemplateRef<any> \| string` | - |  ✅ |

--- a/components/select/doc/index.zh-CN.md
+++ b/components/select/doc/index.zh-CN.md
@@ -47,7 +47,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 | `[nzMode]` | 设置 nz-select 的模式 | `'multiple' \| 'tags' \| 'default'` | `'default'` |
 | `[nzNotFoundContent]` | 当下拉列表为空时显示的内容 | `string \| TemplateRef<void>` | - |
 | `[nzPlaceHolder]` | 选择框默认文字 | `string` | - |
-| `[nzShowArrow]` | 是否显示下拉小箭头 | `boolean` | `true` |
+| `[nzShowArrow]` | 是否显示下拉小箭头 | `boolean` | 单选为 `true`，多选为 `false` |
 | `[nzShowSearch]` | 使单选模式可搜索 | `boolean` | `false` |
 | `[nzSize]` | 选择框大小 | `'large' \| 'small' \| 'default'` | `'default'` |
 | `[nzSuffixIcon]` | 自定义的选择框后缀图标 | `TemplateRef<any> \| string` | - | ✅ |

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -208,7 +208,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
     this._nzShowArrow = value;
   }
   get nzShowArrow(): boolean {
-    return this._nzShowArrow || this.nzMode === 'default';
+    return this._nzShowArrow === undefined ? this.nzMode === 'default' : this._nzShowArrow;
   }
 
   @Output() readonly nzOnSearch = new EventEmitter<string>();

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -100,7 +100,7 @@ export type NzSelectSizeType = 'large' | 'default' | 'small';
       (clear)="onClearSelection()"
     ></nz-select-clear>
     <nz-select-arrow
-      *ngIf="nzShowArrow && nzMode === 'default'"
+      *ngIf="nzShowArrow"
       [loading]="nzLoading"
       [search]="nzOpen && nzShowSearch"
       [suffixIcon]="nzSuffixIcon"
@@ -147,7 +147,7 @@ export type NzSelectSizeType = 'large' | 'default' | 'small';
     '[class.ant-select]': 'true',
     '[class.ant-select-lg]': 'nzSize === "large"',
     '[class.ant-select-sm]': 'nzSize === "small"',
-    '[class.ant-select-show-arrow]': `nzShowArrow && nzMode === 'default'`,
+    '[class.ant-select-show-arrow]': `nzShowArrow`,
     '[class.ant-select-disabled]': 'nzDisabled',
     '[class.ant-select-show-search]': `nzShowSearch || nzMode !== 'default'`,
     '[class.ant-select-allow-clear]': 'nzAllowClear',
@@ -186,7 +186,6 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   @Input() nzClearIcon: TemplateRef<NzSafeAny> | null = null;
   @Input() nzRemoveIcon: TemplateRef<NzSafeAny> | null = null;
   @Input() nzMenuItemSelectedIcon: TemplateRef<NzSafeAny> | null = null;
-  @Input() nzShowArrow = true;
   @Input() nzTokenSeparators: string[] = [];
   @Input() nzMaxTagPlaceholder: TemplateRef<{ $implicit: NzSafeAny[] }> | null = null;
   @Input() nzMaxMultipleCount = Infinity;
@@ -203,6 +202,15 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   @Input() @InputBoolean() nzDisabled = false;
   @Input() @InputBoolean() nzOpen = false;
   @Input() nzOptions: NzSelectOptionInterface[] = [];
+
+  @Input()
+  set nzShowArrow(value: boolean) {
+    this._nzShowArrow = value;
+  }
+  get nzShowArrow(): boolean {
+    return this._nzShowArrow || this.nzMode === 'default';
+  }
+
   @Output() readonly nzOnSearch = new EventEmitter<string>();
   @Output() readonly nzScrollToBottom = new EventEmitter<void>();
   @Output() readonly nzOpenChange = new EventEmitter<boolean>();
@@ -222,6 +230,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
   private isReactiveDriven = false;
   private value: NzSafeAny | NzSafeAny[];
   private destroy$ = new Subject();
+  private _nzShowArrow: boolean | undefined;
   onChange: OnChangeType = () => {};
   onTouched: OnTouchedType = () => {};
   dropDownPosition: 'top' | 'center' | 'bottom' = 'bottom';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5575


## What is the new behavior?

That you can use the arrow icon in multi-select and tag mode.
But by default it's false. So you need to set it true in multi and tag mode.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
