### PR TITLE
fix(pagination): add cdr check while page index change

### DIFF
--- a/components/pagination/pagination.component.ts
+++ b/components/pagination/pagination.component.ts
@@ -132,6 +132,7 @@ export class NzPaginationComponent implements OnInit, OnDestroy, OnChanges {
     if (validIndex !== this.nzPageIndex && !this.nzDisabled) {
       this.nzPageIndex = validIndex;
       this.nzPageIndexChange.emit(this.nzPageIndex);
+      this.cdr.markForCheck();
     }
   }
 

--- a/components/pagination/pagination.component.ts
+++ b/components/pagination/pagination.component.ts
@@ -132,7 +132,6 @@ export class NzPaginationComponent implements OnInit, OnDestroy, OnChanges {
     if (validIndex !== this.nzPageIndex && !this.nzDisabled) {
       this.nzPageIndex = validIndex;
       this.nzPageIndexChange.emit(this.nzPageIndex);
-      this.cdr.markForCheck();
     }
   }
 
@@ -148,7 +147,10 @@ export class NzPaginationComponent implements OnInit, OnDestroy, OnChanges {
   onTotalChange(total: number): void {
     const lastIndex = this.getLastIndex(total, this.nzPageSize);
     if (this.nzPageIndex > lastIndex) {
-      Promise.resolve().then(() => this.onPageIndexChange(lastIndex));
+      Promise.resolve().then(() => {
+        this.onPageIndexChange(lastIndex);
+        this.cdr.markForCheck();
+      });
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Can't trigger page index change while the nzPageIndexChange is not set due to the Zone refresh strategy

Issue Number: 6661
https://github.com/NG-ZORRO/ng-zorro-antd/issues/6661

## What is the new behavior?
Trigger change after emit the output function

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
