### PR TITLE
feat(module:date-picker): date-picker allow multiple formats

### DIFF
--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -259,6 +259,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
   private isCustomPlaceHolder: boolean = false;
   private isCustomFormat: boolean = false;
   private showTime: SupportTimeOptions | boolean = false;
+  private matchingFormat: string = '';
 
   // --- Common API
   @Input() @InputBoolean() nzAllowClear: boolean = true;
@@ -274,7 +275,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
   @Input() nzPopupStyle: object = POPUP_STYLE_PATCH;
   @Input() nzDropdownClassName?: string;
   @Input() nzSize: NzDatePickerSizeType = 'default';
-  @Input() nzFormat!: string;
+  @Input() nzFormat!: string | string[];
   @Input() nzDateRender?: TemplateRef<NzSafeAny> | string | FunctionProp<TemplateRef<Date> | string>;
   @Input() nzDisabledTime?: DisabledTimeFn;
   @Input() nzRenderExtraFooter?: TemplateRef<NzSafeAny> | string | FunctionProp<TemplateRef<NzSafeAny> | string>;
@@ -379,6 +380,14 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
       this.focus();
       this.updateInputWidthAndArrowLeft();
     });
+  }
+
+  setDefaultMatchingFormat() {
+    if (Array.isArray(this.nzFormat)) {
+      this.matchingFormat = this.nzFormat[0];
+    } else {
+      this.matchingFormat = this.nzFormat;
+    }
   }
 
   updateInputWidthAndArrowLeft(): void {
@@ -524,7 +533,11 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
   }
 
   formatValue(value: CandyDate): string {
-    return this.dateHelper.format(value && (value as CandyDate).nativeDate, this.nzFormat);
+    this.setDefaultMatchingFormat();
+    return this.dateHelper.format(
+      value && (value as CandyDate).nativeDate,
+      this.matchingFormat != '' ? this.matchingFormat : (this.nzFormat as string)
+    );
   }
 
   onInputChange(value: string, isEnter: boolean = false): void {
@@ -553,13 +566,25 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
   }
 
   private checkValidDate(value: string): CandyDate | null {
-    const date = new CandyDate(this.dateHelper.parseDate(value, this.nzFormat));
-
-    if (!date.isValid() || value !== this.dateHelper.format(date.nativeDate, this.nzFormat)) {
-      return null;
+    var validDate = new CandyDate(this.dateHelper.parseDate(value, this.matchingFormat));
+    if (Array.isArray(this.nzFormat)) {
+      this.nzFormat.forEach(x => {
+        const date = new CandyDate(this.dateHelper.parseDate(value, x));
+        if (date.isValid() && value === this.dateHelper.format(validDate.nativeDate, x)) {
+          this.matchingFormat = x;
+          validDate = date;
+        }
+      });
+    } else {
+      validDate = new CandyDate(this.dateHelper.parseDate(value, this.nzFormat));
+      this.matchingFormat = this.nzFormat;
     }
-
-    return date;
+    if (validDate.isValid()) {
+      if (value === this.dateHelper.format(validDate.nativeDate, this.matchingFormat)) {
+        return validDate;
+      }
+    }
+    return null;
   }
 
   getPlaceholder(partType?: RangePartType): string {

--- a/components/date-picker/demo/format.ts
+++ b/components/date-picker/demo/format.ts
@@ -7,7 +7,10 @@ import { Component } from '@angular/core';
     <br />
     <nz-date-picker nzMode="month" [nzFormat]="monthFormat"></nz-date-picker>
     <br />
+    <nz-date-picker [nzFormat]="dateFormatList"></nz-date-picker>
+    <br />
     <nz-range-picker [nzFormat]="dateFormat"></nz-range-picker>
+    <nz-range-picker [nzFormat]="dateFormatList"></nz-range-picker>
   `,
   styles: [
     `
@@ -21,4 +24,5 @@ import { Component } from '@angular/core';
 export class NzDemoDatePickerFormatComponent {
   dateFormat = 'yyyy/MM/dd';
   monthFormat = 'yyyy/MM';
+  dateFormatList = ['yyyy/MM/dd', 'yyyy/MM/d'];
 }

--- a/components/date-picker/doc/index.en-US.md
+++ b/components/date-picker/doc/index.en-US.md
@@ -41,7 +41,7 @@ The following APIs are shared by nz-date-picker, nz-range-picker.
 | `[nzDisabled]` | determine whether the nz-date-picker is disabled | `boolean` | `false` | - |
 | `[nzDisabledDate]` | specify the date that cannot be selected | `(current: Date) => boolean` | - | - |
 | `[nzDropdownClassName]` | to customize the className of the popup calendar  | `string` | - | - |
-| `[nzFormat]` | to set the date format, see `nzFormat special instructions` | `string` | - |
+| `[nzFormat]` | to set the date format, see `nzFormat special instructions` | `string \| string[]` | - |
 | `[nzInputReadOnly]` | set the readonly attribute of the input tag (avoids virtual keyboard on touch devices) | `boolean` | `false` | - |
 | `[nzLocale]` | localization configuration | `object` | [default](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) | - |
 | `[nzMode]` | Set picker mode | `'date'` \| `'week'` \| `'month'` \| `'year'` | `'date'` |

--- a/components/date-picker/doc/index.zh-CN.md
+++ b/components/date-picker/doc/index.zh-CN.md
@@ -41,7 +41,7 @@ registerLocaleData(zh);
 | `[nzDisabled]` | 禁用 | `boolean` | `false` | - |
 | `[nzDisabledDate]` | 不可选择的日期 | `(current: Date) => boolean` | - | - |
 | `[nzDropdownClassName]` | 额外的弹出日历 className | `string` | - | - |
-| `[nzFormat]` | 展示的日期格式，见`nzFormat特别说明` | `string` | - |
+| `[nzFormat]` | 展示的日期格式，见`nzFormat特别说明` | `string \| string[]` | - |
 | `[nzInputReadOnly]` | 为 input 标签设置只读属性（避免在移动设备上触发小键盘） | `boolean` | `false` | - |
 | `[nzLocale]` | 国际化配置 | `object` | [默认配置](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) | - |
 | `[nzMode]` | 选择模式 | `'date'` \| `'week'` \| `'month'` \| `'year'` | `'date'` |

--- a/components/i18n/date-helper.service.ts
+++ b/components/i18n/date-helper.service.ts
@@ -6,7 +6,7 @@
 import { formatDate } from '@angular/common';
 import { Inject, Injectable, Injector, Optional } from '@angular/core';
 
-import { format as fnsFormat, getISOWeek as fnsGetISOWeek, parse as fnsParse } from 'date-fns';
+import { format as fnsFormat, getISOWeek as fnsGetISOWeek, isMatch, parse as fnsParse } from 'date-fns';
 
 import { WeekDayIndex, ɵNgTimeParser } from 'ng-zorro-antd/core/time';
 
@@ -34,8 +34,8 @@ export abstract class DateHelperService {
 
   abstract getISOWeek(date: Date): number;
   abstract getFirstDayOfWeek(): WeekDayIndex;
-  abstract format(date: Date | null, formatStr: string): string;
-  abstract parseDate(text: string, formatStr?: string): Date;
+  abstract format(date: Date | null, formatStr: string | string[]): string;
+  abstract parseDate(text: string, formatStr?: string | string[]): Date;
   abstract parseTime(text: string, formatStr?: string): Date | undefined;
 }
 
@@ -66,8 +66,13 @@ export class DateHelperByDateFns extends DateHelperService {
    * @param date Date
    * @param formatStr format string
    */
-  format(date: Date, formatStr: string): string {
-    return date ? fnsFormat(date, formatStr, { locale: this.i18n.getDateLocale() }) : '';
+  format(date: Date, formatStr: string | string[]): string {
+    if (Array.isArray(formatStr)) {
+      formatStr.forEach(x => {
+        if (isMatch(date.toString(), x)) formatStr = x;
+      });
+    }
+    return date ? fnsFormat(date, formatStr as string, { locale: this.i18n.getDateLocale() }) : '';
   }
 
   parseDate(text: string, formatStr: string): Date {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
You can only set one date format with [nzFormat] in datePickers and rangePicker.

Issue Number: #6488


## What is the new behavior?
You can set multipe date formats with [nzFormat] in datePickers and rangePickers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
