### PR TITLE
fix(module:breadcrumb): do not re-enter the Angular zone when calling `navigate`

### DIFF
--- a/components/breadcrumb/breadcrumb.component.ts
+++ b/components/breadcrumb/breadcrumb.component.ts
@@ -11,7 +11,6 @@ import {
   ElementRef,
   Injector,
   Input,
-  NgZone,
   OnDestroy,
   OnInit,
   Optional,
@@ -63,7 +62,6 @@ export class NzBreadCrumbComponent implements OnInit, OnDestroy {
 
   constructor(
     private injector: Injector,
-    private ngZone: NgZone,
     private cdr: ChangeDetectorRef,
     private elementRef: ElementRef,
     private renderer: Renderer2,
@@ -94,8 +92,7 @@ export class NzBreadCrumbComponent implements OnInit, OnDestroy {
 
   navigate(url: string, e: MouseEvent): void {
     e.preventDefault();
-
-    this.ngZone.run(() => this.injector.get(Router).navigateByUrl(url).then()).then();
+    this.injector.get(Router).navigateByUrl(url);
   }
 
   private registerRouterChange(): void {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```

## What is the current behavior?

Currently, the `navigate` method re-enters the Angular zone by calling `ngZone.run`. The `navigate` method is a `click` event handler, template event listeners are added within the Angular zone hence there's no need to re-enter it.

Each `ngZone.run` invocation triggers zone's `onInvoke` lifecycle hook which runs `checkStable()` and might trigger the change detection (considering the number of tasks in the current message loop tick).


## What is the new behavior?

The Angular's zone is not re-entered when the `navigate()` is called.

## Does this PR introduce a breaking change?
```
[x] No
```