### PR TITLE
fix(module:tabs): tabs add btn disappear after all tab closed 

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -80,7 +80,6 @@
     }
 
     .@{tab-prefix-cls}-nav-add {
-      min-height: @tabs-card-height;
       min-width: @tabs-card-height;
       margin-left: @tabs-card-gutter;
       padding: 0 @padding-xs;

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -80,6 +80,7 @@
     }
 
     .@{tab-prefix-cls}-nav-add {
+      min-height: @tabs-card-height;
       min-width: @tabs-card-height;
       margin-left: @tabs-card-gutter;
       padding: 0 @padding-xs;

--- a/components/tabs/style/patch.less
+++ b/components/tabs/style/patch.less
@@ -89,4 +89,11 @@ nz-tabs-nav {
     pointer-events: none;
     color: @disabled-color;
   }
+  > .@{tab-prefix-cls}-nav,
+  > div > .@{tab-prefix-cls}-nav {
+
+    .@{tab-prefix-cls}-nav-add {
+      min-height: @tabs-card-height;
+    }
+  }
 }

--- a/components/tabs/tabset.component.spec.ts
+++ b/components/tabs/tabset.component.spec.ts
@@ -586,6 +586,17 @@ describe('NzTabSet', () => {
 
       expect(fixture.componentInstance.handleSelection).not.toHaveBeenCalled();
     }));
+
+    it('should show add btn after all tabs are removed', () => {
+      const component = fixture.debugElement.componentInstance;
+      component.closable = true;
+      component.type = 'editable-card';
+      fixture.detectChanges();
+      fixture.componentInstance.tabs.splice(0, component.tabs.length);
+      fixture.detectChanges();
+      const btnCount = fixture.debugElement.queryAll(By.css('.ant-tabs-nav-add')).length;
+      expect(btnCount).toBeGreaterThan(0);
+    });
   });
 
   describe('async tabs', () => {
@@ -987,7 +998,11 @@ class DisableTabsTestComponent {
 
 @Component({
   template: `
-    <nz-tabset [(nzSelectedIndex)]="selectedIndex" (nzSelectedIndexChange)="handleSelection($event)">
+    <nz-tabset
+      [(nzSelectedIndex)]="selectedIndex"
+      [nzType]="'editable-card'"
+      (nzSelectedIndexChange)="handleSelection($event)"
+    >
       <nz-tab *ngFor="let tab of tabs" [nzTitle]="tab.title">
         {{ tab.content }}
       </nz-tab>

--- a/components/tabs/tabset.component.ts
+++ b/components/tabs/tabset.component.ts
@@ -64,7 +64,7 @@ let nextId = 0;
   ],
   template: `
     <nz-tabs-nav
-      *ngIf="tabs.length"
+      *ngIf="tabs.length || addable"
       [ngStyle]="nzTabBarStyle"
       [selectedIndex]="nzSelectedIndex || 0"
       [inkBarAnimated]="inkBarAnimated"


### PR DESCRIPTION
There is a problem with the tabs component. When opening and closing the tab page and the Add button, if all the open tab pages are closed, the Add button will not be found. This problem can be repeated in the official website document demo.

Tabs组件有一个问题，当开启关闭tab页和添加按钮时，如果把开启的tab页全部关掉，添加按钮也找不到了，这个问题在官网文档demo中即可复现。

https://ng.ant.design/components/tabs/en#components-tabs-demo-card-top

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
