### PR TITLE
fix(module:select): Console error when interacting with searchable input using keyboard

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -389,10 +389,11 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, OnDestro
     }
     const listOfFilteredOptionNotDisabled = this.listOfContainerItem.filter(item => item.type === 'item').filter(item => !item.nzDisabled);
     const activatedIndex = listOfFilteredOptionNotDisabled.findIndex(item => this.compareWith(item.nzValue, this.activatedValue));
+    const listOfFilteredOptionNotDisabledCount: number = listOfFilteredOptionNotDisabled.length;
     switch (e.keyCode) {
       case UP_ARROW:
         e.preventDefault();
-        if (this.nzOpen) {
+        if (this.nzOpen && listOfFilteredOptionNotDisabledCount) {
           const preIndex = activatedIndex > 0 ? activatedIndex - 1 : listOfFilteredOptionNotDisabled.length - 1;
           this.activatedValue = listOfFilteredOptionNotDisabled[preIndex].nzValue;
         }
@@ -400,8 +401,10 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, OnDestro
       case DOWN_ARROW:
         e.preventDefault();
         if (this.nzOpen) {
-          const nextIndex = activatedIndex < listOfFilteredOptionNotDisabled.length - 1 ? activatedIndex + 1 : 0;
-          this.activatedValue = listOfFilteredOptionNotDisabled[nextIndex].nzValue;
+          if (listOfFilteredOptionNotDisabledCount) {
+            const nextIndex = activatedIndex < listOfFilteredOptionNotDisabled.length - 1 ? activatedIndex + 1 : 0;
+            this.activatedValue = listOfFilteredOptionNotDisabled[nextIndex].nzValue;
+          }
         } else {
           this.setOpenState(true);
         }

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -394,7 +394,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, OnDestro
       case UP_ARROW:
         e.preventDefault();
         if (this.nzOpen && listOfFilteredOptionNotDisabledCount) {
-          const preIndex = activatedIndex > 0 ? activatedIndex - 1 : listOfFilteredOptionNotDisabled.length - 1;
+          const preIndex = activatedIndex > 0 ? activatedIndex - 1 : listOfFilteredOptionNotDisabledCount - 1;
           this.activatedValue = listOfFilteredOptionNotDisabled[preIndex].nzValue;
         }
         break;
@@ -402,7 +402,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, OnDestro
         e.preventDefault();
         if (this.nzOpen) {
           if (listOfFilteredOptionNotDisabledCount) {
-            const nextIndex = activatedIndex < listOfFilteredOptionNotDisabled.length - 1 ? activatedIndex + 1 : 0;
+            const nextIndex = activatedIndex < listOfFilteredOptionNotDisabledCount - 1 ? activatedIndex + 1 : 0;
             this.activatedValue = listOfFilteredOptionNotDisabled[nextIndex].nzValue;
           }
         } else {


### PR DESCRIPTION
Console error when interacting with searchable input using keyboard

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
In searchable select input (when list in empty) click on search input and press down/up key it will console error for nzValue of undefined, This PR avoid this exception and first check the list have item when user press down/up key.

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
In searchable select input (when list in empty) click on search input and press down/up key it will console error for nzValue of undefined.

Issue Number: [6699](https://github.com/NG-ZORRO/ng-zorro-antd/issues/6699)


## What is the new behavior?
In searchable select input (when list in empty) click on search input and press down/up key it will console error for nzValue of undefined, This PR avoid this exception and first check the list have item when user press down/up key.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
