### PR TITLE
fix(module:timepicker): fix ok button + selection of default open value

### DIFF
--- a/components/date-picker/testing/util.ts
+++ b/components/date-picker/testing/util.ts
@@ -21,3 +21,7 @@ export function getPickerInput(debugElement: DebugElement): HTMLInputElement {
 export function getRangePickerRightInput(debugElement: DebugElement): HTMLInputElement {
   return debugElement.queryAll(By.css(`.${PREFIX_CLASS}-input input`))[1].nativeElement as HTMLInputElement;
 }
+
+export function getPickerOkButton(debugElement: DebugElement): HTMLElement {
+  return debugElement.query(By.css(`.${PREFIX_CLASS}-ok`)).nativeElement.querySelector('button') as HTMLElement;
+}

--- a/components/time-picker/time-picker-panel.component.spec.ts
+++ b/components/time-picker/time-picker-panel.component.spec.ts
@@ -84,6 +84,18 @@ describe('time-picker-panel', () => {
     //   expect(listOfSelectedLi[1].innerText).toBe('09');
     //   expect(listOfSelectedLi[2].innerText).toBe('10');
     // }));
+    it('should select default open value on list click', fakeAsync(() => {
+      let listOfSelectedLi = panelElement.nativeElement.querySelectorAll('.ant-picker-time-panel-cell-selected');
+      expect(listOfSelectedLi[0].innerText).toBe('10');
+      expect(listOfSelectedLi[1].innerText).toBe('11');
+      expect(listOfSelectedLi[2].innerText).toBe('12');
+      expect(testComponent.value).toBeUndefined();
+      dispatchFakeEvent(listOfSelectedLi[0], 'click');
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(testComponent.value).not.toBeUndefined();
+    }));
     it('should select scroll work', fakeAsync(() => {
       testComponent.value = new Date(0, 0, 0, 8, 9, 10);
       fixture.detectChanges();

--- a/components/time-picker/time-picker-panel.component.ts
+++ b/components/time-picker/time-picker-panel.component.ts
@@ -382,6 +382,7 @@ export class NzTimePickerPanelComponent implements ControlValueAccessor, OnInit,
     if (this._disabledSeconds || this._disabledMinutes) {
       this.buildSeconds();
     }
+    this.changed();
   }
 
   selectMinute(minute: { index: number; disabled: boolean }): void {
@@ -389,10 +390,12 @@ export class NzTimePickerPanelComponent implements ControlValueAccessor, OnInit,
     if (this._disabledSeconds) {
       this.buildSeconds();
     }
+    this.changed();
   }
 
   selectSecond(second: { index: number; disabled: boolean }): void {
     this.time.setSeconds(second.index, second.disabled);
+    this.changed();
   }
 
   select12Hours(value: { index: number; value: string }): void {
@@ -496,6 +499,8 @@ export class NzTimePickerPanelComponent implements ControlValueAccessor, OnInit,
   }
 
   onClickOk(): void {
+    this.time.setValue(this.time.value, this.nzUse12Hours);
+    this.changed();
     this.closePanel.emit();
   }
 

--- a/components/time-picker/time-picker.component.spec.ts
+++ b/components/time-picker/time-picker.component.spec.ts
@@ -9,7 +9,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { dispatchFakeEvent, dispatchMouseEvent, typeInElement } from 'ng-zorro-antd/core/testing';
 import { PREFIX_CLASS } from 'ng-zorro-antd/date-picker';
-import { getPickerInput } from 'ng-zorro-antd/date-picker/testing/util';
+import { getPickerInput, getPickerOkButton } from 'ng-zorro-antd/date-picker/testing/util';
 
 import { en_GB, NzI18nModule, NzI18nService } from '../i18n';
 import { NzTimePickerComponent } from './time-picker.component';
@@ -187,6 +187,44 @@ describe('time-picker', () => {
 
       expect(getPickerContainer()).toBeNull();
     }));
+    it('should set default opening time when clicking ok', fakeAsync(() => {
+      const onChange = spyOn(testComponent, 'onChange');
+      dispatchMouseEvent(getPickerInput(fixture.debugElement), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(getPickerContainer()).not.toBeNull();
+
+      const okButton = getPickerOkButton(fixture.debugElement);
+      expect(okButton).not.toBeNull();
+      dispatchFakeEvent(okButton, 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      const result = (onChange.calls.allArgs()[0] as Date[])[0];
+      expect(result.getHours()).toEqual(0);
+      expect(result.getMinutes()).toEqual(0);
+      expect(result.getSeconds()).toEqual(0);
+    }));
+    it('should not set time when clicking ok without default opening time', fakeAsync(() => {
+      const onChange = spyOn(testComponent, 'onChange');
+      testComponent.defaultOpenValue = null;
+      dispatchMouseEvent(getPickerInput(fixture.debugElement), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(getPickerContainer()).not.toBeNull();
+
+      const okButton = getPickerOkButton(fixture.debugElement);
+      expect(okButton).not.toBeNull();
+      dispatchFakeEvent(okButton, 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+
+      const result = (onChange.calls.allArgs()[0] as Date[])[0];
+      expect(result).toBeNull();
+    }));
     it('should set previous value when tabbing out with invalid input', fakeAsync(() => {
       testComponent.date = new Date('2020-03-27T13:49:54.917');
 
@@ -279,6 +317,7 @@ describe('time-picker', () => {
       [nzUse12Hours]="use12Hours"
       [nzSuffixIcon]="nzSuffixIcon"
       [nzBackdrop]="nzBackdrop"
+      [nzDefaultOpenValue]="defaultOpenValue"
     ></nz-time-picker>
   `
 })
@@ -291,6 +330,7 @@ export class NzTestTimePickerComponent {
   use12Hours = false;
   nzSuffixIcon?: string;
   nzBackdrop = false;
+  defaultOpenValue: Date | null = new Date('2020-03-27T00:00:00');
   onChange(_: Date | null): void {}
   @ViewChild(NzTimePickerComponent, { static: false }) nzTimePickerComponent!: NzTimePickerComponent;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 6066

+ It was also not possible to select the default open value when opening the picker without a value set.

## What is the new behavior?

It is possible to select the default open value when opening the picker without a value set.
Pressing the 'OK' button without selecting a time will fill in the default open value of the picker. If there is no default value, the value will stay null and the picker will close.
If you click 'OK' when you selected a value, the value will just be whatever you selected and the picker will be closed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
