### PR TITLE
fix(module:input): incorrect background color in disabled state

### DIFF
--- a/components/input/input-group.component.ts
+++ b/components/input/input-group.component.ts
@@ -57,7 +57,6 @@ export class NzInputGroupWhitSuffixOrPrefixDirective {
         *ngIf="isAffix; else contentTemplate"
         class="ant-input-affix-wrapper"
         [class.ant-input-affix-wrapper-disabled]="disabled"
-        [attr.disabled]="disabled || null"
         [class.ant-input-affix-wrapper-sm]="isSmall"
         [class.ant-input-affix-wrapper-lg]="isLarge"
       >

--- a/components/input/input-group.component.ts
+++ b/components/input/input-group.component.ts
@@ -56,6 +56,7 @@ export class NzInputGroupWhitSuffixOrPrefixDirective {
       <span
         *ngIf="isAffix; else contentTemplate"
         class="ant-input-affix-wrapper"
+        [class.ant-input-affix-wrapper-disabled]="disabled"
         [attr.disabled]="disabled || null"
         [class.ant-input-affix-wrapper-sm]="isSmall"
         [class.ant-input-affix-wrapper-lg]="isLarge"

--- a/components/input/input-group.component.ts
+++ b/components/input/input-group.component.ts
@@ -56,6 +56,7 @@ export class NzInputGroupWhitSuffixOrPrefixDirective {
       <span
         *ngIf="isAffix; else contentTemplate"
         class="ant-input-affix-wrapper"
+        [attr.disabled]="disabled || null"
         [class.ant-input-affix-wrapper-sm]="isSmall"
         [class.ant-input-affix-wrapper-lg]="isLarge"
       >


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

incorrect background-color when using `nzSuffix` and `nzAddOnAfter`

Issue Number: [#7247](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7247)

Close:  [#7247](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7247)

## What is the new behavior?
correct background-color

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
