### PR TITLE
fix(module:core): resolve memory leak

### DIFF
--- a/components/core/services/resize.ts
+++ b/components/core/services/resize.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Injectable, NgZone, Renderer2, RendererFactory2 } from '@angular/core';
+import { Injectable, NgZone, OnDestroy, Renderer2, RendererFactory2 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { auditTime, finalize } from 'rxjs/operators';
 
@@ -12,7 +12,7 @@ const NOOP = (): void => {};
 @Injectable({
   providedIn: 'root'
 })
-export class NzResizeService {
+export class NzResizeService implements OnDestroy {
   private readonly resizeSource$ = new Subject<void>();
 
   private listeners = 0;
@@ -29,6 +29,12 @@ export class NzResizeService {
 
   constructor(private ngZone: NgZone, private rendererFactory2: RendererFactory2) {
     this.renderer = this.rendererFactory2.createRenderer(null, null);
+  }
+
+  ngOnDestroy(): void {
+    // Caretaker note: the `handler` is an instance property (it's not defined on the class prototype).
+    // The `handler` captures `this` and prevents the `NzResizeService` from being GC'd.
+    this.handler = NOOP;
   }
 
   subscribe(): Observable<void> {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```

## What is the current behavior?

I've noticed the `NzResizeService` cannot be GC'd since it has the `handler` instance property which captures `this`. This creates a memory leak for server-side rendered applications since the `NzResizeService` is created and destroyed there per each HTTP request:

![image](https://user-images.githubusercontent.com/7337691/125367166-56696980-e380-11eb-92c1-c93310e40c43.png)



## What is the new behavior?

The `NzResizeService` is GC'd successfully.

## Does this PR introduce a breaking change?
```
[x] No
```