### PR TITLE
修复切换Tab时下面的指针切换动画卡顿的问题

### DIFF
--- a/components/tabs/style/position.less
+++ b/components/tabs/style/position.less
@@ -23,7 +23,7 @@
 
         &-animated {
           transition: width @animation-duration-slow, left @animation-duration-slow,
-            right @animation-duration-slow;
+            right @animation-duration-slow, transform @animation-duration-slow;
         }
       }
 

--- a/components/tabs/tabs-ink-bar.directive.ts
+++ b/components/tabs/tabs-ink-bar.directive.ts
@@ -42,7 +42,7 @@ export class NzTabsInkBarDirective {
     if (this.position === 'horizontal') {
       inkBar.style.top = '';
       inkBar.style.height = '';
-      inkBar.style.left = this.getLeftPosition(element);
+      inkBar.style.transform = `translateX(${this.getLeftPosition(element)})`;
       inkBar.style.width = this.getElementWidth(element);
     } else {
       inkBar.style.left = '';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✅] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [✅] Tests for the changes have been added (for bug fixes / features)
- [✅] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✅] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

当前 ant-tabs-ink-bar 使用 left 进行定位，点击后定位改变会导致重绘和回流，会导致卡顿。

Issue Number: N/A


## What is the new behavior?

替换成 transform: translateX 避免重绘和回流，优化视觉效果，特别是在移动端上面，在iOS中，如果开启了省电模式，动画会出现掉帧、卡顿的情况

## Does this PR introduce a breaking change?
```
[ ] Yes
[✅] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
