### PR TITLE
fix(module:modal): footer onClick rethrow error in promise catch

### DIFF
--- a/components/modal/modal-footer.component.ts
+++ b/components/modal/modal-footer.component.ts
@@ -117,7 +117,12 @@ export class NzModalFooterComponent implements OnDestroy {
       const result = this.getButtonCallableProp(options, 'onClick');
       if (options.autoLoading && isPromise(result)) {
         options.loading = true;
-        result.then(() => (options.loading = false)).catch(() => (options.loading = false));
+        result
+          .then(() => (options.loading = false))
+          .catch(e => {
+            options.loading = false;
+            throw e;
+          });
       }
     }
   }

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -1216,6 +1216,13 @@ describe('NzModal', () => {
                   resolve(null);
                 }, 200);
               })
+          },
+          {
+            label: 'Test Button3',
+            onClick: () =>
+              new Promise(() => {
+                throw new Error('Rethrow error');
+              })
           }
         ]
       });
@@ -1227,6 +1234,7 @@ describe('NzModal', () => {
       expect(buttons[0].textContent!.trim()).toBe('Test Button0');
       expect(buttons[1].textContent!.trim()).toBe('Test Button1');
       expect(buttons[2].textContent!.trim()).toBe('Test Button2');
+      expect(buttons[3].textContent!.trim()).toBe('Test Button3');
 
       expect(buttons[1].classList).toContain('ant-btn-loading');
 
@@ -1246,6 +1254,11 @@ describe('NzModal', () => {
       flush();
       fixture.detectChanges();
       expect(buttons[0].classList).not.toContain('ant-btn-loading');
+
+      expect(() => {
+        buttons[3].click();
+        tick();
+      }).toThrowError(/Rethrow error/);
     }));
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://codesandbox.io/s/hopeful-hoover-3eddg?file=/src/app/app.component.ts

![image](https://user-images.githubusercontent.com/35769340/130099806-e84df652-a60d-44e7-aea3-13a686901c3a.png)


No feedback if error occurred in promise without explicitly catching, because `onClick` handler catched the error.


## What is the new behavior?
Rethrow error on catching.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
