### PR TITLE
docs: update Akita documentation website URL

### DIFF
--- a/docs/recommendation.en-US.md
+++ b/docs/recommendation.en-US.md
@@ -29,7 +29,7 @@ Dev Kit |[Angular CLI](https://cli.angular.io/) | Angular CLI
 Dev Kit |[Angular Builders](https://github.com/just-jeb/angular-builders) | Angular build facade extensions
 Dev Kit |[ngx-planet](https://github.com/worktile/ngx-planet) | Micro Frontend library for Angular
 Dev Kit|[Angular Universal](https://universal.angular.io/) | Server Render
-State Management|[Akita](https://netbasal.gitbook.io/akita/) | Akita state management
+State Management|[Akita](https://datorama.github.io/akita/) | Akita state management
 State Management|[ngxs](https://ngxs.io/) | NGXS state management
 State Management|[ngrx](https://ngrx.io/) | NGRX state management
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The linked Akita website is not working. I believe it was the outdated link.

## What is the new behavior?
Replace with the current documentation website

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
