### PR TITLE
refactor(module:tree-view): remove deprecated APIs for v12

### DIFF
--- a/components/tree-view/tree-virtual-scroll-view.ts
+++ b/components/tree-view/tree-virtual-scroll-view.ts
@@ -5,16 +5,7 @@
 
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { CdkTree, CdkTreeNodeOutletContext } from '@angular/cdk/tree';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnChanges,
-  SimpleChanges,
-  ViewChild,
-  ViewEncapsulation
-} from '@angular/core';
-import { warnDeprecation } from 'ng-zorro-antd/core/logger';
+import { ChangeDetectionStrategy, Component, Input, ViewChild, ViewEncapsulation } from '@angular/core';
 
 import { NzTreeVirtualNodeData } from './node';
 import { NzTreeNodeOutletDirective } from './outlet';
@@ -30,7 +21,7 @@ const DEFAULT_SIZE = 28;
     <div class="ant-tree-list">
       <cdk-virtual-scroll-viewport
         class="ant-tree-list-holder"
-        [itemSize]="itemSize"
+        [itemSize]="nzItemSize"
         [minBufferPx]="nzMinBufferPx"
         [maxBufferPx]="nzMaxBufferPx"
       >
@@ -54,17 +45,9 @@ const DEFAULT_SIZE = 28;
     '[class.ant-tree-rtl]': `dir === 'rtl'`
   }
 })
-export class NzTreeVirtualScrollViewComponent<T> extends NzTreeView<T> implements OnChanges {
-  itemSize = DEFAULT_SIZE;
-
+export class NzTreeVirtualScrollViewComponent<T> extends NzTreeView<T> {
   @ViewChild(NzTreeNodeOutletDirective, { static: true }) readonly nodeOutlet!: NzTreeNodeOutletDirective;
   @ViewChild(CdkVirtualScrollViewport, { static: true }) readonly virtualScrollViewport!: CdkVirtualScrollViewport;
-
-  /**
-   * @deprecated use `nzItemSize` instead
-   * @breaking-change 12.0.0
-   */
-  @Input() nzNodeWidth = DEFAULT_SIZE;
 
   @Input() nzItemSize = DEFAULT_SIZE;
   @Input() nzMinBufferPx = DEFAULT_SIZE * 5;
@@ -89,18 +72,5 @@ export class NzTreeVirtualScrollViewComponent<T> extends NzTreeView<T> implement
       context,
       nodeDef: node
     };
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    const { nzNodeWidth, nzItemSize } = changes;
-    if (nzNodeWidth) {
-      warnDeprecation(
-        '`nzNodeWidth` in nz-tree-virtual-scroll-view will be removed in 12.0.0, please use `nzItemSize` instead.'
-      );
-      this.itemSize = nzNodeWidth.currentValue;
-    }
-    if (nzItemSize) {
-      this.itemSize = nzItemSize.currentValue;
-    }
   }
 }

--- a/schematics/ng-update/data/input-names.ts
+++ b/schematics/ng-update/data/input-names.ts
@@ -359,5 +359,19 @@ export const inputNames: VersionChanges<InputNameUpgradeData> = {
         }
       ]
     }
+  ],
+  [ TargetVersion.V12 ]: [
+    {
+      pr     : 'https://github.com/NG-ZORRO/ng-zorro-antd/pull/6754',
+      changes: [
+        {
+          replace    : 'nzNodeWidth',
+          replaceWith: 'nzItemSize',
+          limitedTo  : {
+            elements: ['nz-tree-virtual-scroll-view']
+          }
+        }
+      ]
+    }
   ]
 };


### PR DESCRIPTION
BREAKING CHANGES:
- `[nzNodeWidth]` has been removed, please use `[nzItemSize]` instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
