### PR TITLE
fix(module:code-editor): load Monaco only once

### DIFF
--- a/components/code-editor/typings.ts
+++ b/components/code-editor/typings.ts
@@ -14,7 +14,7 @@ export type JoinedEditorOptions = EditorOptions | DiffEditorOptions;
 
 export type NzEditorMode = 'normal' | 'diff';
 
-export enum NzCodeEditorLoadingStatus {
+export const enum NzCodeEditorLoadingStatus {
   UNLOAD = 'unload',
   LOADING = 'loading',
   LOADED = 'LOADED'


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
```

## What is the current behavior?

We should load Monaco only once, it even has a warning within its source code (see the screenshot). This applies to apps that are bootstrapped and destroyed multiple times.

![monaco-warning](https://user-images.githubusercontent.com/7337691/140002442-2fb98830-0e7a-4bd5-a50f-764d0ab5722b.png)



## What is the new behavior?

Monaco is ensured to be loaded only once.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```