### PR TITLE
refactor(module:all): remove the backdrop of most components

### DIFF
--- a/components/auto-complete/autocomplete.spec.ts
+++ b/components/auto-complete/autocomplete.spec.ts
@@ -154,7 +154,7 @@ describe('auto-complete', () => {
 
       expect(fixture.componentInstance.trigger.panelOpen).toBe(true);
 
-      dispatchFakeEvent(document, 'click');
+      dispatchFakeEvent(document.body, 'click');
 
       expect(fixture.componentInstance.trigger.panelOpen).toBe(false);
     }));

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -111,13 +111,12 @@ const defaultDisplayRender = (labels: string[]) => labels.join(' / ');
     <ng-template
       cdkConnectedOverlay
       nzConnectedOverlay
-      cdkConnectedOverlayHasBackdrop
       [cdkConnectedOverlayOrigin]="origin"
       [cdkConnectedOverlayPositions]="positions"
       [cdkConnectedOverlayTransformOriginOn]="'.ant-cascader-menus'"
-      (backdropClick)="closeMenu()"
-      (detach)="closeMenu()"
       [cdkConnectedOverlayOpen]="menuVisible"
+      (overlayOutsideClick)="onClickOutside($event)"
+      (detach)="closeMenu()"
     >
       <div
         #menu
@@ -310,9 +309,9 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
 
   constructor(
     public cascaderService: NzCascaderService,
-    private i18nService: NzI18nService,
     public nzConfigService: NzConfigService,
     private cdr: ChangeDetectorRef,
+    private i18nService: NzI18nService,
     elementRef: ElementRef,
     renderer: Renderer2,
     @Host() @Optional() public noAnimation?: NzNoAnimationDirective
@@ -585,6 +584,12 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
     this.inSearchingMode
       ? this.cascaderService.setSearchOptionSelected(option as NzCascaderSearchOption)
       : this.cascaderService.setOptionActivated(option, columnIndex, true);
+  }
+
+  onClickOutside(event: MouseEvent): void {
+    if (!this.el.contains(event.target as Node)) {
+      this.closeMenu();
+    }
   }
 
   private isActionTrigger(action: 'click' | 'hover'): boolean {

--- a/components/cascader/style/patch.less
+++ b/components/cascader/style/patch.less
@@ -1,5 +1,5 @@
 .ant-cascader-menus {
   position: relative;
-  margin-top: 4px;
-  margin-bottom: 4px;
+  margin-top: 2px;
+  margin-bottom: 2px;
 }

--- a/components/cascader/style/patch.less
+++ b/components/cascader/style/patch.less
@@ -1,3 +1,5 @@
 .ant-cascader-menus {
   position: relative;
+  margin-top: 4px;
+  margin-bottom: 4px;
 }

--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -66,7 +66,7 @@ describe('NzDatePickerComponent', () => {
       openPickerByClickTrigger();
       expect(getPickerContainer()).not.toBeNull();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -92,7 +92,7 @@ describe('NzDatePickerComponent', () => {
       fixture.detectChanges();
       openPickerByClickTrigger();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -242,7 +242,6 @@ describe('NzDatePickerComponent', () => {
       tick(500);
       fixture.detectChanges();
       expect(getPickerContainer()).not.toBeNull();
-      expect(queryFromOverlay('.cdk-overlay-backdrop')).toBeNull();
 
       fixtureInstance.nzOpen = false;
       fixture.detectChanges();
@@ -362,7 +361,7 @@ describe('NzDatePickerComponent', () => {
       openPickerByClickTrigger();
       expect(nzOnOpenChange).toHaveBeenCalledWith(true);
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       flush();
       expect(nzOnOpenChange).toHaveBeenCalledWith(false);
@@ -776,7 +775,7 @@ describe('NzDatePickerComponent', () => {
       fixture.detectChanges();
       expect(getPickerContainer()).not.toBeNull();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();

--- a/components/date-picker/month-picker.component.spec.ts
+++ b/components/date-picker/month-picker.component.spec.ts
@@ -56,7 +56,7 @@ describe('NzMonthPickerComponent', () => {
       openPickerByClickTrigger();
       expect(getPickerContainer()).not.toBeNull();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -127,7 +127,6 @@ describe('NzMonthPickerComponent', () => {
         tick(500);
         fixture.detectChanges();
         expect(getPickerContainer()).not.toBeNull();
-        expect(queryFromOverlay('.cdk-overlay-backdrop')).toBeNull();
 
         fixtureInstance.nzOpen = false;
         fixture.detectChanges();
@@ -206,7 +205,7 @@ describe('NzMonthPickerComponent', () => {
       openPickerByClickTrigger();
       expect(nzOnOpenChange).toHaveBeenCalledWith(true);
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       flush();
       expect(nzOnOpenChange).toHaveBeenCalledWith(false);

--- a/components/date-picker/picker.component.ts
+++ b/components/date-picker/picker.component.ts
@@ -130,13 +130,12 @@ import { PREFIX_CLASS } from './util';
       nzConnectedOverlay
       [cdkConnectedOverlayOrigin]="origin"
       [cdkConnectedOverlayOpen]="realOpenState"
-      [cdkConnectedOverlayHasBackdrop]="!isOpenHandledByUser()"
       [cdkConnectedOverlayPositions]="overlayPositions"
       [cdkConnectedOverlayTransformOriginOn]="'.ant-picker-wrapper'"
       (positionChange)="onPositionChange($event)"
-      (backdropClick)="onClickBackdrop()"
       (detach)="onOverlayDetach()"
       (overlayKeydown)="onOverlayKeydown($event)"
+      (overlayOutsideClick)="onClickOutside($event)"
     >
       <div
         class="ant-picker-wrapper"
@@ -357,12 +356,17 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
 
   onClickInputBox(event: MouseEvent): void {
     event.stopPropagation();
+    this.focus();
     if (!this.isOpenHandledByUser()) {
       this.showOverlay();
     }
   }
 
-  onClickBackdrop(): void {
+  onClickOutside(event: MouseEvent): void {
+    if (this.elementRef.nativeElement.contains(event.target)) {
+      return;
+    }
+
     if (this.panel?.isAllowed(this.datePickerService.value!, true)) {
       if (Array.isArray(this.datePickerService.value) && wrongSortOrder(this.datePickerService.value)) {
         const index = this.datePickerService.getActiveIndex(this.datePickerService.activeInput);

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -60,7 +60,7 @@ describe('NzRangePickerComponent', () => {
       openPickerByClickTrigger();
       expect(getPickerContainer()).not.toBeNull();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -71,7 +71,7 @@ describe('NzRangePickerComponent', () => {
       fixture.detectChanges();
       openPickerByClickTrigger();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -151,7 +151,6 @@ describe('NzRangePickerComponent', () => {
       tick(500);
       fixture.detectChanges();
       expect(getPickerContainer()).not.toBeNull();
-      expect(queryFromOverlay('.cdk-overlay-backdrop')).toBeNull();
 
       fixtureInstance.nzOpen = false;
       fixture.detectChanges();
@@ -217,7 +216,7 @@ describe('NzRangePickerComponent', () => {
       openPickerByClickTrigger();
       expect(nzOnOpenChange).toHaveBeenCalledWith(true);
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -356,7 +355,7 @@ describe('NzRangePickerComponent', () => {
       dispatchMouseEvent(getSuperNextBtn('left'), 'click');
       fixture.detectChanges();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -430,7 +429,7 @@ describe('NzRangePickerComponent', () => {
       fixture.detectChanges();
       expect(getRangePickerRightInput(fixture.debugElement) === document.activeElement).toBeTruthy();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -511,7 +510,7 @@ describe('NzRangePickerComponent', () => {
       ).toBeTruthy();
 
       // Close left panel
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -537,7 +536,7 @@ describe('NzRangePickerComponent', () => {
       fixture.detectChanges();
 
       // Close left panel
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -548,7 +547,7 @@ describe('NzRangePickerComponent', () => {
       expect(+queryFromOverlay('.ant-picker-time-panel-column:nth-child(3) li:first-child').textContent!.trim()).toBe(1);
 
       // Close left panel
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -767,7 +766,6 @@ describe('NzRangePickerComponent', () => {
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBeNull();
       // TODO: input value should not be change
       // expect(leftInput.value).toBe('2018-09-11');
     }));

--- a/components/date-picker/year-picker.component.spec.ts
+++ b/components/date-picker/year-picker.component.spec.ts
@@ -51,7 +51,7 @@ describe('NzYearPickerComponent', () => {
       openPickerByClickTrigger();
       expect(getPickerContainer()).not.toBeNull();
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -122,9 +122,6 @@ describe('NzYearPickerComponent', () => {
         tick(500);
         fixture.detectChanges();
         expect(getPickerContainer()).not.toBeNull();
-        expect(queryFromOverlay('.cdk-overlay-backdrop')).toBeNull();
-        // dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
-        // expect(getPickerContainer()).not.toBeNull();
 
         fixtureInstance.nzOpen = false;
         fixture.detectChanges();
@@ -200,7 +197,7 @@ describe('NzYearPickerComponent', () => {
       openPickerByClickTrigger();
       expect(nzOnOpenChange).toHaveBeenCalledWith(true);
 
-      dispatchMouseEvent(queryFromOverlay('.cdk-overlay-backdrop'), 'click');
+      dispatchMouseEvent(document.body, 'click');
       fixture.detectChanges();
       flush();
       expect(nzOnOpenChange).toHaveBeenCalledWith(false);

--- a/components/dropdown/doc/index.en-US.md
+++ b/components/dropdown/doc/index.en-US.md
@@ -27,7 +27,6 @@ import { NzDropDownModule } from 'ng-zorro-antd/dropdown';
 | `[nzTrigger]` | the trigger mode which executes the drop-down action | `'click' \| 'hover'` | `'hover'` |
 | `[nzClickHide]` | whether hide menu when click | `boolean` | `true` |
 | `[nzVisible]` | whether the dropdown menu is visible, double binding | `boolean` | - |
-| `[nzBackdrop]` | whether the dropdown has a backdrop when `nzTrigger` is `click` | `boolean` | `true` |
 | `[nzOverlayClassName]` | Class name of the dropdown root element | `string` | - |
 | `[nzOverlayStyle]` | Style of the dropdown root element | `object` | - |
 | `(nzVisibleChange)` | a callback function takes an argument: `nzVisible`, is executed when the visible state is changed | `EventEmitter<boolean>` | - |

--- a/components/dropdown/doc/index.zh-CN.md
+++ b/components/dropdown/doc/index.zh-CN.md
@@ -28,7 +28,6 @@ import { NzDropDownModule } from 'ng-zorro-antd/dropdown';
 | `[nzTrigger]` | 触发下拉的行为 | `'click' \| 'hover'` | `'hover'` |
 | `[nzClickHide]` | 点击后是否隐藏菜单 | `boolean` | `true` |
 | `[nzVisible]` | 菜单是否显示，可双向绑定 | `boolean` | - |
-| `[nzBackdrop]` | 是否在 `nzTrigger` 为 `click`时增加背景蒙版 | `boolean` | `true` |
 | `[nzOverlayClassName]` | 下拉根元素的类名称 | `string` | - |
 | `[nzOverlayStyle]` | 下拉根元素的样式 | `object` | - |
 | `(nzVisibleChange)` | 菜单显示状态改变时调用，参数为 nzVisible | `EventEmitter<boolean>` | - |

--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -21,6 +21,7 @@ import {
   SimpleChanges,
   ViewContainerRef
 } from '@angular/core';
+import { warnDeprecation } from 'ng-zorro-antd/core/logger';
 import { POSITION_MAP } from 'ng-zorro-antd/core/overlay';
 import { BooleanInput, IndexableObject } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
@@ -57,6 +58,10 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
   @Input() nzDropdownMenu: NzDropdownMenuComponent | null = null;
   @Input() nzTrigger: 'click' | 'hover' = 'hover';
   @Input() nzMatchWidthElement: ElementRef | null = null;
+  /**
+   * @deprecated Not supported.
+   * @breaking-change 11.0.0
+   */
   @Input() @InputBoolean() nzBackdrop = true;
   @Input() @InputBoolean() nzClickHide = true;
   @Input() @InputBoolean() nzDisabled = false;
@@ -154,7 +159,6 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
               /** update overlay config **/
               const overlayConfig = this.overlayRef.getConfig();
               overlayConfig.minWidth = triggerWidth;
-              overlayConfig.hasBackdrop = this.nzTrigger === 'click';
             }
             /** open dropdown with animation **/
             this.positionStrategy.withPositions([POSITION_MAP[this.nzPlacement], ...listOfPositions]);
@@ -183,7 +187,7 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    const { nzVisible, nzDisabled, nzOverlayClassName, nzOverlayStyle, nzTrigger } = changes;
+    const { nzVisible, nzDisabled, nzOverlayClassName, nzOverlayStyle, nzTrigger, nzBackdrop } = changes;
     if (nzTrigger) {
       this.nzTrigger$.next(this.nzTrigger);
     }
@@ -204,6 +208,9 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
     }
     if (nzOverlayStyle) {
       this.setDropdownMenuValue('nzOverlayStyle', this.nzOverlayStyle);
+    }
+    if (nzBackdrop) {
+      warnDeprecation('`nzBackdrop` in dropdown component will be removed in 11.0.0.');
     }
   }
 }

--- a/components/mention/nz-mention.spec.ts
+++ b/components/mention/nz-mention.spec.ts
@@ -113,7 +113,7 @@ describe('mention', () => {
       fixture.detectChanges();
       flush();
       expect(mention.isOpen).toBe(true);
-      dispatchFakeEvent(document, 'click');
+      dispatchFakeEvent(document.body, 'click');
       expect(mention.isOpen).toBe(false);
     }));
 

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -119,8 +119,7 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
       cdkConnectedOverlay
       nzConnectedOverlay
       [cdkConnectedOverlayOrigin]="origin"
-      [cdkConnectedOverlayHasBackdrop]="_hasBackdrop"
-      (backdropClick)="hide()"
+      (overlayOutsideClick)="onClickOutside($event)"
       (detach)="hide()"
       (positionChange)="onPositionChange($event)"
       [cdkConnectedOverlayPositions]="_positions"
@@ -180,7 +179,6 @@ export class NzPopconfirmComponent extends NzToolTipComponent implements OnDestr
   protected _trigger: NzTooltipTrigger = 'click';
 
   _prefix = 'ant-popover-placement';
-  _hasBackdrop = true;
 
   constructor(cdr: ChangeDetectorRef, @Host() @Optional() public noAnimation?: NzNoAnimationDirective) {
     super(cdr, noAnimation);

--- a/components/popover/popover.ts
+++ b/components/popover/popover.ts
@@ -75,13 +75,12 @@ export class NzPopoverDirective extends NzTooltipBaseDirective {
       cdkConnectedOverlay
       nzConnectedOverlay
       [cdkConnectedOverlayOrigin]="origin"
-      [cdkConnectedOverlayHasBackdrop]="_hasBackdrop"
-      (backdropClick)="hide()"
-      (detach)="hide()"
-      (positionChange)="onPositionChange($event)"
       [cdkConnectedOverlayPositions]="_positions"
       [cdkConnectedOverlayOpen]="_visible"
       [cdkConnectedOverlayPush]="true"
+      (overlayOutsideClick)="onClickOutside($event)"
+      (detach)="hide()"
+      (positionChange)="onPositionChange($event)"
     >
       <div
         class="ant-popover"

--- a/components/select/select-top-control.component.ts
+++ b/components/select/select-top-control.component.ts
@@ -117,6 +117,10 @@ export class NzSelectTopControlComponent implements OnChanges {
   inputValue: string | null = null;
 
   onHostClick(): void {
+    if (this.open && this.showSearch) {
+      return;
+    }
+
     if (!this.disabled) {
       this.openChange.next(!this.open);
     }

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -109,16 +109,15 @@ export type NzSelectSizeType = 'large' | 'default' | 'small';
     <ng-template
       cdkConnectedOverlay
       nzConnectedOverlay
-      [cdkConnectedOverlayHasBackdrop]="true"
       [cdkConnectedOverlayMinWidth]="$any(nzDropdownMatchSelectWidth ? null : triggerWidth)"
       [cdkConnectedOverlayWidth]="$any(nzDropdownMatchSelectWidth ? triggerWidth : null)"
       [cdkConnectedOverlayOrigin]="origin"
       [cdkConnectedOverlayTransformOriginOn]="'.ant-select-dropdown'"
       [cdkConnectedOverlayPanelClass]="nzDropdownClassName!"
-      (backdropClick)="setOpenState(false)"
+      [cdkConnectedOverlayOpen]="nzOpen"
+      (overlayOutsideClick)="onClickOutside($event)"
       (detach)="setOpenState(false)"
       (positionChange)="onPositionChange($event)"
-      [cdkConnectedOverlayOpen]="nzOpen"
     >
       <nz-option-container
         [ngStyle]="nzDropdownStyle"
@@ -444,6 +443,12 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterVie
 
   onClearSelection(): void {
     this.updateListOfValue([]);
+  }
+
+  onClickOutside(event: MouseEvent): void {
+    if (!this.elementRef.nativeElement.contains(event.target)) {
+      this.setOpenState(false);
+    }
   }
 
   focus(): void {

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -116,6 +116,18 @@ describe('select', () => {
       expect(component.openChange).toHaveBeenCalledTimes(2);
       expect(component.openChange).toHaveBeenCalledWith(true);
     });
+    it('should click input not close in searching mode', () => {
+      component.nzShowSearch = true;
+      fixture.detectChanges();
+      const topSelectElement = selectElement.querySelector('.ant-select-selector')!;
+      dispatchFakeEvent(topSelectElement, 'click');
+      fixture.detectChanges();
+      expect(component.openChange).toHaveBeenCalledTimes(1);
+      expect(component.openChange).toHaveBeenCalledWith(true);
+      dispatchFakeEvent(topSelectElement, 'click');
+      fixture.detectChanges();
+      expect(component.openChange).toHaveBeenCalledTimes(1);
+    });
     it('should nzCustomTemplate works', fakeAsync(() => {
       component.listOfOption = [{ nzValue: 'value', nzLabel: 'label' }];
       fixture.detectChanges();
@@ -384,7 +396,7 @@ describe('select', () => {
       flushChanges();
       expect(document.querySelectorAll('nz-option-item.ant-select-item-option-selected').length).toBe(1);
       expect(document.querySelectorAll('nz-option-item.ant-select-item-option-selected')[0].textContent).toBe('Truthy value');
-      ['disabled', undefined, null].forEach((value) => {
+      ['disabled', undefined, null].forEach(value => {
         component.value = value;
         flushChanges();
         expect(document.querySelectorAll('nz-option-item.ant-select-item-option-selected').length).toBe(0);
@@ -633,7 +645,7 @@ describe('select', () => {
       expect(listOfItem[2].querySelector('.ant-select-selection-item-content')!.textContent).toBe('+ 2 ...');
       component.nzMaxTagPlaceholder = component.tagTemplate;
       fixture.detectChanges();
-      expect(listOfItem[2].textContent).toBe(' and 2 more selected ');
+      expect(listOfItem[2].textContent).toBe('and 2 more selected');
     }));
   });
   describe('default reactive mode', () => {
@@ -1113,7 +1125,7 @@ describe('select', () => {
       expect(listOfItem[2].querySelector('.ant-select-selection-item-content')!.textContent).toBe('+ 2 ...');
       component.nzMaxTagPlaceholder = component.tagTemplate;
       fixture.detectChanges();
-      expect(listOfItem[2].textContent).toBe(' and 2 more selected ');
+      expect(listOfItem[2].textContent).toBe('and 2 more selected');
     }));
   });
 });
@@ -1263,7 +1275,7 @@ export class TestSelectTemplateMultipleComponent {
         [nzHide]="o.nzHide"
       ></nz-option>
     </nz-select>
-    <ng-template #tagTemplate let-selectedList> and {{ selectedList.length }} more selected </ng-template>
+    <ng-template #tagTemplate let-selectedList>and {{ selectedList.length }} more selected</ng-template>
   `
 })
 export class TestSelectTemplateTagsComponent {
@@ -1360,8 +1372,7 @@ export class TestSelectReactiveDefaultComponent {
       [(nzOpen)]="nzOpen"
       (ngModelChange)="valueChange($event)"
       (nzOpenChange)="valueChange($event)"
-    >
-    </nz-select>
+    ></nz-select>
     <ng-template #iconTemplate>icon</ng-template>
   `
 })
@@ -1391,9 +1402,8 @@ export class TestSelectReactiveMultipleComponent {
       [nzTokenSeparators]="nzTokenSeparators"
       [nzMaxTagPlaceholder]="nzMaxTagPlaceholder"
       (ngModelChange)="valueChange($event)"
-    >
-    </nz-select>
-    <ng-template #tagTemplate let-selectedList> and {{ selectedList.length }} more selected </ng-template>
+    ></nz-select>
+    <ng-template #tagTemplate let-selectedList>and {{ selectedList.length }} more selected</ng-template>
   `
 })
 export class TestSelectReactiveTagsComponent {

--- a/components/time-picker/time-picker.component.ts
+++ b/components/time-picker/time-picker.component.ts
@@ -67,14 +67,13 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'timePicker';
     <ng-template
       cdkConnectedOverlay
       nzConnectedOverlay
-      cdkConnectedOverlayHasBackdrop
       [cdkConnectedOverlayPositions]="overlayPositions"
       [cdkConnectedOverlayOrigin]="origin"
       [cdkConnectedOverlayOpen]="nzOpen"
       [cdkConnectedOverlayOffsetY]="-2"
       [cdkConnectedOverlayTransformOriginOn]="'.ant-picker-dropdown'"
       (detach)="close()"
-      (backdropClick)="setCurrentValueAndClose()"
+      (overlayOutsideClick)="onClickOutside($event)"
     >
       <div [@slideMotion]="'enter'" class="ant-picker-dropdown">
         <div class="ant-picker-panel-container">
@@ -217,6 +216,12 @@ export class NzTimePickerComponent implements ControlValueAccessor, OnInit, Afte
   onClickClearBtn(event: MouseEvent): void {
     event.stopPropagation();
     this.emitValue(null);
+  }
+
+  onClickOutside(event: MouseEvent): void {
+    if (!this.element.nativeElement.contains(event.target)) {
+      this.setCurrentValueAndClose();
+    }
   }
 
   onFocus(value: boolean): void {

--- a/components/tooltip/base.ts
+++ b/components/tooltip/base.ts
@@ -328,7 +328,6 @@ export abstract class NzTooltipBaseComponent implements OnDestroy {
 
   set nzTrigger(value: NzTooltipTrigger) {
     this._trigger = value;
-    this._hasBackdrop = this._trigger === 'click';
   }
 
   get nzTrigger(): NzTooltipTrigger {
@@ -352,7 +351,6 @@ export abstract class NzTooltipBaseComponent implements OnDestroy {
   preferredPlacement = 'top';
 
   _classMap: NgClassInterface = {};
-  _hasBackdrop = false;
   _prefix = 'ant-tooltip-placement';
   _positions: ConnectionPositionPair[] = [...DEFAULT_TOOLTIP_POSITIONS];
 
@@ -419,6 +417,12 @@ export abstract class NzTooltipBaseComponent implements OnDestroy {
   setOverlayOrigin(origin: CdkOverlayOrigin): void {
     this.origin = origin;
     this.cdr.markForCheck();
+  }
+
+  onClickOutside(event: MouseEvent): void {
+    if (!this.origin.elementRef.nativeElement.contains(event.target)) {
+      this.hide();
+    }
   }
 
   /**

--- a/components/tooltip/base.ts
+++ b/components/tooltip/base.ts
@@ -349,7 +349,6 @@ export abstract class NzTooltipBaseComponent implements OnDestroy {
 
   origin!: CdkOverlayOrigin;
   preferredPlacement = 'top';
-
   _classMap: NgClassInterface = {};
   _prefix = 'ant-tooltip-placement';
   _positions: ConnectionPositionPair[] = [...DEFAULT_TOOLTIP_POSITIONS];

--- a/components/tooltip/tooltip.spec.ts
+++ b/components/tooltip/tooltip.spec.ts
@@ -49,10 +49,6 @@ describe('nz-tooltip', () => {
     fixture.detectChanges();
   }
 
-  function getTooltipBackdropElement(): HTMLElement {
-    return overlayContainerElement.querySelector('.cdk-overlay-backdrop') as HTMLElement;
-  }
-
   beforeEach(() => {
     fixture = testBed.fixture;
     component = testBed.component;
@@ -129,7 +125,7 @@ describe('nz-tooltip', () => {
       waitingForTooltipToggling();
       expect(overlayContainerElement.textContent).toContain(title);
 
-      dispatchMouseEvent(getTooltipBackdropElement(), 'click');
+      dispatchMouseEvent(document.body, 'click');
       waitingForTooltipToggling();
       expect(overlayContainerElement.textContent).not.toContain(title);
     }));
@@ -251,7 +247,7 @@ describe('nz-tooltip', () => {
       waitingForTooltipToggling();
       expect(overlayContainerElement.textContent).toContain(featureKey);
 
-      dispatchMouseEvent(getTooltipBackdropElement(), 'click');
+      dispatchMouseEvent(document.body, 'click');
       waitingForTooltipToggling();
       expect(overlayContainerElement.textContent).not.toContain(featureKey);
 

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -76,7 +76,7 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
       [cdkConnectedOverlayOpen]="_visible"
       [cdkConnectedOverlayPositions]="_positions"
       [cdkConnectedOverlayPush]="true"
-      (overlayOutsideClick)="hide()"
+      (overlayOutsideClick)="onClickOutside($event)"
       (detach)="hide()"
       (positionChange)="onPositionChange($event)"
     >

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -74,10 +74,9 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
       nzConnectedOverlay
       [cdkConnectedOverlayOrigin]="origin"
       [cdkConnectedOverlayOpen]="_visible"
-      [cdkConnectedOverlayHasBackdrop]="_hasBackdrop"
       [cdkConnectedOverlayPositions]="_positions"
       [cdkConnectedOverlayPush]="true"
-      (backdropClick)="hide()"
+      (overlayOutsideClick)="hide()"
       (detach)="hide()"
       (positionChange)="onPositionChange($event)"
     >

--- a/components/tree-select/tree-select.component.ts
+++ b/components/tree-select/tree-select.component.ts
@@ -66,11 +66,10 @@ const TREE_SELECT_DEFAULT_CLASS = 'ant-select-dropdown ant-select-tree-dropdown'
       nzConnectedOverlay
       [cdkConnectedOverlayOrigin]="cdkOverlayOrigin"
       [cdkConnectedOverlayOpen]="nzOpen"
-      [cdkConnectedOverlayHasBackdrop]="true"
       [cdkConnectedOverlayTransformOriginOn]="'.ant-select-tree-dropdown'"
       [cdkConnectedOverlayMinWidth]="$any(nzDropdownMatchSelectWidth ? null : triggerWidth)"
       [cdkConnectedOverlayWidth]="$any(nzDropdownMatchSelectWidth ? triggerWidth : null)"
-      (backdropClick)="closeDropDown()"
+      (overlayOutsideClick)="onClickOutside($event)"
       (detach)="closeDropDown()"
       (positionChange)="onPositionChange($event)"
     >
@@ -516,6 +515,12 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
       this.removeSelected(node, false);
     });
     this.nzCleared.emit();
+  }
+
+  onClickOutside(event: MouseEvent): void {
+    if (!this.elementRef.nativeElement.contains(event.target)) {
+      this.closeDropDown();
+    }
   }
 
   setSearchValues($event: NzFormatEmitEvent): void {

--- a/components/tree-select/tree-select.spec.ts
+++ b/components/tree-select/tree-select.spec.ts
@@ -103,7 +103,7 @@ describe('tree-select component', () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
-      dispatchFakeEvent(overlayContainerElement.querySelector('.cdk-overlay-backdrop')!, 'click');
+      dispatchFakeEvent(document.body, 'click');
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(false);
       fixture.detectChanges();


### PR DESCRIPTION
related components: cascader, datepicker, timepicker, popconfirm, popover, select, treeselect.
@angular/cdk >= 10.1.0

close #4763
close #5061
close #4259
close #2508

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
