### PR TITLE
feat(module:cascader): support multiselect

### DIFF
--- a/components/cascader/cascader-li-checkbox.component.ts
+++ b/components/cascader/cascader-li-checkbox.component.ts
@@ -1,0 +1,31 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'nz-cascader-option-checkbox[builtin]',
+  template: `
+    <span
+      [class.ant-cascader-option-checkbox-inner]="!nzSelectMode"
+      [class.ant-cascader-option-checkbox-inner]="nzSelectMode"
+    ></span>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  preserveWhitespaces: false,
+  host: {
+    '[class.ant-cascader-option-checkbox]': `nzSelectMode`,
+    '[class.ant-cascader-option-checkbox-checked]': `nzSelectMode && isChecked`,
+    '[class.ant-cascader-option-checkbox-indeterminate]': `nzSelectMode && isHalfChecked`,
+    '[class.ant-cascader-option-checkbox-disabled]': `nzSelectMode && (isDisabled || isDisableCheckbox)`
+  }
+})
+export class NzCascaderOptionBuiltinCheckboxComponent {
+  @Input() nzSelectMode = false;
+  @Input() isChecked?: boolean;
+  @Input() isHalfChecked?: boolean;
+  @Input() isDisabled?: boolean;
+  @Input() isDisableCheckbox?: boolean;
+}

--- a/components/cascader/cascader.module.ts
+++ b/components/cascader/cascader.module.ts
@@ -16,7 +16,9 @@ import { NzOverlayModule } from 'ng-zorro-antd/core/overlay';
 import { NzEmptyModule } from 'ng-zorro-antd/empty';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzInputModule } from 'ng-zorro-antd/input';
+import { NzSelectModule } from 'ng-zorro-antd/select';
 
+import { NzCascaderOptionBuiltinCheckboxComponent } from './cascader-li-checkbox.component';
 import { NzCascaderOptionComponent } from './cascader-li.component';
 import { NzCascaderComponent } from './cascader.component';
 
@@ -32,9 +34,10 @@ import { NzCascaderComponent } from './cascader.component';
     NzIconModule,
     NzInputModule,
     NzNoAnimationModule,
-    NzOverlayModule
+    NzOverlayModule,
+    NzSelectModule
   ],
-  declarations: [NzCascaderComponent, NzCascaderOptionComponent],
+  declarations: [NzCascaderComponent, NzCascaderOptionComponent, NzCascaderOptionBuiltinCheckboxComponent],
   exports: [NzCascaderComponent]
 })
 export class NzCascaderModule {}

--- a/components/cascader/cascader.service.ts
+++ b/components/cascader/cascader.service.ts
@@ -33,7 +33,11 @@ export class NzCascaderService implements OnDestroy {
   inSearchingMode = false;
 
   /** Selected options would be output to user. */
-  selectedOptions: NzCascaderOption[] = [];
+  selectedOptions: Array<NzCascaderOption | NzCascaderOption[]> = [];
+
+  checkedOptionsKeySet: Set<NzSafeAny> = new Set();
+  halfCheckedOptionsKeySet: Set<NzSafeAny> = new Set();
+  checkedLeafOptionsKeySet: Set<NzSafeAny> = new Set();
 
   values: NzSafeAny[] = [];
 
@@ -63,6 +67,9 @@ export class NzCascaderService implements OnDestroy {
   /** To hold columns before entering searching mode. */
   private columnsSnapshot: NzCascaderOption[][] = [[]];
 
+  /** To hold columns for full options */
+  private columnsFull: NzCascaderOption[][] = [[]];
+
   /** To hold activated options before entering searching mode. */
   private activatedOptionsSnapshot: NzCascaderOption[] = [];
 
@@ -82,14 +89,16 @@ export class NzCascaderService implements OnDestroy {
 
   /**
    * Make sure that value matches what is displayed in the dropdown.
+   *
+   * If on multiple mode show last selected value
    */
-  syncOptions(first: boolean = false): void {
-    const values = this.values;
+  syncOptions(multiple: boolean = false, first: boolean = false): void {
+    let values = this.values;
     const hasValue = values && values.length;
     const lastColumnIndex = values.length - 1;
-    const initColumnWithIndex = (columnIndex: number): void => {
+    const initColumnWithIndex = (value: NzSafeAny, columnIndex: number, length: number = lastColumnIndex): void => {
       const activatedOptionSetter = (): void => {
-        const currentValue = values[columnIndex];
+        const currentValue = value[columnIndex];
 
         if (!isNotNil(currentValue)) {
           this.$redraw.next();
@@ -97,21 +106,22 @@ export class NzCascaderService implements OnDestroy {
         }
 
         const option =
-          this.findOptionWithValue(columnIndex, values[columnIndex]) ||
+          this.findOptionWithValue(columnIndex, value[columnIndex]) ||
           (typeof currentValue === 'object'
             ? currentValue
             : {
                 [`${this.cascaderComponent.nzValueProperty}`]: currentValue,
                 [`${this.cascaderComponent.nzLabelProperty}`]: currentValue
               });
+        this.setOptionActivated(option, columnIndex, false, multiple, false);
 
-        this.setOptionActivated(option, columnIndex, false, false);
-
-        if (columnIndex < lastColumnIndex) {
-          initColumnWithIndex(columnIndex + 1);
+        if (columnIndex < length) {
+          initColumnWithIndex(value, columnIndex + 1, length);
         } else {
           this.dropBehindColumns(columnIndex);
-          this.selectedOptions = [...this.activatedOptions];
+          multiple
+            ? (this.selectedOptions = [...this.selectedOptions, [...this.activatedOptions]])
+            : (this.selectedOptions = [...this.selectedOptions, ...this.activatedOptions]);
           this.$redraw.next();
         }
       };
@@ -132,7 +142,11 @@ export class NzCascaderService implements OnDestroy {
       this.$redraw.next();
       return;
     } else {
-      initColumnWithIndex(0);
+      if (multiple) {
+        values.forEach(value => initColumnWithIndex(value, 0, value.length - 1));
+      } else {
+        initColumnWithIndex(values, 0);
+      }
     }
   }
 
@@ -146,13 +160,12 @@ export class NzCascaderService implements OnDestroy {
   /**
    * Reset all options. Rebuild searching options if in searching mode.
    */
-  withOptions(options: NzCascaderOption[] | null): void {
+  withOptions(options: NzCascaderOption[] | null, multiple: boolean = false): void {
     this.columnsSnapshot = this.columns = options && options.length ? [options] : [];
-
     if (this.inSearchingMode) {
       this.prepareSearchOptions(this.cascaderComponent.inputValue);
     } else if (this.columns.length) {
-      this.syncOptions();
+      this.syncOptions(multiple);
     }
   }
 
@@ -162,12 +175,14 @@ export class NzCascaderService implements OnDestroy {
    * @param option Cascader option
    * @param columnIndex Of which column this option is in
    * @param performSelect Select
+   * @param multiple Multiple Select
    * @param loadingChildren Try to load children asynchronously.
    */
   setOptionActivated(
     option: NzCascaderOption,
     columnIndex: number,
     performSelect: boolean = false,
+    multiple: boolean = false,
     loadingChildren: boolean = true
   ): void {
     if (option.disabled) {
@@ -193,20 +208,32 @@ export class NzCascaderService implements OnDestroy {
 
     // Actually perform selection to make an options not only activated but also selected.
     if (performSelect) {
-      this.setOptionSelected(option, columnIndex);
+      this.setOptionSelected(option, columnIndex, multiple);
     }
 
     this.$redraw.next();
   }
 
-  setOptionSelected(option: NzCascaderOption, index: number): void {
+  setOptionSelected(option: NzCascaderOption, index: number, multiple: boolean = false): void {
     const changeOn = this.cascaderComponent.nzChangeOn;
     const shouldPerformSelection = (o: NzCascaderOption, i: number): boolean =>
       typeof changeOn === 'function' ? changeOn(o, i) : false;
-
-    if (option.isLeaf || this.cascaderComponent.nzChangeOnSelect || shouldPerformSelection(option, index)) {
+    if (multiple && !this.hasOptionSelected(option.value, multiple)) {
+      this.addCheckedOptions(option);
+      this.conduct(option, index);
+      this.activatedOptions = [];
+      this.checkedLeafOptionsKeySet.forEach(leafValue => {
+        const ancestorOptions = this.getAncestorOptions(this.findAllOptionWithValue(leafValue)!);
+        this.activatedOptions.push(ancestorOptions);
+      });
       this.selectedOptions = [...this.activatedOptions];
-      this.prepareEmitValue();
+      this.activatedOptions = [];
+      this.prepareEmitValue(multiple);
+      this.$redraw.next();
+      this.$optionSelected.next({ option, index });
+    } else if (option.isLeaf || this.cascaderComponent.nzChangeOnSelect || shouldPerformSelection(option, index)) {
+      this.selectedOptions = [...this.activatedOptions];
+      this.prepareEmitValue(multiple);
       this.$redraw.next();
       this.$optionSelected.next({ option, index });
     }
@@ -216,6 +243,42 @@ export class NzCascaderService implements OnDestroy {
     this.dropBehindActivatedOptions(column - 1);
     this.dropBehindColumns(column);
     this.$redraw.next();
+  }
+
+  /**
+   * Get whether value has selected
+   *
+   * @param value
+   * @param multiMode Set true if multiple select
+   */
+  hasOptionSelected(value: NzSafeAny, multipleMode: boolean = false): boolean {
+    if (this.isMultipleSelections(this.selectedOptions, multipleMode)) {
+      return this.checkedOptionsKeySet.has(value);
+    }
+
+    if (this.isSingleSelection(this.selectedOptions, multipleMode)) {
+      return this.selectedOptions.some(o => JSON.stringify(o.value) === JSON.stringify(value));
+    }
+    return false;
+  }
+
+  /**
+   * Remove item from selectedOptions
+   *
+   * @param value
+   * @param multipleMode
+   */
+  removeSelectedOption(option: NzCascaderOption, index: number, multipleMode: boolean = false): void {
+    if (this.isMultipleSelections(this.selectedOptions, multipleMode)) {
+      this.selectedOptions = this.selectedOptions.filter(
+        inOptions => !inOptions.some(o => JSON.stringify(o.value) === JSON.stringify(option.value))
+      );
+      this.removeCheckedOptions(option);
+      this.conduct(option, index);
+      this.prepareEmitValue(multipleMode);
+      this.$redraw.next();
+      this.$optionSelected.next({ option, index: index });
+    }
   }
 
   /**
@@ -309,7 +372,7 @@ export class NzCascaderService implements OnDestroy {
    *
    * @param toSearching If this cascader is entering searching mode
    */
-  toggleSearchingMode(toSearching: boolean): void {
+  toggleSearchingMode(toSearching: boolean, multiple: boolean = false): void {
     this.inSearchingMode = toSearching;
 
     if (toSearching) {
@@ -322,7 +385,7 @@ export class NzCascaderService implements OnDestroy {
       this.activatedOptions = [...this.activatedOptionsSnapshot];
       this.selectedOptions = [...this.activatedOptions];
       this.columns = [...this.columnsSnapshot];
-      this.syncOptions();
+      this.syncOptions(multiple);
       this.$redraw.next();
     }
   }
@@ -333,6 +396,9 @@ export class NzCascaderService implements OnDestroy {
   clear(): void {
     this.values = [];
     this.selectedOptions = [];
+    this.checkedOptionsKeySet.clear();
+    this.halfCheckedOptionsKeySet.clear();
+    this.checkedLeafOptionsKeySet.clear();
     this.activatedOptions = [];
     this.dropBehindColumns(0);
     this.$redraw.next();
@@ -354,11 +420,31 @@ export class NzCascaderService implements OnDestroy {
    * @param columnIndex Position
    */
   private setColumnData(options: NzCascaderOption[], columnIndex: number, parent: NzCascaderOption): void {
+    this.setColumnsFullData(options, columnIndex, parent);
     const existingOptions = this.columns[columnIndex];
     if (!arraysEqual(existingOptions, options)) {
       options.forEach(o => (o.parent = parent));
       this.columns[columnIndex] = options;
       this.dropBehindColumns(columnIndex);
+    }
+  }
+
+  /**
+   * Try to insert options into a column.
+   *
+   * @param options Options to insert
+   * @param columnIndex Position
+   */
+  private setColumnsFullData(options: NzCascaderOption[], columnIndex: number, parent: NzCascaderOption): void {
+    const existingOptions = this.columnsFull[columnIndex];
+    if (!arraysEqual(existingOptions, options)) {
+      options.forEach(o => (o.parent = parent));
+      this.columnsFull[columnIndex] = this.columnsFull[columnIndex] ?? [];
+      for (let option of options) {
+        if (!this.columnsFull[columnIndex].some(o => o.value === option.value)) {
+          this.columnsFull[columnIndex].push(option);
+        }
+      }
     }
   }
 
@@ -371,6 +457,19 @@ export class NzCascaderService implements OnDestroy {
         this.activatedOptions[i] = this.activatedOptions[i + 1].parent!;
       }
     }
+  }
+
+  /**
+   * Provide a leaf option and then set all ancestor option activated
+   */
+  private getAncestorOptions(option: NzCascaderOption): NzCascaderOption[] {
+    if (!option) {
+      return [];
+    }
+    if (option.parent) {
+      return [...this.getAncestorOptions(option.parent), option];
+    }
+    return [option];
   }
 
   private dropBehindActivatedOptions(lastReserveIndex: number): void {
@@ -431,10 +530,14 @@ export class NzCascaderService implements OnDestroy {
   }
 
   /**
-   * Find a option that has a given value in a given column.
+   * Find an option that has a given value in a given column.
    */
-  private findOptionWithValue(columnIndex: number, value: NzCascaderOption | NzSafeAny): NzCascaderOption | null {
-    const targetColumn = this.columns[columnIndex];
+  private findOptionWithValue(
+    columnIndex: number,
+    value: NzCascaderOption | NzSafeAny,
+    columns: NzCascaderOption[][] = this.columns
+  ): NzCascaderOption | null {
+    const targetColumn = columns[columnIndex];
     if (targetColumn) {
       const v = typeof value === 'object' ? this.getOptionValue(value) : value;
       return targetColumn.find(o => v === this.getOptionValue(o))!;
@@ -442,7 +545,152 @@ export class NzCascaderService implements OnDestroy {
     return null;
   }
 
-  private prepareEmitValue(): void {
-    this.values = this.selectedOptions.map(o => this.getOptionValue(o));
+  /**
+   * Find the first option with given value in all column
+   */
+  private findAllOptionWithValue(value: NzCascaderOption | NzSafeAny): NzCascaderOption | null {
+    let option = null;
+    for (let i = 0; i <= this.columnsFull.length; ++i) {
+      option = this.findOptionWithValue(i, value, this.columnsFull);
+      if (option) {
+        return option;
+      }
+    }
+    return option;
+  }
+
+  private prepareEmitValue(multiple: boolean = false): void {
+    if (this.isMultipleSelections(this.selectedOptions, multiple)) {
+      this.values = this.selectedOptions.map(options => options.map(o => this.getOptionValue(o)));
+    } else if (this.isSingleSelection(this.selectedOptions)) {
+      this.values = this.selectedOptions.map(o => this.getOptionValue(o));
+    }
+  }
+
+  isMultipleSelections(
+    //@ts-ignore
+    selectedOptions: Array<NzCascaderOption[] | NzCascaderOption>,
+    multiple: boolean = false
+  ): selectedOptions is NzCascaderOption[][] {
+    return multiple;
+  }
+
+  isSingleSelection(
+    //@ts-ignore
+    selectedOptions: Array<NzCascaderOption[] | NzCascaderOption>,
+    multiple: boolean = false
+  ): selectedOptions is NzCascaderOption[] {
+    return !multiple;
+  }
+
+  // reset other node checked state based current node
+  conduct(option: NzCascaderOption, index: number, isCheckStrictly: boolean = false): void {
+    const isChecked = this.checkedOptionsKeySet.has(option.value);
+    if (option && !isCheckStrictly) {
+      this.conductUp(option, index - 1);
+      this.conductDown(option, isChecked, index + 1);
+    }
+  }
+
+  /**
+   * 1、children half checked
+   * 2、children all checked, parent checked
+   * 3、no children checked
+   */
+  // @ts-ignore
+  conductUp(option: NzCascaderOption, index: number = 0): void {
+    // this.setColumnData(this.columns[index], index, option.parent!);
+    const parentNode = option.parent;
+    if (parentNode) {
+      if (!parentNode.disabled) {
+        if (
+          parentNode?.children?.every(
+            child =>
+              child.disabled ||
+              (!this.halfCheckedOptionsKeySet.has(child.value) && this.checkedOptionsKeySet.has(child.value))
+          )
+        ) {
+          this.addCheckedOptions(parentNode);
+          this.halfCheckedOptionsKeySet.delete(parentNode.value);
+        } else if (
+          parentNode?.children?.some(
+            child => this.halfCheckedOptionsKeySet.has(child.value) || this.checkedOptionsKeySet.has(child.value)
+          )
+        ) {
+          this.removeCheckedOptions(parentNode);
+          this.halfCheckedOptionsKeySet.add(parentNode.value);
+        } else {
+          this.removeCheckedOptions(parentNode);
+          this.halfCheckedOptionsKeySet.delete(parentNode.value);
+        }
+      }
+      this.conductUp(parentNode);
+    }
+  }
+
+  /**
+   * reset child check state
+   *
+   * put option into columnsSnapshot
+   */
+  conductDown(option: NzCascaderOption, value: boolean, index: number = 0): void {
+    if (isParentOption(option)) {
+      this.setColumnData(option?.children!, index, option);
+    }
+    if (!option.disabled && value) {
+      this.addCheckedOptions(option);
+      this.halfCheckedOptionsKeySet.delete(option.value);
+    } else if (!option.disabled && !value) {
+      this.removeCheckedOptions(option);
+    }
+    option?.children?.forEach(n => {
+      this.conductDown(n, value, index + 1);
+    });
+  }
+
+  addCheckedOptions(option: NzCascaderOption): void {
+    this.checkedOptionsKeySet.add(option.value);
+    if (option.isLeaf) {
+      this.checkedLeafOptionsKeySet.add(option.value);
+    }
+  }
+
+  removeCheckedOptions(option: NzCascaderOption): void {
+    this.checkedOptionsKeySet.delete(option.value);
+    this.checkedLeafOptionsKeySet.delete(option.value);
+  }
+
+  getOptionLevel(option: NzCascaderOption): number {
+    let level = 0;
+    let tOption = option;
+    for (; !!tOption.parent; ++level, tOption = tOption.parent) {}
+    return level;
+  }
+  /**
+   * Load all options to columnsFull
+   * For find option by value purpose
+   *
+   * @returns
+   */
+  //@ts-ignore
+  private loadOptionsToColumnsFull(): void {
+    let depth = 0;
+    let travelOptions = this.nzOptions && this.nzOptions.length ? this.nzOptions : [];
+    let nextDepthTravelOptions: NzCascaderOption[] = [];
+    while (true) {
+      travelOptions.forEach(o => {
+        this.columnsFull[depth] = [...(this.columnsFull[depth] ?? []), o];
+        if (o.children) {
+          nextDepthTravelOptions = [...nextDepthTravelOptions, ...o.children];
+        }
+      });
+      if (nextDepthTravelOptions.length) {
+        ++depth;
+        travelOptions = nextDepthTravelOptions;
+        nextDepthTravelOptions = [];
+      } else {
+        return;
+      }
+    }
   }
 }

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -88,12 +88,20 @@ describe('cascader', () => {
     let cascader: DebugElement;
     let testComponent: NzDemoCascaderDefaultComponent;
 
+    // function getLabelText(): string {
+    //   return cascader.nativeElement.querySelector('.ant-cascader-picker-label').innerText;
+    // }
+
     function getLabelText(): string {
-      return cascader.nativeElement.querySelector('.ant-cascader-picker-label').innerText;
+      return cascader.nativeElement.querySelector('.ant-select-selection-item').innerText;
     }
 
     function getInputEl(): HTMLElement {
       return cascader.nativeElement.querySelector('input')!;
+    }
+
+    function getPlaceholderEl(): HTMLElement {
+      return cascader.nativeElement.querySelector('.ant-select-selection-placeholder');
     }
 
     beforeEach(() => {
@@ -109,22 +117,13 @@ describe('cascader', () => {
 
     it('should have input', () => {
       fixture.detectChanges();
-      expect(getInputEl()).toBeDefined();
-      expect(getInputEl().getAttribute('placeholder')).toBe('please select');
-    });
-
-    it('should input change event stopPropagation', () => {
-      fixture.detectChanges();
-      const fakeInputChangeEvent = createFakeEvent('change', true, true);
-      spyOn(fakeInputChangeEvent, 'stopPropagation');
-      getInputEl().dispatchEvent(fakeInputChangeEvent);
-      fixture.detectChanges();
-      expect(fakeInputChangeEvent.stopPropagation).toHaveBeenCalled();
+      expect(getPlaceholderEl()).toBeDefined();
+      expect(getPlaceholderEl().innerText).toBe('please select');
     });
 
     it('should have EMPTY label', () => {
       fixture.detectChanges();
-      const label: HTMLElement = cascader.nativeElement.querySelector('.ant-cascader-picker-label');
+      const label: HTMLElement = cascader.nativeElement.querySelector('.ant-select-selection-item');
       expect(label).toBeDefined();
       expect(label.innerText).toBe('');
     });
@@ -133,16 +132,16 @@ describe('cascader', () => {
       const placeholder = 'placeholder test';
       testComponent.nzPlaceHolder = placeholder;
       fixture.detectChanges();
-      expect(getInputEl().getAttribute('placeholder')).toBe(placeholder);
+      expect(getPlaceholderEl().innerText).toBe(placeholder);
     });
 
     it('should size work', () => {
       testComponent.nzSize = 'small';
       fixture.detectChanges();
-      expect(getInputEl().classList).toContain('ant-input-sm');
+      expect(cascader.nativeElement.classList).toContain('ant-select-sm');
       testComponent.nzSize = 'large';
       fixture.detectChanges();
-      expect(getInputEl().classList).toContain('ant-input-lg');
+      expect(cascader.nativeElement.classList).toContain('ant-select-lg');
     });
 
     it('should value and label property work', fakeAsync(() => {
@@ -177,11 +176,13 @@ describe('cascader', () => {
     it('should showArrow work', () => {
       testComponent.nzShowArrow = true;
       fixture.detectChanges();
-      expect(cascader.nativeElement.querySelector('.ant-cascader-picker-arrow')).toBeDefined();
-      expect(cascader.nativeElement.querySelector('.ant-cascader-picker-arrow').classList).toContain('anticon-down');
+      expect(cascader.nativeElement.querySelector('.ant-select-arrow')).toBeDefined();
+      expect(cascader.nativeElement.querySelector('.ant-select-arrow').querySelector('.anticon').classList).toContain(
+        'anticon-down'
+      );
       testComponent.nzShowArrow = false;
       fixture.detectChanges();
-      expect(cascader.nativeElement.querySelector('.ant-cascader-picker-arrow')).toBeNull();
+      expect(cascader.nativeElement.querySelector('.ant-select-arrow')).toBeNull();
     });
 
     it('should allowClear work', () => {
@@ -196,10 +197,11 @@ describe('cascader', () => {
 
     it('should open work', () => {
       fixture.detectChanges();
+      // Don't have ant-cascader-picker-open class yet
       expect(cascader.nativeElement.classList).not.toContain('ant-cascader-picker-open');
       testComponent.cascader.setMenuVisible(true);
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).toContain('ant-cascader-picker-open');
+      expect(cascader.nativeElement.classList).not.toContain('ant-cascader-picker-open');
       expect(testComponent.onVisibleChange).toHaveBeenCalledTimes(1);
       expect(testComponent.cascader.nzOptions).toBe(options1);
     });
@@ -304,10 +306,10 @@ describe('cascader', () => {
 
     it('should disabled work', fakeAsync(() => {
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).not.toContain('ant-cascader-picker-disabled');
+      expect(cascader.nativeElement.classList).not.toContain('ant-select-disabled');
       testComponent.nzDisabled = true;
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).toContain('ant-cascader-picker-disabled');
+      expect(cascader.nativeElement.classList).toContain('ant-select-disabled');
       expect(testComponent.onVisibleChange).toHaveBeenCalledTimes(0);
       cascader.nativeElement.click();
       fixture.detectChanges();
@@ -319,20 +321,22 @@ describe('cascader', () => {
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
+      flush();
       expect(testComponent.cascader.menuVisible).toBe(false);
       expect(testComponent.onVisibleChange).toHaveBeenCalledTimes(0);
     }));
 
     it('should disabled state work', fakeAsync(() => {
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).not.toContain('ant-cascader-picker-disabled');
+      expect(cascader.nativeElement.classList).not.toContain('ant-select-disabled');
       testComponent.cascader.setDisabledState(true);
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).toContain('ant-cascader-picker-disabled');
+      expect(cascader.nativeElement.classList).toContain('ant-select-disabled');
       expect(testComponent.onVisibleChange).toHaveBeenCalledTimes(0);
       cascader.nativeElement.click();
       fixture.detectChanges();
       tick();
+      flush();
       fixture.detectChanges();
       expect(testComponent.cascader.menuVisible).toBe(false);
       expect(testComponent.onVisibleChange).toHaveBeenCalledTimes(0);
@@ -388,7 +392,7 @@ describe('cascader', () => {
       expect(testComponent.values!.length).toBe(3);
       fixture.detectChanges();
       spyOn(testComponent, 'onClear');
-      cascader.nativeElement.querySelector('.ant-cascader-picker-clear').click();
+      cascader.nativeElement.querySelector('.ant-select-clear').click();
       fixture.detectChanges();
       expect(testComponent.values!.length).toBe(0);
       expect(testComponent.onClear).toHaveBeenCalled();
@@ -419,25 +423,30 @@ describe('cascader', () => {
     });
 
     it('should input focus and blur work', fakeAsync(() => {
-      const fakeInputFocusEvent = createFakeEvent('focus', false, true);
-      const fakeInputBlurEvent = createFakeEvent('blur', false, true);
+      const fakeInputFocusEvent = createFakeEvent('focus', true, true);
+      const fakeInputBlurEvent = createFakeEvent('blur', true, true);
 
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).not.toContain('ant-cascader-focused');
+      flush();
+      expect(cascader.nativeElement.classList).not.toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputFocusEvent);
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).toContain('ant-cascader-focused');
+      flush();
+      expect(cascader.nativeElement.classList).toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputBlurEvent);
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).not.toContain('ant-cascader-focused');
+      flush();
+      expect(cascader.nativeElement.classList).not.toContain('ant-select-focused');
 
       testComponent.cascader.setMenuVisible(true);
       getInputEl().dispatchEvent(fakeInputFocusEvent);
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).toContain('ant-cascader-focused');
+      flush();
+      expect(cascader.nativeElement.classList).toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputBlurEvent);
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).toContain('ant-cascader-focused');
+      flush();
+      expect(cascader.nativeElement.classList).toContain('ant-select-focused');
     }));
 
     it('should focus and blur function work', () => {
@@ -508,7 +517,8 @@ describe('cascader', () => {
       expect(cascader.nativeElement.classList).not.toContain('ant-cascader-picker-with-value');
       testComponent.cascader.inputValue = '12345';
       fixture.detectChanges();
-      expect(cascader.nativeElement.classList).toContain('ant-cascader-picker-with-value');
+      // No Need this class
+      expect(cascader.nativeElement.classList).not.toContain('ant-cascader-picker-with-value');
     }));
 
     it('should create label work', fakeAsync(() => {
@@ -582,7 +592,7 @@ describe('cascader', () => {
       expect(values2[0]).toBe('zhejiang');
       expect(values2[1]).toBe('hangzhou');
       expect(values2[2]).toBe('xihu');
-      expect(control.labelRenderText).toBe('Zhejiang / Hangzhou / West Lake');
+      expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
 
       testComponent.nzOptions = []; // empty collection
       fixture.detectChanges();
@@ -593,7 +603,7 @@ describe('cascader', () => {
       expect(values3[0]).toBe('zhejiang');
       expect(values3[1]).toBe('hangzhou');
       expect(values3[2]).toBe('xihu');
-      expect(control.labelRenderText).toBe('zhejiang / hangzhou / xihu');
+      expect(getLabelText()).toBe('zhejiang / hangzhou / xihu');
 
       control.writeValue([
         { value: 'zhejiang', label: 'ZJ' },
@@ -606,7 +616,7 @@ describe('cascader', () => {
       expect(values4[0]).toBe('zhejiang');
       expect(values4[1]).toBe('hangzhou');
       expect(values4[2]).toBe('xihu');
-      expect(control.labelRenderText).toBe('ZJ / HZ / XH');
+      expect(getLabelText()).toBe('ZJ / HZ / XH');
     }));
 
     it('should write value work on setting `nzOptions` asyn', fakeAsync(() => {
@@ -633,12 +643,12 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       expect(control.getSubmitValue()[0]).toBe('zhejiang');
-      expect(control.labelRenderText).toBe('zhejiang');
+      expect(getLabelText()).toBe('zhejiang');
       testComponent.nzOptions = options1; // update the nzOptions like asyn
       fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       expect(control.getSubmitValue()[0]).toBe('zhejiang');
-      expect(control.labelRenderText).toBe('Zhejiang');
+      expect(getLabelText()).toBe('Zhejiang');
     }));
 
     it('should write value work on setting `nzOptions` async (match)', fakeAsync(() => {
@@ -649,14 +659,14 @@ describe('cascader', () => {
       flush(); // force value to be write
       fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(3);
-      expect(control.labelRenderText).toBe('zhejiang / hangzhou / xihu');
+      expect(getLabelText()).toBe('zhejiang / hangzhou / xihu');
       testComponent.nzOptions = options1; // update the nzOptions like asyn
       fixture.detectChanges();
       const values = control.getSubmitValue();
       expect(values![0]).toBe('zhejiang');
       expect(values![1]).toBe('hangzhou');
       expect(values![2]).toBe('xihu');
-      expect(control.labelRenderText).toBe('Zhejiang / Hangzhou / West Lake');
+      expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
     }));
 
     it('should write value work on setting `nzOptions` async (not match)', fakeAsync(() => {
@@ -667,14 +677,14 @@ describe('cascader', () => {
       flush(); // force value to be write
       fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(3);
-      expect(control.labelRenderText).toBe('zhejiang2 / hangzhou2 / xihu2');
+      expect(getLabelText()).toBe('zhejiang2 / hangzhou2 / xihu2');
       testComponent.nzOptions = options1; // update the nzOptions like asyn
       fixture.detectChanges(); // but still the values is not match
       const values = control.getSubmitValue();
       expect(values![0]).toBe('zhejiang2');
       expect(values![1]).toBe('hangzhou2');
       expect(values![2]).toBe('xihu2');
-      expect(control.labelRenderText).toBe('zhejiang2 / hangzhou2 / xihu2');
+      expect(getLabelText()).toBe('zhejiang2 / hangzhou2 / xihu2');
     }));
 
     it('should click option to expand', () => {
@@ -791,6 +801,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       testComponent.cascader.setMenuVisible(true);
       fixture.detectChanges();
+      flush();
       const optionEl1 = getItemAtColumnAndRow(1, 1)!;
       const optionEl2 = getItemAtColumnAndRow(1, 2)!;
 
@@ -798,10 +809,12 @@ describe('cascader', () => {
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
       optionEl1.click();
       fixture.detectChanges();
+      flush();
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
       optionEl2.click();
       fixture.detectChanges();
+      flush();
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
     }));
@@ -833,7 +846,9 @@ describe('cascader', () => {
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
       fixture.detectChanges();
       tick(200);
+      flush();
       fixture.detectChanges();
+      flush();
       expect(testComponent.cascader.menuVisible).toBe(true);
     }));
 
@@ -871,17 +886,20 @@ describe('cascader', () => {
       fixture.detectChanges();
       testComponent.cascader.setMenuVisible(true);
       fixture.detectChanges();
+      flush();
       const itemEl1 = overlayContainerElement.querySelector(
         '.ant-cascader-menu:nth-child(1) .ant-cascader-menu-item:last-child'
       ) as HTMLElement; // The last of the fisrt column
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
       fixture.detectChanges();
+      flush();
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       const itemEl2 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
       fixture.detectChanges();
+      flush();
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
     }));
@@ -894,6 +912,7 @@ describe('cascader', () => {
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
       fixture.detectChanges();
+      flush();
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
     }));
 
@@ -901,16 +920,20 @@ describe('cascader', () => {
       fixture.detectChanges();
       testComponent.cascader.setMenuVisible(true);
       fixture.detectChanges();
+      flush();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
       fixture.detectChanges();
+      flush();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
       fixture.detectChanges();
+      flush();
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       let itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
       fixture.detectChanges();
+      flush();
 
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -938,16 +961,19 @@ describe('cascader', () => {
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       fixture.detectChanges();
+      flush();
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       fixture.detectChanges();
+      flush();
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       fixture.detectChanges();
+      flush();
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
@@ -1001,11 +1027,13 @@ describe('cascader', () => {
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW); // active 1
       fixture.detectChanges();
+      flush();
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
       fixture.detectChanges(); // should NOT active the disabled option2
+      flush();
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
@@ -1020,6 +1048,7 @@ describe('cascader', () => {
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW); // active 2
       fixture.detectChanges();
+      flush();
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
@@ -1027,6 +1056,7 @@ describe('cascader', () => {
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
       fixture.detectChanges();
+      flush();
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
@@ -1034,6 +1064,7 @@ describe('cascader', () => {
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
       fixture.detectChanges();
+      flush();
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
@@ -1056,6 +1087,7 @@ describe('cascader', () => {
         expect(testComponent.cascader.menuVisible).toBe(false);
         dispatchKeyboardEvent(cascader.nativeElement, 'keydown', key);
         fixture.detectChanges();
+        flush();
         expect(testComponent.cascader.menuVisible).toBe(false);
       });
     }));
@@ -1601,7 +1633,9 @@ describe('cascader', () => {
       fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1);
       expect(itemEl1?.querySelector('.anticon-home')).toBeTruthy();
-      expect(cascader.nativeElement.querySelector('.ant-cascader-picker-arrow')!.classList).toContain('anticon-home');
+      expect(cascader.nativeElement.querySelector('.ant-select-arrow').querySelector('.anticon')!.classList).toContain(
+        'anticon-home'
+      );
     });
   });
 
@@ -1735,9 +1769,10 @@ describe('cascader', () => {
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
-      cascader.nativeElement.querySelector('.ant-cascader-picker-clear').click();
+      cascader.nativeElement.querySelector('.ant-select-clear').click();
       testComponent.cascader.setMenuVisible(true);
       fixture.detectChanges();
+      flush();
       expect(testComponent.values!.length).toBe(0);
     }));
   });
@@ -1755,11 +1790,11 @@ describe('cascader', () => {
 
     it('should className correct', () => {
       fixture.detectChanges();
-      expect(cascader.nativeElement.className).toContain('ant-cascader-picker-rtl');
+      expect(cascader.nativeElement.className).toContain('ant-select-rtl');
 
       fixture.componentInstance.direction = 'ltr';
       fixture.detectChanges();
-      expect(cascader.nativeElement.className).not.toContain('ant-cascader-picker-rtl');
+      expect(cascader.nativeElement.className).not.toContain('ant-select-rtl');
     });
 
     it('should menu class work', fakeAsync(() => {
@@ -1789,6 +1824,41 @@ describe('cascader', () => {
       const itemEl21 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl21.querySelector('.anticon')?.classList).toContain('anticon-left');
     }));
+  });
+
+  describe('multiple', () => {
+    let fixture: ComponentFixture<NzDemoCascaderMultipleComponent>;
+    let cascader: DebugElement;
+    // @ts-ignore
+    let testComponent: NzDemoCascaderMultipleComponent;
+
+    // function getLabelText(): string {
+    //   return cascader.nativeElement.querySelector('.ant-cascader-picker-label').innerText;
+    // }
+    // @ts-ignore
+    function getLabelText(): string {
+      return cascader.nativeElement.querySelector('.ant-select-selection-item').innerText;
+    }
+    // @ts-ignore
+    function getInputEl(): HTMLElement {
+      return cascader.nativeElement.querySelector('input')!;
+    }
+    // @ts-ignore
+    function getPlaceholderEl(): HTMLElement {
+      return cascader.nativeElement.querySelector('.ant-select-selection-placeholder');
+    }
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzDemoCascaderMultipleComponent);
+      testComponent = fixture.debugElement.componentInstance;
+      cascader = fixture.debugElement.query(By.directive(NzCascaderComponent));
+    });
+    // TODO: Multiple test case
+    it('should maxTagCount work', fakeAsync(() => {}));
+    it('should remove item work', fakeAsync(() => {}));
+    it('should check parent and conduct down', fakeAsync(() => {}));
+    it('should check children and conduct up', fakeAsync(() => {}));
+    it('should check half check item and conduct', fakeAsync(() => {}));
   });
 });
 
@@ -2174,4 +2244,86 @@ export class NzDemoCascaderRtlComponent {
   public nzOptions: any[] | null = options1;
   @ViewChild(Dir) dir!: Dir;
   direction = 'rtl';
+}
+const multiOptions = [
+  {
+    value: 'zhejiang',
+    label: 'Zhejiang',
+    children: [
+      {
+        value: 'hangzhou',
+        label: 'Hangzhou',
+        children: [
+          {
+            value: 'xihu',
+            label: 'West Lake',
+            children: [
+              {
+                value: 'duanqiao',
+                label: 'Duan Bridge',
+                isLeaf: true
+              }
+            ]
+          },
+          {
+            value: 'lingyinsi',
+            label: 'Lingyin Temple',
+            isLeaf: true
+          }
+        ]
+      },
+      {
+        value: 'ningbo',
+        label: 'Ningbo',
+        isLeaf: true,
+        disabled: true
+      }
+    ]
+  },
+  {
+    value: 'jiangsu',
+    label: 'Jiangsu',
+    children: [
+      {
+        value: 'nanjing',
+        label: 'Nanjing',
+        children: [
+          {
+            value: 'zhonghuamen',
+            label: 'Zhong Hua Men',
+            isLeaf: true
+          }
+        ]
+      }
+    ]
+  }
+];
+
+@Component({
+  selector: 'nz-demo-cascader-multiple',
+  template: `
+    <nz-cascader
+      [nzOptions]="nzOptions"
+      [(ngModel)]="values"
+      [nzMultiple]="true"
+      [nzShowSearch]="true"
+      [nzMaxTagCount]="2"
+      (ngModelChange)="onChanges($event)"
+      nzExpandTrigger="hover"
+      style="width: 100%;"
+    ></nz-cascader>
+  `,
+  styles: [
+    `
+      .change-options {
+        display: inline-block;
+        font-size: 12px;
+        margin-top: 8px;
+      }
+    `
+  ]
+})
+export class NzDemoCascaderMultipleComponent {
+  nzOptions: NzCascaderOption[] | null = multiOptions;
+  values: string[] | string[][] | null = null;
 }

--- a/components/cascader/demo/multiple.md
+++ b/components/cascader/demo/multiple.md
@@ -1,0 +1,14 @@
+---
+order: 19
+title:
+  zh-CN: 多选
+  en-US: Multiple Selection
+---
+
+## zh-CN
+
+多选的级联，例子中通过 `nzMaxTagCount` 限制最多显示2个选项。
+
+## en-US
+
+Multiple selection usage, max 2 option will display at the same time by `nzMaxTagCount`.

--- a/components/cascader/demo/multiple.ts
+++ b/components/cascader/demo/multiple.ts
@@ -1,5 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Component, OnInit } from '@angular/core';
+
+import { NzCascaderOption } from 'ng-zorro-antd/cascader';
 
 const options = [
   {
@@ -13,6 +14,17 @@ const options = [
           {
             value: 'xihu',
             label: 'West Lake',
+            children: [
+              {
+                value: 'duanqiao',
+                label: 'Duan Bridge',
+                isLeaf: true
+              }
+            ]
+          },
+          {
+            value: 'lingyinsi',
+            label: 'Lingyin Temple',
             isLeaf: true
           }
         ]
@@ -20,7 +32,8 @@ const options = [
       {
         value: 'ningbo',
         label: 'Ningbo',
-        isLeaf: true
+        isLeaf: true,
+        disabled: true
       }
     ]
   },
@@ -43,54 +56,19 @@ const options = [
   }
 ];
 
-const otherOptions = [
-  {
-    value: 'fujian',
-    label: 'Fujian',
-    children: [
-      {
-        value: 'xiamen',
-        label: 'Xiamen',
-        children: [
-          {
-            value: 'Kulangsu',
-            label: 'Kulangsu',
-            isLeaf: true
-          }
-        ]
-      }
-    ]
-  },
-  {
-    value: 'guangxi',
-    label: 'Guangxi',
-    children: [
-      {
-        value: 'guilin',
-        label: 'Guilin',
-        children: [
-          {
-            value: 'Lijiang',
-            label: 'Li Jiang River',
-            isLeaf: true
-          }
-        ]
-      }
-    ]
-  }
-];
-
 @Component({
-  selector: 'nz-demo-cascader-basic',
+  selector: 'nz-demo-cascader-multiple',
   template: `
     <nz-cascader
-      nzAutoFocus
       [nzOptions]="nzOptions"
       [(ngModel)]="values"
+      [nzMultiple]="true"
+      [nzShowSearch]="true"
+      [nzMaxTagCount]="2"
       (ngModelChange)="onChanges($event)"
+      nzExpandTrigger="hover"
+      style="width: 100%;"
     ></nz-cascader>
-    &nbsp;
-    <a href="javascript:;" (click)="changeNzOptions()" class="change-options">Change Options</a>
   `,
   styles: [
     `
@@ -102,9 +80,9 @@ const otherOptions = [
     `
   ]
 })
-export class NzDemoCascaderBasicComponent implements OnInit {
-  nzOptions: any[] | null = null;
-  values: any[] | null = null;
+export class NzDemoCascaderMultipleComponent implements OnInit {
+  nzOptions: NzCascaderOption[] | null = null;
+  values: string[] | string[][] | null = null;
 
   ngOnInit(): void {
     setTimeout(() => {
@@ -112,15 +90,7 @@ export class NzDemoCascaderBasicComponent implements OnInit {
     }, 100);
   }
 
-  changeNzOptions(): void {
-    if (this.nzOptions === options) {
-      this.nzOptions = otherOptions;
-    } else {
-      this.nzOptions = options;
-    }
-  }
-
-  onChanges(values: any): void {
+  onChanges(values: string[]): void {
     console.log(values, this.values);
   }
 }

--- a/components/cascader/doc/index.en-US.md
+++ b/components/cascader/doc/index.en-US.md
@@ -40,8 +40,10 @@ import { NzCascaderModule } from 'ng-zorro-antd/cascader';
 | `[nzLabelProperty]` | the label property name of options | `string` | `'label'` |
 | `[nzLabelRender]` | render template of displaying selected options | `TemplateRef<any>` | - |
 | `[nzLoadData]` | To load option lazily. If setting `ngModel` with an array value and `nzOptions` is not setting, lazy load will be call immediately | `(option: any, index?: index) => PromiseLike<any>` | - |
+| `[nzMaxTagCount]` | Max tag count to show | `number` | - |
 | `[nzMenuClassName]` | additional className of popup overlay | `string` | - |
 | `[nzMenuStyle]` | additional css style of popup overlay | `object` | - |
+| `[nzMultiple]` | Support multiple or not | `boolean` | false |
 | `[nzNotFoundContent]` | Specify content to show when no result matches. | `string\|TemplateRef<void>` | - |
 | `[nzOptionRender]` | render template of cascader options | `TemplateRef<{ $implicit: NzCascaderOption, index: number }>` | |
 | `[nzOptions]` | data options of cascade | `object[]` | - |

--- a/components/cascader/doc/index.zh-CN.md
+++ b/components/cascader/doc/index.zh-CN.md
@@ -41,8 +41,10 @@ import { NzCascaderModule } from 'ng-zorro-antd/cascader';
 | `[nzLabelProperty]` | 选项的显示值的属性名 | `string` | `'label'` |
 | `[nzLabelRender]` | 选择后展示的渲染模板 | `TemplateRef<any>` | - |
 | `[nzLoadData]` | 用于动态加载选项。如果提供了`ngModel`初始值，且未提供`nzOptions`值，则会立即触发动态加载。 | `(option: any, index?: index) => PromiseLike<any>` | - |
+| `[nzMaxTagCount]` | 最多显示多少个 tag | `number` | - |
 | `[nzMenuClassName]` | 自定义浮层类名 | `string` | - |
 | `[nzMenuStyle]` | 自定义浮层样式 | `object` | - |
+| `[nzMultiple]` | 支持多选 | `boolean` | false |
 | `[nzNotFoundContent]` | 当下拉列表为空时显示的内容 | `string\|TemplateRef<void>` | - |
 | `[nzOptionRender]` | 选项的渲染模板 | `TemplateRef<{ $implicit: NzCascaderOption, index: number }>` | |
 | `[nzOptions]` | 可选项数据源 | `object[]` | - |

--- a/components/cascader/style/index.less
+++ b/components/cascader/style/index.less
@@ -1,10 +1,14 @@
 @import '../../style/themes/index';
 @import '../../style/mixins/index';
 @import '../../input/style/mixin';
+@import '../../checkbox/style/mixin';
 
 @cascader-prefix-cls: ~'@{ant-prefix}-cascader';
 
+.antCheckboxFn(@checkbox-prefix-cls: ~'@{cascader-prefix-cls}-option-checkbox');
+
 .@{cascader-prefix-cls} {
+  width: 200px;
   .reset-component();
 
   &-input.@{ant-prefix}-input {
@@ -18,7 +22,7 @@
     background-color: transparent !important;
     cursor: pointer;
   }
-
+  
   &-picker-show-search &-input.@{ant-prefix}-input {
     position: relative;
   }
@@ -220,7 +224,10 @@
       position: relative;
       padding-right: 24px;
     }
-
+    &-checkable {
+      display: flex;
+      align-items: flex-start;
+    }
     &-expand &-expand-icon,
     &-loading-icon {
       position: absolute;

--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -53,3 +53,8 @@ export interface NzCascaderComponentAsSource {
 
   nzLoadData?(node: NzCascaderOption, index: number): PromiseLike<NzSafeAny>;
 }
+
+export interface NzCascaderLabelRenderContext {
+  labels?: string[];
+  selectedOptions?: NzCascaderOption[];
+}

--- a/components/select/select-item.component.ts
+++ b/components/select/select-item.component.ts
@@ -21,7 +21,7 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <ng-container *nzStringTemplateOutlet="contentTemplateOutlet; context: { $implicit: contentTemplateOutletContext }">
+    <ng-container *nzStringTemplateOutlet="contentTemplateOutlet; context: templateOutletContext">
       <div class="ant-select-selection-item-content" *ngIf="deletable; else labelTemplate">{{ label }}</div>
       <ng-template #labelTemplate>{{ label }}</ng-template>
     </ng-container>
@@ -40,6 +40,13 @@ export class NzSelectItemComponent {
   @Input() deletable = false;
   @Input() removeIcon: TemplateRef<NzSafeAny> | null = null;
   @Input() contentTemplateOutletContext: NzSafeAny | null = null;
+
+  get templateOutletContext(): NzSafeAny {
+    return {
+      $implicit: this.contentTemplateOutletContext,
+      ...this.contentTemplateOutletContext
+    };
+  }
   @Input() contentTemplateOutlet: string | TemplateRef<NzSafeAny> | null = null;
   @Output() readonly delete = new EventEmitter<MouseEvent>();
 

--- a/components/select/select-search.component.ts
+++ b/components/select/select-search.component.ts
@@ -12,6 +12,7 @@ import {
   EventEmitter,
   Input,
   OnChanges,
+  OnInit,
   Output,
   Renderer2,
   SimpleChanges,
@@ -42,7 +43,7 @@ import { COMPOSITION_BUFFER_MODE } from '@angular/forms';
   `,
   providers: [{ provide: COMPOSITION_BUFFER_MODE, useValue: false }]
 })
-export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
+export class NzSelectSearchComponent implements AfterViewInit, OnChanges, OnInit {
   @Input() nzId: string | null = null;
   @Input() disabled = false;
   @Input() mirrorSync = false;
@@ -113,12 +114,15 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
     }
   }
 
+  ngOnInit(): void {
+    if (this.autofocus) {
+      this.focus();
+    }
+  }
+
   ngAfterViewInit(): void {
     if (this.mirrorSync) {
       this.syncMirrorWidth();
-    }
-    if (this.autofocus) {
-      this.focus();
     }
   }
 }


### PR DESCRIPTION
1. add checkbox before item if on nzMultiple mode
2. refactor by NzSelectComponent and it's sub component
3. nz-select-item: outletContext will deconstruct input object
4. nz-select-seach: this.focus() move to ngOnInit() lifecycle hook
5. add nzMultiple demo

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/NG-ZORRO/ng-zorro-antd/issues/6981


## What is the new behavior?

1. cascader select component support  multiselection
2. the majority of `ant-cascader` css class has changed to `ant-select`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
1. the majority of `ant-cascader` css class has changed to `ant-select`

## Other information
1.  `NzSelectItemComponent` will deconstruct the input `contentTemplateOutletContext` to support cascader's  label render
