### PR TITLE
fix(module:carousel): fix nzAfterChange callback value not correctly

### DIFF
--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -308,7 +308,7 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
       this.nzBeforeChange.emit({ from, to });
       this.strategy!.switch(this.activeIndex, index).subscribe(() => {
         this.scheduleNextTransition();
-        this.nzAfterChange.emit(index);
+        this.nzAfterChange.emit(to);
         this.isTransiting = false;
       });
       this.markContentActive(to);

--- a/components/carousel/carousel.spec.ts
+++ b/components/carousel/carousel.spec.ts
@@ -17,7 +17,7 @@ describe('carousel', () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [BidiModule, NzCarouselModule],
-      declarations: [NzTestCarouselBasicComponent, NzTestCarouselRtlComponent]
+      declarations: [NzTestCarouselBasicComponent, NzTestCarouselRtlComponent, NzTestCarouselActiveIndexComponent]
     });
     TestBed.compileComponents();
   }));
@@ -284,6 +284,26 @@ describe('carousel', () => {
     // already covered in components specs.
     // describe('opacity strategy', () => {});
   });
+
+  describe('carousel nzAfterChange return value', () => {
+    let fixture: ComponentFixture<NzTestCarouselActiveIndexComponent>;
+    let testComponent: NzTestCarouselActiveIndexComponent;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzTestCarouselActiveIndexComponent);
+      fixture.detectChanges();
+      testComponent = fixture.debugElement.componentInstance;
+    });
+
+    it('carousel activeIndex should be equal to nzAfterChange return value', fakeAsync(() => {
+      fixture.detectChanges();
+      [0, 1, 2, 3, 4].forEach(_ => {
+        testComponent.nzCarouselComponent.next();
+        tickMilliseconds(fixture, 700);
+        expect(testComponent.index).toBe(testComponent.nzCarouselComponent.activeIndex);
+      });
+    }));
+  });
 });
 
 describe('carousel custom strategies', () => {
@@ -420,4 +440,23 @@ export class NzTestCarouselBasicComponent {
 export class NzTestCarouselRtlComponent {
   @ViewChild(Dir) dir!: Dir;
   direction = 'rtl';
+}
+
+@Component({
+  template: `
+    <nz-carousel (nzAfterChange)="afterChange($event)">
+      <div nz-carousel-content *ngFor="let index of array">
+        <h3>{{ index }}</h3>
+      </div>
+    </nz-carousel>
+  `
+})
+export class NzTestCarouselActiveIndexComponent {
+  @ViewChild(NzCarouselComponent, { static: true }) nzCarouselComponent!: NzCarouselComponent;
+  array = [0, 1, 2, 3, 4];
+  index = 0;
+
+  afterChange(index: number): void {
+    this.index = index;
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#7323](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7323)


## What is the new behavior?
nzAfterChange callback return correctly 
Closed:  [#7323](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7323)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
