### PR TITLE
refactor(module:dropdown): move nzBackDrop deprecation to v12

### DIFF
--- a/components/dropdown/dropdown.directive.spec.ts
+++ b/components/dropdown/dropdown.directive.spec.ts
@@ -82,29 +82,13 @@ describe('dropdown', () => {
     }).not.toThrowError();
   }));
 
-  describe('when nzBackdrop=false', () => {
+  describe('when nzHasBackdrop=true', () => {
     let fixture: ComponentFixture<NzTestDropdownComponent>;
 
     beforeEach(() => {
       fixture = createComponent(NzTestDropdownComponent, [], []);
-      fixture.componentInstance.backdrop = false;
+      fixture.componentInstance.backdrop = true;
     });
-
-    it('backdrop should be invisible if nzTrigger=click', fakeAsync(() => {
-      fixture.componentInstance.trigger = 'click';
-      fixture.detectChanges();
-
-      expect(() => {
-        const dropdownElement = fixture.debugElement.query(By.directive(NzDropDownDirective)).nativeElement;
-        dispatchFakeEvent(dropdownElement, 'click');
-
-        tick(1000);
-        fixture.detectChanges();
-
-        const backdrop = overlayContainerElement.querySelector('.nz-overlay-transparent-backdrop');
-        expect(backdrop).not.toBeNull();
-      }).not.toThrowError();
-    }));
 
     it('should disappear if invisible backdrop clicked if nzTrigger=click', fakeAsync(() => {
       fixture.componentInstance.trigger = 'click';
@@ -117,15 +101,14 @@ describe('dropdown', () => {
         tick(1000);
         fixture.detectChanges();
 
-        const backdrop = overlayContainerElement.querySelector('.nz-overlay-transparent-backdrop');
+        const backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop');
         expect(backdrop).not.toBeNull();
 
         dispatchFakeEvent(backdrop as Element, 'click');
         tick(1000);
         fixture.detectChanges();
 
-        const nullBackdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop');
-        expect(nullBackdrop).toBeNull();
+        expect(overlayContainerElement.querySelector('.cdk-overlay-backdrop')).toBeNull();
       }).not.toThrowError();
     }));
   });
@@ -133,6 +116,7 @@ describe('dropdown', () => {
   it('should disappear if Escape pressed', fakeAsync(() => {
     const fixture = createComponent(NzTestDropdownComponent, [], []);
     fixture.componentInstance.trigger = 'click';
+    fixture.componentInstance.backdrop = true;
     fixture.detectChanges();
 
     expect(() => {
@@ -207,10 +191,11 @@ describe('dropdown', () => {
       [nzTrigger]="trigger"
       [nzDisabled]="disabled"
       [nzPlacement]="placement"
-      [nzBackdrop]="backdrop"
+      [nzHasBackdrop]="backdrop"
       [nzOverlayClassName]="className"
       [nzOverlayStyle]="overlayStyle"
-      >Trigger
+    >
+      Trigger
     </a>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu>
@@ -222,7 +207,7 @@ describe('dropdown', () => {
   `
 })
 export class NzTestDropdownComponent {
-  backdrop = true;
+  backdrop = false;
   trigger = 'hover';
   placement = 'bottomLeft';
   disabled = false;
@@ -232,9 +217,9 @@ export class NzTestDropdownComponent {
 
 @Component({
   template: `
-    <a nz-dropdown [nzDropdownMenu]="menu" [nzClickHide]="false" [(nzVisible)]="visible" (nzVisibleChange)="triggerVisible($event)"
-      >Hover me</a
-    >
+    <a nz-dropdown [nzDropdownMenu]="menu" [nzClickHide]="false" [(nzVisible)]="visible" (nzVisibleChange)="triggerVisible($event)">
+      Hover me
+    </a>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu>
         <li nz-menu-item class="first-menu">Clicking me will not close the menu.</li>

--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -37,6 +37,7 @@ const listOfPositions = [POSITION_MAP.bottomLeft, POSITION_MAP.bottomRight, POSI
 })
 export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges, OnInit {
   static ngAcceptInputType_nzBackdrop: BooleanInput;
+  static ngAcceptInputType_nzHasBackdrop: BooleanInput;
   static ngAcceptInputType_nzClickHide: BooleanInput;
   static ngAcceptInputType_nzDisabled: BooleanInput;
   static ngAcceptInputType_nzVisible: BooleanInput;
@@ -56,10 +57,11 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
   @Input() nzTrigger: 'click' | 'hover' = 'hover';
   @Input() nzMatchWidthElement: ElementRef | null = null;
   /**
-   * @deprecated Not supported.
-   * @breaking-change 11.0.0
+   * @deprecated Not supported, use `nzHasBackDrop` instead.
+   * @breaking-change 12.0.0
    */
-  @Input() @InputBoolean() nzBackdrop = true;
+  @Input() @InputBoolean() nzBackdrop = false;
+  @Input() @InputBoolean() nzHasBackdrop = false;
   @Input() @InputBoolean() nzClickHide = true;
   @Input() @InputBoolean() nzDisabled = false;
   @Input() @InputBoolean() nzVisible = false;
@@ -144,13 +146,13 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
                 positionStrategy: this.positionStrategy,
                 minWidth: triggerWidth,
                 disposeOnNavigation: true,
-                hasBackdrop: this.nzTrigger === 'click',
-                backdropClass: this.nzBackdrop ? undefined : 'nz-overlay-transparent-backdrop',
+                hasBackdrop: (this.nzHasBackdrop || this.nzBackdrop) && this.nzTrigger === 'click',
                 scrollStrategy: this.overlay.scrollStrategies.reposition()
               });
               merge(
                 this.overlayRef.backdropClick(),
                 this.overlayRef.detachments(),
+                this.overlayRef.outsidePointerEvents().pipe(filter((e: MouseEvent) => !this.elementRef.nativeElement.contains(e.target))),
                 this.overlayRef.keydownEvents().pipe(filter(e => e.keyCode === ESCAPE && !hasModifierKey(e)))
               )
                 .pipe(mapTo(false), takeUntil(this.destroy$))
@@ -210,7 +212,7 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges,
       this.setDropdownMenuValue('nzOverlayStyle', this.nzOverlayStyle);
     }
     if (nzBackdrop) {
-      warnDeprecation('`nzBackdrop` in dropdown component will be removed in 11.0.0.');
+      warnDeprecation('`nzBackdrop` in dropdown component will be removed in 12.0.0, please use `nzHasBackdrop` instead.');
     }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
1. `nzBackDrop` will be deprecated in v12.
2. Introduce replaced input `nzHasBackDrop`.
3. Default values of both are set to false.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
