### PR TITLE
fix(module:input): do not set box-sizing when measuring

### DIFF
--- a/components/input/autosize.spec.ts
+++ b/components/input/autosize.spec.ts
@@ -219,11 +219,10 @@ describe('autoresize', () => {
   encapsulation: ViewEncapsulation.None,
   styles: [
     `
-      textarea.cdk-textarea-autosize-measuring {
+      textarea.nz-textarea-autosize-measuring {
         height: auto !important;
         overflow: hidden !important;
         padding: 2px 0 !important;
-        box-sizing: content-box !important;
       }
     `
   ]
@@ -237,11 +236,10 @@ export class NzTestInputWithTextAreaAutoSizeStringComponent {
   encapsulation: ViewEncapsulation.None,
   styles: [
     `
-      textarea.cdk-textarea-autosize-measuring {
+      textarea.nz-textarea-autosize-measuring {
         height: auto !important;
         overflow: hidden !important;
         padding: 2px 0 !important;
-        box-sizing: content-box !important;
       }
     `
   ]
@@ -256,11 +254,10 @@ export class NzTestInputWithTextAreaAutoSizeObjectComponent {
   encapsulation: ViewEncapsulation.None,
   styles: [
     `
-      textarea.cdk-textarea-autosize-measuring {
+      textarea.nz-textarea-autosize-measuring {
         height: auto !important;
         overflow: hidden !important;
         padding: 2px 0 !important;
-        box-sizing: content-box !important;
       }
     `
   ]

--- a/components/input/style/patch.less
+++ b/components/input/style/patch.less
@@ -4,7 +4,6 @@ textarea.nz-textarea-autosize-measuring {
   // Having 2px top and bottom padding seems to fix a bug where Chrome gets an incorrect
   // measurement. We just have to account for it later and subtract it off the final result.
   padding: 2px 0 !important;
-  box-sizing: content-box !important;
 }
 
 .@{search-prefix} {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7203 


## What is the new behavior?

The textarea auto resizes correctly

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
