### PR TITLE
refactor(module:modal, drawer): remove deprecated APIs for v12

### DIFF
--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -10,7 +10,6 @@ import { Overlay, OverlayConfig, OverlayKeyboardDispatcher, OverlayRef } from '@
 import { CdkPortalOutlet, ComponentPortal, TemplatePortal } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
 import {
-  AfterContentInit,
   AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -37,7 +36,6 @@ import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
-import { warnDeprecation } from 'ng-zorro-antd/core/logger';
 import { BooleanInput, NgStyleInterface, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, toCssPixel } from 'ng-zorro-antd/core/util';
 
@@ -84,7 +82,9 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
                 [class.ant-drawer-header-no-title]="!nzTitle"
               >
                 <div *ngIf="nzTitle" class="ant-drawer-title">
-                  <ng-container *nzStringTemplateOutlet="nzTitle"><div [innerHTML]="nzTitle"></div></ng-container>
+                  <ng-container *nzStringTemplateOutlet="nzTitle">
+                    <div [innerHTML]="nzTitle"></div>
+                  </ng-container>
                 </div>
                 <button
                   *ngIf="nzClosable"
@@ -110,10 +110,11 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
                     <ng-template [ngTemplateOutlet]="contentFromContentChild"></ng-template>
                   </ng-container>
                 </ng-template>
-                <ng-content *ngIf="!(nzContent || contentFromContentChild)"></ng-content>
               </div>
               <div *ngIf="nzFooter" class="ant-drawer-footer">
-                <ng-container *nzStringTemplateOutlet="nzFooter"><div [innerHTML]="nzFooter"></div></ng-container>
+                <ng-container *nzStringTemplateOutlet="nzFooter">
+                  <div [innerHTML]="nzFooter"></div>
+                </ng-container>
               </div>
             </div>
           </div>
@@ -126,7 +127,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
 })
 export class NzDrawerComponent<T = NzSafeAny, R = NzSafeAny, D = NzSafeAny>
   extends NzDrawerRef<T, R>
-  implements OnInit, OnDestroy, AfterViewInit, OnChanges, AfterContentInit, NzDrawerOptionsOfComponent
+  implements OnInit, OnDestroy, AfterViewInit, OnChanges, NzDrawerOptionsOfComponent
 {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   static ngAcceptInputType_nzClosable: BooleanInput;
@@ -291,14 +292,6 @@ export class NzDrawerComponent<T = NzSafeAny, R = NzSafeAny, D = NzSafeAny>
     setTimeout(() => {
       this.nzOnViewInit.emit();
     });
-  }
-
-  ngAfterContentInit(): void {
-    if (!(this.contentFromContentChild || this.nzContent)) {
-      warnDeprecation(
-        'Usage `<ng-content></ng-content>` is deprecated, which will be removed in 12.0.0. Please instead use `<ng-template nzDrawerContent></ng-template>` to declare the content of the drawer.'
-      );
-    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/components/modal/modal.component.ts
+++ b/components/modal/modal.component.ts
@@ -16,12 +16,10 @@ import {
   SimpleChanges,
   TemplateRef,
   Type,
-  ViewChild,
   ViewContainerRef
 } from '@angular/core';
 
 import { NzButtonType } from 'ng-zorro-antd/button';
-import { warnDeprecation } from 'ng-zorro-antd/core/logger';
 import { BooleanInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 import { Observable, Subject } from 'rxjs';
@@ -39,11 +37,7 @@ import { getConfigFromComponent } from './utils';
 @Component({
   selector: 'nz-modal',
   exportAs: 'nzModal',
-  template: `
-    <ng-template>
-      <ng-content></ng-content>
-    </ng-template>
-  `,
+  template: ``,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NzModalComponent<T = NzSafeAny, R = NzSafeAny> implements OnChanges, NzModalLegacyAPI<T, R>, OnDestroy {
@@ -106,8 +100,6 @@ export class NzModalComponent<T = NzSafeAny, R = NzSafeAny> implements OnChanges
   @Output() readonly nzAfterOpen = new EventEmitter<void>();
   @Output() readonly nzAfterClose = new EventEmitter<R>();
   @Output() readonly nzVisibleChange = new EventEmitter<boolean>();
-
-  @ViewChild(TemplateRef, { static: true }) contentTemplateRef!: TemplateRef<{}>;
 
   @ContentChild(NzModalTitleDirective, { static: true, read: TemplateRef })
   set modalTitle(value: TemplateRef<NzSafeAny>) {
@@ -230,14 +222,7 @@ export class NzModalComponent<T = NzSafeAny, R = NzSafeAny> implements OnChanges
   private getConfig(): ModalOptions {
     const componentConfig = getConfigFromComponent(this);
     componentConfig.nzViewContainerRef = this.viewContainerRef;
-    if (!this.nzContent && !this.contentFromContentChild) {
-      componentConfig.nzContent = this.contentTemplateRef;
-      warnDeprecation(
-        'Usage `<ng-content></ng-content>` is deprecated, which will be removed in 12.0.0. Please instead use `<ng-template nzModalContent></ng-template>` to declare the content of the modal.'
-      );
-    } else {
-      componentConfig.nzContent = this.nzContent || this.contentFromContentChild;
-    }
+    componentConfig.nzContent = this.nzContent || this.contentFromContentChild;
     return componentConfig;
   }
 

--- a/components/modal/utils.ts
+++ b/components/modal/utils.ts
@@ -26,7 +26,7 @@ export function getValueWithConfig<T>(
  * Assign the params into the content component instance.
  *
  * @deprecated Should use dependency injection to get the params for user
- * @breaking-change 12.0.0
+ * @breaking-change 13.0.0
  */
 export function setContentInstanceParams<T>(instance: T, params: Partial<T> | undefined): void {
   Object.assign(instance, params);


### PR DESCRIPTION
BREAKING CHANGES:
- Modal
  * usage of `ng-content` has been removed, please use `<ng-template nzModalContent></ng-template>` instead.
- Drawer
  * usage of `ng-content` has been removed, please use `<ng-template nzDrawerContent></ng-template>` instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
