### PR TITLE
fix(module:cascader): add nzClear functionality to cascader

### DIFF
--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -474,6 +474,7 @@ export class NzCascaderComponent implements NzCascaderComponentAsSource, OnInit,
     this.inputValue = '';
     this.setMenuVisible(false);
     this.cascaderService.clear();
+    this.nzClear.emit();
   }
 
   getSubmitValue(): NzSafeAny[] {

--- a/components/cascader/cascader.service.ts
+++ b/components/cascader/cascader.service.ts
@@ -335,7 +335,6 @@ export class NzCascaderService implements OnDestroy {
     this.selectedOptions = [];
     this.activatedOptions = [];
     this.dropBehindColumns(0);
-    this.prepareEmitValue();
     this.$redraw.next();
     this.$optionSelected.next(null);
   }

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -386,9 +386,11 @@ describe('cascader', () => {
       flush();
       expect(testComponent.values!.length).toBe(3);
       fixture.detectChanges();
+      spyOn(testComponent, 'onClear');
       cascader.nativeElement.querySelector('.ant-cascader-picker-clear').click();
       fixture.detectChanges();
       expect(testComponent.values!.length).toBe(0);
+      expect(testComponent.onClear).toHaveBeenCalled();
     }));
 
     it('should clear value work 2', fakeAsync(() => {
@@ -398,9 +400,11 @@ describe('cascader', () => {
       flush();
       expect(testComponent.values!.length).toBe(3);
       fixture.detectChanges();
+      spyOn(testComponent, 'onClear');
       testComponent.cascader.clearSelection();
       fixture.detectChanges();
       expect(testComponent.values!.length).toBe(0);
+      expect(testComponent.onClear).toHaveBeenCalled();
     }));
 
     it('should autofocus work', () => {
@@ -2030,6 +2034,7 @@ const options5: any[] = []; // eslint-disable-line @typescript-eslint/no-explici
       (ngModelChange)="onValueChanges($event)"
       (nzVisibleChange)="onVisibleChange($event)"
       (nzSelect)="onSelect($event)"
+      (nzClear)="onClear()"
     ></nz-cascader>
 
     <ng-template #renderTpl let-labels="labels" let-selectedOptions="selectedOptions">
@@ -2087,6 +2092,7 @@ export class NzDemoCascaderDefaultComponent {
   }
 
   onSelect(_d: { option: NzCascaderOption; index: number }): void {}
+  onClear(): void {}
 }
 
 @Component({


### PR DESCRIPTION
Add the missing nzClear emit to the clearSelection method on the cascader component.
Extend the cascader e2e tests to ensure that the event emitter works as expected.

fix #6751

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The nzClear event emitter would not emit when the cascader value was cleared as the implementation was missing.

Issue Number: #6751 


## What is the new behavior?
When the clearSelection method is executed on the cascader component, the nzClear event emitter will now emit to inform any cascader component consumers.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Used .spyOn and .toHaveBeenCalled to test the event emitter in the e2e spec for the cascader file.
Tests are passing.