### PR TITLE
fix(module:image): resolve memory leak

### DIFF
--- a/components/image/image-preview-ref.ts
+++ b/components/image/image-preview-ref.ts
@@ -5,12 +5,15 @@
 
 import { ESCAPE, hasModifierKey } from '@angular/cdk/keycodes';
 import { OverlayRef } from '@angular/cdk/overlay';
-import { filter, take } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { filter, take, takeUntil } from 'rxjs/operators';
 
 import { NzImagePreviewOptions } from './image-preview-options';
 import { NzImagePreviewComponent } from './image-preview.component';
 
 export class NzImagePreviewRef {
+  private destroy$ = new Subject<void>();
+
   constructor(
     public previewInstance: NzImagePreviewComponent,
     private config: NzImagePreviewOptions,
@@ -28,11 +31,11 @@ export class NzImagePreviewRef {
       this.overlayRef.dispose();
     });
 
-    previewInstance.containerClick.pipe(take(1)).subscribe(() => {
+    previewInstance.containerClick.pipe(take(1), takeUntil(this.destroy$)).subscribe(() => {
       this.close();
     });
 
-    previewInstance.closeClick.pipe(take(1)).subscribe(() => {
+    previewInstance.closeClick.pipe(take(1), takeUntil(this.destroy$)).subscribe(() => {
       this.close();
     });
 
@@ -63,6 +66,7 @@ export class NzImagePreviewRef {
   }
 
   private dispose(): void {
+    this.destroy$.next();
     this.overlayRef.dispose();
   }
 }

--- a/components/image/image.spec.ts
+++ b/components/image/image.spec.ts
@@ -83,8 +83,7 @@ describe('Placeholder', () => {
     fixture.detectChanges();
     tick(300);
     fixture.detectChanges();
-    // @ts-ignore
-    imageComponent.backLoadImage.onload({});
+    imageComponent.backLoadImage.dispatchEvent(new Event('load'));
     fixture.detectChanges();
     expect(imageElement.getAttribute('src')).toBe(QUICK_SRC);
   }));
@@ -114,7 +113,7 @@ describe('Fallback', () => {
     context.src = 'error.png';
     context.fallback = FALLBACK;
     fixture.detectChanges();
-    context.image.backLoadImage.onerror!('');
+    context.image.backLoadImage.dispatchEvent(new ErrorEvent('error'));
     tick();
     fixture.detectChanges();
     const image = debugElement.nativeElement.querySelector('img');


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```

## What is the current behavior?

Currently, event listeners are not removed from the image element when the directive is destroyed, tho they keep capturing `this` and prevent the directive from being GC'd.

`__ngContext__[2] & 256` is `lView[FLAGS] & LViewFlags.Destroyed`, which checks if the directive is in destroyed status (it is):

![image](https://user-images.githubusercontent.com/7337691/125439353-fb136bf7-69ef-4b57-856b-16e2dc77919b.png)

The image preview can be closed by clicking on the close button on either container. This means that one of the streams will emit (`containerClick` or `closeClick`). If `containerClick` emits, then the `closeClick` will never complete and vice-versa:

![image](https://user-images.githubusercontent.com/7337691/125440409-00f3ac08-d62e-4a47-9d56-432804befa9c.png)


## What is the new behavior?

The `NzImageDirective` is GC'd successfully.

## Does this PR introduce a breaking change?
```
[x] No
```