### PR TITLE
fix(module:drawer): fix close icon position without title property

### DIFF
--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -75,7 +75,11 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
         >
           <div class="ant-drawer-content">
             <div class="ant-drawer-wrapper-body" [style.height]="isLeftOrRight ? '100%' : null">
-              <div *ngIf="nzTitle || nzClosable" [class.ant-drawer-header-close-only]="!nzTitle">
+              <div
+                *ngIf="nzTitle || nzClosable"
+                class="ant-drawer-header"
+                [class.ant-drawer-header-close-only]="!nzTitle"
+              >
                 <div *ngIf="nzTitle" class="ant-drawer-title">
                   <ng-container *nzStringTemplateOutlet="nzTitle">
                     <div [innerHTML]="nzTitle"></div>

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -80,22 +80,24 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
                 class="ant-drawer-header"
                 [class.ant-drawer-header-close-only]="!nzTitle"
               >
-                <div *ngIf="nzTitle" class="ant-drawer-title">
-                  <ng-container *nzStringTemplateOutlet="nzTitle">
-                    <div [innerHTML]="nzTitle"></div>
-                  </ng-container>
+                <div class="ant-drawer-header-title">
+                  <button
+                    *ngIf="nzClosable"
+                    (click)="closeClick()"
+                    aria-label="Close"
+                    class="ant-drawer-close"
+                    style="--scroll-bar: 0px;"
+                  >
+                    <ng-container *nzStringTemplateOutlet="nzCloseIcon; let closeIcon">
+                      <i nz-icon [nzType]="closeIcon"></i>
+                    </ng-container>
+                  </button>
+                  <div *ngIf="nzTitle" class="ant-drawer-title">
+                    <ng-container *nzStringTemplateOutlet="nzTitle">
+                      <div [innerHTML]="nzTitle"></div>
+                    </ng-container>
+                  </div>
                 </div>
-                <button
-                  *ngIf="nzClosable"
-                  (click)="closeClick()"
-                  aria-label="Close"
-                  class="ant-drawer-close"
-                  style="--scroll-bar: 0px;"
-                >
-                  <ng-container *nzStringTemplateOutlet="nzCloseIcon; let closeIcon">
-                    <i nz-icon [nzType]="closeIcon"></i>
-                  </ng-container>
-                </button>
               </div>
               <div class="ant-drawer-body" [ngStyle]="nzBodyStyle">
                 <ng-template cdkPortalOutlet></ng-template>

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -75,11 +75,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
         >
           <div class="ant-drawer-content">
             <div class="ant-drawer-wrapper-body" [style.height]="isLeftOrRight ? '100%' : null">
-              <div
-                *ngIf="nzTitle || nzClosable"
-                [class.ant-drawer-header]="!!nzTitle"
-                [class.ant-drawer-header-close-only]="!nzTitle"
-              >
+              <div *ngIf="nzTitle || nzClosable" [class.ant-drawer-header-close-only]="!nzTitle">
                 <div *ngIf="nzTitle" class="ant-drawer-title">
                   <ng-container *nzStringTemplateOutlet="nzTitle">
                     <div [innerHTML]="nzTitle"></div>

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -191,8 +191,6 @@
     }
 
     &-close-only {
-      padding-bottom: 0;
-      border: none;
       justify-content: flex-end;
     }
   }

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -191,7 +191,8 @@
     }
 
     &-close-only {
-      justify-content: flex-end;
+      padding-bottom: 0;
+      border: none;
     }
   }
 

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -193,6 +193,7 @@
     &-close-only {
       padding-bottom: 0;
       border: none;
+      justify-content: flex-end;
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
fix close icon button without title property
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  [#7164](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7164)


## What is the new behavior?
close icon button will align right,  when does not set nzTitle property

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
