### PR TITLE
feat(module:picker&select): block global scroll to overlay component(#6029)

### DIFF
--- a/components/core/util/public-api.ts
+++ b/components/core/util/public-api.ts
@@ -19,3 +19,4 @@ export * from './measure-scrollbar';
 export * from './ensure-in-bounds';
 export * from './tick';
 export * from './observable';
+export * from './scroll-trategy';

--- a/components/core/util/scroll-trategy.ts
+++ b/components/core/util/scroll-trategy.ts
@@ -1,0 +1,13 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
+import { InjectionToken } from '@angular/core';
+
+export const NzScrollStrategyToken = new InjectionToken<ScrollStrategy>('NzScrollStrategyToken');
+
+export function ScrollStrategyProviderFactory(overlay: Overlay): ScrollStrategy {
+  return overlay.scrollStrategies.block();
+}

--- a/components/date-picker/picker.component.ts
+++ b/components/date-picker/picker.component.ts
@@ -10,6 +10,8 @@ import {
   ConnectedOverlayPositionChange,
   ConnectionPositionPair,
   HorizontalConnectionPos,
+  Overlay,
+  ScrollStrategy,
   VerticalConnectionPos
 } from '@angular/cdk/overlay';
 import { Platform } from '@angular/cdk/platform';
@@ -41,6 +43,7 @@ import { NzResizeObserver } from 'ng-zorro-antd/core/resize-observers';
 import { Direction } from '@angular/cdk/bidi';
 import { CandyDate, CompatibleValue, wrongSortOrder } from 'ng-zorro-antd/core/time';
 import { NgStyleInterface, NzSafeAny } from 'ng-zorro-antd/core/types';
+import { NzScrollStrategyToken, ScrollStrategyProviderFactory } from 'ng-zorro-antd/core/util';
 import { DateHelperService } from 'ng-zorro-antd/i18n';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -151,6 +154,7 @@ import { PREFIX_CLASS } from './util';
       [cdkConnectedOverlayOpen]="realOpenState"
       [cdkConnectedOverlayPositions]="overlayPositions"
       [cdkConnectedOverlayTransformOriginOn]="'.ant-picker-wrapper'"
+      [cdkConnectedOverlayScrollStrategy]="scrollStrategy"
       (positionChange)="onPositionChange($event)"
       (detach)="onOverlayDetach()"
       (overlayKeydown)="onOverlayKeydown($event)"
@@ -160,7 +164,14 @@ import { PREFIX_CLASS } from './util';
     </ng-template>
   `,
   animations: [slideMotion],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: NzScrollStrategyToken,
+      deps: [Overlay],
+      useFactory: ScrollStrategyProviderFactory
+    }
+  ]
 })
 export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
   @Input() noAnimation: boolean = false;
@@ -199,6 +210,7 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   inputValue!: NzSafeAny;
   activeBarStyle: object = {};
   overlayOpen: boolean = false; // Available when "open"=undefined
+  scrollStrategy: ScrollStrategy;
   overlayPositions: ConnectionPositionPair[] = [
     {
       offsetX: -12,
@@ -248,10 +260,13 @@ export class NzPickerComponent implements OnInit, AfterViewInit, OnChanges, OnDe
     private platform: Platform,
     private nzResizeObserver: NzResizeObserver,
     public datePickerService: DatePickerService,
+    @Inject(NzScrollStrategyToken) scrollStrategyFactory: ScrollStrategy,
     @Inject(DOCUMENT) doc: NzSafeAny
   ) {
     this.document = doc;
     this.origin = new CdkOverlayOrigin(this.elementRef);
+
+    this.scrollStrategy = scrollStrategyFactory;
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6029


## What is the new behavior?

 block global scroll when overlay component(e.g date picker, select and time picker) open!   

  I researched that [material v7](https://v7.material.angular.io/components/select/overview) had the same problem ,but it uses this PR strategy in latest [material](https://material.angular.io/components/select/overview)
 
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
