### PR TITLE
fix(module:tree-view): fix innerTrackBy function #7118

### DIFF
--- a/components/tree-view/node.ts
+++ b/components/tree-view/node.ts
@@ -166,7 +166,7 @@ export class NzTreeVirtualScrollNodeOutletDirective<T> implements OnChanges {
           return true;
         }
       }
-      return false;
+      return ctxChange.previousValue?.data !== ctxChange.currentValue?.data;
     }
     return true;
   }

--- a/components/tree-view/tree-virtual-scroll-view.ts
+++ b/components/tree-view/tree-virtual-scroll-view.ts
@@ -65,10 +65,12 @@ export class NzTreeVirtualScrollViewComponent<T> extends NzTreeView<T> implement
   innerTrackBy: TrackByFunction<NzTreeVirtualNodeData<T>> = i => i;
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.trackBy && typeof changes.trackBy.currentValue === 'function') {
-      this.innerTrackBy = (index: number, n) => this.trackBy(index, n.data);
-    } else {
-      this.innerTrackBy = i => i;
+    if (changes.trackBy) {
+      if (typeof changes.trackBy.currentValue === 'function') {
+        this.innerTrackBy = (index: number, n) => this.trackBy(index, n.data);
+      } else {
+        this.innerTrackBy = i => i;
+      }
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
1. default `innerTrackBy` function value being assigned on each `OnChanges` call 
2. during scroll further and back of VirtualTree, nodes is broken 

-   Reproduce - [Codesandbox](https://codesandbox.io/s/kwdhb) 

Issue Number: #7118


## What is the new behavior?
1. innerTrackBy function value being assigned only in case when `@Input trackBy` changing
2. VirtualTree scroll recreates nodes as it should be

- Fixed VirtualTree - [CodeSandbox](https://codesandbox.io/s/antd--9tn4j?file=/src/app/nz/nz-tree-virtual-scroll-node-outlet.directive.ts)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
