### PR TITLE
fix(module:date-picker): time picker panel not scroll at first time

### DIFF
--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -1072,7 +1072,7 @@ describe('NzDatePickerComponent', () => {
   }
 
   function triggerInputBlur(): void {
-    dispatchFakeEvent(getPickerInput(fixture.debugElement), 'blur');
+    dispatchFakeEvent(getPickerInput(fixture.debugElement), 'focusout');
   }
 });
 

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -78,7 +78,6 @@ export type NzDatePickerSizeType = 'large' | 'default' | 'small';
       [nzId]="nzId"
     >
       <date-range-popup
-        *ngIf="picker.realOpenState || nzInline"
         [isRange]="isRange"
         [inline]="nzInline"
         [defaultPickerValue]="nzDefaultPickerValue"
@@ -210,7 +209,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Cont
 
     // Default value
     this.datePickerService.isRange = this.isRange;
-    this.datePickerService.initValue();
+    this.datePickerService.initValue(true);
     this.datePickerService.emitValue$.pipe(takeUntil(this.destroyed$)).subscribe(_ => {
       const value = this.datePickerService.value;
       this.datePickerService.initialValue = cloneDate(value);

--- a/components/date-picker/date-picker.service.ts
+++ b/components/date-picker/date-picker.service.ts
@@ -10,7 +10,7 @@ import { CompatibleDate, NzDateMode, RangePartType } from './standard-types';
 
 @Injectable()
 export class DatePickerService implements OnDestroy {
-  initialValue?: CompatibleValue;
+  initialValue!: CompatibleValue;
   value!: CompatibleValue;
   activeDate?: CompatibleValue;
   activeInput: RangePartType = 'left';
@@ -21,12 +21,11 @@ export class DatePickerService implements OnDestroy {
   emitValue$ = new Subject<void>();
   inputPartChange$ = new Subject<RangePartType>();
 
-  initValue(): void {
-    if (this.isRange) {
-      this.initialValue = [];
-    } else {
-      this.initialValue = null;
+  initValue(reset: boolean = false): void {
+    if (reset) {
+      this.initialValue = this.isRange ? [] : null;
     }
+
     this.setValue(this.initialValue);
   }
 

--- a/components/date-picker/month-picker.component.spec.ts
+++ b/components/date-picker/month-picker.component.spec.ts
@@ -56,7 +56,7 @@ describe('NzMonthPickerComponent', () => {
       openPickerByClickTrigger();
       expect(getPickerContainer()).not.toBeNull();
 
-      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'blur');
+      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'focusout');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -205,7 +205,7 @@ describe('NzMonthPickerComponent', () => {
       openPickerByClickTrigger();
       expect(nzOnOpenChange).toHaveBeenCalledWith(true);
 
-      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'blur');
+      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'focusout');
       fixture.detectChanges();
       flush();
       expect(nzOnOpenChange).toHaveBeenCalledWith(false);

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -1017,9 +1017,9 @@ describe('NzRangePickerComponent', () => {
 
   function triggerInputBlur(part: 'left' | 'right' = 'left'): void {
     if (part === 'left') {
-      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'blur');
+      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'focusout');
     } else {
-      dispatchFakeEvent(getRangePickerRightInput(fixture.debugElement), 'blur');
+      dispatchFakeEvent(getRangePickerRightInput(fixture.debugElement), 'focusout');
     }
   }
 });

--- a/components/date-picker/year-picker.component.spec.ts
+++ b/components/date-picker/year-picker.component.spec.ts
@@ -51,7 +51,7 @@ describe('NzYearPickerComponent', () => {
       openPickerByClickTrigger();
       expect(getPickerContainer()).not.toBeNull();
 
-      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'blur');
+      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'focusout');
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
@@ -197,7 +197,7 @@ describe('NzYearPickerComponent', () => {
       openPickerByClickTrigger();
       expect(nzOnOpenChange).toHaveBeenCalledWith(true);
 
-      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'blur');
+      dispatchFakeEvent(getPickerInput(fixture.debugElement), 'focusout');
       fixture.detectChanges();
       flush();
       expect(nzOnOpenChange).toHaveBeenCalledWith(false);


### PR DESCRIPTION
`blur` event has not the `relatedTarget` in IE11, use `focusout` instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
