### PR TITLE
fix(module:grid): `nzGutter` support string type

### DIFF
--- a/components/grid/doc/index.en-US.md
+++ b/components/grid/doc/index.en-US.md
@@ -89,7 +89,7 @@ import { NzGridModule } from 'ng-zorro-antd/grid';
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
 | `[nzAlign]` | the vertical alignment | `'top'\|'middle'\|'bottom'` | - |
-| `[nzGutter]` | spacing between grids, could be a number or a object like `{ xs: 8, sm: 16, md: 24}`. or you can use array to make horizontal and vertical spacing work at the same time `[horizontal, vertical]` | `number\|object\|[number, number]\|[object, object]` | `0` |
+| `[nzGutter]` | spacing between grids, could be a number or a object like `{ xs: 8, sm: 16, md: 24}`. or you can use array to make horizontal and vertical spacing work at the same time `[horizontal, vertical]` | `string\|number\|object\|[number, number]\|[object, object]` | `0` |
 | `[nzJustify]` | horizontal arrangement | `'start'\|'end'\|'center'\|'space-around'\|'space-between'` | - |
 
 ### [nz-col]

--- a/components/grid/doc/index.zh-CN.md
+++ b/components/grid/doc/index.zh-CN.md
@@ -88,7 +88,7 @@ import { NzGridModule } from 'ng-zorro-antd/grid';
 | 成员 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | `[nzAlign]` | 垂直对齐方式 | `'top' \| 'middle' \| 'bottom'` | - |
-| `[nzGutter]` | 栅格间隔，可以写成像素值或支持响应式的对象写法来设置水平间隔 `{ xs: 8, sm: 16, md: 24}`。或者使用数组形式同时设置 `[水平间距, 垂直间距]`。 | `number\|object\|[number, number]\|[object, object]` | - |
+| `[nzGutter]` | 栅格间隔，可以写成像素值或支持响应式的对象写法来设置水平间隔 `{ xs: 8, sm: 16, md: 24}`。或者使用数组形式同时设置 `[水平间距, 垂直间距]`。 | `string\|number\|object\|[number, number]\|[object, object]` | - |
 | `[nzJustify]` | 水平排列方式 | `'start' \| 'end' \| 'center' \| 'space-around' \| 'space-between'` | - |
 
 ### [nz-col]

--- a/components/grid/grid.spec.ts
+++ b/components/grid/grid.spec.ts
@@ -50,6 +50,14 @@ describe('grid', () => {
       expect(rowElement.style.cssText).toBe('margin-left: -8px; margin-right: -8px;');
       expect(colElement.style.cssText).toBe('padding-left: 8px; padding-right: 8px;');
     });
+    it('should gutter string work', () => {
+      expect(rowElement.style.cssText).toBe('');
+      expect(colElement.style.cssText).toBe('');
+      testBed.component.gutter = '16';
+      testBed.fixture.detectChanges();
+      expect(rowElement.style.cssText).toBe('margin-left: -8px; margin-right: -8px;');
+      expect(colElement.style.cssText).toBe('padding-left: 8px; padding-right: 8px;');
+    });
     it('should gutter number array work', () => {
       testBed.component.gutter = [16, 16];
       testBed.fixture.detectChanges();
@@ -202,7 +210,13 @@ describe('grid', () => {
   `
 })
 export class TestGridComponent {
-  gutter: number | null | [number, number] | { [key: string]: number } | [{ [key: string]: number }, { [key: string]: number }] = null;
+  gutter:
+    | string
+    | number
+    | null
+    | [number, number]
+    | { [key: string]: number }
+    | [{ [key: string]: number }, { [key: string]: number }] = null;
   flex: string | null = null;
   justify: string | null = null;
   align: string | null = null;

--- a/components/grid/row.directive.ts
+++ b/components/grid/row.directive.ts
@@ -21,6 +21,7 @@ import {
 } from '@angular/core';
 import { gridResponsiveMap, NzBreakpointKey, NzBreakpointService } from 'ng-zorro-antd/core/services';
 import { IndexableObject } from 'ng-zorro-antd/core/types';
+import { toNumber } from 'ng-zorro-antd/core/util';
 import { ReplaySubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -45,7 +46,7 @@ export type NzAlign = 'top' | 'middle' | 'bottom';
 export class NzRowDirective implements OnInit, OnChanges, AfterViewInit, OnDestroy {
   @Input() nzAlign: NzAlign | null = null;
   @Input() nzJustify: NzJustify | null = null;
-  @Input() nzGutter: number | IndexableObject | [number, number] | [IndexableObject, IndexableObject] | null = null;
+  @Input() nzGutter: string | number | IndexableObject | [number, number] | [IndexableObject, IndexableObject] | null = null;
 
   readonly actualGutter$ = new ReplaySubject<[number | null, number | null]>(1);
 
@@ -66,7 +67,7 @@ export class NzRowDirective implements OnInit, OnChanges, AfterViewInit, OnDestr
           }
         });
       } else {
-        results[index] = g || null;
+        results[index] = toNumber(g, null);
       }
     });
     return results;

--- a/components/grid/row.directive.ts
+++ b/components/grid/row.directive.ts
@@ -21,7 +21,6 @@ import {
 } from '@angular/core';
 import { gridResponsiveMap, NzBreakpointKey, NzBreakpointService } from 'ng-zorro-antd/core/services';
 import { IndexableObject } from 'ng-zorro-antd/core/types';
-import { toNumber } from 'ng-zorro-antd/core/util';
 import { ReplaySubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -67,7 +66,7 @@ export class NzRowDirective implements OnInit, OnChanges, AfterViewInit, OnDestr
           }
         });
       } else {
-        results[index] = toNumber(g, null);
+        results[index] = Number(g) || null;
       }
     });
     return results;


### PR DESCRIPTION
The following code style is better in `strictTemplates` mode:

```html
<nz-row [nzGutter]="16">
```

better:

```html
<nz-row nzGutter="16">
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
