### PR TITLE
fix(module:code-editor): only emit update if value changed

### DIFF
--- a/components/code-editor/code-editor.component.ts
+++ b/components/code-editor/code-editor.component.ts
@@ -248,6 +248,12 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
   }
 
   private emitValue(value: string): void {
+    if (this.value === value) {
+      // If the value didn't change there's no reason to send an update.
+      // Specifically this may happen during an update from the model (writeValue) where sending an update to the model would actually be incorrect.
+      return;
+    }
+
     this.value = value;
     this.onChange(value);
   }


### PR DESCRIPTION
Before notifying Angular (through the ControlValueAccessor mechanism) of a change to
the value we make sure that the value has actually changed. This is necessary to
avoid feedback loops as writeValue (model -> view) would otherwise cause this to be
fired (view -> model) which can cause infinite loop issues on the usage side or
broken validation detection.

fixes #5869

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features) (Note: there currently are no tests for code-editor)
- [ ] Docs have been added / updated (for bug fixes / features) (Note: not required)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #5869

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```