### PR TITLE
fix(module:select) do not select on return key press first disabled i…

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -409,6 +409,13 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, OnDestro
       case ENTER:
         e.preventDefault();
         if (this.nzOpen) {
+          if(this.listOfContainerItem && this.listOfContainerItem.length > 0 && this.listOfContainerItem[0].key == this.activatedValue && this.listOfContainerItem[0].nzDisabled == true){
+            let firstNotDisabledOption = this.listOfContainerItem.find(item => item.nzDisabled != true);
+            if(firstNotDisabledOption){
+              this.activatedValue = firstNotDisabledOption.key;
+            }
+            // else this.activatedValue = ''; TOCHECK: if is wanted to not be selected any option in case of all options are disabled
+          }
           if (isNotNil(this.activatedValue)) {
             this.onItemClick(this.activatedValue);
           }

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -286,7 +286,6 @@ describe('select', () => {
 
       expect(component.nzOpen).toBe(false);
     }));
-
     it('should keydown up arrow and down arrow', fakeAsync(() => {
       const flushChanges = () => {
         fixture.detectChanges();
@@ -324,6 +323,26 @@ describe('select', () => {
       flushChanges();
       expect(component.openChange).toHaveBeenCalledWith(false);
       expect(component.openChange).toHaveBeenCalledTimes(3);
+    }));
+    it('should select first option after of disabled item, in case of first item is disabled on return key press', fakeAsync(() => {
+      const flushChanges = () => {
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
+      };
+      component.listOfOption = [
+        { nzValue: 'test_01', nzLabel: 'test_01', nzDisabled: true },
+        { nzValue: 'test_01_2', nzLabel: 'test_01', nzDisabled: true },
+        { nzValue: 'test_03', nzLabel: 'test_03' },
+        { nzValue: 'test_04', nzLabel: 'test_04' }
+      ];
+
+      component.nzOpen = true;
+      flushChanges();
+      const inputElement = selectElement.querySelector('input')!;
+      dispatchKeyboardEvent(inputElement, 'keydown', ENTER, inputElement);
+      flushChanges();
+      expect(component.value).toBe('test_03');
     }));
     it('should mouseenter activated option work', fakeAsync(() => {
       const flushChanges = () => {
@@ -1159,6 +1178,7 @@ describe('select', () => {
       fixture.detectChanges();
       expect(listOfItem[2].textContent).toBe('and 2 more selected');
     }));
+
   });
 });
 


### PR DESCRIPTION
…tem (#6868)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Pressing the return key is selecting the first disabled option.

Issue Number: (#6868)

## What is the new behavior?
Now if first option is disabled on return key press is selecting the first enabled option
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
