### PR TITLE
fix(module:select): accept 0 value on enter

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -35,7 +35,7 @@ import { slideMotion } from 'ng-zorro-antd/core/animation';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { BooleanInput, NzSafeAny, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
-import { InputBoolean } from 'ng-zorro-antd/core/util';
+import { InputBoolean, isNotNil } from 'ng-zorro-antd/core/util';
 import { BehaviorSubject, combineLatest, merge, Subject } from 'rxjs';
 import { startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { NzOptionGroupComponent } from './option-group.component';
@@ -395,7 +395,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
       case ENTER:
         e.preventDefault();
         if (this.nzOpen) {
-          if (this.activatedValue) {
+          if (isNotNil(this.activatedValue)) {
             this.onItemClick(this.activatedValue);
           }
         } else {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using nz-select component with an option where `[nzValue]="0"` and hitting enter the value is not being saved, because `this.activatedValue = 0` and it is a falsy value thus not entering the if block to call the `onItemClick` method.

Issue Number: N/A


## What is the new behavior?
Optional @Input() was added to solve this problem. By passing `[nzAcceptZeroValue]="true"` to `NzSelectComponent`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I don't know Chinese the Chinese docs were Google translated.