### PR TITLE
fix(module:code-editor): memorize cursor position and selections

### DIFF
--- a/components/code-editor/code-editor.component.ts
+++ b/components/code-editor/code-editor.component.ts
@@ -212,7 +212,8 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
 
     if (this.nzEditorMode === 'normal') {
       if (this.modelSet) {
-        (this.editorInstance.getModel() as ITextModel).setValue(this.value);
+        const model = this.editorInstance.getModel() as ITextModel;
+        this.preservePositionAndSelections(() => model.setValue(this.value));
       } else {
         (this.editorInstance as IStandaloneCodeEditor).setModel(
           monaco.editor.createModel(this.value, (this.editorOptionCached as EditorOptions).language)
@@ -222,8 +223,10 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
     } else {
       if (this.modelSet) {
         const model = (this.editorInstance as IStandaloneDiffEditor).getModel()!;
-        model.modified.setValue(this.value);
-        model.original.setValue(this.nzOriginalText);
+        this.preservePositionAndSelections(() => {
+          model.modified.setValue(this.value);
+          model.original.setValue(this.nzOriginalText);
+        });
       } else {
         const language = (this.editorOptionCached as EditorOptions).language;
         (this.editorInstance as IStandaloneDiffEditor).setModel({
@@ -232,6 +235,30 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
         });
         this.modelSet = true;
       }
+    }
+  }
+
+  /**
+   * {@link editor.ICodeEditor}#setValue resets the cursor position to the start of the document.
+   * This helper memorizes the cursor position and selections and restores them after the given
+   * function has been called.
+   */
+  private preservePositionAndSelections(fn: () => unknown): void {
+    if (!this.editorInstance) {
+      fn();
+      return;
+    }
+
+    const position = this.editorInstance.getPosition();
+    const selections = this.editorInstance.getSelections();
+
+    fn();
+
+    if (position) {
+      this.editorInstance.setPosition(position);
+    }
+    if (selections) {
+      this.editorInstance.setSelections(selections);
     }
   }
 


### PR DESCRIPTION
Calling #setValue() on a monaco editor instance causes the mouse cursor to jump to the
beginning of the document, which is undesirable for a ControlValueAccessor implementation
which should only update the content. Also see
https://github.com/microsoft/monaco-editor/issues/1397 for more information.

Unfortunately, using #executeEdits() doesn't really work as a replacement because it will
mess with selections. Therefore we memorize and restore the cursor position before/after
setting the value. Since #setValue() also causes a selection to be lost we do the same for
those. Restoring selections may produce slightly unexpected results if the selection covers
part of the content that has been changed, but is still preferable to losing the selection
altogether.

fixes #6038

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features) (there are no working code-editor tests)
- [ ] Docs have been added / updated (for bug fixes / features) (not required)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```