### PR TITLE
fix(module:cascader): scroll active options into view

### DIFF
--- a/components/cascader/cascader-li.component.ts
+++ b/components/cascader/cascader-li.component.ts
@@ -53,9 +53,11 @@ export class NzCascaderOptionComponent {
   @Input() columnIndex!: number;
 
   @Input() expandIcon: string | TemplateRef<void> = 'right';
+  readonly nativeElement: HTMLElement;
 
   constructor(private cdr: ChangeDetectorRef, elementRef: ElementRef, renderer: Renderer2) {
     renderer.addClass(elementRef.nativeElement, 'ant-cascader-menu-item');
+    this.nativeElement = elementRef.nativeElement;
   }
 
   get optionLabel(): string {

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -427,6 +427,7 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
     }
     if (visible) {
       this.cascaderService.syncOptions();
+      this.scrollToActivatedOptions();
     }
 
     this.menuVisible = visible;
@@ -748,5 +749,17 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
   private setLocale(): void {
     this.locale = this.i18nService.getLocaleData('global');
     this.cdr.markForCheck();
+  }
+
+  private scrollToActivatedOptions(): void {
+    // scroll only until option menu view is ready
+    Promise.resolve().then(() => {
+      this.cascaderItems
+        .toArray()
+        .filter(e => e.activated)
+        .forEach(e => {
+          e.nativeElement?.scrollIntoView({ block: 'start', inline: 'nearest' });
+        });
+    });
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The menu stays at top no matter whether there are activated options.
Issue Number: #6037


## What is the new behavior?
After the cascader is selected, the menu scrolls to activated options every time it is opened.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
