### PR TITLE
fix(module:icon): resolve memory leak

### DIFF
--- a/components/icon/icon.service.ts
+++ b/components/icon/icon.service.ts
@@ -5,9 +5,9 @@
 
 import { DOCUMENT } from '@angular/common';
 import { HttpBackend } from '@angular/common/http';
-import { Inject, Injectable, InjectionToken, Optional, RendererFactory2, Self } from '@angular/core';
+import { Inject, Injectable, InjectionToken, OnDestroy, Optional, RendererFactory2, Self } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 
 import { IconDefinition, IconService } from '@ant-design/icons-angular';
 
@@ -31,10 +31,18 @@ export const DEFAULT_TWOTONE_COLOR = '#1890ff';
 @Injectable({
   providedIn: 'root'
 })
-export class NzIconService extends IconService {
+export class NzIconService extends IconService implements OnDestroy {
   configUpdated$ = new Subject<void>();
 
   private iconfontCache = new Set<string>();
+  private subscription: Subscription | null = null;
+
+  ngOnDestroy(): void {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+      this.subscription = null;
+    }
+  }
 
   normalizeSvgElement(svg: SVGElement): void {
     if (!svg.getAttribute('viewBox')) {
@@ -81,7 +89,7 @@ export class NzIconService extends IconService {
   }
 
   private onConfigChange(): void {
-    this.nzConfigService.getConfigChangeEventForComponent('icon').subscribe(() => {
+    this.subscription = this.nzConfigService.getConfigChangeEventForComponent('icon').subscribe(() => {
       this.configDefaultTwotoneColor();
       this.configDefaultTheme();
       this.configUpdated$.next();


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```

## What is the current behavior?

I've noticed the `NzIconService` cannot be GC'd since it subscribes `configUpdated$` which is a subject and keeps subscribers in its `observers` property until it's teardowned. The creates a memory leak for server-side rendered application since the `NzIconService` is created and destroyed there per each HTTP request.

![image](https://user-images.githubusercontent.com/7337691/125209380-07003c00-e2a1-11eb-85ca-428f001b81d3.png)



## What is the new behavior?

The `NzIconService` is GC'd successfully.


## Does this PR introduce a breaking change?
```
[x] No
```