### PR TITLE
fix(module:table): show empty state regardless of loading value

### DIFF
--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -305,7 +305,8 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    const { nzScroll, nzPageIndex, nzPageSize, nzFrontPagination, nzData, nzWidthConfig, nzNoResult, nzTemplateMode } = changes;
+    const { nzScroll, nzPageIndex, nzPageSize, nzFrontPagination, nzData, nzWidthConfig, nzNoResult, nzTemplateMode } =
+      changes;
     if (nzPageIndex) {
       this.nzTableDataService.updatePageIndex(this.nzPageIndex);
     }

--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -305,16 +305,7 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    const {
-      nzScroll,
-      nzPageIndex,
-      nzPageSize,
-      nzFrontPagination,
-      nzData,
-      nzWidthConfig,
-      nzNoResult,
-      nzTemplateMode
-    } = changes;
+    const { nzScroll, nzPageIndex, nzPageSize, nzFrontPagination, nzData, nzWidthConfig, nzNoResult, nzTemplateMode } = changes;
     if (nzPageIndex) {
       this.nzTableDataService.updatePageIndex(this.nzPageIndex);
     }

--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -195,7 +195,6 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
   hasFixRight = false;
   showPagination = true;
   private destroy$ = new Subject<void>();
-  private loading$ = new BehaviorSubject<boolean>(false);
   private templateMode$ = new BehaviorSubject<boolean>(false);
   dir: Direction = 'ltr';
   @ContentChild(NzTableVirtualScrollDirective, { static: false })
@@ -285,9 +284,9 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
       this.cdr.markForCheck();
     });
 
-    combineLatest([total$, this.loading$, this.templateMode$])
+    combineLatest([total$, this.templateMode$])
       .pipe(
-        map(([total, loading, templateMode]) => total === 0 && !loading && !templateMode),
+        map(([total, templateMode]) => total === 0 && !templateMode),
         takeUntil(this.destroy$)
       )
       .subscribe(empty => {
@@ -314,7 +313,6 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
       nzData,
       nzWidthConfig,
       nzNoResult,
-      nzLoading,
       nzTemplateMode
     } = changes;
     if (nzPageIndex) {
@@ -335,9 +333,6 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
     }
     if (nzWidthConfig) {
       this.nzTableStyleService.setTableWidthConfig(this.nzWidthConfig);
-    }
-    if (nzLoading) {
-      this.loading$.next(this.nzLoading);
     }
     if (nzTemplateMode) {
       this.templateMode$.next(this.nzTemplateMode);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when the table is initially loaded (with `nzLoading="true"`) then only table header is shown with loading icon on the top and it does not look good. I've checked React behavior and it shows additionally empty icon in the table body.

Issue Number: N/A


## What is the new behavior?
The new behavior shows empty state regardless of loading value. So initially when there is no data and `nzLoading="true"` is set - it will display empty state together with loading icon.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
