### PR TITLE
fix(module:upload): do not trigger change detection for `nz-upload-btn`

### DIFF
--- a/components/upload/upload.spec.ts
+++ b/components/upload/upload.spec.ts
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { Component, DebugElement, Injector, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+  ApplicationRef,
+  Component,
+  DebugElement,
+  Injector,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -998,7 +1006,20 @@ describe('upload', () => {
         fixture.detectChanges();
       });
 
-      describe('should be trigger upload', () => {
+      describe('should trigger upload', () => {
+        describe('change detection', () => {
+          it('should not run change detection when the <input type=file> is being clicked', () => {
+            const appRef = TestBed.inject(ApplicationRef);
+            spyOn(appRef, 'tick');
+            spyOn(instance.comp.file.nativeElement, 'click');
+            expect(instance.comp.file.nativeElement.click).not.toHaveBeenCalled();
+            fixture.debugElement.query(By.css('div')).nativeElement.click();
+            // Caretaker note: previously click events on the `nz-upload-btn` elements did trigger
+            // change detection since they were added via the `host` property.
+            expect(appRef.tick).toHaveBeenCalledTimes(0);
+            expect(instance.comp.file.nativeElement.click).toHaveBeenCalled();
+          });
+        });
         describe('via onClick', () => {
           it('', () => {
             spyOn(instance.comp.file.nativeElement, 'click');


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
```

## What is the current behavior?

Currently, it runs change detection each time the `nz-upload-btn` is clicked, tho it opens a native OS file picker. This is considered as a "dead" change detection (`ApplicationRef.tick()` is run, but there's nothing to update). This may cause a frame drop when opening a native file picker (because Angular has to run the whole change detection before opening it).

## What is the new behavior?

There's no dead change detection when the `nz-upload-btn` is clicked.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```