### PR TITLE
fix(module:upload): fix upload drag drop will open new tab in firefox 91 and 92

### DIFF
--- a/components/upload/upload.component.ts
+++ b/components/upload/upload.component.ts
@@ -180,7 +180,7 @@ export class NzUploadComponent implements OnInit, AfterViewInit, OnChanges, OnDe
 
   constructor(
     private ngZone: NgZone,
-    @Inject(DOCUMENT) private document: Document,
+    @Inject(DOCUMENT) private document: NzSafeAny,
     private cdr: ChangeDetectorRef,
     private i18n: NzI18nService,
     @Optional() private directionality: Directionality
@@ -353,7 +353,7 @@ export class NzUploadComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   ngAfterViewInit(): void {
     // fix firefox drop open new tab
     this.ngZone.runOutsideAngular(() =>
-      fromEvent(this.document.body, 'drop')
+      fromEvent<MouseEvent>(this.document.body, 'drop')
         .pipe(takeUntil(this.destroy$))
         .subscribe(event => {
           event.preventDefault();

--- a/components/upload/upload.component.ts
+++ b/components/upload/upload.component.ts
@@ -4,6 +4,7 @@
  */
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
+import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -22,7 +23,6 @@ import {
   Inject,
   ViewEncapsulation
 } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
 import { Observable, of, Subject, Subscription, fromEvent } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
@@ -179,7 +179,7 @@ export class NzUploadComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   // #endregion
 
   constructor(
-    private ngZone: NgZone, 
+    private ngZone: NgZone,
     @Inject(DOCUMENT) private document: Document,
     private cdr: ChangeDetectorRef,
     private i18n: NzI18nService,
@@ -352,10 +352,14 @@ export class NzUploadComponent implements OnInit, AfterViewInit, OnChanges, OnDe
 
   ngAfterViewInit(): void {
     // fix firefox drop open new tab
-    this.ngZone.runOutsideAngular(() => fromEvent(this.document.body, 'drop').pipe(takeUntil(this.destroy$)).subscribe((event) => {
-      event.preventDefault();
-      event.stopPropagation();
-    }));
+    this.ngZone.runOutsideAngular(() =>
+      fromEvent(this.document.body, 'drop')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(event => {
+          event.preventDefault();
+          event.stopPropagation();
+        })
+    );
   }
 
   ngOnChanges(): void {

--- a/components/upload/upload.component.ts
+++ b/components/upload/upload.component.ts
@@ -11,6 +11,7 @@ import {
   EventEmitter,
   Input,
   OnChanges,
+  AfterViewInit,
   OnDestroy,
   OnInit,
   Optional,
@@ -52,7 +53,7 @@ import { NzUploadListComponent } from './upload-list.component';
     '[class.ant-upload-picture-card-wrapper]': 'nzListType === "picture-card"'
   }
 })
-export class NzUploadComponent implements OnInit, OnChanges, OnDestroy {
+export class NzUploadComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
   static ngAcceptInputType_nzLimit: NumberInput;
   static ngAcceptInputType_nzSize: NumberInput;
   static ngAcceptInputType_nzDirectory: BooleanInput;
@@ -328,6 +329,12 @@ export class NzUploadComponent implements OnInit, OnChanges, OnDestroy {
     this.cdr.detectChanges();
   }
 
+  // fix firefox drop open new tab
+  private handleDropOpenNewTab(e: DragEvent){
+    e.preventDefault();
+    e.stopPropagation()
+  }
+
   // #endregion
 
   ngOnInit(): void {
@@ -344,6 +351,10 @@ export class NzUploadComponent implements OnInit, OnChanges, OnDestroy {
     });
   }
 
+  ngAfterViewInit(): void {
+    document.body.addEventListener('drop', this.handleDropOpenNewTab);
+  }
+
   ngOnChanges(): void {
     this.zipOptions().setClassMap();
   }
@@ -351,5 +362,6 @@ export class NzUploadComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+    document.body.removeEventListener('drop', this.handleDropOpenNewTab)
   }
 }


### PR DESCRIPTION
…91 and 92

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
解决nz-upload在火狐浏览器91及92版本上拖拽上传时会默认打开一个新窗口

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
