### PR TITLE
fix(module:drawer): trigger change detection only if there are `nzOnViewInit` listeners

### DIFF
--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -288,9 +288,13 @@ export class NzDrawerComponent<T = NzSafeAny, R = NzSafeAny, D = NzSafeAny>
 
   ngAfterViewInit(): void {
     this.attachBodyContent();
-    setTimeout(() => {
-      this.nzOnViewInit.emit();
-    });
+    // The `setTimeout` triggers change detection. There's no sense to schedule the DOM timer if anyone is
+    // listening to the `nzOnViewInit` event inside the template, for instance `<nz-drawer (nzOnViewInit)="...">`.
+    if (this.nzOnViewInit.observers.length) {
+      setTimeout(() => {
+        this.nzOnViewInit.emit();
+      });
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```

## What is the current behavior?

The drawer component schedules the DOM timer which causes Angular to run the change detection even if there're no `nzOnViewInit` listeners. This sometimes causes frame drops if the composite thread is busy doing layout stuff but can't delay that timer until next  message loop tick.


## What is the new behavior?

It won't schedule the timer and trigger `tick()` until there're `nzOnViewInit` listeners.


## Does this PR introduce a breaking change?
```
[x] No
```