### PR TITLE
feat(schematics): make ng-add schematics chainable

### DIFF
--- a/schematics/ng-add/index.spec.ts
+++ b/schematics/ng-add/index.spec.ts
@@ -1,6 +1,7 @@
 import { normalize } from '@angular-devkit/core';
 import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import { Tree } from '@angular-devkit/schematics';
+import { NodePackageName } from '@angular-devkit/schematics/tasks/package-manager/options';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { addModuleImportToRootModule, getProjectFromWorkspace, getProjectTargetOptions } from '@angular/cdk/schematics';
 import { getFileContent } from '@schematics/angular/utility/test';
@@ -24,7 +25,9 @@ describe('ng-add schematic', () => {
     const dependencies = packageJson.dependencies;
 
     expect(dependencies['ng-zorro-antd']).toBeDefined();
-    expect(runner.tasks.some(task => task.name === 'run-schematic')).toBe(true);
+
+    console.log(runner.tasks.map(e => e.name));
+    expect(runner.tasks.some(task => task.name === NodePackageName)).toBe(true);
   });
 
   it('should add hammerjs to package.json', async () => {
@@ -43,6 +46,12 @@ describe('ng-add schematic', () => {
     const dependencies = packageJson.dependencies;
 
     expect(dependencies['ng-zorro-antd']).toBeUndefined();
+  });
+
+  it('should skip install dependency package', async () => {
+    await runner.runSchematicAsync('ng-add', {skipInstall: true}, appTree).toPromise();
+
+    expect(runner.tasks.some(task => task.name === NodePackageName)).toBe(false);
   });
 
   it('should add hammerjs import to project main file', async () => {

--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -1,6 +1,5 @@
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
-import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
-import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schematics/tasks';
+import { chain, Rule, schematic, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { getProjectFromWorkspace } from '@angular/cdk/schematics';
 import { getWorkspace } from '@schematics/angular/utility/workspace';
 import { addPackageToPackageJson } from '../utils/package-config';
@@ -8,25 +7,31 @@ import { getProjectStyle } from '../utils/project-style';
 import { hammerjsVersion, zorroVersion } from '../utils/version-names';
 import { Schema } from './schema';
 
-export default function(options: Schema): Rule {
-  return async (host: Tree, context: SchematicContext) => {
-    if (!options.skipPackageJson) {
-      addPackageToPackageJson(host, 'ng-zorro-antd', zorroVersion);
-      if (options.gestures) {
-        addPackageToPackageJson(host, 'hammerjs', hammerjsVersion);
+export default function (options: Schema): Rule {
+  return chain([
+    (host: Tree) => {
+      if (!options.skipPackageJson) {
+        addPackageToPackageJson(host, 'ng-zorro-antd', zorroVersion);
+        if (options.gestures) {
+          addPackageToPackageJson(host, 'hammerjs', hammerjsVersion);
+        }
       }
+    },
+    schematic('ng-add-setup-project', options),
+    async (host: Tree) => {
+      if (options.template) {
+        const workspace = await getWorkspace(host);
+        const project = getProjectFromWorkspace(workspace, options.project);
+        const style = getProjectStyle(project);
+
+        return schematic(options.template, {...options, style: style});
+      }
+    },
+    (_: Tree, context: SchematicContext) => {
+      if (options.skipInstall) {
+        return;
+      }
+      context.addTask(new NodePackageInstallTask());
     }
-
-    const installTaskId = context.addTask(new NodePackageInstallTask());
-
-    context.addTask(new RunSchematicTask('ng-add-setup-project', options), [installTaskId]);
-
-    if (options.template) {
-      const workspace = await getWorkspace(host);
-      const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, options.project);
-      const style = getProjectStyle(project);
-      context.addTask(new RunSchematicTask(options.template, {...options, style: style}));
-    }
-
-  };
+  ]);
 }

--- a/schematics/ng-add/schema.json
+++ b/schematics/ng-add/schema.json
@@ -16,6 +16,11 @@
       "default": false,
       "description": "Do not add ng-zorro-antd dependencies to package.json (e.g., --skipPackageJson)"
     },
+    "skipInstall": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not install dependency package."
+    },
     "dynamicIcon": {
       "type": "boolean",
       "default": false,

--- a/schematics/ng-add/schema.ts
+++ b/schematics/ng-add/schema.ts
@@ -48,6 +48,7 @@ export interface Schema {
   project?: string;
   /** Whether to skip package.json install. */
   skipPackageJson?: boolean;
+  skipInstall?: boolean;
   dynamicIcon?: boolean;
   theme?: boolean;
   gestures?: boolean;

--- a/schematics/ng-generate/side-menu/index.spec.ts
+++ b/schematics/ng-generate/side-menu/index.spec.ts
@@ -33,7 +33,7 @@ describe('side-menu schematic', () => {
   });
 
   it('should set the style preprocessor correctly', async () => {
-    const tree = await runner.runSchematicAsync('sidemenu', {style: Style.Less}, appTree).toPromise();
+    const tree = await runner.runSchematicAsync('sidemenu', { style: Style.Less }, appTree).toPromise();
     const files = tree.files;
     const appContent = getFileContent(tree, '/projects/ng-zorro/src/app/app.component.ts');
     const welcomeContent = getFileContent(tree, '/projects/ng-zorro/src/app/pages/welcome/welcome.component.ts');
@@ -51,21 +51,37 @@ describe('side-menu schematic', () => {
 
   it('should fall back to the @schematics/angular:component option value', async () => {
     appTree = await createTestApp(runner, {style: Style.Less});
-    await runner.runSchematicAsync(
+    const tree = await runner.runSchematicAsync(
       'ng-add',
       {template: 'sidemenu'},
       appTree).toPromise();
 
-    // tslint:disable-next-line:no-any
-    const sideMenuSchematic = runner.tasks.find(task => task.name === 'run-schematic' && (task.options as any).name  && (task.options as any).name! === 'sidemenu');
-    expect(sideMenuSchematic).toBeDefined();
+    expect(tree.files).toEqual(
+      jasmine.arrayContaining([
+        '/projects/ng-zorro/src/app/app.component.less',
+        '/projects/ng-zorro/src/app/pages/welcome/welcome.component.less'
+      ])
+    );
+  });
 
-    // tslint:disable-next-line:no-any
-    const sideMenuSchematicOption = (sideMenuSchematic.options as any).options;
-    expect(sideMenuSchematicOption).toBeDefined();
-    expect(sideMenuSchematicOption.template).toBe('sidemenu');
-    expect(sideMenuSchematicOption.style).toBe(Style.Less);
+  it('should fall back to the @schematics/angular:component option value', async () => {
+    appTree = await createTestApp(runner, {inlineStyle: true});
+    const tree = await runner.runSchematicAsync(
+      'ng-add',
+      {template: 'sidemenu'},
+      appTree).toPromise();
 
+    expect(tree.files).not.toEqual('/projects/ng-zorro/src/app/pages/welcome/welcome.component.css');
+  });
+
+  it('should fall back to the @schematics/angular:component option value', async () => {
+    appTree = await createTestApp(runner, {inlineTemplate: true});
+    const tree = await runner.runSchematicAsync(
+      'ng-add',
+      {template: 'sidemenu'},
+      appTree).toPromise();
+
+    expect(tree.files).not.toEqual('/projects/ng-zorro/src/app/pages/welcome/welcome.component.html');
   });
 
   it('should set the prefix correctly', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
目前 ng-add Schematic 内使用 `RunSchematicTask` 来执行内部 Schematic，由于外部无法获取 `RunSchematicTask` 的 TaskId 导致其无法与其他（外部） Schematic 进行串联
Issue Number: N/A


## What is the new behavior?
使用 `chain` 和 `schematic` 方法重写 ng-add Schematic 逻辑，现在可以很好的与其他 Schematic 进行串联

```typescript
export function mySchematic(options: NgNewSchema): Rule {
  return chain([
    schematic('ng-new', options),
    externalSchematic('ng-zorro-antd', 'ng-add', {
      project: options.name,
      locale: 'zh_CN',
      dynamicIcon: true,
      theme: false,
      template: 'blank',
      // 先跳过安装，等后续步骤完成后再统一安装
      skipInstall: true,
    } as ZorroSchema),
    (_: Tree, context: SchematicContext) => {
      // 等 ng-zorro-antd 初始化完成后，做点其他什么事情
      context.addTask(new NodePackageInstallTask());
    }
  ]);
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
同时添加 `skipInstall` 参数，必要的时候可以不执行 `npm install` 而由调用方选择合适的时机进行 `npm install` 任务