### PR TITLE
feat(module:image): nz-image add press `left` or `right` to switch image

### DIFF
--- a/components/image/doc/index.en-US.md
+++ b/components/image/doc/index.en-US.md
@@ -54,13 +54,12 @@ Other attributes [<img\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Elem
 
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
-| nzKeyboard      | Whether support press `esc` to close | `boolean` | `true` |
+| nzKeyboard      | Whether support press `esc` to close, press `left` or `right` to switch image | `boolean` | `true` |
 | nzMaskClosable      | Whether to close the image preview when the mask (area outside the image) is clicked | `boolean` | `true` |
 | nzCloseOnNavigation      | Whether to close the image preview when the user goes backwards/forwards in history. Note that this usually doesn't include clicking on links (unless the user is using the HashLocationStrategy). | `boolean` | `true` |
 | nzZIndex      | The z-index of the image preview | `number` | 1000 |
 | nzZoom      | Zoom rate | `number` | 1 |
 | nzRotate      | Rotate rate | `number` | 0 |
-| nzEnableLeftRightArrow      | Whether support press `left` or `right` to switch image | `boolean` | `true` |
 
 ### NzImagePreviewRef
 

--- a/components/image/doc/index.en-US.md
+++ b/components/image/doc/index.en-US.md
@@ -60,6 +60,7 @@ Other attributes [<img\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Elem
 | nzZIndex      | The z-index of the image preview | `number` | 1000 |
 | nzZoom      | Zoom rate | `number` | 1 |
 | nzRotate      | Rotate rate | `number` | 0 |
+| nzEnableLeftRightArrow      | Whether support press `left` or `right` to switch image | `boolean` | `true` |
 
 ### NzImagePreviewRef
 

--- a/components/image/doc/index.zh-CN.md
+++ b/components/image/doc/index.zh-CN.md
@@ -54,13 +54,12 @@ import { NzImageModule } from 'ng-zorro-antd/image';
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| nzKeyboard      | 是否支持键盘 esc 关闭 | `boolean` | `true` |
+| nzKeyboard      | 是否支持键盘 esc 关闭、左右键切换图片 | `boolean` | `true` |
 | nzMaskClosable      | 点击蒙层是否允许关闭 | `boolean` | `true` |
 | nzCloseOnNavigation      | 当用户在历史中前进/后退时是否关闭预览。注意，这通常不包括点击链接（除非用户使用HashLocationStrategy）。 | `boolean` | `true` |
 | nzZIndex      | 设置预览层的 z-index | `number` | 1000 |
 | nzZoom      | 缩放比例 | `number` | 1 |
 | nzRotate      | 旋转角度 | `number` | 0 |
-| nzEnableLeftRightArrow      | 是否支持键盘方向键切换图片 | `boolean` | `true` |
 
 ### NzImagePreviewRef
 

--- a/components/image/doc/index.zh-CN.md
+++ b/components/image/doc/index.zh-CN.md
@@ -60,6 +60,7 @@ import { NzImageModule } from 'ng-zorro-antd/image';
 | nzZIndex      | 设置预览层的 z-index | `number` | 1000 |
 | nzZoom      | 缩放比例 | `number` | 1 |
 | nzRotate      | 旋转角度 | `number` | 0 |
+| nzEnableLeftRightArrow      | 是否支持键盘方向键切换图片 | `boolean` | `true` |
 
 ### NzImagePreviewRef
 

--- a/components/image/image-preview-options.ts
+++ b/components/image/image-preview-options.ts
@@ -14,7 +14,6 @@ export class NzImagePreviewOptions {
   nzZoom?: number;
   nzRotate?: number;
   nzDirection?: Direction;
-  nzEnableLeftRightArrow?: boolean = true;
 }
 
 export interface NzImage {

--- a/components/image/image-preview-options.ts
+++ b/components/image/image-preview-options.ts
@@ -14,6 +14,7 @@ export class NzImagePreviewOptions {
   nzZoom?: number;
   nzRotate?: number;
   nzDirection?: Direction;
+  nzEnableLeftRightArrow?: boolean = true;
 }
 
 export interface NzImage {

--- a/components/image/image-preview-ref.ts
+++ b/components/image/image-preview-ref.ts
@@ -21,25 +21,25 @@ export class NzImagePreviewRef {
   ) {
     overlayRef
       .keydownEvents()
-      .pipe(filter(event => (this.config.nzKeyboard as boolean) && event.keyCode === ESCAPE && !hasModifierKey(event)))
-      .subscribe(event => {
-        event.preventDefault();
-        this.close();
-      });
-
-    overlayRef
-      .keydownEvents()
       .pipe(
         filter(
           event =>
-            (this.config.nzEnableLeftRightArrow as boolean) &&
-            (event.keyCode === LEFT_ARROW || event.keyCode === RIGHT_ARROW) &&
+            (this.config.nzKeyboard as boolean) &&
+            (event.keyCode === ESCAPE || event.keyCode === LEFT_ARROW || event.keyCode === RIGHT_ARROW) &&
             !hasModifierKey(event)
         )
       )
       .subscribe(event => {
         event.preventDefault();
-        event.keyCode === LEFT_ARROW ? this.prev() : this.next();
+        if (event.keyCode === ESCAPE) {
+          this.close();
+        }
+        if (event.keyCode === LEFT_ARROW) {
+          this.prev();
+        }
+        if (event.keyCode === RIGHT_ARROW) {
+          this.next();
+        }
       });
 
     overlayRef.detachments().subscribe(() => {

--- a/components/image/image-preview-ref.ts
+++ b/components/image/image-preview-ref.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ESCAPE, hasModifierKey } from '@angular/cdk/keycodes';
+import { ESCAPE, hasModifierKey, LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import { OverlayRef } from '@angular/cdk/overlay';
 import { Subject } from 'rxjs';
 import { filter, take, takeUntil } from 'rxjs/operators';
@@ -25,6 +25,21 @@ export class NzImagePreviewRef {
       .subscribe(event => {
         event.preventDefault();
         this.close();
+      });
+
+    overlayRef
+      .keydownEvents()
+      .pipe(
+        filter(
+          event =>
+            (this.config.nzEnableLeftRightArrow as boolean) &&
+            (event.keyCode === LEFT_ARROW || event.keyCode === RIGHT_ARROW) &&
+            !hasModifierKey(event)
+        )
+      )
+      .subscribe(event => {
+        event.preventDefault();
+        event.keyCode === LEFT_ARROW ? this.prev() : this.next();
       });
 
     overlayRef.detachments().subscribe(() => {

--- a/components/image/image.spec.ts
+++ b/components/image/image.spec.ts
@@ -3,6 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import { Overlay, OverlayContainer } from '@angular/cdk/overlay';
 import { Component, DebugElement, NgModule, ViewChild } from '@angular/core';
 import {
@@ -27,7 +28,7 @@ import {
   ZoomOutOutline
 } from '@ant-design/icons-angular/icons';
 
-import { dispatchFakeEvent } from 'ng-zorro-antd/core/testing';
+import { dispatchFakeEvent, dispatchKeyboardEvent } from 'ng-zorro-antd/core/testing';
 import { NzIconModule, NZ_ICONS } from 'ng-zorro-antd/icon';
 import {
   getFitContentPosition,
@@ -398,6 +399,19 @@ describe('Preview', () => {
       expect(previewImageElement.src).toContain(images[0].src);
       context.previewRef?.next();
       fixture.detectChanges();
+      previewImageElement = getPreviewImageElement();
+      expect(previewImageElement.src).toContain(images[1].src);
+
+      dispatchKeyboardEvent(overlayContainerElement, 'keydown', RIGHT_ARROW);
+      tickChanges();
+      previewImageElement = getPreviewImageElement();
+      expect(previewImageElement.src).toContain(images[1].src);
+      dispatchKeyboardEvent(overlayContainerElement, 'keydown', LEFT_ARROW);
+      tickChanges();
+      previewImageElement = getPreviewImageElement();
+      expect(previewImageElement.src).toContain(images[0].src);
+      dispatchKeyboardEvent(overlayContainerElement, 'keydown', RIGHT_ARROW);
+      tickChanges();
       previewImageElement = getPreviewImageElement();
       expect(previewImageElement.src).toContain(images[1].src);
     }));


### PR DESCRIPTION
The nz-image add nzEnableLeftRightArrow to support press `left` or `right` to switch image

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
