### PR TITLE
fix(doc layout): duplicated binding description

### DIFF
--- a/components/layout/doc/index.en-US.md
+++ b/components/layout/doc/index.en-US.md
@@ -81,7 +81,6 @@ The sidebar.
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
 | `[nzBreakpoint]` | breakpoints of the responsive layout | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'xxl'` | - |
-| `[nzCollapsed]` | to set the current status | `boolean` | - |
 | `[nzCollapsedWidth]` | width of the collapsed sidebar, by setting to `0` a special trigger will appear | `number` | `64` |
 | `[nzCollapsible]` | whether can be collapsed | `boolean` | `false` |
 | `[nzCollapsed]` | the collapsed status can be double binding | `boolean` | `false` |

--- a/components/layout/doc/index.zh-CN.md
+++ b/components/layout/doc/index.zh-CN.md
@@ -82,7 +82,6 @@ import { NzLayoutModule } from 'ng-zorro-antd/layout';
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | `[nzBreakpoint]` | 触发响应式布局的断点 | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'xxl'` | - |
-| `[nzCollapsed]` | 当前收起状态 | `boolean` | - |
 | `[nzCollapsedWidth]` | 收缩宽度，设置为 0 会出现特殊 trigger | `number` | `64` |
 | `[nzCollapsible]` | 是否可收起 | `boolean` | `false` |
 | `[nzCollapsed]` | 当前收起状态，可双向绑定 | `boolean` | `false` |


### PR DESCRIPTION
nzCollapsed is describe twice

https://ng.ant.design/components/layout/en

![image](https://user-images.githubusercontent.com/2951285/96303480-bbaf4a80-0ffa-11eb-9a56-aff8771def76.png)
