### PR TITLE
perf(module:modal): call `focus()` on the next rendering frame to prevent frame drop

### DIFF
--- a/components/modal/modal-container.directive.ts
+++ b/components/modal/modal-container.directive.ts
@@ -23,6 +23,7 @@ import { fromEvent, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzConfigService } from 'ng-zorro-antd/core/config';
+import { reqAnimFrame } from 'ng-zorro-antd/core/polyfill';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { getElementOffset, isNotNil } from 'ng-zorro-antd/core/util';
 
@@ -157,7 +158,7 @@ export class BaseModalContainerComponent extends BasePortalOutlet implements OnD
     if (this.document) {
       this.elementFocusedBeforeModalWasOpened = this.document.activeElement as HTMLElement;
       if (this.host.nativeElement.focus) {
-        this.ngZone.runOutsideAngular(() => Promise.resolve().then(() => this.host.nativeElement.focus()));
+        this.ngZone.runOutsideAngular(() => reqAnimFrame(() => this.host.nativeElement.focus()));
       }
     }
   }

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -1095,7 +1095,7 @@ describe('NzModal', () => {
       });
 
       fixture.detectChanges();
-      flushMicrotasks();
+      tick(16);
 
       expect(document.activeElement!.tagName).toBe('NZ-MODAL-CONTAINER', 'Expected modal container to be focused.');
     }));


### PR DESCRIPTION
Calling `focus()` on the element causes browsers to do re-layouts. This can been seen here:
https://gist.github.com/paulirish/5d52fb081b3570c81e3a#setting-focus
Microtasks are executed asynchronously, but within the current rendering frame. Using `requestAnimationFrame`
except of `Promise.resolve` basically unloads the current frame and calls `focus()` on the next rendering
frame, this prevent frame drops on slower devices when the modal is opened:

### Flame graph

![image](https://user-images.githubusercontent.com/7337691/156751586-51800453-7a01-4010-b019-27f13ceb89c0.png)

### Reason

![image](https://user-images.githubusercontent.com/7337691/156751701-8d395a01-fe82-4959-a307-c8f53c117358.png)
