### PR TITLE
fix(module:empty): consistent empty style

### DIFF
--- a/components/empty/style/index.less
+++ b/components/empty/style/index.less
@@ -24,6 +24,10 @@
     }
   }
 
+  &-description {
+    color: @disabled-color;
+  }
+
   &-footer {
     margin-top: 16px;
   }
@@ -34,7 +38,7 @@
     color: @disabled-color;
 
     .@{empty-prefix-cls}-image {
-      height: 40px;
+      height: 100px;
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The empty component is not consistent, it has a smaller image, but when used in some other component it has a different style (bigger image and different color of description).

Issue Number: #6905 


## What is the new behavior?
It will have `disabled-color` (0.25 black opacity) for description text and image height of 100px, equal to `.ant-empty-image` class for `normal` state. This is similar to `small` state with different image size.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
