### PR TITLE
fix(module:table): resolve leak within the `nz-table-fixed-row`

### DIFF
--- a/components/table/src/table/table-fixed-row.component.ts
+++ b/components/table/src/table/table-fixed-row.component.ts
@@ -38,7 +38,7 @@ import { NzTableStyleService } from '../table-style.service';
   `
 })
 export class NzTableFixedRowComponent implements OnInit, OnDestroy, AfterViewInit {
-  @ViewChild('tdElement') tdElement!: ElementRef;
+  @ViewChild('tdElement', { static: true }) tdElement!: ElementRef;
   hostWidth$ = new BehaviorSubject<number | null>(null);
   enableAutoMeasure$ = new BehaviorSubject<boolean>(false);
   private destroy$ = new Subject();
@@ -47,7 +47,7 @@ export class NzTableFixedRowComponent implements OnInit, OnDestroy, AfterViewIni
     if (this.nzTableStyleService) {
       const { enableAutoMeasure$, hostWidth$ } = this.nzTableStyleService;
       enableAutoMeasure$.pipe(takeUntil(this.destroy$)).subscribe(this.enableAutoMeasure$);
-      hostWidth$.subscribe(this.hostWidth$);
+      hostWidth$.pipe(takeUntil(this.destroy$)).subscribe(this.hostWidth$);
     }
   }
   ngAfterViewInit(): void {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

The `hostWidth$` subject keeps the `NzTableFixedRowComponent.hostWidth$` within its `observers` property until it unsubscribes.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```