### PR TITLE
fix(module:tabs): make remove icon of nz-tab-link clickable

### DIFF
--- a/components/tabs/style/patch.less
+++ b/components/tabs/style/patch.less
@@ -14,6 +14,10 @@ a[nz-tab-link] {
     background-color: transparent;
     content: '';
   }
+
+  ~ * {
+    position: relative;
+  }
 }
 
 nz-tabset,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
PR #5708 为了增大 `nz-tab-link` 的可点击区域而增加的 `::before` 元素的蒙层会覆盖整个 Tab 的点击区域，导致关闭按钮无法点击。
Issue Number: N/A


## What is the new behavior?
通过为关闭按钮添加 `position: relative` 属性来激活其 `z-index`，使得位于 `[nz-tab-link]::before` 之后的 `ant-tabs-tab-remove` 默认拥有更高的层级，以避免被覆盖。

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
