### PR TITLE
fix(module:cascader): font color of focusd search bar

### DIFF
--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -99,8 +99,8 @@ const defaultDisplayRender = (labels: string[]) => labels.join(' / ');
         <i *ngIf="isLoading" nz-icon nzType="loading" class="ant-cascader-picker-arrow"></i>
         <span
           class="ant-cascader-picker-label"
-          [class.ant-cascader-show-search]="!!nzShowSearch"
-          [class.ant-focusd]="!!nzShowSearch && isFocused && !inputValue"
+          [class.ant-cascader-picker-show-search]="!!nzShowSearch"
+          [class.ant-cascader-picker-focused]="!!nzShowSearch && isFocused && !inputValue"
         >
           <ng-container *ngIf="!isLabelRenderTemplate; else labelTemplate">{{ labelRenderText }}</ng-container>
           <ng-template #labelTemplate>

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -352,7 +352,7 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
         this.nzSelectionChange.emit([]);
       } else {
         const { option, index } = data;
-        const shouldClose = option.isLeaf;
+        const shouldClose = option.isLeaf || this.nzChangeOnSelect;
         if (shouldClose) {
           this.delaySetMenuVisible(false);
         }

--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -23,6 +23,10 @@
     position: relative;
   }
 
+  &-show-search.ant-focusd {
+    color: @disabled-color;
+  }
+
   &-picker {
     .reset-component;
 

--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -23,10 +23,6 @@
     position: relative;
   }
 
-  &-show-search.ant-focusd {
-    color: @disabled-color;
-  }
-
   &-picker {
     .reset-component;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
when Cascader search bar is not empty and focused, the font color is pure black
Issue Number: https://github.com/NG-ZORRO/ng-zorro-antd/issues/6020


## What is the new behavior?
when Cascader search bar is not empty and focused, the font color is gray

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
