### PR TITLE
refactor(module:date-picker): will not sort range date

### DIFF
--- a/components/core/time/candy-date.spec.ts
+++ b/components/core/time/candy-date.spec.ts
@@ -1,4 +1,4 @@
-import { CandyDate } from './candy-date';
+import { CandyDate, normalizeRangeValue, SingleValue } from './candy-date';
 
 describe('candy-date coverage supplements', () => {
   const date = new CandyDate('2018-5-5 12:12:12');
@@ -82,5 +82,26 @@ describe('candy-date coverage supplements', () => {
   it('should throw error while putting invalid date input', () => {
     const errorMessage = 'The input date type is not supported ("Date" is now recommended)';
     expect(() => new CandyDate({} as any)).toThrowError(errorMessage); // tslint:disable-line:no-any
+  });
+
+  it('should normalizeRangeValue work', () => {
+    const randomDay = new CandyDate('2020-09-17');
+    const now = new Date();
+    let result: SingleValue[];
+    result = normalizeRangeValue([null, randomDay]);
+    expect(result[0]!.getMonth()).toEqual(7);
+    expect(result[1]!.getMonth()).toEqual(8);
+
+    result = normalizeRangeValue([randomDay, null]);
+    expect(result[0]!.getMonth()).toEqual(8);
+    expect(result[1]!.getMonth()).toEqual(9);
+
+    result = normalizeRangeValue([null, null]);
+    expect(result[0]!.getMonth()).toEqual(now.getMonth());
+    expect(result[1]!.getMonth()).toEqual(now.getMonth() + 1);
+
+    result = normalizeRangeValue([new CandyDate(), new CandyDate()]);
+    expect(result[0]!.getMonth()).toEqual(now.getMonth());
+    expect(result[1]!.getMonth()).toEqual(now.getMonth() + 1);
   });
 }); // /candy-date coverage supplements

--- a/components/core/time/candy-date.spec.ts
+++ b/components/core/time/candy-date.spec.ts
@@ -88,20 +88,24 @@ describe('candy-date coverage supplements', () => {
     const randomDay = new CandyDate('2020-09-17');
     const now = new Date();
     let result: SingleValue[];
-    result = normalizeRangeValue([null, randomDay]);
+    result = normalizeRangeValue([null, randomDay], false);
     expect(result[0]!.getMonth()).toEqual(7);
     expect(result[1]!.getMonth()).toEqual(8);
 
-    result = normalizeRangeValue([randomDay, null]);
+    result = normalizeRangeValue([randomDay, null], false);
     expect(result[0]!.getMonth()).toEqual(8);
     expect(result[1]!.getMonth()).toEqual(9);
 
-    result = normalizeRangeValue([null, null]);
+    result = normalizeRangeValue([null, null], false);
     expect(result[0]!.getMonth()).toEqual(now.getMonth());
     expect(result[1]!.getMonth()).toEqual(now.getMonth() + 1);
 
-    result = normalizeRangeValue([new CandyDate(), new CandyDate()]);
+    result = normalizeRangeValue([new CandyDate(), new CandyDate()], false);
     expect(result[0]!.getMonth()).toEqual(now.getMonth());
     expect(result[1]!.getMonth()).toEqual(now.getMonth() + 1);
+
+    result = normalizeRangeValue([new CandyDate(), new CandyDate()], true);
+    expect(result[0]!.getMonth()).toEqual(now.getMonth());
+    expect(result[1]!.getMonth()).toEqual(now.getMonth());
   });
 }); // /candy-date coverage supplements

--- a/components/core/time/candy-date.ts
+++ b/components/core/time/candy-date.ts
@@ -41,7 +41,7 @@ export function wrongSortOrder(rangeValue: SingleValue[]): boolean {
   return !!start && !!end && start.isAfterSecond(end);
 }
 
-export function normalizeRangeValue(value: SingleValue[]): CandyDate[] {
+export function normalizeRangeValue(value: SingleValue[], allowSameMonth: boolean): CandyDate[] {
   const [start, end] = value;
   let newStart: CandyDate = start || new CandyDate();
   let newEnd: CandyDate = end || new CandyDate();
@@ -52,7 +52,7 @@ export function normalizeRangeValue(value: SingleValue[]): CandyDate[] {
     newStart = end.addMonths(-1);
     newEnd = end;
   }
-  if (newEnd.isSameMonth(newStart)) {
+  if (newEnd.isSameMonth(newStart) && !allowSameMonth) {
     newEnd = newStart.addMonths(1);
   }
   return [newStart, newEnd];

--- a/components/core/time/candy-date.ts
+++ b/components/core/time/candy-date.ts
@@ -29,24 +29,32 @@ import startOfWeek from 'date-fns/startOfWeek';
 import { warn } from 'ng-zorro-antd/core/logger';
 import { IndexableObject, NzSafeAny } from 'ng-zorro-antd/core/types';
 
+type CandyDateCompareGrain = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
+
 export type WeekDayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-export type CandyDateCompareGrain = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
 export type CandyDateType = CandyDate | Date | null;
 export type SingleValue = CandyDate | null;
 export type CompatibleValue = SingleValue | SingleValue[];
 
-export function sortRangeValue(rangeValue: SingleValue[]): SingleValue[] {
-  if (Array.isArray(rangeValue)) {
-    const [start, end] = rangeValue;
-    return start && end && start.isAfterSecond(end) ? [end, start] : [start, end];
-  }
-  return rangeValue;
+export function wrongSortOrder(rangeValue: SingleValue[]): boolean {
+  const [start, end] = rangeValue;
+  return !!start && !!end && start.isAfterSecond(end);
 }
 
 export function normalizeRangeValue(value: SingleValue[]): CandyDate[] {
-  const [start, end] = value || [];
-  const newStart = start || new CandyDate();
-  const newEnd = end?.isSameMonth(newStart) ? end.addMonths(1) : end || newStart.addMonths(1);
+  const [start, end] = value;
+  let newStart: CandyDate = start || new CandyDate();
+  let newEnd: CandyDate = end || new CandyDate();
+  if (start && !end) {
+    newStart = start;
+    newEnd = start.addMonths(1);
+  } else if (!start && end) {
+    newStart = end.addMonths(-1);
+    newEnd = end;
+  }
+  if (newEnd.isSameMonth(newStart)) {
+    newEnd = newStart.addMonths(1);
+  }
   return [newStart, newEnd];
 }
 

--- a/components/date-picker/date-picker.service.ts
+++ b/components/date-picker/date-picker.service.ts
@@ -33,7 +33,7 @@ export class DatePickerService implements OnDestroy {
 
   hasValue(value: CompatibleValue = this.value): boolean {
     if (Array.isArray(value)) {
-      return !!value[0] && !!value[1];
+      return !!value[0] || !!value[1];
     } else {
       return !!value;
     }

--- a/components/date-picker/date-picker.service.ts
+++ b/components/date-picker/date-picker.service.ts
@@ -47,9 +47,9 @@ export class DatePickerService implements OnDestroy {
     }
   }
 
-  setActiveDate(value: CompatibleValue, normalize: boolean = false): void {
+  setActiveDate(value: CompatibleValue, allowSameMonth: boolean = false): void {
     if (this.isRange) {
-      this.activeDate = normalize ? normalizeRangeValue(value as CandyDate[]) : value;
+      this.activeDate = normalizeRangeValue(value as CandyDate[], allowSameMonth);
     } else {
       this.activeDate = cloneDate(value);
     }

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -196,7 +196,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
     const activeDate = this.datePickerService.hasValue()
       ? this.datePickerService.value
       : this.datePickerService.makeValue(this.defaultPickerValue!);
-    this.datePickerService.setActiveDate(activeDate, !this.showTime);
+    this.datePickerService.setActiveDate(activeDate, this.hasTimePicker);
   }
 
   onClickOk(): void {
@@ -243,11 +243,9 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
 
   onActiveDateChange(value: CandyDate, partType: RangePartType): void {
     if (this.isRange) {
-      if (partType === 'left') {
-        this.datePickerService.setActiveDate([value, value.addMonths(1)]);
-      } else {
-        this.datePickerService.setActiveDate([value.addMonths(-1), value]);
-      }
+      const activeDate: SingleValue[] = [];
+      activeDate[this.datePickerService.getActiveIndex(partType)] = value;
+      this.datePickerService.setActiveDate(activeDate, this.hasTimePicker);
     } else {
       this.datePickerService.setActiveDate(value);
     }

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -18,7 +18,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { CandyDate, cloneDate, CompatibleValue, SingleValue, sortRangeValue } from 'ng-zorro-antd/core/time';
+import { CandyDate, cloneDate, CompatibleValue, SingleValue, wrongSortOrder } from 'ng-zorro-antd/core/time';
 import { FunctionProp } from 'ng-zorro-antd/core/types';
 import { NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
 import { Subject } from 'rxjs';
@@ -152,6 +152,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
   endPanelMode: NzDateMode | NzDateMode[] = 'date';
   timeOptions: SupportTimeOptions | SupportTimeOptions[] | null = null;
   hoverValue: SingleValue[] = []; // Range ONLY
+  checkedPartArr: boolean[] = [false, false];
   destroy$ = new Subject();
 
   get hasTimePicker(): boolean {
@@ -166,7 +167,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnInit(): void {
     this.datePickerService.valueChange$.pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.initActiveDate();
+      this.updateActiveDate();
       this.cdr.markForCheck();
     });
   }
@@ -182,7 +183,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
       this.endPanelMode = this.panelMode;
     }
     if (changes.defaultPickerValue) {
-      this.initActiveDate();
+      this.updateActiveDate();
     }
   }
 
@@ -191,7 +192,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
     this.destroy$.complete();
   }
 
-  initActiveDate(): void {
+  updateActiveDate(): void {
     const activeDate = this.datePickerService.hasValue()
       ? this.datePickerService.value
       : this.datePickerService.makeValue(this.defaultPickerValue!);
@@ -237,19 +238,18 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
     } else {
       this.panelMode = mode;
     }
-    // this.cdr.markForCheck();
     this.panelModeChange.emit(this.panelMode);
   }
 
   onActiveDateChange(value: CandyDate, partType: RangePartType): void {
     if (this.isRange) {
       if (partType === 'left') {
-        this.datePickerService.activeDate = [value, value.addMonths(1)];
+        this.datePickerService.setActiveDate([value, value.addMonths(1)]);
       } else {
-        this.datePickerService.activeDate = [value.addMonths(-1), value];
+        this.datePickerService.setActiveDate([value.addMonths(-1), value]);
       }
     } else {
-      this.datePickerService.activeDate = value;
+      this.datePickerService.setActiveDate(value);
     }
   }
 
@@ -269,49 +269,54 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
 
   changeValueFromSelect(value: CandyDate, emitValue: boolean = true): void {
     if (this.isRange) {
-      let selectedValue: SingleValue[] = cloneDate(this.datePickerService.value) as CandyDate[];
-      let otherPart: RangePartType;
-      if (this.datePickerService.activeInput === 'left') {
-        otherPart = 'right';
-        selectedValue[0] = value;
-      } else {
-        otherPart = 'left';
-        selectedValue[1] = value;
-      }
+      const selectedValue: SingleValue[] = cloneDate(this.datePickerService.value) as CandyDate[];
+      const checkedPart: RangePartType = this.datePickerService.activeInput;
+      const otherPart = this.reversedPart(checkedPart);
 
-      selectedValue = sortRangeValue(selectedValue);
+      selectedValue[this.datePickerService.getActiveIndex(checkedPart)] = value;
+      this.checkedPartArr[this.datePickerService.getActiveIndex(checkedPart)] = true;
       this.hoverValue = selectedValue;
-      this.datePickerService.setValue(selectedValue);
-      this.datePickerService.setActiveDate(selectedValue, !this.showTime);
-      this.datePickerService.inputPartChange$.next();
-
-      if (!this.isAllowed(selectedValue)) {
-        return;
-      }
 
       if (emitValue) {
-        // If the other input has value
-        if (this.isBothAllowed(selectedValue)) {
+        /**
+         * if sort order is wrong, clear the other part's value
+         */
+        if (wrongSortOrder(selectedValue)) {
+          // selectedValue = sortRangeValue(selectedValue);
+          selectedValue[this.datePickerService.getActiveIndex(otherPart)] = null;
+          this.checkedPartArr[this.datePickerService.getActiveIndex(otherPart)] = false;
+        }
+
+        this.datePickerService.setValue(selectedValue);
+
+        /**
+         * range date usually selected paired,
+         * so we emit the date value only both date is allowed and both part are checked
+         */
+        if (this.isBothAllowed(selectedValue) && this.checkedPartArr[0] && this.checkedPartArr[1]) {
           this.calendarChange.emit(selectedValue);
           this.clearHoverValue();
           this.datePickerService.emitValue$.next();
-        } else {
+        } else if (this.isAllowed(selectedValue)) {
           this.calendarChange.emit([value.clone()]);
-          this.datePickerService.inputPartChange$.next(otherPart!);
+          this.datePickerService.inputPartChange$.next(otherPart);
         }
+      } else {
+        this.datePickerService.setValue(selectedValue);
+        this.datePickerService.inputPartChange$.next();
       }
     } else {
       this.datePickerService.setValue(value);
-      this.datePickerService.setActiveDate(value, !this.showTime);
       this.datePickerService.inputPartChange$.next();
 
-      if (!this.isAllowed(value)) {
-        return;
-      }
-      if (emitValue) {
+      if (emitValue && this.isAllowed(value)) {
         this.datePickerService.emitValue$.next();
       }
     }
+  }
+
+  reversedPart(part: RangePartType): RangePartType {
+    return part === 'left' ? 'right' : 'left';
   }
 
   getPanelMode(panelMode: NzDateMode | NzDateMode[], partType?: RangePartType): NzDateMode {

--- a/components/date-picker/picker.component.ts
+++ b/components/date-picker/picker.component.ts
@@ -3,6 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { ESCAPE } from '@angular/cdk/keycodes';
 import {
   CdkConnectedOverlay,
   CdkOverlayOrigin,
@@ -36,8 +37,7 @@ import {
 } from '@angular/core';
 import { slideMotion } from 'ng-zorro-antd/core/animation';
 
-import { ESCAPE } from '@angular/cdk/keycodes';
-import { CandyDate, CompatibleValue } from 'ng-zorro-antd/core/time';
+import { CandyDate, CompatibleValue, wrongSortOrder } from 'ng-zorro-antd/core/time';
 import { NgStyleInterface, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { DateHelperService } from 'ng-zorro-antd/i18n';
 import { fromEvent, Subject } from 'rxjs';
@@ -360,6 +360,12 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
 
   onClickBackdrop(): void {
     if (this.panel?.isAllowed(this.datePickerService.value!, true)) {
+      if (Array.isArray(this.datePickerService.value) && wrongSortOrder(this.datePickerService.value)) {
+        const index = this.datePickerService.getActiveIndex(this.datePickerService.activeInput);
+        const value = this.datePickerService.value[index];
+        this.panel?.changeValueFromSelect(value!, true);
+        return;
+      }
       this.updateInputValue();
       this.datePickerService.emitValue$.next();
     } else {

--- a/components/date-picker/picker.component.ts
+++ b/components/date-picker/picker.component.ts
@@ -179,8 +179,8 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   @ViewChild(CdkConnectedOverlay, { static: false }) cdkConnectedOverlay?: CdkConnectedOverlay;
   @ViewChild('separatorElement', { static: false }) separatorElement?: ElementRef;
   @ViewChild('pickerInput', { static: false }) pickerInput?: ElementRef<HTMLInputElement>;
-  @ViewChildren('rangePickerInput') rangePickerInputs!: QueryList<ElementRef<HTMLInputElement>>;
-  @ContentChild(DateRangePopupComponent) panel!: DateRangePopupComponent;
+  @ViewChildren('rangePickerInput') rangePickerInputs?: QueryList<ElementRef<HTMLInputElement>>;
+  @ContentChild(DateRangePopupComponent) panel?: DateRangePopupComponent;
 
   origin: CdkOverlayOrigin;
   document: Document;
@@ -189,8 +189,7 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   arrowLeft?: number;
   destroy$ = new Subject();
   prefixCls = PREFIX_CLASS;
-  // Index signature in type 'string | string[]' only permits reading
-  inputValue: NzSafeAny = '';
+  inputValue!: NzSafeAny;
   activeBarStyle: object = { position: 'absolute' };
   animationOpenState = false;
   overlayOpen: boolean = false; // Available when "open"=undefined
@@ -250,7 +249,7 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
 
   ngOnInit(): void {
     this.inputSize = Math.max(10, this.format.length) + 2;
-
+    this.inputValue = this.isRange ? ['', ''] : '';
     this.datePickerService.valueChange$.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.updateInputValue();
     });
@@ -280,9 +279,7 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
         ...this.datePickerService.arrowPositionStyle,
         width: `${this.inputWidth}px`
       };
-      if (this.document.activeElement !== this.getInput(this.datePickerService.activeInput)) {
-        this.focus();
-      }
+      this.focus();
       this.panel?.cdr.markForCheck();
       this.cdr.markForCheck();
     });
@@ -304,16 +301,19 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
     this.arrowLeft = this.inputWidth + this.separatorElement?.nativeElement.offsetWidth || 0;
   }
 
-  getInput(partType?: RangePartType): HTMLInputElement {
+  getInput(partType?: RangePartType): HTMLInputElement | undefined {
     return this.isRange
       ? partType === 'left'
-        ? this.rangePickerInputs.first.nativeElement
-        : this.rangePickerInputs.last.nativeElement
+        ? this.rangePickerInputs?.first.nativeElement
+        : this.rangePickerInputs?.last.nativeElement
       : this.pickerInput!.nativeElement;
   }
 
   focus(): void {
-    this.getInput(this.datePickerService.activeInput).focus(); // Focus on the first input
+    const activeInputElement = this.getInput(this.datePickerService.activeInput);
+    if (this.document.activeElement !== activeInputElement) {
+      activeInputElement?.focus();
+    }
   }
 
   onFocus(partType?: RangePartType): void {
@@ -359,7 +359,7 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   }
 
   onClickBackdrop(): void {
-    if (this.panel.isAllowed(this.datePickerService.value!, true)) {
+    if (this.panel?.isAllowed(this.datePickerService.value!, true)) {
       this.updateInputValue();
       this.datePickerService.emitValue$.next();
     } else {

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -232,7 +232,7 @@ describe('NzRangePickerComponent', () => {
       fixtureInstance.nzDefaultPickerValue = [new Date('2012-01-18'), new Date('2019-11-11')];
       fixture.detectChanges();
       openPickerByClickTrigger();
-      expect(queryFromOverlay('.ant-picker-panel .ant-picker-header-month-btn').textContent!.indexOf('1') > -1).toBeTruthy();
+      expect(getHeaderMonthBtn().textContent!.indexOf('1') > -1).toBeTruthy();
       expect(queryFromOverlay('.ant-picker-panel:last-child .ant-picker-header-month-btn').textContent!.indexOf('11') > -1).toBeTruthy();
     }));
 
@@ -330,13 +330,13 @@ describe('NzRangePickerComponent', () => {
       // Click previous month button
       dispatchMouseEvent(getPreBtn('left'), 'click');
       fixture.detectChanges();
-      expect(queryFromOverlay('.ant-picker-panel .ant-picker-header-month-btn').textContent!.indexOf('5') > -1).toBeTruthy();
+      expect(getHeaderMonthBtn().textContent!.indexOf('5') > -1).toBeTruthy();
       // Click next month button * 2
       dispatchMouseEvent(getNextBtn('left'), 'click');
       fixture.detectChanges();
       dispatchMouseEvent(getNextBtn('left'), 'click');
       fixture.detectChanges();
-      expect(queryFromOverlay('.ant-picker-panel .ant-picker-header-month-btn').textContent!.indexOf('7') > -1).toBeTruthy();
+      expect(getHeaderMonthBtn().textContent!.indexOf('7') > -1).toBeTruthy();
     }));
 
     it('should support keep initValue when reopen panel', fakeAsync(() => {
@@ -653,8 +653,6 @@ describe('NzRangePickerComponent', () => {
       fixtureInstance.nzDisabledDate = (current: Date) => differenceInDays(current, initial[0]) < 0;
       fixtureInstance.nzShowTime = true;
       fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
       openPickerByClickTrigger();
 
       // Click start date
@@ -669,11 +667,9 @@ describe('NzRangePickerComponent', () => {
       fixtureInstance.modelValue = [new Date('2018-05-15'), new Date('2018-05-15')];
       fixtureInstance.nzShowTime = true;
       fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
       openPickerByClickTrigger();
 
-      expect(queryFromOverlay('.ant-picker-panel .ant-picker-header-month-btn').textContent).toContain('5');
+      expect(getHeaderMonthBtn().textContent).toContain('5');
     }));
 
     it('should support nzRanges', fakeAsync(() => {
@@ -739,8 +735,6 @@ describe('NzRangePickerComponent', () => {
       fixtureInstance.modelValue = [new Date('2019-11-11 11:22:33'), new Date('2019-12-12 11:22:33')];
       fixtureInstance.nzShowTime = true;
       fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
       openPickerByClickTrigger();
 
       const leftInput = getPickerInput(fixture.debugElement);
@@ -796,6 +790,23 @@ describe('NzRangePickerComponent', () => {
       fixture.detectChanges();
       expect(leftInput.value).toBe('');
       expect(rightInput.value).toBe('2018-02-06');
+    }));
+
+    it('should panel date follows the selected date', fakeAsync(() => {
+      fixtureInstance.nzShowTime = true;
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+
+      const leftInput = getPickerInput(fixture.debugElement);
+      typeInElement('2027-09-17 11:08:22', leftInput);
+      fixture.detectChanges();
+      leftInput.dispatchEvent(ENTER_EVENT);
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(getHeaderYearBtn('left').textContent).toContain('2027');
+      // panel month will increase 1
+      expect(getHeaderMonthBtn().textContent).toContain('10');
     }));
   }); // /specified date picker testing
 
@@ -857,6 +868,10 @@ describe('NzRangePickerComponent', () => {
 
   function getHeaderYearBtn(part: RangePartType): HTMLElement {
     return queryFromOverlay(`.ant-picker-panel .ant-picker-header-year-btn:${getCssIndex(part)}`);
+  }
+
+  function getHeaderMonthBtn(): HTMLElement {
+    return queryFromOverlay(`.ant-picker-panel .ant-picker-header-month-btn`);
   }
 
   function getFirstCell(partial: 'left' | 'right'): HTMLElement {

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -296,7 +296,13 @@ describe('NzRangePickerComponent', () => {
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
-      expect(nzOnChange).toHaveBeenCalled();
+      expect(nzOnChange).not.toHaveBeenCalled();
+      // now the cursor focus on right
+      const right = getFirstCell('right');
+      dispatchMouseEvent(right, 'click');
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
       const result = (nzOnChange.calls.allArgs()[0] as Date[][])[0];
       expect((result[0] as Date).getDate()).toBe(+leftText);
     }));
@@ -570,10 +576,10 @@ describe('NzRangePickerComponent', () => {
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
-      expect(leftInput.value.trim()).toBe('2018-12-12 00:00:00');
-      expect(okButton.getAttribute('disabled')).not.toBe(null);
+      expect(leftInput.value.trim()).toBe('2019-11-11 01:00:00');
+      expect(okButton.getAttribute('disabled')).toEqual(null);
 
-      const newValidDateString = ['2018-12-12 01:00:00', '2019-11-11 00:00:00'];
+      const newValidDateString = ['2020-12-12 01:00:00', '2021-11-11 00:00:00'];
       typeInElement(newValidDateString[0], leftInput);
       fixture.detectChanges();
       dispatchMouseEvent(okButton, 'click');
@@ -784,12 +790,12 @@ describe('NzRangePickerComponent', () => {
       fixture.detectChanges();
       typeInElement('2018-02-06', rightInput);
       fixture.detectChanges();
-      getPickerInput(fixture.debugElement).dispatchEvent(ENTER_EVENT);
+      getRangePickerRightInput(fixture.debugElement).dispatchEvent(ENTER_EVENT);
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
-      expect(leftInput.value).toBe('2018-02-06');
-      expect(rightInput.value).toBe('2019-08-10');
+      expect(leftInput.value).toBe('');
+      expect(rightInput.value).toBe('2018-02-06');
     }));
   }); // /specified date picker testing
 
@@ -805,8 +811,11 @@ describe('NzRangePickerComponent', () => {
 
       // Click the first cell to change ngModel
       const left = getFirstCell('left');
+      const right = getFirstCell('right');
       const leftText = left.textContent!.trim();
       dispatchMouseEvent(left, 'click');
+      fixture.detectChanges();
+      dispatchMouseEvent(right, 'click');
       fixture.detectChanges();
       expect(fixtureInstance.modelValue[0]!.getDate()).toBe(+leftText);
     }));


### PR DESCRIPTION
Closes #5572
Closes #5651
Closes #5631

- if one value change, the cursor will always move to the other input although has value.
- will not sort the range date.
- when sorting is wrong, reset the other input.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
