### PR TITLE
fix(module:carousel): prevent iOS from triggering navigation

### DIFF
--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -371,6 +371,10 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
    */
   pointerDown = (event: TouchEvent | MouseEvent): void => {
     if (!this.isDragging && !this.isTransiting && this.nzEnableSwipe) {
+      if (this.platform.IOS && event instanceof TouchEvent) {
+        this.preventIOSSafariNavigation(event);
+      }
+
       this.clearScheduledTransition();
       this.gestureRect = this.slickListEl.getBoundingClientRect();
 
@@ -401,6 +405,14 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
       );
     }
   };
+
+  private preventIOSSafariNavigation(event: TouchEvent): void {
+    const navigationGestureMargin = 20;
+    const touch = event.touches[0];
+    if (touch.clientX < navigationGestureMargin) {
+      event.preventDefault();
+    }
+  }
 
   layout(): void {
     if (this.strategy) {

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -407,7 +407,7 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
   };
 
   private preventIOSSafariNavigation(event: TouchEvent): void {
-    const navigationGestureMargin = 20;
+    const navigationGestureMargin = 20; // TODO@wendellhu: this may change
     const touch = event.touches[0];
     if (touch.clientX < navigationGestureMargin) {
       event.preventDefault();

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -407,11 +407,14 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
   };
 
   private preventIOSSafariNavigation(event: TouchEvent): void {
-    const navigationGestureMargin = 20; // TODO@wendellhu: this may change
+    const navigationGestureMargin = 10;
     const touch = event.touches[0];
-    if (touch.clientX < navigationGestureMargin) {
-      event.preventDefault();
+
+    if (touch.pageX > navigationGestureMargin && touch.pageX < window.innerWidth - navigationGestureMargin) {
+      return;
     }
+
+    event.preventDefault();
   }
 
   layout(): void {

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -370,6 +370,7 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
    * Drag carousel.
    */
   pointerDown = (event: TouchEvent | MouseEvent): void => {
+    /* istanbul ignore if  */
     if (this.nzEnableSwipe && this.platform.IOS && event instanceof TouchEvent) {
       this.preventIOSSafariNavigation(event);
     }
@@ -409,6 +410,7 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
   /**
    * @link https://github.com/vercel/commerce/pull/132/files
    */
+  /* istanbul ignore next */
   private preventIOSSafariNavigation(event: TouchEvent): void {
     const navigationGestureMargin = 10;
     const touch = event.touches[0];

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -371,7 +371,7 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
    */
   pointerDown = (event: TouchEvent | MouseEvent): void => {
     if (this.nzEnableSwipe && this.platform.IOS && event instanceof TouchEvent) {
-        this.preventIOSSafariNavigation(event);
+      this.preventIOSSafariNavigation(event);
     }
 
     if (!this.isDragging && !this.isTransiting && this.nzEnableSwipe) {
@@ -415,7 +415,10 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
     const touchCenterX = touch.pageX;
     const touchRadius = touch.radiusX;
 
-    if (touchCenterX - touchRadius < navigationGestureMargin || touchCenterX + touchRadius > window.innerWidth - navigationGestureMargin) {
+    if (
+      touchCenterX - touchRadius < navigationGestureMargin ||
+      touchCenterX + touchRadius > window.innerWidth - navigationGestureMargin
+    ) {
       event.preventDefault();
     }
   }

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -370,11 +370,11 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
    * Drag carousel.
    */
   pointerDown = (event: TouchEvent | MouseEvent): void => {
-    if (!this.isDragging && !this.isTransiting && this.nzEnableSwipe) {
-      if (this.platform.IOS && event instanceof TouchEvent) {
+    if (this.nzEnableSwipe && this.platform.IOS && event instanceof TouchEvent) {
         this.preventIOSSafariNavigation(event);
-      }
+    }
 
+    if (!this.isDragging && !this.isTransiting && this.nzEnableSwipe) {
       this.clearScheduledTransition();
       this.gestureRect = this.slickListEl.getBoundingClientRect();
 

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -406,15 +406,18 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
     }
   };
 
+  /**
+   * @link https://github.com/vercel/commerce/pull/132/files
+   */
   private preventIOSSafariNavigation(event: TouchEvent): void {
-    const navigationGestureMargin = 50;
+    const navigationGestureMargin = 10;
     const touch = event.touches[0];
+    const touchCenterX = touch.pageX;
+    const touchRadius = touch.radiusX;
 
-    if (touch.pageX > navigationGestureMargin && touch.pageX < window.innerWidth - navigationGestureMargin) {
-      return;
+    if (touchCenterX - touchRadius < navigationGestureMargin || touchCenterX + touchRadius > window.innerWidth - navigationGestureMargin) {
+      event.preventDefault();
     }
-
-    event.preventDefault();
   }
 
   layout(): void {

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -407,7 +407,7 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
   };
 
   private preventIOSSafariNavigation(event: TouchEvent): void {
-    const navigationGestureMargin = 10;
+    const navigationGestureMargin = 50;
     const touch = event.touches[0];
 
     if (touch.pageX > navigationGestureMargin && touch.pageX < window.innerWidth - navigationGestureMargin) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features), not required for this edge case
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

If a user swipes the carousel on the edge of the carousel on an iOS device, it would trigger a navigation event.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
