### PR TITLE
refactor(module:tabs): remove deprecated APIs for v11

### DIFF
--- a/components/tabs/tab-link.directive.ts
+++ b/components/tabs/tab-link.directive.ts
@@ -6,8 +6,6 @@
 import { Directive, Host, Optional, Self, TemplateRef } from '@angular/core';
 import { RouterLink, RouterLinkWithHref } from '@angular/router';
 
-import { warnDeprecation } from 'ng-zorro-antd/core/logger';
-
 import { TabTemplateContext } from './interfaces';
 
 /**
@@ -29,13 +27,5 @@ export class NzTabLinkTemplateDirective {
   exportAs: 'nzTabLink'
 })
 export class NzTabLinkDirective {
-  constructor(
-    @Optional() @Self() public routerLink?: RouterLink,
-    @Optional() @Self() public routerLinkWithHref?: RouterLinkWithHref,
-    @Optional() nzTabLinkTemplateDirective?: NzTabLinkTemplateDirective
-  ) {
-    if (!nzTabLinkTemplateDirective) {
-      warnDeprecation(`'a[nz-tab-link]' is deprecated. Please use 'ng-template[nzTabLink] > a[nz-tab-link]' instead.`);
-    }
-  }
+  constructor(@Optional() @Self() public routerLink?: RouterLink, @Optional() @Self() public routerLinkWithHref?: RouterLinkWithHref) {}
 }

--- a/components/tabs/tab.component.ts
+++ b/components/tabs/tab.component.ts
@@ -13,7 +13,6 @@ import {
   Input,
   OnChanges,
   OnDestroy,
-  OnInit,
   Output,
   SimpleChanges,
   TemplateRef,
@@ -48,7 +47,7 @@ export const NZ_TAB_SET = new InjectionToken<NzSafeAny>('NZ_TAB_SET');
     <ng-template #contentTemplate><ng-content></ng-content></ng-template>
   `
 })
-export class NzTabComponent implements OnChanges, OnDestroy, OnInit {
+export class NzTabComponent implements OnChanges, OnDestroy {
   static ngAcceptInputType_nzDisabled: BooleanInput;
   static ngAcceptInputType_nzClosable: BooleanInput;
   static ngAcceptInputType_nzForceRender: BooleanInput;
@@ -63,11 +62,6 @@ export class NzTabComponent implements OnChanges, OnDestroy, OnInit {
   @Output() readonly nzClick = new EventEmitter<void>();
   @Output() readonly nzContextmenu = new EventEmitter<MouseEvent>();
 
-  /**
-   * @deprecated Will be removed in 11.0.0
-   * @breaking-change 11.0.0
-   */
-  @ViewChild('tabLinkTemplate', { static: true }) tabLinkTemplate!: TemplateRef<void>;
   @ContentChild(NzTabLinkTemplateDirective, { static: false }) nzTabLinkTemplateDirective!: NzTabLinkTemplateDirective;
   @ContentChild(NzTabDirective, { static: false, read: TemplateRef }) template: TemplateRef<void> | null = null;
   @ContentChild(NzTabLinkDirective, { static: false }) linkDirective!: NzTabLinkDirective;
@@ -83,7 +77,7 @@ export class NzTabComponent implements OnChanges, OnDestroy, OnInit {
   }
 
   get label(): string | TemplateRef<NzSafeAny> {
-    return this.nzTitle || this.nzTabLinkTemplateDirective?.templateRef || this.tabLinkTemplate;
+    return this.nzTitle || this.nzTabLinkTemplateDirective?.templateRef;
   }
 
   constructor(@Inject(NZ_TAB_SET) public closestTabSet: NzSafeAny) {}
@@ -98,6 +92,4 @@ export class NzTabComponent implements OnChanges, OnDestroy, OnInit {
   ngOnDestroy(): void {
     this.stateChanges.complete();
   }
-
-  ngOnInit(): void {}
 }

--- a/components/tabs/tabset.component.ts
+++ b/components/tabs/tabset.component.ts
@@ -16,13 +16,11 @@ import {
   ContentChildren,
   EventEmitter,
   Input,
-  OnChanges,
   OnDestroy,
   OnInit,
   Optional,
   Output,
   QueryList,
-  SimpleChanges,
   TemplateRef,
   ViewChild,
   ViewEncapsulation
@@ -33,7 +31,7 @@ import { merge, Observable, of, Subject, Subscription } from 'rxjs';
 import { delay, filter, first, startWith, takeUntil } from 'rxjs/operators';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
-import { PREFIX, warnDeprecation } from 'ng-zorro-antd/core/logger';
+import { PREFIX } from 'ng-zorro-antd/core/logger';
 import { BooleanInput, NumberInput, NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 import { InputBoolean, wrapIntoObservable } from 'ng-zorro-antd/core/util';
 
@@ -151,7 +149,7 @@ let nextId = 0;
     '[class.ant-tabs-large]': `nzSize === 'large'`
   }
 })
-export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy, AfterContentInit, OnChanges {
+export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy, AfterContentInit {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 
   static ngAcceptInputType_nzHideAdd: BooleanInput;
@@ -160,11 +158,6 @@ export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy
   static ngAcceptInputType_nzLinkRouter: BooleanInput;
   static ngAcceptInputType_nzLinkExact: BooleanInput;
   static ngAcceptInputType_nzSelectedIndex: NumberInput;
-  /**
-   * @deprecated
-   * @breaking-change 11.0.0
-   */
-  static ngAcceptInputType_nzShowPagination: NumberInput;
 
   @Input()
   get nzSelectedIndex(): number | null {
@@ -193,22 +186,6 @@ export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy
   @Output() readonly nzTabListScroll = new EventEmitter<NzTabScrollEvent>();
   @Output() readonly nzClose = new EventEmitter<{ index: number }>();
   @Output() readonly nzAdd = new EventEmitter<void>();
-
-  /**
-   * @deprecated Not supported.
-   * @breaking-change 11.0.0
-   */
-  @Input() @InputBoolean() nzShowPagination = true;
-  /**
-   * @deprecated Not supported.
-   * @breaking-change 11.0.0
-   */
-  @Output() readonly nzOnNextClick = new EventEmitter<void>();
-  /**
-   * @deprecated Not supported.
-   * @breaking-change 11.0.0
-   */
-  @Output() readonly nzOnPrevClick = new EventEmitter<void>();
 
   get position(): NzTabPositionMode {
     return ['top', 'bottom'].indexOf(this.nzTabPosition) === -1 ? 'vertical' : 'horizontal';
@@ -263,13 +240,6 @@ export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy
   }
 
   ngOnInit(): void {
-    if (this.nzOnNextClick.observers.length) {
-      warnDeprecation(`(nzOnNextClick) of nz-tabset is not support, will be removed in 11.0.0`);
-    }
-    if (this.nzOnPrevClick.observers.length) {
-      warnDeprecation(`(nzOnPrevClick) of nz-tabset is not support, will be removed in 11.0.0`);
-    }
-
     this.dir = this.directionality.value;
     this.directionality.change?.pipe(takeUntil(this.destroy$)).subscribe((direction: Direction) => {
       this.dir = direction;
@@ -492,12 +462,6 @@ export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy
 
   private isLinkActive(router: Router): (link?: RouterLink | RouterLinkWithHref) => boolean {
     return (link?: RouterLink | RouterLinkWithHref) => (link ? router.isActive(link.urlTree, this.nzLinkExact) : false);
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.hasOwnProperty('nzShowPagination')) {
-      warnDeprecation(`[nzOnPrevClick] of nz-tabset is not support, will be removed in 11.0.0`);
-    }
   }
 
   private getTabContentMarginValue(): number {

--- a/schematics/ng-update/index.ts
+++ b/schematics/ng-update/index.ts
@@ -14,6 +14,9 @@ import { IconTemplateRule } from './upgrade-rules/checks/icon-template-rule';
 import { ModalTemplateRule } from './upgrade-rules/checks/modal-template-rule';
 import { SecondaryEntryPointsRule } from './upgrade-rules/checks/secondary-entry-points-rule';
 import { TableTemplateRule } from './upgrade-rules/checks/table-template-rule';
+import { TabsInputRule } from './upgrade-rules/checks/tabs-input-rule';
+import { TabsOutputRule } from './upgrade-rules/checks/tabs-output-rule';
+import { TabsTemplateRule } from './upgrade-rules/checks/tabs-template-rule';
 import { TooltipLikeTemplateRule } from './upgrade-rules/checks/tooltip-like-template-rule';
 
 const migrations: NullableDevkitMigration[] = [
@@ -27,6 +30,9 @@ const migrations: NullableDevkitMigration[] = [
   DateFnsCompatibleRule,
   FormTemplateRule,
   GridTemplateRule,
+  TabsInputRule,
+  TabsOutputRule,
+  TabsTemplateRule,
   TableTemplateRule,
   ModalTemplateRule,
   SecondaryEntryPointsRule,

--- a/schematics/ng-update/test-cases/v11/tabs-deprecated.spec.ts
+++ b/schematics/ng-update/test-cases/v11/tabs-deprecated.spec.ts
@@ -1,0 +1,106 @@
+import { getSystemPath, normalize, virtualFs } from '@angular-devkit/core';
+import { TempScopedNodeJsSyncHost } from '@angular-devkit/core/node/testing';
+import { HostTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import * as shx from 'shelljs';
+import { SchematicsTestNGConfig, SchematicsTestTsConfig } from '../config';
+
+describe('tabs migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+  let warnOutput: string[];
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', require.resolve('../../../migration.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify(SchematicsTestTsConfig));
+    writeFile('/angular.json', JSON.stringify(SchematicsTestNGConfig));
+
+    warnOutput = [];
+    runner.logger.subscribe(logEntry => {
+      if (logEntry.level === 'warn') {
+        warnOutput.push(logEntry.message);
+      }
+    });
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    shx.cd(tmpDirPath);
+
+    writeFakeAngular();
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  function writeFakeAngular(): void { writeFile('/node_modules/@angular/core/index.d.ts', ``); }
+
+  function writeFile(filePath: string, contents: string): void {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  // tslint:disable-next-line:no-any
+  async function runMigration(): Promise<any> {
+    await runner.runSchematicAsync('migration-v11', {}, tree).toPromise();
+  }
+
+  describe('nz-tab components', () => {
+
+    it('should properly report deprecated input and output', async() => {
+      writeFile('/index.ts', `
+      import {Component} from '@angular/core';
+      @Component({
+        template: \`
+          <nz-tabset (nzOnPrevClick)="mockPre()" (nzOnNextClick)="mockNext()" [nzShowPagination]="false">
+            <nz-tab nzTitle="Tab 1">
+              Content of Tab Pane 1
+            </nz-tab>
+            <nz-tab nzTitle="Tab 2">
+              Content of Tab Pane 2
+            </nz-tab>
+            <nz-tab nzTitle="Tab 3">
+              Content of Tab Pane 3
+            </nz-tab>
+          </nz-tabset>
+        \`
+      })
+      export class MyComp {
+        mockPre(): void {}
+        mockNext(): void {}
+      }`);
+      await runMigration();
+      const output = warnOutput.toString();
+      expect(output).toContain( '/index.ts@5:23 - Found deprecated output \'(nzOnPrevClick)\'. Please manually remove this output.');
+      expect(output).toContain( '/index.ts@5:51 - Found deprecated output \'(nzOnNextClick)\'. Please manually remove this output.');
+      expect(output).toContain( '/index.ts@5:80 - Found deprecated input \'[nzShowPagination]\'. Please manually remove this input.');
+    });
+
+    it('should properly report deprecated selector', async () => {
+      writeFile('/index.ts', `
+      import {Component} from '@angular/core';
+      @Component({
+        template: \`
+          <nz-tabset nzLinkRouter>
+            <nz-tab>
+              <a nz-tab-link [routerLink]="['.']">Default</a>
+            </nz-tab>
+          </nz-tabset>
+        \`
+      })
+      export class MyComp {
+      }`);
+      await runMigration();
+      const output = warnOutput.toString();
+      expect(output).toContain( '/index.ts@7:15 - Found deprecated selector \'a[nz-tab-link]\', please use \'ng-template[nzTabLink] > a[nz-tab-link]\' instead.');
+    });
+  });
+
+});

--- a/schematics/ng-update/upgrade-rules/checks/tabs-input-rule.ts
+++ b/schematics/ng-update/upgrade-rules/checks/tabs-input-rule.ts
@@ -1,0 +1,19 @@
+import { findInputsOnElementWithTag, Migration, ResolvedResource, TargetVersion, UpgradeData } from '@angular/cdk/schematics';
+
+export class TabsInputRule extends Migration<UpgradeData> {
+
+  enabled = this.targetVersion === TargetVersion.V11;
+
+  visitTemplate(template: ResolvedResource): void {
+
+    findInputsOnElementWithTag(template.content, 'nzShowPagination', ['nz-tabset'])
+      .forEach(offset => {
+        this.failures.push({
+          filePath: template.filePath,
+          position: template.getCharacterAndLineOfPosition(offset),
+          message: `Found deprecated input '[nzShowPagination]'. Please manually remove this input.`
+        });
+      })
+
+  }
+}

--- a/schematics/ng-update/upgrade-rules/checks/tabs-output-rule.ts
+++ b/schematics/ng-update/upgrade-rules/checks/tabs-output-rule.ts
@@ -1,0 +1,33 @@
+import {
+  findOutputsOnElementWithTag,
+  Migration,
+  ResolvedResource,
+  TargetVersion,
+  UpgradeData
+} from '@angular/cdk/schematics';
+
+export class TabsOutputRule extends Migration<UpgradeData> {
+
+  enabled = this.targetVersion === TargetVersion.V11;
+
+  visitTemplate(template: ResolvedResource): void {
+
+    findOutputsOnElementWithTag(template.content, 'nzOnNextClick', ['nz-tabset'])
+      .forEach(offset => {
+        this.failures.push({
+          filePath: template.filePath,
+          position: template.getCharacterAndLineOfPosition(offset),
+          message: `Found deprecated output '(nzOnNextClick)'. Please manually remove this output.`
+        });
+      })
+
+    findOutputsOnElementWithTag(template.content, 'nzOnPrevClick', ['nz-tabset'])
+      .forEach(offset => {
+        this.failures.push({
+          filePath: template.filePath,
+          position: template.getCharacterAndLineOfPosition(offset),
+          message: `Found deprecated output '(nzOnPrevClick)'. Please manually remove this output.`
+        });
+      })
+  }
+}

--- a/schematics/ng-update/upgrade-rules/checks/tabs-template-rule.ts
+++ b/schematics/ng-update/upgrade-rules/checks/tabs-template-rule.ts
@@ -1,0 +1,20 @@
+import { Migration, ResolvedResource, TargetVersion, UpgradeData } from '@angular/cdk/schematics';
+import { findElementWithoutStructuralDirective } from '../../../utils/ng-update/elements';
+
+export class TabsTemplateRule extends Migration<UpgradeData> {
+
+  enabled = this.targetVersion === TargetVersion.V11;
+
+  visitTemplate(template: ResolvedResource): void {
+
+    findElementWithoutStructuralDirective(template.content, 'a', 'nzTabLink', 'nz-tab-link')
+      .forEach(offset => {
+        this.failures.push({
+          filePath: template.filePath,
+          position: template.getCharacterAndLineOfPosition(offset),
+          message: `Found deprecated selector 'a[nz-tab-link]', please use 'ng-template[nzTabLink] > a[nz-tab-link]' instead.`
+        });
+      })
+
+  }
+}

--- a/schematics/utils/ng-update/elements.ts
+++ b/schematics/utils/ng-update/elements.ts
@@ -4,6 +4,29 @@ const hasClassName = (node: DefaultTreeElement, className: string) => {
   return node.attrs?.find?.(attr => attr.name === 'class' && attr.value.indexOf(className) !== -1)
 };
 
+export function findElementWithoutStructuralDirective(html: string, tagName: string, directiveName: string, attr: string): number[] {
+  const document = parseFragment(html, {sourceCodeLocationInfo: true}) as DefaultTreeDocument;
+  const elements: DefaultTreeElement[] = [];
+
+  const visitNodes = nodes => {
+    nodes.forEach(node => {
+      if (node.childNodes && !(node.tagName === 'ng-template' && !!node.attrs.find(a => a.name!.toLowerCase() === directiveName.toLowerCase()))) {
+        visitNodes(node.childNodes);
+      }
+
+      if (node.tagName?.toLowerCase() === tagName.toLowerCase() && !!node.attrs.find(a => a.name!.toLowerCase() === attr.toLowerCase()) && !node.attrs.find(a => a.name!.toLowerCase() === `*${directiveName}`.toLowerCase())) {
+        elements.push(node);
+      }
+    });
+  };
+
+  visitNodes(document.childNodes);
+
+  return elements
+    .filter(e => e?.sourceCodeLocation?.startTag)
+    .map(element => element.sourceCodeLocation.startTag.startOffset)
+}
+
 export function findElementWithTag(html: string, tagName: string): number[] {
   const document = parseFragment(html, {sourceCodeLocationInfo: true}) as DefaultTreeDocument;
   const elements: DefaultTreeElement[] = [];


### PR DESCRIPTION
BREAKING CHANGES:
- `[nzShowPagination]` input has been removed, please remove it manually.
- `(nzOnPrevClick)` output has been removed, please remove it manually.
- `(nzOnNextClick)` output has been removed, please remove it manually.
- `a[nz-tab-link]` selector has been removed, please use `ng-template[nzTabLink] > a[nz-tab-link]` instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
