### PR TITLE
fix(module:table): showPagination in ngIf when nzHideOnSinglePage

### DIFF
--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -95,7 +95,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
     </nz-spin>
     <ng-template #paginationTemplate>
       <nz-pagination
-        *ngIf="nzShowPagination && data.length"
+        *ngIf="nzShowPagination && showPagination && data.length"
         class="ant-table-pagination ant-table-pagination-right"
         [nzShowSizeChanger]="nzShowSizeChanger"
         [nzPageSizeOptions]="nzPageSizeOptions"
@@ -177,6 +177,7 @@ export class NzTableComponent<T = NzSafeAny> implements OnInit, OnDestroy, OnCha
   listOfManualColWidth: Array<string | null> = [];
   hasFixLeft = false;
   hasFixRight = false;
+  showPagination = true;
   private destroy$ = new Subject<void>();
   private loading$ = new BehaviorSubject<boolean>(false);
   private templateMode$ = new BehaviorSubject<boolean>(false);
@@ -294,9 +295,7 @@ export class NzTableComponent<T = NzSafeAny> implements OnInit, OnDestroy, OnCha
       this.nzTableDataService.updateFrontPagination(this.nzFrontPagination);
     }
     if (nzScroll) {
-      this.scrollX = (this.nzScroll && this.nzScroll.x) || null;
-      this.scrollY = (this.nzScroll && this.nzScroll.y) || null;
-      this.nzTableStyleService.setScroll(this.scrollX, this.scrollY);
+      this.setScrollOnChanges();
     }
     if (nzWidthConfig) {
       this.nzTableStyleService.setTableWidthConfig(this.nzWidthConfig);
@@ -310,6 +309,9 @@ export class NzTableComponent<T = NzSafeAny> implements OnInit, OnDestroy, OnCha
     if (nzNoResult) {
       this.nzTableStyleService.setNoResult(this.nzNoResult);
     }
+
+    this.showPagination =
+      (this.nzHideOnSinglePage && this.nzData.length > this.nzPageSize) || (this.nzData.length > 0 && !this.nzHideOnSinglePage);
   }
 
   ngAfterViewInit(): void {
@@ -332,5 +334,11 @@ export class NzTableComponent<T = NzSafeAny> implements OnInit, OnDestroy, OnCha
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private setScrollOnChanges(): void {
+    this.scrollX = (this.nzScroll && this.nzScroll.x) || null;
+    this.scrollY = (this.nzScroll && this.nzScroll.y) || null;
+    this.nzTableStyleService.setScroll(this.scrollX, this.scrollY);
   }
 }

--- a/components/table/src/testing/table.spec.ts
+++ b/components/table/src/testing/table.spec.ts
@@ -205,7 +205,7 @@ describe('nz-table', () => {
       testComponent.hideOnSinglePage = true;
       testComponent.dataSet = [{}];
       fixture.detectChanges();
-      expect(table.nativeElement.querySelector('.ant-pagination').children.length).toBe(0);
+      expect(table.nativeElement.querySelector('.ant-pagination')).toBeNull();
     });
     it('#18n', () => {
       testComponent.dataSet = [];


### PR DESCRIPTION
close NG-ZORRO#6080

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6080 


## What is the new behavior?
No remaining pagination style including vertical margin is shown after nzHideOnSinglePage.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
