### PR TITLE
fix(module:modal): fix the click behavior of the modal wrap (#5938)

### DIFF
--- a/components/modal/modal-container.ts
+++ b/components/modal/modal-container.ts
@@ -80,7 +80,7 @@ export class BaseModalContainerComponent extends BasePortalOutlet implements OnD
   }
 
   onContainerClick(e: MouseEvent): void {
-    if (e.target === e.currentTarget && !this.mouseDown && this.showMask && this.maskClosable) {
+    if (e.target === e.currentTarget && !this.mouseDown && this.maskClosable) {
       this.containerClick.emit();
     }
   }

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -444,41 +444,67 @@ describe('NzModal', () => {
     flush();
   }));
 
-  it(
-    'should not close when clicking on the modal wrap and ' + 'nzMaskClosable or nzMask is false',
-    fakeAsync(() => {
-      const modalRef = modalService.create({
-        nzContent: TestWithModalContentComponent,
-        nzMaskClosable: false
-      });
+  it('should not close when clicking on the modal wrap and nzMaskClosable is false', fakeAsync(() => {
+    const modalRef = modalService.create({
+      nzContent: TestWithModalContentComponent,
+      nzMaskClosable: false
+    });
 
-      fixture.detectChanges();
+    fixture.detectChanges();
 
-      const modalWrap = overlayContainerElement.querySelector('nz-modal-container') as HTMLElement;
-      dispatchMouseEvent(modalWrap, 'mousedown');
-      fixture.detectChanges();
-      dispatchMouseEvent(modalWrap, 'mouseup');
-      flush();
-      expect(overlayContainerElement.querySelector('nz-modal-container')).toBeTruthy();
+    const modalWrap = overlayContainerElement.querySelector('nz-modal-container') as HTMLElement;
+    dispatchMouseEvent(modalWrap, 'mousedown');
+    fixture.detectChanges();
+    dispatchMouseEvent(modalWrap, 'mouseup');
+    flush();
+    modalWrap.click();
+    fixture.detectChanges();
+    flush();
+    expect(overlayContainerElement.querySelector('nz-modal-container')).toBeTruthy();
 
-      modalRef.updateConfig({
-        nzMaskClosable: true,
-        nzMask: false
-      });
+    modalRef.updateConfig({
+      nzMaskClosable: false,
+      nzMask: false
+    });
 
-      fixture.detectChanges();
+    fixture.detectChanges();
 
-      dispatchMouseEvent(modalWrap, 'mousedown');
-      fixture.detectChanges();
-      dispatchMouseEvent(modalWrap, 'mouseup');
-      flush();
-      expect(overlayContainerElement.querySelector('nz-modal-container')).toBeTruthy();
+    dispatchMouseEvent(modalWrap, 'mousedown');
+    fixture.detectChanges();
+    dispatchMouseEvent(modalWrap, 'mouseup');
+    flush();
+    modalWrap.click();
+    fixture.detectChanges();
+    flush();
+    expect(overlayContainerElement.querySelector('nz-modal-container')).toBeTruthy();
 
-      modalRef.close();
-      fixture.detectChanges();
-      flush();
-    })
-  );
+    modalRef.close();
+    fixture.detectChanges();
+    flush();
+  }));
+
+  it('should close when clicking on the modal wrap with nzMaskClosable is true and nzMask is false', fakeAsync(() => {
+    const modalRef = modalService.create({
+      nzContent: TestWithModalContentComponent,
+      nzMask: false
+    });
+
+    fixture.detectChanges();
+
+    const modalWrap = overlayContainerElement.querySelector('nz-modal-container') as HTMLElement;
+    dispatchMouseEvent(modalWrap, 'mousedown');
+    fixture.detectChanges();
+    dispatchMouseEvent(modalWrap, 'mouseup');
+    flush();
+    modalWrap.click();
+    fixture.detectChanges();
+    flush();
+    expect(overlayContainerElement.querySelector('nz-modal-container')).toBeFalsy();
+
+    modalRef.close();
+    fixture.detectChanges();
+    flush();
+  }));
 
   it('should notify the observers if all open modals have finished closing', fakeAsync(() => {
     const ref1 = modalService.create({


### PR DESCRIPTION
closes #5938 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5938 


## What is the new behavior?

when `nzMask` set to false, click on the mask will close modal

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
