### PR TITLE
fix(module:slider): fix reverse slider value with min and max

### DIFF
--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -325,7 +325,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
   }
 
   private getLogicalValue(value: number): number {
-    return this.nzReverse ? this.nzMax - value : value;
+    return this.nzReverse ? this.nzMax - value + this.nzMin : value;
   }
 
   private onDragEnd(): void {

--- a/components/slider/slider.spec.ts
+++ b/components/slider/slider.spec.ts
@@ -534,6 +534,35 @@ describe('nz-slider', () => {
     });
   });
 
+  describe('reverse and min and max', () => {
+    let testBed: ComponentBed<ReverseSliderWithMinAndMaxComponent>;
+    let fixture: ComponentFixture<ReverseSliderWithMinAndMaxComponent>;
+
+    beforeEach(() => {
+      testBed = createComponentBed(ReverseSliderWithMinAndMaxComponent, {
+        imports: [NzSliderModule, FormsModule, ReactiveFormsModule, NoopAnimationsModule]
+      });
+      fixture = testBed.fixture;
+      fixture.detectChanges();
+
+      getReferenceFromFixture(fixture);
+    });
+
+    it('should set the correct maximum value', () => {
+      dispatchClickEventSequence(sliderNativeElement, 0);
+      fixture.detectChanges();
+
+      expect(sliderInstance.value).toEqual(6);
+    });
+
+    it('should set the correct minimum value', () => {
+      dispatchClickEventSequence(sliderNativeElement, 1);
+      fixture.detectChanges();
+
+      expect(sliderInstance.value).toEqual(4);
+    });
+  });
+
   describe('mixed usage', () => {
     let testBed: ComponentBed<MixedSliderComponent>;
     let fixture: ComponentFixture<MixedSliderComponent>;
@@ -786,14 +815,18 @@ const styles = `
 `;
 
 @Component({
-  template: ` <nz-slider [nzDisabled]="disabled"></nz-slider> `,
+  template: `
+    <nz-slider [nzDisabled]="disabled"></nz-slider>
+  `,
   styles: [styles]
 })
 class NzTestSliderComponent {
   disabled = false;
 }
 @Component({
-  template: ` <nz-slider [nzMin]="min" [nzMax]="max"></nz-slider> `,
+  template: `
+    <nz-slider [nzMin]="min" [nzMax]="max"></nz-slider>
+  `,
   styles: [styles]
 })
 class SliderWithMinAndMaxComponent {
@@ -802,13 +835,17 @@ class SliderWithMinAndMaxComponent {
 }
 
 @Component({
-  template: ` <nz-slider [ngModel]="26"></nz-slider> `,
+  template: `
+    <nz-slider [ngModel]="26"></nz-slider>
+  `,
   styles: [styles]
 })
 class SliderWithValueComponent {}
 
 @Component({
-  template: ` <nz-slider [nzStep]="step"></nz-slider> `,
+  template: `
+    <nz-slider [nzStep]="step"></nz-slider>
+  `,
   styles: [styles]
 })
 class SliderWithStepComponent {
@@ -816,19 +853,25 @@ class SliderWithStepComponent {
 }
 
 @Component({
-  template: ` <nz-slider [ngModel]="3" [nzMin]="4" [nzMax]="6"></nz-slider> `,
+  template: `
+    <nz-slider [ngModel]="3" [nzMin]="4" [nzMax]="6"></nz-slider>
+  `,
   styles: [styles]
 })
 class SliderWithValueSmallerThanMinComponent {}
 
 @Component({
-  template: ` <nz-slider [ngModel]="7" [nzMin]="4" [nzMax]="6"></nz-slider> `,
+  template: `
+    <nz-slider [ngModel]="7" [nzMin]="4" [nzMax]="6"></nz-slider>
+  `,
   styles: [styles]
 })
 class SliderWithValueGreaterThanMaxComponent {}
 
 @Component({
-  template: ` <nz-slider nzVertical></nz-slider> `,
+  template: `
+    <nz-slider nzVertical></nz-slider>
+  `,
   styles: [styles]
 })
 class VerticalSliderComponent {}
@@ -841,6 +884,14 @@ class VerticalSliderComponent {}
   `
 })
 class ReverseSliderComponent {}
+
+@Component({
+  template: `
+    <nz-slider [nzMin]="4" [nzMax]="6" nzReverse></nz-slider>
+  `,
+  styles: [styles]
+})
+class ReverseSliderWithMinAndMaxComponent {}
 
 @Component({
   template: `
@@ -888,7 +939,9 @@ class SliderWithFormControlComponent implements OnInit {
 }
 
 @Component({
-  template: ` <nz-slider [nzTooltipVisible]="show" [ngModel]="value"></nz-slider> `
+  template: `
+    <nz-slider [nzTooltipVisible]="show" [ngModel]="value"></nz-slider>
+  `
 })
 class SliderShowTooltipComponent {
   show: NzSliderShowTooltip = 'default';
@@ -896,7 +949,9 @@ class SliderShowTooltipComponent {
 }
 
 @Component({
-  template: ` <nz-slider [nzRange]="range"></nz-slider> `
+  template: `
+    <nz-slider [nzRange]="range"></nz-slider>
+  `
 })
 class NzTestSliderKeyboardComponent {
   range = false;


### PR DESCRIPTION
Fix slider value when min and max value is defined.
Previously the value was calculated incorrectly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

When specifying the nzMin on a reversed slider, the value would be calculated incorrectly.
This would create a bug where the selected position on the slider wouldn't align with the value it created.

Issue Number: N/A


## What is the new behavior?

The value gets calculated correctly and takes the min value in account.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
