### PR TITLE
fix(module:slider): fix slider style + reverse marks if reversed slider

### DIFF
--- a/components/slider/demo/reverse.ts
+++ b/components/slider/demo/reverse.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { NzMarks } from 'ng-zorro-antd/slider';
 
 @Component({
   selector: 'nz-demo-slider-reverse',
@@ -6,7 +7,9 @@ import { Component } from '@angular/core';
     <div>
       <nz-slider [ngModel]="30" [nzReverse]="reverse"></nz-slider>
       <nz-slider nzRange [ngModel]="[20, 50]" [nzReverse]="reverse"></nz-slider>
-      Reversed: <nz-switch nzSize="small" [(ngModel)]="reverse"></nz-switch>
+      <nz-slider [nzMarks]="marks" [ngModel]="30" [nzReverse]="reverse"></nz-slider>
+      Reversed:
+      <nz-switch nzSize="small" [(ngModel)]="reverse"></nz-switch>
     </div>
   `,
   styles: [
@@ -23,4 +26,16 @@ import { Component } from '@angular/core';
 })
 export class NzDemoSliderReverseComponent {
   reverse = true;
+
+  marks: NzMarks = {
+    0: '0°C',
+    26: '26°C',
+    37: '37°C',
+    100: {
+      style: {
+        color: '#f50'
+      },
+      label: '<strong>100°C</strong>'
+    }
+  };
 }

--- a/components/slider/marks.component.ts
+++ b/components/slider/marks.component.ts
@@ -23,8 +23,7 @@ import { NzDisplayedMark, NzExtendedMark, NzMark, NzMarkObj } from './typings';
         [class.ant-slider-mark-active]="attr.active"
         [ngStyle]="attr.style!"
         [innerHTML]="attr.label"
-      >
-      </span>
+      ></span>
     </div>
   `
 })
@@ -39,17 +38,18 @@ export class NzSliderMarksComponent implements OnChanges {
   @Input() max!: number;
   @Input() @InputBoolean() vertical = false;
   @Input() @InputBoolean() included = false;
+  @Input() reverse!: boolean;
 
   marks: NzDisplayedMark[] = [];
 
   ngOnChanges(changes: SimpleChanges): void {
-    const { marksArray, lowerBound, upperBound } = changes;
+    const { marksArray, lowerBound, upperBound, reverse } = changes;
 
-    if (marksArray) {
+    if (marksArray || reverse) {
       this.buildMarks();
     }
 
-    if (marksArray || lowerBound || upperBound) {
+    if (marksArray || lowerBound || upperBound || reverse) {
       this.togglePointActive();
     }
   }
@@ -79,16 +79,17 @@ export class NzSliderMarksComponent implements OnChanges {
 
   private getMarkStyles(value: number, range: number, config: NzMark): NgStyleInterface {
     let style;
+    const markValue = this.reverse ? this.max + this.min - value : value;
 
     if (this.vertical) {
       style = {
         marginBottom: '-50%',
-        bottom: `${((value - this.min) / range) * 100}%`
+        bottom: `${((markValue - this.min) / range) * 100}%`
       };
     } else {
       style = {
         transform: `translate3d(-50%, 0, 0)`,
-        left: `${((value - this.min) / range) * 100}%`
+        left: `${((markValue - this.min) / range) * 100}%`
       };
     }
 

--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -80,10 +80,13 @@ import { NzExtendedMark, NzMarks, NzSliderHandler, NzSliderShowTooltip, NzSlider
       <nz-slider-step
         *ngIf="marksArray"
         [vertical]="nzVertical"
+        [min]="nzMin"
+        [max]="nzMax"
         [lowerBound]="$any(bounds.lower)"
         [upperBound]="$any(bounds.upper)"
         [marksArray]="marksArray"
         [included]="nzIncluded"
+        [reverse]="nzReverse"
       ></nz-slider-step>
       <nz-slider-handle
         *ngFor="let handle of handles"
@@ -105,6 +108,7 @@ import { NzExtendedMark, NzMarks, NzSliderHandler, NzSliderShowTooltip, NzSlider
         [upperBound]="$any(bounds.upper)"
         [marksArray]="marksArray"
         [included]="nzIncluded"
+        [reverse]="nzReverse"
       ></nz-slider-marks>
     </div>
   `

--- a/components/slider/slider.spec.ts
+++ b/components/slider/slider.spec.ts
@@ -257,6 +257,35 @@ describe('nz-slider', () => {
     });
   });
 
+  describe('marks', () => {
+    let testBed: ComponentBed<SliderWithMarksComponent>;
+    let fixture: ComponentFixture<SliderWithMarksComponent>;
+    let markListElement: HTMLElement;
+
+    beforeEach(() => {
+      testBed = createComponentBed(SliderWithMarksComponent, {
+        imports: [NzSliderModule, FormsModule, ReactiveFormsModule, NoopAnimationsModule]
+      });
+      fixture = testBed.fixture;
+      fixture.detectChanges();
+
+      getReferenceFromFixture(fixture);
+      markListElement = sliderNativeElement.querySelector('.ant-slider-mark') as HTMLElement;
+    });
+
+    it('should have start mark at the start', () => {
+      const value0Mark = markListElement.children[0] as HTMLElement;
+
+      expect(value0Mark.style.left).toEqual('0%');
+    });
+
+    it('should have end mark at the end', () => {
+      const value100Mark = markListElement.children[1] as HTMLElement;
+
+      expect(value100Mark.style.left).toEqual('100%');
+    });
+  });
+
   describe('step', () => {
     let testBed: ComponentBed<SliderWithStepComponent>;
     let fixture: ComponentFixture<SliderWithStepComponent>;
@@ -531,6 +560,24 @@ describe('nz-slider', () => {
 
       const trackElement = (sliderDebugElements[0].nativeElement as HTMLElement).querySelector('.ant-slider-track') as HTMLElement;
       expect(trackElement.style.width).toBe('1%');
+    });
+
+    it('should reverse marks', () => {
+      const markList = (sliderDebugElements[0].nativeElement as HTMLElement).querySelector('.ant-slider-mark') as HTMLElement;
+      const value0Mark = markList.children[0] as HTMLElement;
+      const value100Mark = markList.children[1] as HTMLElement;
+
+      expect(value0Mark.style.left).toEqual('100%');
+      expect(value100Mark.style.left).toEqual('0%');
+    });
+
+    it('should reverse steps', () => {
+      const stepList = (sliderDebugElements[0].nativeElement as HTMLElement).querySelector('.ant-slider-step') as HTMLElement;
+      const value0Step = stepList.children[0] as HTMLElement;
+      const value100Step = stepList.children[1] as HTMLElement;
+
+      expect(value0Step.style.left).toEqual('100%');
+      expect(value100Step.style.left).toEqual('0%');
     });
   });
 
@@ -869,6 +916,15 @@ class SliderWithValueComponent {}
 
 @Component({
   template: `
+    <nz-slider [nzMarks]="marks"></nz-slider>
+  `
+})
+class SliderWithMarksComponent {
+  marks: { [mark: number]: string } = { 100: '(100%)', 0: '(0%)' };
+}
+
+@Component({
+  template: `
     <nz-slider [nzStep]="step"></nz-slider>
   `,
   styles: [styles]
@@ -903,12 +959,14 @@ class VerticalSliderComponent {}
 
 @Component({
   template: `
-    <nz-slider nzReverse></nz-slider>
+    <nz-slider nzReverse [nzMarks]="marks"></nz-slider>
     <nz-slider nzReverse nzRange></nz-slider>
     <nz-slider nzVertical nzReverse></nz-slider>
   `
 })
-class ReverseSliderComponent {}
+class ReverseSliderComponent {
+  marks: { [mark: number]: string } = { 100: '(100%)', 0: '(0%)' };
+}
 
 @Component({
   template: `

--- a/components/slider/step.component.ts
+++ b/components/slider/step.component.ts
@@ -23,8 +23,7 @@ import { NzDisplayedStep, NzExtendedMark } from './typings';
         *ngFor="let mark of steps; trackBy: trackById"
         [class.ant-slider-dot-active]="mark.active"
         [ngStyle]="mark.style!"
-      >
-      </span>
+      ></span>
     </div>
   `
 })
@@ -35,16 +34,21 @@ export class NzSliderStepComponent implements OnChanges {
   @Input() lowerBound: number | null = null;
   @Input() upperBound: number | null = null;
   @Input() marksArray: NzExtendedMark[] = [];
+  @Input() min!: number;
+  @Input() max!: number;
   @Input() @InputBoolean() vertical = false;
   @Input() @InputBoolean() included = false;
+  @Input() reverse!: boolean;
 
   steps: NzDisplayedStep[] = [];
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.marksArray) {
+    const { marksArray, lowerBound, upperBound, reverse } = changes;
+
+    if (marksArray || reverse) {
       this.buildSteps();
     }
-    if (changes.marksArray || changes.lowerBound || changes.upperBound) {
+    if (marksArray || lowerBound || upperBound || reverse) {
       this.togglePointActive();
     }
   }
@@ -57,7 +61,13 @@ export class NzSliderStepComponent implements OnChanges {
     const orient = this.vertical ? 'bottom' : 'left';
 
     this.steps = this.marksArray.map(mark => {
-      const { value, offset, config } = mark;
+      const { value, config } = mark;
+      let offset = mark.offset;
+      const range = this.max - this.min;
+
+      if (this.reverse) {
+        offset = ((this.max - value) / range) * 100;
+      }
 
       return {
         value,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the marks and steps of sliders don't get updated when the slider get reversed. When you reverse a slider with marks, the '0' mark will be under value 100 and the '100' mark will be under value 0. The same thing happens for steps, when you have slider value 50 the '0' step doesn't show as 'active', while the '100' step does.

Issue Number: N/A


## What is the new behavior?
Now the marks get built while taking the reversed state of the slider into account. The marks also stay under the right value.

The main issue I wanted to solve here is the styling of the steps. But while testing I saw that the marks didn't do what I was expecting either, so I added the functionality that they stay under the right value. If you think this isn't what the marks should do, please tell me so that I can remove it from this PR.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
