### PR TITLE
fix(module:datepicker): fixed opacity 0 on inline datepicker reopen

### DIFF
--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -155,48 +155,37 @@ export type NzDatePickerSizeType = 'large' | 'default' | 'small';
 
     <ng-template #inlineMode>
       <div
-        class="ant-picker-wrapper"
-        [nzNoAnimation]="!!noAnimation?.nzNoAnimation"
-        [@slideMotion]="'enter'"
-        style="position: relative;"
+        class="{{ prefixCls }}-dropdown {{ nzDropdownClassName }}"
+        [class.ant-picker-dropdown-rtl]="dir === 'rtl'"
+        [class.ant-picker-dropdown-placement-bottomLeft]="currentPositionY === 'bottom' && currentPositionX === 'start'"
+        [class.ant-picker-dropdown-placement-topLeft]="currentPositionY === 'top' && currentPositionX === 'start'"
+        [class.ant-picker-dropdown-placement-bottomRight]="currentPositionY === 'bottom' && currentPositionX === 'end'"
+        [class.ant-picker-dropdown-placement-topRight]="currentPositionY === 'top' && currentPositionX === 'end'"
+        [class.ant-picker-dropdown-range]="isRange"
+        [class.ant-picker-active-left]="datePickerService.activeInput === 'left'"
+        [class.ant-picker-active-right]="datePickerService.activeInput === 'right'"
+        [ngStyle]="nzPopupStyle"
       >
-        <div
-          class="{{ prefixCls }}-dropdown {{ nzDropdownClassName }}"
-          [class.ant-picker-dropdown-rtl]="dir === 'rtl'"
-          [class.ant-picker-dropdown-placement-bottomLeft]="
-            currentPositionY === 'bottom' && currentPositionX === 'start'
-          "
-          [class.ant-picker-dropdown-placement-topLeft]="currentPositionY === 'top' && currentPositionX === 'start'"
-          [class.ant-picker-dropdown-placement-bottomRight]="
-            currentPositionY === 'bottom' && currentPositionX === 'end'
-          "
-          [class.ant-picker-dropdown-placement-topRight]="currentPositionY === 'top' && currentPositionX === 'end'"
-          [class.ant-picker-dropdown-range]="isRange"
-          [class.ant-picker-active-left]="datePickerService.activeInput === 'left'"
-          [class.ant-picker-active-right]="datePickerService.activeInput === 'right'"
-          [ngStyle]="nzPopupStyle"
-        >
-          <date-range-popup
-            [isRange]="isRange"
-            [inline]="nzInline"
-            [defaultPickerValue]="nzDefaultPickerValue"
-            [showWeek]="nzMode === 'week'"
-            [panelMode]="panelMode"
-            (panelModeChange)="onPanelModeChange($event)"
-            (calendarChange)="onCalendarChange($event)"
-            [locale]="nzLocale?.lang!"
-            [showToday]="nzMode === 'date' && nzShowToday && !isRange && !nzShowTime"
-            [showNow]="nzMode === 'date' && nzShowNow && !isRange && !!nzShowTime"
-            [showTime]="nzShowTime"
-            [dateRender]="nzDateRender"
-            [disabledDate]="nzDisabledDate"
-            [disabledTime]="nzDisabledTime"
-            [extraFooter]="extraFooter"
-            [ranges]="nzRanges"
-            [dir]="dir"
-            (resultOk)="onResultOk()"
-          ></date-range-popup>
-        </div>
+        <date-range-popup
+          [isRange]="isRange"
+          [inline]="nzInline"
+          [defaultPickerValue]="nzDefaultPickerValue"
+          [showWeek]="nzMode === 'week'"
+          [panelMode]="panelMode"
+          (panelModeChange)="onPanelModeChange($event)"
+          (calendarChange)="onCalendarChange($event)"
+          [locale]="nzLocale?.lang!"
+          [showToday]="nzMode === 'date' && nzShowToday && !isRange && !nzShowTime"
+          [showNow]="nzMode === 'date' && nzShowNow && !isRange && !!nzShowTime"
+          [showTime]="nzShowTime"
+          [dateRender]="nzDateRender"
+          [disabledDate]="nzDisabledDate"
+          [disabledTime]="nzDisabledTime"
+          [extraFooter]="extraFooter"
+          [ranges]="nzRanges"
+          [dir]="dir"
+          (resultOk)="onResultOk()"
+        ></date-range-popup>
       </div>
     </ng-template>
 
@@ -213,7 +202,14 @@ export type NzDatePickerSizeType = 'large' | 'default' | 'small';
       (detach)="close()"
       (overlayKeydown)="onOverlayKeydown($event)"
     >
-      <ng-container *ngTemplateOutlet="inlineMode"></ng-container>
+      <div
+        class="ant-picker-wrapper"
+        [nzNoAnimation]="!!noAnimation?.nzNoAnimation"
+        [@slideMotion]="'enter'"
+        style="position: relative;"
+      >
+        <ng-container *ngTemplateOutlet="inlineMode"></ng-container>
+      </div>
     </ng-template>
   `,
   host: {

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -155,20 +155,11 @@ export type NzDatePickerSizeType = 'large' | 'default' | 'small';
 
     <ng-template #inlineMode>
       <div
-        *ngIf="!nzInline"
         class="ant-picker-wrapper"
         [nzNoAnimation]="!!noAnimation?.nzNoAnimation"
         [@slideMotion]="'enter'"
         style="position: relative;"
       >
-        <ng-container *ngTemplateOutlet="calendarInside"></ng-container>
-      </div>
-
-      <div *ngIf="nzInline" class="ant-picker-wrapper" style="position: relative;">
-        <ng-container *ngTemplateOutlet="calendarInside"></ng-container>
-      </div>
-
-      <ng-template #calendarInside>
         <div
           class="{{ prefixCls }}-dropdown {{ nzDropdownClassName }}"
           [class.ant-picker-dropdown-rtl]="dir === 'rtl'"
@@ -206,7 +197,7 @@ export type NzDatePickerSizeType = 'large' | 'default' | 'small';
             (resultOk)="onResultOk()"
           ></date-range-popup>
         </div>
-      </ng-template>
+      </div>
     </ng-template>
 
     <!-- Overlay -->

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -155,11 +155,20 @@ export type NzDatePickerSizeType = 'large' | 'default' | 'small';
 
     <ng-template #inlineMode>
       <div
+        *ngIf="!nzInline"
         class="ant-picker-wrapper"
         [nzNoAnimation]="!!noAnimation?.nzNoAnimation"
         [@slideMotion]="'enter'"
         style="position: relative;"
       >
+        <ng-container *ngTemplateOutlet="calendarInside"></ng-container>
+      </div>
+
+      <div *ngIf="nzInline" class="ant-picker-wrapper" style="position: relative;">
+        <ng-container *ngTemplateOutlet="calendarInside"></ng-container>
+      </div>
+
+      <ng-template #calendarInside>
         <div
           class="{{ prefixCls }}-dropdown {{ nzDropdownClassName }}"
           [class.ant-picker-dropdown-rtl]="dir === 'rtl'"
@@ -197,7 +206,7 @@ export type NzDatePickerSizeType = 'large' | 'default' | 'small';
             (resultOk)="onResultOk()"
           ></date-range-popup>
         </div>
-      </div>
+      </ng-template>
     </ng-template>
 
     <!-- Overlay -->


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/NG-ZORRO/ng-zorro-antd/issues/6897

Issue Number: 6897


## What is the new behavior?
There is no animation for inline mode datepicker so it's not going invisible after re-opening

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Inline datepicker don't need to have animation because it's inline, nothing is opened through dropdown. Problems was in animation attached to inline mode so it's going to make `opacity: 0` on inline datepicker after re-opening
