### PR TITLE
fix(schematics): fix `add-icon-assets`  schema path

### DIFF
--- a/schematics/collection.json
+++ b/schematics/collection.json
@@ -31,7 +31,7 @@
     "add-icon-assets": {
       "description": "Add icon assets into CLI config",
       "factory": "./ng-add/setup-project/add-icon-assets#addIconToAssets",
-      "schema": "./ng-generate/boot-page/schema.json",
+      "schema": "./ng-generate/blank/schema.json",
       "aliases": ["fix-icon"]
     },
     "component": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`collection.json` 中的 `add-icon-assets` 配置引用了一个错误的 `schema` 路径，导致如果其他 schematics 扩展了 ng-zorro-antd 的 schematics 后，执行 `ng g --help` 命令会由于配置不正确而报错

经查找，应该在某次提交 NG-ZORRO/ng-zorro-antd@69072de8a83e3a5beb264eb628fd18e7c97dfdc4 中，原有的 `schema.json` 被移除了

简单起见，复用了 `blank` schematic 目录中的 `schema.json` （因为 git 的 diff 结果也是显示 boot-page 被重命名为 blank 了）

## What is the new behavior?
正确引用相应的 `schema.json`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
`add-icon-assets` 实际上已经被移动到 setup-project 中作为项目初始化的一个 `Rule` 来用了，是否可以考虑废弃该公共 schematic