### PR TITLE
fix(module:spin): make delay behave more accurately

### DIFF
--- a/components/spin/demo/delay-and-debounce.md
+++ b/components/spin/demo/delay-and-debounce.md
@@ -12,15 +12,3 @@ title:
 ## en-US
 
 Specifies a delay for loading state. If `spinning` ends during delay, loading status won't appear.
-
-
-````css
-.example {
-  text-align: center;
-  background: rgba(0,0,0,0.05);
-  border-radius: 4px;
-  margin-bottom: 20px;
-  padding: 30px 50px;
-  margin: 20px 0;
-}
-````

--- a/components/spin/spin.component.ts
+++ b/components/spin/spin.component.ts
@@ -73,7 +73,7 @@ export class NzSpinComponent implements OnChanges, OnDestroy, OnInit {
   private destroy$ = new Subject<void>();
   private spinning$ = new BehaviorSubject(this.nzSpinning);
   private delay$ = new ReplaySubject<number>(1);
-  isLoading = true;
+  isLoading = false;
 
   constructor(public nzConfigService: NzConfigService, private cdr: ChangeDetectorRef) {}
 

--- a/components/spin/spin.component.ts
+++ b/components/spin/spin.component.ts
@@ -18,8 +18,8 @@ import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/con
 import { BooleanInput, NumberInput, NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 import { InputBoolean, InputNumber } from 'ng-zorro-antd/core/util';
 
-import { BehaviorSubject, Subject } from 'rxjs';
-import { debounceTime, mergeMap, takeUntil } from 'rxjs/operators';
+import { BehaviorSubject, ReplaySubject, Subject, timer } from 'rxjs';
+import { debounce, distinctUntilChanged, startWith, switchMap, takeUntil } from 'rxjs/operators';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'spin';
 
@@ -72,20 +72,21 @@ export class NzSpinComponent implements OnChanges, OnDestroy, OnInit {
   @Input() @InputBoolean() nzSpinning = true;
   private destroy$ = new Subject<void>();
   private spinning$ = new BehaviorSubject(this.nzSpinning);
-  private delay$ = new BehaviorSubject(this.nzDelay);
+  private delay$ = new ReplaySubject<number>(1);
   isLoading = true;
 
   constructor(public nzConfigService: NzConfigService, private cdr: ChangeDetectorRef) {}
 
   ngOnInit(): void {
-    const loading$ = this.spinning$.pipe(
-      mergeMap(() => this.delay$),
-      mergeMap(delay => {
+    const loading$ = this.delay$.pipe(
+      startWith(this.nzDelay),
+      distinctUntilChanged(),
+      switchMap(delay => {
         if (delay === 0) {
           return this.spinning$;
-        } else {
-          return this.spinning$.pipe(debounceTime(delay));
         }
+
+        return this.spinning$.pipe(debounce(spinning => timer(spinning ? delay : 0)));
       }),
       takeUntil(this.destroy$)
     );

--- a/components/spin/spin.spec.ts
+++ b/components/spin/spin.spec.ts
@@ -83,19 +83,31 @@ describe('spin', () => {
     });
 
     it('should delay work', fakeAsync(() => {
+      testComponent.delay = 500;
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
-      testComponent.delay = 500;
+
+      // true -> false
+      // This should work immediately
       testComponent.spinning = false;
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
-      expect(spin.nativeElement.querySelector('.ant-spin')).toBeDefined();
+      expect(spin.nativeElement.querySelector('.ant-spin')).toBeNull();
+
+      // false -> true
+      // This should be debounced
+      testComponent.spinning = true;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+      expect(spin.nativeElement.querySelector('.ant-spin')).toBeNull();
+
       fixture.detectChanges();
       tick(1000);
       fixture.detectChanges();
-      expect(spin.nativeElement.querySelector('.ant-spin')).toBeNull();
+      expect(spin.nativeElement.querySelector('.ant-spin')).toBeDefined();
     }));
 
     it('should wrapper work', fakeAsync(() => {
@@ -123,7 +135,7 @@ describe('spin', () => {
 
 @Component({
   template: `
-    <ng-template #indicatorTemplate><i nz-icon nzType="loading" style="font-size: 24px;"></i> </ng-template>
+    <ng-template #indicatorTemplate><i nz-icon nzType="loading" style="font-size: 24px;"></i></ng-template>
     <nz-spin [nzTip]="tip" [nzSize]="size" [nzDelay]="delay" [nzSpinning]="spinning" [nzSimple]="simple" [nzIndicator]="indicator">
       <div>test</div>
     </nz-spin>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the new behavior?

* delay is now also respected when the component is initialized
* delay is only considered when nzSpinning turns from false to true, but not vice versa

If you don't agree with either change let me know and I can update the PR.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

fixes #5926 
fixes #5928