### PR TITLE
fix(module:popconfirm): add nzOkDanger option for nz-popconfirm

### DIFF
--- a/components/popconfirm/doc/index.en-US.md
+++ b/components/popconfirm/doc/index.en-US.md
@@ -40,7 +40,7 @@ import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
 | ----- | ----------- | ---- | ------------- | ------------ |
 | `[nzCancelText]` | Text of the Cancel button | `string` | `'Cancel'` | - |
 | `[nzOkText]` | Text of the Confirm button | `string` | `'Confirm'` | - |
-| `[nzOkType]` | Button `type` of the Confirm button | `'primary' \| 'ghost' \| 'dashed' \| 'default'` | `'primary'` | - |
+| `[nzOkType]` | Button `type` of the Confirm button | `'primary' \| 'ghost' \| 'dashed' \| 'danger' \| 'default'` | `'primary'` | - |
 | `[nzOkDanger]` | Danger status of the OK button. <i>Consistent with the `nzDanger` of the `nz-button`.</i> | `boolean` | `false` | - |
 | `[nzCondition]` | Whether to directly emit `onConfirm` without showing Popconfirm | `boolean` | `false` | - |
 | `[nzIcon]` | Customize icon of confirmation  | `string \| TemplateRef<void>` | - | - |

--- a/components/popconfirm/doc/index.en-US.md
+++ b/components/popconfirm/doc/index.en-US.md
@@ -40,7 +40,8 @@ import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
 | ----- | ----------- | ---- | ------------- | ------------ |
 | `[nzCancelText]` | Text of the Cancel button | `string` | `'Cancel'` | - |
 | `[nzOkText]` | Text of the Confirm button | `string` | `'Confirm'` | - |
-| `[nzOkType]` | Button `type` of the Confirm button | `'primary' \| 'ghost' \| 'dashed' \| 'danger' \| 'default'` | `'primary'` | - |
+| `[nzOkType]` | Button `type` of the Confirm button | `'primary' \| 'ghost' \| 'dashed' \| 'default'` | `'primary'` | - |
+| `[nzOkDanger]` | Danger status of the OK button. <i>Consistent with the `nzDanger` of the `nz-button`.</i> | `boolean` | `false` | - |
 | `[nzCondition]` | Whether to directly emit `onConfirm` without showing Popconfirm | `boolean` | `false` | - |
 | `[nzIcon]` | Customize icon of confirmation  | `string \| TemplateRef<void>` | - | - |
 | `[nzAutoFocus]` | Autofocus a button | `null \| 'ok' \| 'cancel'` | `null` | ✅ |

--- a/components/popconfirm/doc/index.zh-CN.md
+++ b/components/popconfirm/doc/index.zh-CN.md
@@ -44,7 +44,7 @@ import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
 | --- | --- | --- | --- | --- |
 | `[nzCancelText]` | 取消按钮文字 | `string` | `'取消'` | - |
 | `[nzOkText]` | 确认按钮文字 | `string` | `'确定'` | - |
-| `[nzOkType]` | 确认按钮类型 | `'primary' \| 'ghost' \| 'dashed' \| 'default'` | `'primary'` | - |
+| `[nzOkType]` | 确认按钮类型 | `'primary' \| 'ghost' \| 'dashed' \| 'danger' \| 'default'` | `'primary'` | - |
 | `[nzOkDanger]` | 确认按钮是否为危险按钮。<i>与 `nz-button` 的 `nzDanger` 值保持一致</i> | `boolean` | `false` | - |
 | `[nzCondition]` | 是否直接触发 `nzOnConfirm` 而不弹出框 | `boolean` | `false` | - |
 | `[nzIcon]` | 自定义弹出框的 icon  | `string \| TemplateRef<void>` | - | - |

--- a/components/popconfirm/doc/index.zh-CN.md
+++ b/components/popconfirm/doc/index.zh-CN.md
@@ -44,7 +44,8 @@ import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
 | --- | --- | --- | --- | --- |
 | `[nzCancelText]` | 取消按钮文字 | `string` | `'取消'` | - |
 | `[nzOkText]` | 确认按钮文字 | `string` | `'确定'` | - |
-| `[nzOkType]` | 确认按钮类型 | `'primary' \| 'ghost' \| 'dashed' \| 'danger' \| 'default'` | `'primary'` | - |
+| `[nzOkType]` | 确认按钮类型 | `'primary' \| 'ghost' \| 'dashed' \| 'default'` | `'primary'` | - |
+| `[nzOkDanger]` | 确认按钮是否为危险按钮。<i>与 `nz-button` 的 `nzDanger` 值保持一致</i> | `boolean` | `false` | - |
 | `[nzCondition]` | 是否直接触发 `nzOnConfirm` 而不弹出框 | `boolean` | `false` | - |
 | `[nzIcon]` | 自定义弹出框的 icon  | `string \| TemplateRef<void>` | - | - |
 | `[nzAutoFocus]` | 按钮的自动聚焦 | `null \| 'ok' \| 'cancel'` | `null` | ✅ |

--- a/components/popconfirm/popconfirm.spec.ts
+++ b/components/popconfirm/popconfirm.spec.ts
@@ -72,6 +72,10 @@ describe('NzPopconfirm', () => {
     component.nzOkType = 'danger';
     fixture.detectChanges();
 
+    const triggerElement = component.stringTemplate.nativeElement;
+    dispatchMouseEvent(triggerElement, 'click');
+    fixture.detectChanges();
+
     expect(getTooltipTrigger(1).classList).toContain('ant-btn-dangerous');
     expect(getTooltipTrigger(1).classList).toContain('ant-btn-primary');
   });
@@ -201,7 +205,7 @@ export class NzPopconfirmTestNewComponent {
   confirm = jasmine.createSpy('confirm');
   cancel = jasmine.createSpy('cancel');
   condition = false;
-  nzOkType: NzButtonType | 'danger' = 'primary';
+  nzOkType: NzButtonType | 'danger' = 'default';
   nzPopconfirmShowArrow = true;
   icon: string | undefined = undefined;
   nzPopconfirmBackdrop = false;

--- a/components/popconfirm/popconfirm.spec.ts
+++ b/components/popconfirm/popconfirm.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, fakeAsync, inject, tick } from '@angular/core/testing
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
+import { NzButtonType } from 'ng-zorro-antd/button';
 import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
 import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 import { NzIconTestModule } from 'ng-zorro-antd/icon/testing';
@@ -65,6 +66,14 @@ describe('NzPopconfirm', () => {
     expect(getTooltipTrigger(0).textContent).toContain('cancel-text');
     expect(getTooltipTrigger(1).textContent).toContain('ok-text');
     expect(getTooltipTrigger(1).classList).not.toContain('ant-btn-primary');
+  });
+
+  it('should support nzOkType danger case', () => {
+    component.nzOkType = 'danger';
+    fixture.detectChanges();
+
+    expect(getTooltipTrigger(1).classList).toContain('ant-btn-dangerous');
+    expect(getTooltipTrigger(1).classList).toContain('ant-btn-primary');
   });
 
   it('should cancel work', fakeAsync(() => {
@@ -161,7 +170,7 @@ describe('NzPopconfirm', () => {
       #stringTemplate
       nzPopconfirmTitle="title-string"
       nzOkText="ok-text"
-      nzOkType="default"
+      [nzOkType]="nzOkType"
       nzCancelText="cancel-text"
       [nzAutofocus]="autoFocus"
       [nzCondition]="condition"
@@ -192,6 +201,7 @@ export class NzPopconfirmTestNewComponent {
   confirm = jasmine.createSpy('confirm');
   cancel = jasmine.createSpy('cancel');
   condition = false;
+  nzOkType: NzButtonType | 'danger' = 'primary';
   nzPopconfirmShowArrow = true;
   icon: string | undefined = undefined;
   nzPopconfirmBackdrop = false;

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -183,8 +183,8 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
                     nz-button
                     #okBtn
                     [nzSize]="'small'"
-                    [nzType]="nzOkType"
-                    [nzDanger]="nzOkDanger"
+                    [nzType]="nzOkType !== 'danger' ? nzOkType : 'primary'"
+                    [nzDanger]="nzOkDanger || nzOkType === 'danger'"
                     (click)="onConfirm()"
                     [attr.cdkFocusInitial]="nzAutoFocus === 'ok' || null"
                   >
@@ -209,7 +209,7 @@ export class NzPopconfirmComponent extends NzToolTipComponent implements OnDestr
   nzPopconfirmShowArrow = true;
   nzIcon?: string | TemplateRef<void>;
   nzOkText?: string;
-  nzOkType: NzButtonType = 'primary';
+  nzOkType: NzButtonType | 'danger' = 'primary';
   nzOkDanger: boolean = false;
   nzAutoFocus: NzAutoFocusType = null;
 

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -66,6 +66,7 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
   @Input('nzPopconfirmVisible') visible?: boolean;
   @Input() nzOkText?: string;
   @Input() nzOkType?: string;
+  @Input() nzOkDanger?: boolean;
   @Input() nzCancelText?: string;
   @Input() nzIcon?: string | TemplateRef<void>;
   @Input() @InputBoolean() nzCondition: boolean = false;
@@ -85,6 +86,7 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
     return {
       nzOkText: ['nzOkText', () => this.nzOkText],
       nzOkType: ['nzOkType', () => this.nzOkType],
+      nzOkDanger: ['nzOkDanger', () => this.nzOkDanger],
       nzCancelText: ['nzCancelText', () => this.nzCancelText],
       nzCondition: ['nzCondition', () => this.nzCondition],
       nzIcon: ['nzIcon', () => this.nzIcon],
@@ -182,6 +184,7 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
                     #okBtn
                     [nzSize]="'small'"
                     [nzType]="nzOkType"
+                    [nzDanger]="nzOkDanger"
                     (click)="onConfirm()"
                     [attr.cdkFocusInitial]="nzAutoFocus === 'ok' || null"
                   >
@@ -207,6 +210,7 @@ export class NzPopconfirmComponent extends NzToolTipComponent implements OnDestr
   nzIcon?: string | TemplateRef<void>;
   nzOkText?: string;
   nzOkType: NzButtonType = 'primary';
+  nzOkDanger: boolean = false;
   nzAutoFocus: NzAutoFocusType = null;
 
   readonly nzOnCancel = new Subject<void>();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
nzOkType="danger" is not applied to the ok button

Issue Number: #6864


## What is the new behavior?
adding new property as nzOkDanger to apply Danger style to the ok button

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

I guess, same as for the Modal Footer component, maybe the migration steps needed here ?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
