### PR TITLE
fix: dropdown and autocomplete animations

### DIFF
--- a/components/auto-complete/autocomplete.component.ts
+++ b/components/auto-complete/autocomplete.component.ts
@@ -3,6 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { AnimationEvent } from '@angular/animations';
 import {
   AfterContentInit,
   AfterViewInit,
@@ -58,7 +59,8 @@ export type AutocompleteDataSource = Array<AutocompleteDataSourceItem | string |
         [ngClass]="nzOverlayClassName"
         [ngStyle]="nzOverlayStyle"
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
-        [@slideMotion]="'enter'"
+        @slideMotion
+        (@slideMotion.done)="onAnimationEvent($event)"
         [@.disabled]="noAnimation?.nzNoAnimation"
       >
         <div style="max-height: 256px; overflow-y: auto; overflow-anchor: none;">
@@ -102,6 +104,7 @@ export class NzAutocompleteComponent implements AfterContentInit, AfterViewInit,
   activeItem!: NzAutocompleteOptionComponent;
   dir: Direction = 'ltr';
   private destroy$ = new Subject<void>();
+  animationStateChange = new EventEmitter<AnimationEvent>();
 
   /**
    * Options accessor, its source may be content or dataSource
@@ -163,6 +166,10 @@ export class NzAutocompleteComponent implements AfterContentInit, AfterViewInit,
     });
 
     this.dir = this.directionality.value;
+  }
+
+  onAnimationEvent(event: AnimationEvent): void {
+    this.animationStateChange.emit(event);
   }
 
   ngAfterContentInit(): void {

--- a/components/auto-complete/autocomplete.spec.ts
+++ b/components/auto-complete/autocomplete.spec.ts
@@ -302,6 +302,7 @@ describe('auto-complete', () => {
 
       componentInstance.trigger.handleKeydown(TAB_EVENT);
       fixture.detectChanges();
+      flush();
 
       expect(input.value).not.toBe('Burns Bay Road');
 

--- a/components/dropdown/dropdown-menu.component.ts
+++ b/components/dropdown/dropdown-menu.component.ts
@@ -3,6 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { AnimationEvent } from '@angular/animations';
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import {
   AfterContentInit,
@@ -10,6 +11,7 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   Host,
   OnDestroy,
   OnInit,
@@ -48,7 +50,8 @@ export type NzPlacementType = 'bottomLeft' | 'bottomCenter' | 'bottomRight' | 't
         [class.ant-dropdown-rtl]="dir === 'rtl'"
         [ngClass]="nzOverlayClassName"
         [ngStyle]="nzOverlayStyle"
-        [@slideMotion]="'enter'"
+        @slideMotion
+        (@slideMotion.done)="onAnimationEvent($event)"
         [@.disabled]="noAnimation?.nzNoAnimation"
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         (mouseenter)="setMouseState(true)"
@@ -66,12 +69,17 @@ export class NzDropdownMenuComponent implements AfterContentInit, OnDestroy, OnI
   mouseState$ = new BehaviorSubject<boolean>(false);
   isChildSubMenuOpen$ = this.nzMenuService.isChildSubMenuOpen$;
   descendantMenuItemClick$ = this.nzMenuService.descendantMenuItemClick$;
+  animationStateChange$ = new EventEmitter<AnimationEvent>();
   nzOverlayClassName: string = '';
   nzOverlayStyle: IndexableObject = {};
   @ViewChild(TemplateRef, { static: true }) templateRef!: TemplateRef<NzSafeAny>;
 
   dir: Direction = 'ltr';
   private destroy$ = new Subject<void>();
+
+  onAnimationEvent(event: AnimationEvent): void {
+    this.animationStateChange$.emit(event);
+  }
 
   setMouseState(visible: boolean): void {
     this.mouseState$.next(visible);

--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -155,8 +155,10 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
                 this.overlayRef.outsidePointerEvents().pipe(filter((e: MouseEvent) => !this.elementRef.nativeElement.contains(e.target))),
                 this.overlayRef.keydownEvents().pipe(filter(e => e.keyCode === ESCAPE && !hasModifierKey(e)))
               )
-                .pipe(mapTo(false), takeUntil(this.destroy$))
-                .subscribe(this.overlayClose$);
+                .pipe(takeUntil(this.destroy$))
+                .subscribe(() => {
+                  this.overlayClose$.next(false);
+                });
             } else {
               /** update overlay config **/
               const overlayConfig = this.overlayRef.getConfig();
@@ -176,6 +178,15 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
             }
           }
         });
+
+      this.nzDropdownMenu!.animationStateChange$.pipe(takeUntil(this.destroy$)).subscribe(event => {
+        if (event.toState === 'void') {
+          if (this.overlayRef) {
+            this.overlayRef.dispose();
+          }
+          this.overlayRef = null;
+        }
+      });
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6018 


## What is the new behavior?
Dropdown has open animation every time which triggers it. Autocompletion has close animation after clicking outside the input.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
