### PR TITLE
feat(module:input-number): support input-number-group and new apis

### DIFF
--- a/components/input-number/demo/addon.md
+++ b/components/input-number/demo/addon.md
@@ -1,0 +1,14 @@
+---
+order: 2
+title:
+    zh-CN: 前置/后置标签
+    en-US: Pre / Post tab
+---
+
+## zh-CN
+
+用于配置一些固定组合。
+
+## en-US
+
+Using pre & post tabs example.

--- a/components/input-number/demo/addon.ts
+++ b/components/input-number/demo/addon.ts
@@ -1,0 +1,55 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'nz-demo-input-number-addon',
+  template: `
+    <nz-input-number-group nzAddOnBefore="+" nzAddOnAfter="$">
+      <nz-input-number [ngModel]="value"></nz-input-number>
+    </nz-input-number-group>
+    <br />
+    <br />
+    <nz-input-number-group [nzAddOnBefore]="selectBefore" [nzAddOnAfter]="selectAfter">
+      <nz-input-number [ngModel]="value"></nz-input-number>
+      <ng-template #selectBefore>
+        <nz-select [ngModel]="'add'">
+          <nz-option [nzValue]="'add'" nzLabel="+"></nz-option>
+          <nz-option [nzValue]="'minus'" nzLabel="-"></nz-option>
+        </nz-select>
+      </ng-template>
+      <ng-template #selectAfter>
+        <nz-select [ngModel]="'USD'">
+          <nz-option [nzValue]="'USD'" nzLabel="$"></nz-option>
+          <nz-option [nzValue]="'EUR'" nzLabel="€"></nz-option>
+          <nz-option [nzValue]="'GBP'" nzLabel="£"></nz-option>
+          <nz-option [nzValue]="'CNY'" nzLabel="¥"></nz-option>
+        </nz-select>
+      </ng-template>
+    </nz-input-number-group>
+    <br />
+    <br />
+    <nz-input-number-group nzAddOnAfterIcon="setting">
+      <nz-input-number [ngModel]="value"></nz-input-number>
+    </nz-input-number-group>
+    <br />
+    <br />
+    <nz-input-number-group [nzAddOnBefore]="cascaderAddon">
+      <nz-input-number [ngModel]="value"></nz-input-number>
+      <ng-template #cascaderAddon>
+        <nz-cascader nzPlaceHolder="cascader"></nz-cascader>
+      </ng-template>
+    </nz-input-number-group>
+  `,
+  styles: [
+    `
+      nz-select {
+        width: 60px;
+      }
+      nz-cascader {
+        width: 150px;
+      }
+    `
+  ]
+})
+export class NzDemoInputNumberAddonComponent {
+  value = 100;
+}

--- a/components/input-number/demo/borderless.md
+++ b/components/input-number/demo/borderless.md
@@ -1,0 +1,14 @@
+---
+order: 6
+title:
+    zh-CN: 无边框
+    en-US: Borderless
+---
+
+## zh-CN
+
+没有边框。
+
+## en-US
+
+No border.

--- a/components/input-number/demo/borderless.ts
+++ b/components/input-number/demo/borderless.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'nz-demo-input-number-borderless',
+  template: ` <nz-input-number nzBorderless [nzMin]="1" [nzMax]="3" [ngModel]="value"></nz-input-number> `
+})
+export class NzDemoInputNumberBorderlessComponent {
+  value = 3;
+}

--- a/components/input-number/demo/digit.md
+++ b/components/input-number/demo/digit.md
@@ -1,5 +1,5 @@
 ---
-order: 3
+order: 4
 title:
     zh-CN: 小数
     en-US: Decimals

--- a/components/input-number/demo/disabled.md
+++ b/components/input-number/demo/disabled.md
@@ -1,5 +1,5 @@
 ---
-order: 2
+order: 3
 title:
     zh-CN: 不可用
     en-US: Disabled

--- a/components/input-number/demo/formatter.md
+++ b/components/input-number/demo/formatter.md
@@ -1,5 +1,5 @@
 ---
-order: 4
+order: 5
 title:
     zh-CN: 格式化展示
     en-US: Formatter

--- a/components/input-number/demo/module
+++ b/components/input-number/demo/module
@@ -1,4 +1,6 @@
 import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzSelectModule } from 'ng-zorro-antd/select';
+import { NzCascaderModule } from "ng-zorro-antd/cascader";
 
-export const moduleList = [ NzInputNumberModule, NzButtonModule ];
+export const moduleList = [ NzInputNumberModule, NzButtonModule, NzSelectModule, NzCascaderModule ];

--- a/components/input-number/demo/precision.md
+++ b/components/input-number/demo/precision.md
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 7
 title:
     zh-CN: 精度
     en-US: Precision

--- a/components/input-number/demo/prefix.md
+++ b/components/input-number/demo/prefix.md
@@ -1,0 +1,14 @@
+---
+order: 8
+title:
+    zh-CN: 前缀
+    en-US: Prefix
+---
+
+## zh-CN
+
+在输入框上添加前缀图标。
+
+## en-US
+
+Add a prefix inside input.

--- a/components/input-number/demo/prefix.ts
+++ b/components/input-number/demo/prefix.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'nz-demo-input-number-prefix',
+  template: `
+    <nz-input-number-group nzPrefix="￥">
+      <nz-input-number [ngModel]="value"></nz-input-number>
+    </nz-input-number-group>
+    <br />
+    <br />
+    <nz-input-number-group [nzAddOnBefore]="icon" nzPrefix="￥">
+      <nz-input-number [ngModel]="value"></nz-input-number>
+      <ng-template #icon><i nz-icon nzType="user" nzTheme="outline"></i></ng-template>
+    </nz-input-number-group>
+    <br />
+    <br />
+    <nz-input-number-group nzPrefix="￥">
+      <nz-input-number nzDisabled></nz-input-number>
+    </nz-input-number-group>
+  `,
+  styles: [
+    `
+      nz-input-number-group {
+        width: 100%;
+      }
+    `
+  ]
+})
+export class NzDemoInputNumberPrefixComponent {
+  value = null;
+}

--- a/components/input-number/doc/index.en-US.md
+++ b/components/input-number/doc/index.en-US.md
@@ -24,6 +24,8 @@ import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 | `[ngModel]` | current value, double binding | `number \| string`  \|  `string` | - |
 | `[nzAutoFocus]` | get focus when component mounted | `boolean` | `false` |
 | `[nzDisabled]` | disable the input | `boolean` | `false` |
+| `[nzBorderless]` | hide the border style or not | `boolean` | `false` |
+| `[nzControls]` | show `+-` controls or not | `boolean` | `true` |
 | `[nzMax]` | max value | `number` | `Infinity` |
 | `[nzMin]` | min value | `number` | `-Infinity` |
 | `[nzFormatter]` | Specifies the format of the value presented | `(value: number \| string) => string \| number` | - |
@@ -38,6 +40,18 @@ import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 | `(ngModelChange)` | The callback triggered when the value is changed | `EventEmitter<number>` | - |
 | `(nzFocus)` | focus callback | `EventEmitter<void>` | - |
 | `(nzBlur)` | blur callback | `EventEmitter<void>` | - |
+
+### nz-input-number-group
+
+| property | description | type | default |
+| --- | --- | --- | --- |
+| `[nzSize]` | set the sizes of all `nz-input-number` inside `nz-input-number-group` | `'large' \| 'small' \| 'default'` | `'default'` |
+| `[nzAddOnAfter]` | the label text displayed after (on the right side of) the input field | `string \| TemplateRef<void>` | - |
+| `[nzAddOnBefore]` | the label text displayed before (on the left side of) the input field | `string \| TemplateRef<void>` | - |
+| `[nzAddOnAfterIcon]` | define the `outline` Icon type inside `nzAddonAfter` | `string` | - |
+| `[nzAddOnBeforeIcon]` | define the `outline` Icon type inside `nzAddonBefore` | `string` | - |
+| `[nzPrefix]` | define the prefix label | `string \| TemplateRef<void>` | - |
+| `[nzPrefixIcon]` | define the `outline` Icon type of the prefix label | `string` | - |
 
 #### Methods
 

--- a/components/input-number/doc/index.zh-CN.md
+++ b/components/input-number/doc/index.zh-CN.md
@@ -25,6 +25,8 @@ import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 | `[ngModel]` | 当前值，可双向绑定 | `number \| string`  \|  `string` | - |
 | `[nzAutoFocus]` | 自动获取焦点 | `boolean` | `false` |
 | `[nzDisabled]` | 禁用 | `boolean` | `false` |
+| `[nzBorderless]` | 是否隐藏边框 | `boolean` | `false` |
+| `[nzControls]` | 是否显示增减按钮 | `boolean` | `true` |
 | `[nzMax]` | 最大值 | `number` | `Infinity` |
 | `[nzMin]` | 最小值 | `number` | `-Infinity` |
 | `[nzFormatter]` | 指定输入框展示值的格式 | `(value: number \| string) => string \| number` | - |
@@ -39,6 +41,18 @@ import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 | `(ngModelChange)` | 数值改变时回调 | `EventEmitter<number>` | - |
 | `(nzFocus)` | focus时回调 | `EventEmitter<void>` | - |
 | `(nzBlur)` | blur时回调 | `EventEmitter<void>` | - |
+
+### nz-input-number-group
+
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| `[nzSize]` | `nz-input-number-group` 中所有的 `nz-input-number` 的大小 | `'large' \| 'small' \| 'default'` | `'default'` |
+| `[nzAddOnAfter]` | 带标签的 input，设置后置标签，可以与 `nzAddOnBefore` 配合使用 | `string \| TemplateRef<void>` | - |
+| `[nzAddOnBefore]` | 带标签的 input，设置前置标签，可以与 `nzAddOnAfter` 配合使用 | `string \| TemplateRef<void>` | - |
+| `[nzAddOnAfterIcon]` | 设置后置标签的 Icon，支持 `outline` 类型 | `string` | - |
+| `[nzAddOnBeforeIcon]` | 设置前置标签的 Icon，支持 `outline` 类型 | `string` | - |
+| `[nzPrefix]` | 带有前缀图标的 input | `string \| TemplateRef<void>` | - |
+| `[nzPrefixIcon]` | 设置前缀的 Icon，支持 `outline` 类型 | `string` | - |
 
 #### 方法
 

--- a/components/input-number/input-number-group-slot.component.ts
+++ b/components/input-number/input-number-group-slot.component.ts
@@ -1,0 +1,26 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: '[nz-input-number-group-slot]',
+  preserveWhitespaces: false,
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <i nz-icon [nzType]="icon" *ngIf="icon"></i>
+    <ng-container *nzStringTemplateOutlet="template">{{ template }}</ng-container>
+  `,
+  host: {
+    '[class.ant-input-number-group-addon]': `type === 'addon'`,
+    '[class.ant-input-number-prefix]': `type === 'prefix'`
+  }
+})
+export class NzInputNumberGroupSlotComponent {
+  @Input() icon?: string | null = null;
+  @Input() type: 'addon' | 'prefix' | null = null;
+  @Input() template?: string | TemplateRef<{}> | null = null;
+}

--- a/components/input-number/input-number-group.component.ts
+++ b/components/input-number/input-number-group.component.ts
@@ -1,0 +1,177 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { FocusMonitor } from '@angular/cdk/a11y';
+import { Direction, Directionality } from '@angular/cdk/bidi';
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Optional,
+  QueryList,
+  SimpleChanges,
+  TemplateRef,
+  ViewEncapsulation
+} from '@angular/core';
+import { merge, Subject } from 'rxjs';
+import { map, mergeMap, startWith, switchMap, takeUntil } from 'rxjs/operators';
+
+import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
+
+import { NzInputNumberComponent } from './input-number.component';
+
+@Component({
+  selector: 'nz-input-number-group',
+  exportAs: 'nzInputNumberGroup',
+  preserveWhitespaces: false,
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="ant-input-number-wrapper ant-input-number-group" *ngIf="isAddOn; else noAddOnTemplate">
+      <div
+        *ngIf="nzAddOnBefore || nzAddOnBeforeIcon"
+        nz-input-number-group-slot
+        type="addon"
+        [icon]="nzAddOnBeforeIcon"
+        [template]="nzAddOnBefore"
+      >
+      </div>
+      <div
+        *ngIf="isAffix; else contentTemplate"
+        class="ant-input-number-affix-wrapper"
+        [class.class.ant-input-number-group-wrapper-rtl]="dir === 'rtl'"
+        [class.ant-input-number-affix-wrapper-disabled]="disabled"
+        [class.ant-input-number-affix-wrapper-focused]="focused"
+      >
+        <ng-template [ngTemplateOutlet]="affixTemplate"></ng-template>
+      </div>
+      <div
+        *ngIf="nzAddOnAfter || nzAddOnAfterIcon"
+        nz-input-number-group-slot
+        type="addon"
+        [icon]="nzAddOnAfterIcon"
+        [template]="nzAddOnAfter"
+      >
+      </div>
+    </div>
+    <ng-template #noAddOnTemplate>
+      <ng-template [ngIf]="isAffix" [ngIfElse]="contentTemplate">
+        <ng-template [ngTemplateOutlet]="affixTemplate"></ng-template>
+      </ng-template>
+    </ng-template>
+    <ng-template #affixTemplate>
+      <div
+        *ngIf="nzPrefix || nzPrefixIcon"
+        nz-input-number-group-slot
+        type="prefix"
+        [icon]="nzPrefixIcon"
+        [template]="nzPrefix"
+      >
+      </div>
+      <ng-template [ngTemplateOutlet]="contentTemplate"></ng-template>
+    </ng-template>
+    <ng-template #contentTemplate>
+      <ng-content></ng-content>
+    </ng-template>
+  `,
+  host: {
+    '[class.ant-input-number-group]': `!isAffix && !isAddOn`,
+    '[class.ant-input-number-group-rtl]': `dir === 'rtl'`,
+    '[class.ant-input-number-group-wrapper]': `isAddOn`,
+    '[class.ant-input-number-group-wrapper-rtl]': `dir === 'rtl'`,
+    '[class.ant-input-number-affix-wrapper]': `!isAddOn && isAffix`,
+    '[class.ant-input-number-affix-wrapper-disabled]': '!isAddOn && isAffix && disabled',
+    '[class.ant-input-number-affix-wrapper-focused]': '!isAddOn && isAffix && focused',
+    '[class.ant-input-number-affix-wrapper-rtl]': `dir === 'rtl'`
+  }
+})
+export class NzInputNumberGroupComponent implements OnInit, OnChanges, AfterContentInit, OnDestroy {
+  @Input() nzAddOnBeforeIcon: string | null = null;
+  @Input() nzAddOnAfterIcon: string | null = null;
+  @Input() nzPrefixIcon: string | null = null;
+  @Input() nzAddOnBefore?: string | TemplateRef<{}>;
+  @Input() nzAddOnAfter?: string | TemplateRef<{}>;
+  @Input() nzPrefix?: string | TemplateRef<{}>;
+  @Input() nzSize: NzSizeLDSType = 'default';
+  @ContentChildren(NzInputNumberComponent) listOfNzInputNumber!: QueryList<NzInputNumberComponent>;
+  focused = false;
+  disabled = false;
+  isAffix = false;
+  isAddOn = false;
+  dir: Direction = 'ltr';
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private focusMonitor: FocusMonitor,
+    private elementRef: ElementRef,
+    private cdr: ChangeDetectorRef,
+    @Optional() private directionality: Directionality
+  ) {}
+
+  updateChildrenSize(): void {
+    if (this.listOfNzInputNumber) {
+      this.listOfNzInputNumber.forEach(item => (item.nzSize = this.nzSize));
+    }
+  }
+
+  ngAfterContentInit(): void {
+    this.updateChildrenSize();
+    const listOfInputChange$ = this.listOfNzInputNumber.changes.pipe(startWith(this.listOfNzInputNumber));
+    listOfInputChange$
+      .pipe(
+        switchMap(list =>
+          merge(...[listOfInputChange$, ...list.map((input: NzInputNumberComponent) => input.disabled$)])
+        ),
+        mergeMap(() => listOfInputChange$),
+        map(list => list.some((input: NzInputNumberComponent) => input.nzDisabled)),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(disabled => {
+        this.disabled = disabled;
+        this.cdr.markForCheck();
+      });
+  }
+
+  ngOnInit(): void {
+    this.focusMonitor
+      .monitor(this.elementRef, true)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(focusOrigin => {
+        this.focused = !!focusOrigin;
+        this.cdr.markForCheck();
+      });
+
+    this.dir = this.directionality.value;
+    this.directionality.change?.pipe(takeUntil(this.destroy$)).subscribe((direction: Direction) => {
+      this.dir = direction;
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const { nzSize, nzPrefix, nzPrefixIcon, nzAddOnAfter, nzAddOnBefore, nzAddOnAfterIcon, nzAddOnBeforeIcon } =
+      changes;
+    if (nzSize) {
+      this.updateChildrenSize();
+    }
+    if (nzPrefix || nzPrefixIcon) {
+      this.isAffix = !!(this.nzPrefix || this.nzPrefixIcon);
+    }
+    if (nzAddOnAfter || nzAddOnBefore || nzAddOnAfterIcon || nzAddOnBeforeIcon) {
+      this.isAddOn = !!(this.nzAddOnAfter || this.nzAddOnBefore || this.nzAddOnAfterIcon || this.nzAddOnBeforeIcon);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/components/input-number/input-number-group.spec.ts
+++ b/components/input-number/input-number-group.spec.ts
@@ -1,0 +1,137 @@
+import { Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
+import { NzIconTestModule } from 'ng-zorro-antd/icon/testing';
+import { NzInputNumberGroupComponent } from 'ng-zorro-antd/input-number/input-number-group.component';
+import { NzInputNumberModule } from 'ng-zorro-antd/input-number/input-number.module';
+
+describe('input number group', () => {
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [NzInputNumberModule, NzIconTestModule],
+      declarations: [NzTestInputNumberGroupBasicComponent]
+    });
+    TestBed.compileComponents();
+  }));
+  describe('input number group basic', () => {
+    let fixture: ComponentFixture<NzTestInputNumberGroupBasicComponent>;
+    let testComponent: NzTestInputNumberGroupBasicComponent;
+    let inputNumberGroup: DebugElement;
+    let inputNumberGroupElement: HTMLInputElement;
+    let inputNumberElement: HTMLInputElement;
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzTestInputNumberGroupBasicComponent);
+      fixture.detectChanges();
+      testComponent = fixture.debugElement.componentInstance;
+      inputNumberGroup = fixture.debugElement.query(By.directive(NzInputNumberGroupComponent));
+      inputNumberGroupElement = inputNumberGroup.nativeElement;
+      inputNumberElement = inputNumberGroup.nativeElement.querySelector('nz-input-number');
+    });
+    it('should basic className correct', () => {
+      fixture.detectChanges();
+      expect(inputNumberGroup.nativeElement.classList).toContain('ant-input-number-group');
+    });
+    it('should nzSize work', () => {
+      testComponent.size = 'large';
+      fixture.detectChanges();
+      expect(inputNumberElement.classList).toContain('ant-input-number-lg');
+      testComponent.size = 'small';
+      fixture.detectChanges();
+      expect(inputNumberElement.classList).toContain('ant-input-number-sm');
+    });
+    it('should nzAddonBefore work', () => {
+      testComponent.addonBefore = 'test';
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-group-addon')).not.toBe(null);
+      testComponent.addonBefore = testComponent.testTemplate;
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-group-addon')).not.toBe(null);
+      testComponent.addonBefore = undefined;
+      fixture.detectChanges();
+      expect(inputNumberElement.querySelector('.ant-input-number-group-addon')).toBe(null);
+    });
+    it('should nzAddonAfter work', () => {
+      testComponent.addonAfter = 'test';
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-group-addon')).not.toBe(null);
+      testComponent.addonAfter = testComponent.testTemplate;
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-group-addon')).not.toBe(null);
+      testComponent.addonAfter = undefined;
+      fixture.detectChanges();
+      expect(inputNumberElement.querySelector('.ant-input-number-group-addon')).toBe(null);
+    });
+    it('should nzPrefix work', () => {
+      testComponent.prefix = 'test';
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-prefix')).not.toBe(null);
+      testComponent.prefix = testComponent.testTemplate;
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-prefix')).not.toBe(null);
+      testComponent.prefix = undefined;
+      fixture.detectChanges();
+      expect(inputNumberElement.querySelector('.ant-input-number-prefix')).toBe(null);
+    });
+    it('should nzAddonBeforeIcon work', () => {
+      testComponent.addonBeforeIcon = 'setting';
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-group-addon')).not.toBe(null);
+      expect(inputNumberGroupElement.querySelector('i.anticon.anticon-setting')).not.toBe(null);
+      testComponent.addonBeforeIcon = undefined;
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-group-addon')).toBe(null);
+      expect(inputNumberElement.querySelector('i.anticon.anticon-setting')).toBe(null);
+    });
+    it('should nzAddonAfterIcon work', () => {
+      testComponent.addonAfterIcon = 'setting';
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-group-addon')).not.toBe(null);
+      expect(inputNumberGroupElement.querySelector('i.anticon.anticon-setting')).not.toBe(null);
+      testComponent.addonAfterIcon = undefined;
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-group-addon')).toBe(null);
+      expect(inputNumberElement.querySelector('i.anticon.anticon-setting')).toBe(null);
+    });
+    it('should nzPrefixIcon work', () => {
+      testComponent.prefixIcon = 'setting';
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-prefix')).not.toBe(null);
+      expect(inputNumberGroupElement.querySelector('i.anticon.anticon-setting')).not.toBe(null);
+      testComponent.prefixIcon = undefined;
+      fixture.detectChanges();
+      expect(inputNumberGroupElement.querySelector('.ant-input-number-prefix')).toBe(null);
+      expect(inputNumberElement.querySelector('i.anticon.anticon-setting')).toBe(null);
+    });
+  });
+});
+
+@Component({
+  template: `
+    <nz-input-number-group
+      [nzSize]="size"
+      [nzAddOnBefore]="addonBefore"
+      [nzAddOnAfter]="addonAfter"
+      [nzPrefix]="prefix"
+      [nzAddOnAfterIcon]="addonAfterIcon"
+      [nzAddOnBeforeIcon]="addonBeforeIcon"
+      [nzPrefixIcon]="prefixIcon"
+    >
+      <nz-input-number></nz-input-number>
+    </nz-input-number-group>
+    <ng-template #testTemplate>
+      <span>test</span>
+    </ng-template>
+  `
+})
+export class NzTestInputNumberGroupBasicComponent {
+  @ViewChild('testTemplate', { static: false }) testTemplate!: TemplateRef<{}>;
+  size: NzSizeLDSType = 'default';
+  addonBefore?: string | TemplateRef<{}>;
+  addonAfter?: string | TemplateRef<{}>;
+  prefix?: string | TemplateRef<{}>;
+  addonBeforeIcon?: string;
+  addonAfterIcon?: string;
+  prefixIcon?: string;
+}

--- a/components/input-number/input-number.component.ts
+++ b/components/input-number/input-number.component.ts
@@ -36,7 +36,7 @@ import { InputBoolean, isNotNil } from 'ng-zorro-antd/core/util';
   selector: 'nz-input-number',
   exportAs: 'nzInputNumber',
   template: `
-    <div class="ant-input-number-handler-wrap">
+    <div *ngIf="nzControls" class="ant-input-number-handler-wrap">
       <span
         unselectable="unselectable"
         class="ant-input-number-handler ant-input-number-handler-up"
@@ -87,6 +87,7 @@ import { InputBoolean, isNotNil } from 'ng-zorro-antd/core/util';
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-input-number',
+    '[class.ant-input-number-borderless]': 'nzBorderless',
     '[class.ant-input-number-focused]': 'isFocused',
     '[class.ant-input-number-lg]': `nzSize === 'large'`,
     '[class.ant-input-number-sm]': `nzSize === 'small'`,
@@ -97,6 +98,8 @@ import { InputBoolean, isNotNil } from 'ng-zorro-antd/core/util';
 export class NzInputNumberComponent implements ControlValueAccessor, AfterViewInit, OnChanges, OnInit, OnDestroy {
   static ngAcceptInputType_nzDisabled: BooleanInput;
   static ngAcceptInputType_nzAutoFocus: BooleanInput;
+  static ngAcceptInputType_nzBorderless: BooleanInput;
+  static ngAcceptInputType_nzControls: BooleanInput;
 
   private autoStepTimer?: number;
   private parsedValue?: string | number;
@@ -106,6 +109,7 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   isFocused = false;
   disabledUp = false;
   disabledDown = false;
+  disabled$ = new Subject<boolean>();
   dir: Direction = 'ltr';
   onChange: OnChangeType = () => {};
   onTouched: OnTouchedType = () => {};
@@ -126,6 +130,8 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   @Input() nzStep = 1;
   @Input() nzInputMode: string = 'decimal';
   @Input() nzId: string | null = null;
+  @Input() @InputBoolean() nzControls = true;
+  @Input() @InputBoolean() nzBorderless = false;
   @Input() @InputBoolean() nzDisabled = false;
   @Input() @InputBoolean() nzAutoFocus = false;
   @Input() nzFormatter: (value: number) => string | number = value => value;
@@ -426,6 +432,10 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   }
 
   ngOnChanges(changes: SimpleChanges): void {
+    const { disabled } = changes;
+    if (disabled) {
+      this.disabled$.next(this.nzDisabled);
+    }
     if (changes.nzFormatter && !changes.nzFormatter.isFirstChange()) {
       const validValue = this.getCurrentValidValue(this.parsedValue!);
       this.setValue(validValue);
@@ -443,5 +453,6 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
     this.focusMonitor.stopMonitoring(this.elementRef);
     this.destroy$.next();
     this.destroy$.complete();
+    this.disabled$.complete();
   }
 }

--- a/components/input-number/input-number.module.ts
+++ b/components/input-number/input-number.module.ts
@@ -8,13 +8,16 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
+import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
+import { NzInputNumberGroupSlotComponent } from './input-number-group-slot.component';
+import { NzInputNumberGroupComponent } from './input-number-group.component';
 import { NzInputNumberComponent } from './input-number.component';
 
 @NgModule({
-  imports: [BidiModule, CommonModule, FormsModule, NzIconModule],
-  declarations: [NzInputNumberComponent],
-  exports: [NzInputNumberComponent]
+  imports: [BidiModule, CommonModule, FormsModule, NzIconModule, NzOutletModule, NzOutletModule],
+  declarations: [NzInputNumberComponent, NzInputNumberGroupComponent, NzInputNumberGroupSlotComponent],
+  exports: [NzInputNumberComponent, NzInputNumberGroupComponent]
 })
 export class NzInputNumberModule {}

--- a/components/input-number/input-number.spec.ts
+++ b/components/input-number/input-number.spec.ts
@@ -79,6 +79,22 @@ describe('input number', () => {
       fixture.detectChanges();
       expect(inputNumber.nativeElement.classList).toContain('ant-input-number-sm');
     });
+    it('should nzBorderless work', () => {
+      testComponent.borderless = true;
+      fixture.detectChanges();
+      expect(inputNumber.nativeElement.classList).toContain('ant-input-number-borderless');
+      testComponent.borderless = false;
+      fixture.detectChanges();
+      expect(inputNumber.nativeElement.classList).not.toContain('ant-input-number-borderless');
+    });
+    it('should nzControls work', () => {
+      testComponent.controls = false;
+      fixture.detectChanges();
+      expect(inputNumber.nativeElement.querySelector('.ant-input-number-handler-wrap')).toBe(null);
+      testComponent.controls = true;
+      fixture.detectChanges();
+      expect(inputNumber.nativeElement.querySelector('.ant-input-number-handler-wrap')).not.toBe(null);
+    });
     it('should autofocus work', () => {
       fixture.detectChanges();
       testComponent.autofocus = true;
@@ -476,6 +492,8 @@ describe('input number', () => {
       (ngModelChange)="modelChange($event)"
       [nzDisabled]="disabled"
       [nzAutoFocus]="autofocus"
+      [nzBorderless]="borderless"
+      [nzControls]="controls"
       [nzSize]="size"
       [nzMin]="min"
       [nzMax]="max"
@@ -493,6 +511,8 @@ export class NzTestInputNumberBasicComponent {
   value?: number | string;
   autofocus = false;
   disabled = false;
+  borderless = false;
+  controls = true;
   min = -1;
   max = 1;
   size = 'default';

--- a/components/input-number/public-api.ts
+++ b/components/input-number/public-api.ts
@@ -5,3 +5,5 @@
 
 export * from './input-number.component';
 export * from './input-number.module';
+export * from './input-number-group.component';
+export * from './input-number-group-slot.component';

--- a/components/input-number/style/affix.less
+++ b/components/input-number/style/affix.less
@@ -1,0 +1,64 @@
+@import '../../input/style/mixin';
+@import (reference) '../../style/themes/index';
+@input-prefix-cls: ~'@{ant-prefix}-input';
+
+@input-affix-margin: 4px;
+
+.@{ant-prefix}-input-number {
+  &-affix-wrapper {
+    .input();
+    // or number handler will cover form status
+    position: static;
+    display: inline-flex;
+    width: 90px;
+    padding: 0;
+    padding-inline-start: @input-padding-horizontal-base;
+
+    &:not(&-disabled):hover {
+      .hover();
+      z-index: 1;
+    }
+
+    &-focused,
+    &:focus {
+      z-index: 1;
+    }
+
+    &-disabled {
+      .@{ant-prefix}-input-number[disabled] {
+        background: transparent;
+      }
+    }
+
+    > div.@{ant-prefix}-input-number {
+      width: 100%;
+      border: none;
+      outline: none;
+
+      &.@{ant-prefix}-input-number-focused {
+        box-shadow: none !important;
+      }
+    }
+
+    input.@{ant-prefix}-input-number-input {
+      padding: 0;
+    }
+
+    &::before {
+      width: 0;
+      visibility: hidden;
+      content: '\a0';
+    }
+  }
+
+  &-prefix {
+    display: flex;
+    flex: none;
+    align-items: center;
+    margin-inline-end: @input-affix-margin;
+  }
+}
+
+.@{ant-prefix}-input-number-group-wrapper .@{ant-prefix}-input-number-affix-wrapper {
+  width: 100%;
+}

--- a/components/input-number/style/entry.less
+++ b/components/input-number/style/entry.less
@@ -1,1 +1,2 @@
 @import './index.less';
+@import './patch.less';

--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -1,6 +1,7 @@
 @import '../../style/themes/index';
 @import '../../style/mixins/index';
 @import '../../input/style/mixin';
+@import './affix';
 
 @input-number-prefix-cls: ~'@{ant-prefix}-input-number';
 @form-item-prefix-cls: ~'@{ant-prefix}-form-item';

--- a/components/input-number/style/patch.less
+++ b/components/input-number/style/patch.less
@@ -1,0 +1,13 @@
+.@{ant-prefix}-input-number {
+  &-affix-wrapper {
+    .@{ant-prefix}-input-number {
+      width: 100%;
+      border: none;
+      outline: none;
+
+      &.@{ant-prefix}-input-number-focused {
+        box-shadow: none !important;
+      }
+    }
+  }
+}

--- a/components/input/public-api.ts
+++ b/components/input/public-api.ts
@@ -5,7 +5,6 @@
 
 export * from './input-group.component';
 export * from './input.module';
-export * from './input-group.component';
 export * from './input-group-slot.component';
 export * from './input.directive';
 export * from './autosize.directive';


### PR DESCRIPTION
close #7228 
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Introduce `<nz-input-number-group></nz-input-number-group>` and the following APIs:
- `[nzAddonBefore]`
- `[nzAddonAfter]`
- `[nzPrefix]`
- `[nzControls]`
- `[nzBorderless]`
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7228 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Reference PRs from Ant Design:
https://github.com/ant-design/ant-design/pull/31432
https://github.com/ant-design/ant-design/pull/31548