### PR TITLE
fix(module:select): allow using arrow buttons on empty list

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -394,14 +394,14 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, OnDestro
         e.preventDefault();
         if (this.nzOpen) {
           const preIndex = activatedIndex > 0 ? activatedIndex - 1 : listOfFilteredOptionNotDisabled.length - 1;
-          this.activatedValue = listOfFilteredOptionNotDisabled[preIndex].nzValue;
+          this.activatedValue = listOfFilteredOptionNotDisabled[preIndex]?.nzValue;
         }
         break;
       case DOWN_ARROW:
         e.preventDefault();
         if (this.nzOpen) {
           const nextIndex = activatedIndex < listOfFilteredOptionNotDisabled.length - 1 ? activatedIndex + 1 : 0;
-          this.activatedValue = listOfFilteredOptionNotDisabled[nextIndex].nzValue;
+          this.activatedValue = listOfFilteredOptionNotDisabled[nextIndex]?.nzValue;
         } else {
           this.setOpenState(true);
         }

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -434,6 +434,26 @@ describe('select', () => {
         expect(document.querySelectorAll('nz-option-item.ant-select-item-option-selected').length).toBe(0);
       });
     }));
+
+    it('should allow keydown up arrow and down arrow on empty list', fakeAsync(() => {
+      const flushChanges = () => {
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
+      };
+      component.listOfOption = [];
+      component.value = null;
+      component.nzOpen = true;
+      flushChanges();
+      const inputElement = selectElement.querySelector('input')!;
+      dispatchKeyboardEvent(inputElement, 'keydown', UP_ARROW, inputElement);
+      flushChanges();
+      dispatchKeyboardEvent(inputElement, 'keydown', DOWN_ARROW, inputElement);
+      flushChanges();
+      dispatchKeyboardEvent(inputElement, 'keydown', ENTER, inputElement);
+      flushChanges();
+      expect(component.valueChange).not.toHaveBeenCalled();
+    }));
   });
   describe('multiple template mode', () => {
     let testBed: ComponentBed<TestSelectTemplateMultipleComponent>;


### PR DESCRIPTION
Prevent the error Cannot read property 'nzValue' of undefined

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Using arrow button on empty list will throw an error "Cannot read property 'nzValue' of undefined"

Issue Number: N/A


## What is the new behavior?
Select component will not throw the error

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
