### PR TITLE
perf(module:select): do not run change detection if the `triggerWidth` has not been changed

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -37,7 +37,7 @@ import { startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { slideMotion } from 'ng-zorro-antd/core/animation';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
-import { reqAnimFrame } from 'ng-zorro-antd/core/polyfill';
+import { cancelRequestAnimationFrame, reqAnimFrame } from 'ng-zorro-antd/core/polyfill';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
 import { BooleanInput, NzSafeAny, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
 import { InputBoolean, isNotNil } from 'ng-zorro-antd/core/util';
@@ -242,6 +242,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   private isReactiveDriven = false;
   private value: NzSafeAny | NzSafeAny[];
   private _nzShowArrow: boolean | undefined;
+  private requestId: number = -1;
   onChange: OnChangeType = () => {};
   onTouched: OnTouchedType = () => {};
   dropDownPosition: 'top' | 'center' | 'bottom' = 'bottom';
@@ -491,9 +492,18 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
 
   updateCdkConnectedOverlayStatus(): void {
     if (this.platform.isBrowser && this.originElement.nativeElement) {
-      reqAnimFrame(() => {
+      const triggerWidth = this.triggerWidth;
+      cancelRequestAnimationFrame(this.requestId);
+      this.requestId = reqAnimFrame(() => {
+        // Blink triggers style and layout pipelines anytime the `getBoundingClientRect()` is called, which may cause a
+        // frame drop. That's why it's scheduled through the `requestAnimationFrame` to unload the composite thread.
         this.triggerWidth = this.originElement.nativeElement.getBoundingClientRect().width;
-        this.cdr.markForCheck();
+        if (triggerWidth !== this.triggerWidth) {
+          // The `requestAnimationFrame` will trigger change detection, but we're inside an `OnPush` component which won't have
+          // the `ChecksEnabled` state. Calling `markForCheck()` will allow Angular to run the change detection from the root component
+          // down to the `nz-select`. But we'll trigger only local change detection if the `triggerWidth` has been changed.
+          this.cdr.detectChanges();
+        }
       });
     }
   }
@@ -672,6 +682,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
     }
   }
   ngOnDestroy(): void {
+    cancelRequestAnimationFrame(this.requestId);
     this.focusMonitor.stopMonitoring(this.elementRef);
   }
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?

Currently, the `nz-select` calls `updateCdkConnectedOverlayStatus` every time the select is opened or closed. The `updateCdkConnectedOverlayStatus` schedules a frame callback which is triggering the whole layout update (due to `getBoundingClientRect()`) and it calls `markForCheck()` which forces Angular to run the change detection from the root component down to `nz-select`.

It causes frame drops since the main thread is busy with:
1) updating layout
2) executing `tick()`

We don't need to run the `markForCheck()` since we don't need the "global" change detection. The `triggerWidth` is bound to `cdkConnectedOverlayMinWidth`, the `triggerWidth` is a number, number bindings are not updated each change detection cycle, since Angular uses `Object.is` comparison to determine if the binding has been changed or not:

```js
function bindingUpdated(lView, bindingIndex, value) {
  const oldValue = lView[bindingIndex];
  if (Object.is(oldValue, value)) {
    return false;
  }
}
```

This means that if the `triggerWidth` hasn't been updated, the `cdkConnectedOverlayMinWidth` binding will not be re-evaluated. This means we have a "dead" change detection (the `tick()` has been run, but there's nothing to update).

![image](https://user-images.githubusercontent.com/7337691/125532657-0cb70a5e-26c4-4397-aded-f5a967e2a538.png)



## What is the new behavior?

The change detection is not running anymore from the root component when the frame callback fires since it'll check if the `triggerWidth` has been changed or not.

## Does this PR introduce a breaking change?
```
[x] No
```