### PR TITLE
fix(module:slider): wrong handle position when value is zero

### DIFF
--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -526,7 +526,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
   }
 
   private formatValue(value: NzSliderValue | null): NzSliderValue {
-    if (!value) {
+    if (value !== 0 && !value) {
       return this.nzRange ? [this.nzMin, this.nzMax] : this.nzMin;
     } else if (assertValueValid(value, this.nzRange)) {
       return isValueRange(value)


### PR DESCRIPTION
If you'll set nzMin=-10 and nzMax =10 for example and ngModel value will be 0,
position of slider won't be at the middle of slider as expected,
it will be on the start (-10).

fixes #6400

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you'll set nzMin=-10 and nzMax =10 for example and ngModel value will be 0, position of slider won't be at the middle of slider as expected, it will be on the start (-10).

Issue Number: #6400 


## What is the new behavior?
The handle will go to the proper position.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
