### PR TITLE
fix(module:select): change order for clear and arrow

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -94,17 +94,17 @@ export type NzSelectSizeType = 'large' | 'default' | 'small';
       (deleteItem)="onItemDelete($event)"
       (keydown)="onKeyDown($event)"
     ></nz-select-top-control>
-    <nz-select-clear
-      *ngIf="nzAllowClear && !nzDisabled && listOfValue.length"
-      [clearIcon]="nzClearIcon"
-      (clear)="onClearSelection()"
-    ></nz-select-clear>
     <nz-select-arrow
       *ngIf="nzShowArrow"
       [loading]="nzLoading"
       [search]="nzOpen && nzShowSearch"
       [suffixIcon]="nzSuffixIcon"
     ></nz-select-arrow>
+    <nz-select-clear
+      *ngIf="nzAllowClear && !nzDisabled && listOfValue.length"
+      [clearIcon]="nzClearIcon"
+      (clear)="onClearSelection()"
+    ></nz-select-clear>
     <ng-template
       cdkConnectedOverlay
       nzConnectedOverlay


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
can clear content when clear and arrow icon overlap in nz-select component

Issue Number: N/A
#5989


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information
