### PR TITLE
fix(module:slider): fix keydown not trigger nzOnAfterChange

### DIFF
--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -272,6 +272,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
     } else if (!valuesEqual(this.value!, value!)) {
       this.value = value;
       this.updateTrackAndHandles();
+      this.nzOnAfterChange.emit(this.getValue(true));
       this.onValueChange(this.getValue(true));
     }
   }

--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -259,6 +259,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
       ? (this.value as number[])[this.activeValueIndex!] + step
       : (this.value as number) + step;
     this.setActiveValue(ensureNumberInRange(newVal, this.nzMin, this.nzMax));
+    this.nzOnAfterChange.emit(this.getValue(true));
   }
 
   onHandleFocusIn(index: number): void {
@@ -272,9 +273,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
     } else if (!valuesEqual(this.value!, value!)) {
       this.value = value;
       this.updateTrackAndHandles();
-      const sliderValue = this.getValue(true);
-      this.nzOnAfterChange.emit(sliderValue);
-      this.onValueChange(sliderValue);
+      this.onValueChange(this.getValue(true));
     }
   }
 
@@ -385,6 +384,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
   }
 
   private onDragEnd(): void {
+    console.log('onDragEnd');
     this.nzOnAfterChange.emit(this.getValue(true));
     this.toggleDragMoving(false);
     this.cacheSliderProperty(true);

--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -272,8 +272,9 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
     } else if (!valuesEqual(this.value!, value!)) {
       this.value = value;
       this.updateTrackAndHandles();
-      this.nzOnAfterChange.emit(this.getValue(true));
-      this.onValueChange(this.getValue(true));
+      const sliderValue = this.getValue(true);
+      this.nzOnAfterChange.emit(sliderValue);
+      this.onValueChange(sliderValue);
     }
   }
 

--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -384,7 +384,6 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
   }
 
   private onDragEnd(): void {
-    console.log('onDragEnd');
     this.nzOnAfterChange.emit(this.getValue(true));
     this.toggleDragMoving(false);
     this.cacheSliderProperty(true);

--- a/components/slider/slider.spec.ts
+++ b/components/slider/slider.spec.ts
@@ -918,6 +918,16 @@ describe('nz-slider', () => {
       expect(sliderInstance.value).toEqual([2, 99]);
     });
 
+    it('should trigger nzOnAfterChange', () => {
+      const onChangeSpy = jasmine.createSpy('slider onChange');
+
+      sliderInstance.nzOnAfterChange.subscribe(onChangeSpy);
+      dispatchKeyboardEvent(sliderNativeElement, 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should work for range slider when activeValueIndex is undefined', () => {
       testComponent.range = true;
       fixture.detectChanges();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The key down event won't trigger the nzOnAfterChange callback

Issue Number: [#7251](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7251)


## What is the new behavior?
The key down event will trigger the nzOnAfterChange callback

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
