### PR TITLE
fix(module:collapse): fix bug in header style

### DIFF
--- a/components/collapse/collapse-panel.component.ts
+++ b/components/collapse/collapse-panel.component.ts
@@ -44,7 +44,9 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapsePanel';
           <i nz-icon [nzType]="expandedIcon || 'right'" class="ant-collapse-arrow" [nzRotate]="nzActive ? 90 : 0"></i>
         </ng-container>
       </ng-container>
-      <ng-container *nzStringTemplateOutlet="nzHeader">{{ nzHeader }}</ng-container>
+      <div class="ant-collapse-title">
+        <ng-container *nzStringTemplateOutlet="nzHeader">{{ nzHeader }}</ng-container>
+      </div>
       <div class="ant-collapse-extra" *ngIf="nzExtra">
         <ng-container *nzStringTemplateOutlet="nzExtra">{{ nzExtra }}</ng-container>
       </div>

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -28,6 +28,8 @@
       line-height: @line-height-base;
       cursor: pointer;
       transition: all 0.3s, visibility 0s;
+      display: flex;
+      align-items: center;
       .clearfix();
 
       .@{collapse-prefix-cls}-arrow {
@@ -40,9 +42,8 @@
           transition: transform 0.24s;
         }
       }
-
-      .@{collapse-prefix-cls}-extra {
-        float: right;
+      .@{collapse-prefix-cls}-title {
+        flex-grow: 1;
       }
 
       &:focus {


### PR DESCRIPTION
fix header style when adding nz-row and nz-col inside header as templateRef

(#6920)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6920


## What is the new behavior?
Using nz-row and nz-col inside header as templateRef does not break the line.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
