### PR TITLE
chore: add pre-commit npm script to display command process stdout

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 export NODE_OPTIONS="--max-old-space-size=4096"
-npx --no-install tsc -p components/tsconfig.json --noEmit
-npx --no-install lint-staged
+npm run pre-commit

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp": "gulp",
     "lint": "eslint --cache . --ext .ts,.html",
     "lint:fix": "eslint --fix --cache . --ext .ts,.html",
+    "pre-commit": "tsc -p components/tsconfig.json --noEmit && lint-staged",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
Currently no stdout during pre-commit hook. By add a npm script we can display this process's stdout.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
