### PR TITLE
fix(module:auto-complete): do not run change detection on `mousedown` and `mouseenter` for `nz-auto-option`

### DIFF
--- a/components/auto-complete/autocomplete-option.component.ts
+++ b/components/auto-complete/autocomplete-option.component.ts
@@ -10,10 +10,15 @@ import {
   ElementRef,
   EventEmitter,
   Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
   Optional,
   Output,
   ViewEncapsulation
 } from '@angular/core';
+import { fromEvent, Subject } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { BooleanInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, scrollIntoView } from 'ng-zorro-antd/core/util';
@@ -44,12 +49,10 @@ export class NzOptionSelectionChange {
     '[class.ant-select-item-option-disabled]': 'nzDisabled',
     '[attr.aria-selected]': 'selected.toString()',
     '[attr.aria-disabled]': 'nzDisabled.toString()',
-    '(click)': 'selectViaInteraction()',
-    '(mouseenter)': 'onMouseEnter()',
-    '(mousedown)': '$event.preventDefault()'
+    '(click)': 'selectViaInteraction()'
   }
 })
-export class NzAutocompleteOptionComponent {
+export class NzAutocompleteOptionComponent implements OnInit, OnDestroy {
   static ngAcceptInputType_nzDisabled: BooleanInput;
 
   @Input() nzValue: NzSafeAny;
@@ -61,12 +64,36 @@ export class NzAutocompleteOptionComponent {
   active = false;
   selected = false;
 
+  private destroy$ = new Subject<void>();
+
   constructor(
+    private ngZone: NgZone,
     private changeDetectorRef: ChangeDetectorRef,
-    private element: ElementRef,
+    private element: ElementRef<HTMLElement>,
     @Optional()
     public nzAutocompleteOptgroupComponent: NzAutocompleteOptgroupComponent
   ) {}
+
+  ngOnInit(): void {
+    this.ngZone.runOutsideAngular(() => {
+      fromEvent(this.element.nativeElement, 'mouseenter')
+        .pipe(
+          filter(() => this.mouseEntered.observers.length > 0),
+          takeUntil(this.destroy$)
+        )
+        .subscribe(() => {
+          this.ngZone.run(() => this.mouseEntered.emit(this));
+        });
+
+      fromEvent(this.element.nativeElement, 'mousedown')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(event => event.preventDefault());
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+  }
 
   select(emit: boolean = true): void {
     this.selected = true;
@@ -74,10 +101,6 @@ export class NzAutocompleteOptionComponent {
     if (emit) {
       this.emitSelectionChangeEvent();
     }
-  }
-
-  onMouseEnter(): void {
-    this.mouseEntered.emit(this);
   }
 
   deselect(): void {

--- a/components/auto-complete/autocomplete.spec.ts
+++ b/components/auto-complete/autocomplete.spec.ts
@@ -3,6 +3,7 @@ import { DOWN_ARROW, ENTER, ESCAPE, TAB, UP_ARROW } from '@angular/cdk/keycodes'
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import {
+  ApplicationRef,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -250,6 +251,25 @@ describe('auto-complete', () => {
       fixture.detectChanges();
 
       expect(panel.classList).toContain('ant-select-dropdown-hidden');
+    }));
+
+    it('should not run change detection on `mouseenter` and `mousedown` events for `nz-auto-option`', fakeAsync(() => {
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+      flush();
+
+      const appRef = TestBed.inject(ApplicationRef);
+      spyOn(appRef, 'tick');
+
+      const option = overlayContainerElement.querySelector('nz-auto-option') as HTMLElement;
+      const event = new MouseEvent('mousedown');
+      spyOn(event, 'preventDefault');
+
+      option.dispatchEvent(event);
+      option.dispatchEvent(new MouseEvent('mouseenter'));
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(appRef.tick).not.toHaveBeenCalled();
     }));
   });
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```