### PR TITLE
feat(module:graph): export nz-graph-zoom as nzGraphZoom

### DIFF
--- a/components/graph/graph-zoom.directive.ts
+++ b/components/graph/graph-zoom.directive.ts
@@ -14,7 +14,8 @@ import { NzZoomTransform, RelativePositionInfo } from './interface';
 Selection.bind('transition', d3Transition);
 
 @Directive({
-  selector: '[nz-graph-zoom]'
+  selector: '[nz-graph-zoom]',
+  exportAs: 'nzGraphZoom'
 })
 export class NzGraphZoomDirective implements OnDestroy, AfterViewInit {
   @Input() nzZoom?: number;


### PR DESCRIPTION
This allows a usage from the template without being forced to go through
a ViewChild query:

```
<nz-graph nz-graph-zoom #zoomController="nzGraphZoom" …></nz-graph>
<button (click)="zoomController?.fitCenter()" …></button>
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

To access the zoom directive we need to use a ViewChild query.

## What is the new behavior?

The directive is exported.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```