### PR TITLE
fix(module:cascader):  menu closing behavoir

### DIFF
--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -352,7 +352,7 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
         this.nzSelectionChange.emit([]);
       } else {
         const { option, index } = data;
-        const shouldClose = option.isLeaf;
+        const shouldClose = option.isLeaf || this.nzChangeOnSelect;
         if (shouldClose) {
           this.delaySetMenuVisible(false);
         }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Cascader popover is not closed after clicking a none-leaf node when using nzChangeOnSelect and hover trigger, which is very misleading.

Issue Number: https://github.com/NG-ZORRO/ng-zorro-antd/issues/6022


## What is the new behavior?
Cascader popover is closed after clicking a none-leaf node when using nzChangeOnSelect and hover trigger

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
https://react-fvmcpb-2ij3hv.stackblitz.io
Both react and vue port of Ant Design works well