### PR TITLE
fix(module:button): prevent default event fire

### DIFF
--- a/components/button/button.component.ts
+++ b/components/button/button.component.ts
@@ -141,10 +141,10 @@ export class NzButtonComponent implements OnDestroy, OnChanges, AfterViewInit, A
       // The compiler generates the `ɵɵlistener` instruction which wraps the actual listener internally into the
       // function, which runs `markDirty()` before running the actual listener (the decorated class method).
       // Since we're preventing the default behavior and stopping event propagation this doesn't require Angular to run the change detection.
-      fromEvent<MouseEvent>(this.elementRef.nativeElement, 'click')
+      fromEvent<MouseEvent>(this.elementRef.nativeElement, 'click', { capture: true })
         .pipe(takeUntil(this.destroy$))
         .subscribe(event => {
-          if (this.disabled && (event.target as HTMLElement)?.tagName === 'A') {
+          if ((this.disabled && (event.target as HTMLElement)?.tagName === 'A') || this.nzLoading) {
             event.preventDefault();
             event.stopImmediatePropagation();
           }

--- a/components/button/button.spec.ts
+++ b/components/button/button.spec.ts
@@ -84,7 +84,7 @@ describe('button', () => {
       expect(buttonElement.className).toBe('ant-btn');
     });
   });
-  describe('loading state', () => {
+  describe('loading icon', () => {
     it('should hide icon when loading correct', fakeAsync(() => {
       const testBed = createComponentBed(TestButtonBindingComponent, {
         imports: [NzIconTestModule],

--- a/components/button/button.spec.ts
+++ b/components/button/button.spec.ts
@@ -184,11 +184,12 @@ describe('button', () => {
     it('prevent default and stop propagation when the button state is loading', fakeAsync(() => {
       testBed.component.nzLoading = true;
       testBed.fixture.detectChanges();
-      buttonElement.click();
-      testBed.fixture.detectChanges();
-      buttonElement.click();
-      testBed.fixture.detectChanges();
-      expect(testBed.component.buttonClick).toHaveBeenCalledTimes(0);
+      const event = new MouseEvent('click');
+      const preventDefaultSpy = spyOn(event, 'preventDefault').and.callThrough();
+      const stopImmediatePropagationSpy = spyOn(event, 'stopImmediatePropagation').and.callThrough();
+      buttonElement.dispatchEvent(event);
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+      expect(stopImmediatePropagationSpy).toHaveBeenCalledTimes(1);
     }));
   });
 });
@@ -226,7 +227,6 @@ describe('anchor', () => {
       [nzShape]="nzShape"
       [nzBlock]="nzBlock"
       [nzSize]="nzSize"
-      (click)="buttonClick()"
     >
       button
     </button>
@@ -241,7 +241,6 @@ export class TestButtonComponent {
   @Input() nzType: NzButtonType = null;
   @Input() nzShape: NzButtonShape = null;
   @Input() nzSize: NzButtonSize = 'default';
-  buttonClick = jasmine.createSpy('buttonClick');
 }
 // https://github.com/NG-ZORRO/ng-zorro-antd/issues/2191
 @Component({
@@ -292,6 +291,13 @@ export class TestButtonIconOnlyComponent {}
   `
 })
 export class TestButtonIconOnlyLoadingComponent {}
+
+@Component({
+  template: `<button nz-button [nzLoading]="nzLoading" (click)="buttonClick()">click me</button> `
+})
+export class TestButtonWithLoadingComponent {
+  @Input() nzLoading: boolean = false;
+}
 
 @Component({
   template: `

--- a/components/button/button.spec.ts
+++ b/components/button/button.spec.ts
@@ -84,7 +84,7 @@ describe('button', () => {
       expect(buttonElement.className).toBe('ant-btn');
     });
   });
-  describe('loading icon', () => {
+  describe('loading state', () => {
     it('should hide icon when loading correct', fakeAsync(() => {
       const testBed = createComponentBed(TestButtonBindingComponent, {
         imports: [NzIconTestModule],
@@ -180,6 +180,18 @@ describe('button', () => {
       // Previously, it would've caused `tick()` to be called 2 times, because 2 click events have been triggered.
       expect(spy).toHaveBeenCalledTimes(0);
     });
+
+    it('prevent default and stop propagation when the button state is loading', fakeAsync(() => {
+      testBed.component.nzLoading = true;
+      testBed.fixture.detectChanges();
+      const buttonElement = testBed.debugElement.query(By.directive(NzButtonComponent)).nativeElement;
+      const event = new MouseEvent('click');
+      const preventDefaultSpy = spyOn(event, 'preventDefault').and.callThrough();
+      const stopImmediatePropagationSpy = spyOn(event, 'stopImmediatePropagation').and.callThrough();
+      buttonElement.dispatchEvent(event);
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+      expect(stopImmediatePropagationSpy).toHaveBeenCalledTimes(1);
+    }));
   });
 });
 

--- a/components/button/button.spec.ts
+++ b/components/button/button.spec.ts
@@ -184,13 +184,11 @@ describe('button', () => {
     it('prevent default and stop propagation when the button state is loading', fakeAsync(() => {
       testBed.component.nzLoading = true;
       testBed.fixture.detectChanges();
-      const buttonElement = testBed.debugElement.query(By.directive(NzButtonComponent)).nativeElement;
-      const event = new MouseEvent('click');
-      const preventDefaultSpy = spyOn(event, 'preventDefault').and.callThrough();
-      const stopImmediatePropagationSpy = spyOn(event, 'stopImmediatePropagation').and.callThrough();
-      buttonElement.dispatchEvent(event);
-      expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
-      expect(stopImmediatePropagationSpy).toHaveBeenCalledTimes(1);
+      buttonElement.click();
+      testBed.fixture.detectChanges();
+      buttonElement.click();
+      testBed.fixture.detectChanges();
+      expect(testBed.component.buttonClick).toHaveBeenCalledTimes(0);
     }));
   });
 });
@@ -228,6 +226,7 @@ describe('anchor', () => {
       [nzShape]="nzShape"
       [nzBlock]="nzBlock"
       [nzSize]="nzSize"
+      (click)="buttonClick()"
     >
       button
     </button>
@@ -242,6 +241,7 @@ export class TestButtonComponent {
   @Input() nzType: NzButtonType = null;
   @Input() nzShape: NzButtonShape = null;
   @Input() nzSize: NzButtonSize = 'default';
+  buttonClick = jasmine.createSpy('buttonClick');
 }
 // https://github.com/NG-ZORRO/ng-zorro-antd/issues/2191
 @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#7264](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7264)


## What is the new behavior?
When the button state is loading or disabled, the default event will not fire

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
