### PR TITLE
fix(module:tooltip): fix tooltip for deeply wrapped focusable elements

### DIFF
--- a/components/tooltip/base.ts
+++ b/components/tooltip/base.ts
@@ -231,8 +231,8 @@ export abstract class NzTooltipBaseDirective implements OnChanges, OnDestroy, Af
         })
       );
     } else if (trigger === 'focus') {
-      this.triggerDisposables.push(this.renderer.listen(el, 'focus', () => this.show()));
-      this.triggerDisposables.push(this.renderer.listen(el, 'blur', () => this.hide()));
+      this.triggerDisposables.push(this.renderer.listen(el, 'focusin', () => this.show()));
+      this.triggerDisposables.push(this.renderer.listen(el, 'focusout', () => this.hide()));
     } else if (trigger === 'click') {
       this.triggerDisposables.push(
         this.renderer.listen(el, 'click', (e: MouseEvent) => {

--- a/components/tooltip/tooltip.spec.ts
+++ b/components/tooltip/tooltip.spec.ts
@@ -134,11 +134,11 @@ describe('nz-tooltip', () => {
       const title = 'focus';
       const triggerElement = component.focusTemplate.nativeElement;
 
-      dispatchMouseEvent(triggerElement, 'focus');
+      dispatchMouseEvent(triggerElement, 'focusin');
       waitingForTooltipToggling();
       expect(overlayContainerElement.textContent).toContain(title);
 
-      dispatchMouseEvent(triggerElement, 'blur');
+      dispatchMouseEvent(triggerElement, 'focusout');
       waitingForTooltipToggling();
       expect(overlayContainerElement.textContent).not.toContain(title);
     }));


### PR DESCRIPTION
close #6955

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6955

Since `focus` and `blur` are events that don't propagate, nz-tooltip and other components such as nz-popconfirm and nz-popover fail to detect a focus event on a deeply wrapped child element.

## What is the new behavior?

Use `focusin` and `focusout` events which can propagate and [IE11-compatible](https://caniuse.com/?search=focusin) instead. `trigger="focus"` works for deeply wrapped focusable child elements.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
