### PR TITLE
docs(module:notification): use more reasonable content for duration demo

### DIFF
--- a/components/notification/demo/duration.ts
+++ b/components/notification/demo/duration.ts
@@ -11,7 +11,7 @@ export class NzDemoNotificationDurationComponent {
   createBasicNotification(): void {
     this.notification.blank(
       'Notification Title',
-      'I will never close automatically. I will be close automatically. I will never close automatically.',
+      'I will never close automatically. This is a purposely very very long description that has many many characters and words.',
       { nzDuration: 0 }
     );
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The notification content in the demo-duration does not seem reasonable:

```
I will never close automatically. I will be close automatically. I will never close automatically.
```

Issue Number: N/A


## What is the new behavior?

Replace the notification content of demo-duration with the same as the react version

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
