### PR TITLE
fix(module:code-editor): re-enter the Angular zone only if the value has been changed

### DIFF
--- a/components/code-editor/code-editor.component.ts
+++ b/components/code-editor/code-editor.component.ts
@@ -271,9 +271,7 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
     ) as ITextModel;
 
     model.onDidChangeContent(() => {
-      this.ngZone.run(() => {
-        this.emitValue(model.getValue());
-      });
+      this.emitValue(model.getValue());
     });
   }
 
@@ -285,7 +283,11 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
     }
 
     this.value = value;
-    this.onChange(value);
+    // We're re-entering the Angular zone only if the value has been changed since there's a `return` expression previously.
+    // This won't cause "dead" change detections (basically when the `tick()` has been run, but there's nothing to update).
+    this.ngZone.run(() => {
+      this.onChange(value);
+    });
   }
 
   private updateOptionToMonaco(): void {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```

## What is the current behavior?

Currently, it's running `tick()` whenever the `onDidChangeContent` callback is invoked, but there's an `if` condition which checks if the value has been changed and does nothing if **not**.


## What is the new behavior?
The `nz-code-editor` will run `tick()` only if the value has been changed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```