### PR TITLE
fix(module:modal): no longer trigger any action when closing

### DIFF
--- a/components/modal/modal-ref.ts
+++ b/components/modal/modal-ref.ts
@@ -167,6 +167,9 @@ export class NzModalRef<T = NzSafeAny, R = NzSafeAny> implements NzModalLegacyAP
   }
 
   private async trigger(action: NzTriggerAction): Promise<void> {
+    if (this.state === NzModalState.CLOSING) {
+      return;
+    }
     const trigger = { ok: this.config.nzOnOk, cancel: this.config.nzOnCancel }[action];
     const loadingKey = { ok: 'nzOkLoading', cancel: 'nzCancelLoading' }[action] as 'nzOkLoading' | 'nzCancelLoading';
     const loading = this.config[loadingKey];

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -908,6 +908,32 @@ describe('NzModal', () => {
       expect(overlayContainerElement.querySelectorAll('nz-modal-container').length).toBe(0);
     }));
 
+    it('should omit any action when closing', async function () {
+      const onOk = jasmine.createSpy('onOk', () => {});
+      const onCancel = jasmine.createSpy('onCancel', () => {});
+      const modalRef = modalService.create({
+        nzContent: TestWithModalContentComponent,
+        nzOnOk: onOk,
+        nzOnCancel: onCancel
+      });
+      fixture.detectChanges();
+      expect(overlayContainerElement.querySelectorAll('nz-modal-container').length).toBe(1);
+      await modalRef.triggerOk();
+      expect(onOk).toHaveBeenCalledTimes(1);
+      fakeAsync(() => {
+        expect(modalRef.getState()).toBe(NzModalState.CLOSING);
+        modalRef.triggerOk();
+        modalRef.triggerOk();
+        modalRef.triggerCancel();
+        modalRef.triggerCancel();
+        expect(onOk).toHaveBeenCalledTimes(1);
+        expect(onCancel).toHaveBeenCalledTimes(0);
+        fixture.detectChanges();
+        flush();
+        expect(overlayContainerElement.querySelectorAll('nz-modal-container').length).toBe(0);
+      });
+    });
+
     it('should set loading state when the callback is promise', fakeAsync(() => {
       const modalRef = modalService.create({
         nzContent: TestWithModalContentComponent,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
目前在关闭 Modal 的动画窗口期仍然能够触发 `nzOnOK` 或 `nzOnCancel`，造成用户意外的双击或者快速点击的情况下会重复的触发事件
Issue Number: N/A


## What is the new behavior?
当 Modal 处于 `Closing` 状态下时，将忽略 `nzOnOK` 或 `nzOnCancel` 的事件

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
