### PR TITLE
fix(module:tree): tree select search slow in virtual mode

### DIFF
--- a/components/tree-select/demo/virtual-scroll.ts
+++ b/components/tree-select/demo/virtual-scroll.ts
@@ -11,6 +11,7 @@ import { NzTreeNodeOptions } from 'ng-zorro-antd/tree';
       nzShowSearch
       nzPlaceHolder="Please select"
       nzVirtualHeight="300px"
+      nzHideUnMatched="true"
     ></nz-tree-select>
   `
 })

--- a/components/tree/tree.component.ts
+++ b/components/tree/tree.component.ts
@@ -485,7 +485,10 @@ export class NzTreeComponent
 
   ngOnInit(): void {
     this.nzTreeService.flattenNodes$.pipe(takeUntil(this.destroy$)).subscribe(data => {
-      this.nzFlattenNodes = !!this.nzVirtualHeight && this.nzHideUnMatched ? data.filter(d => !d.canHide) : data;
+      this.nzFlattenNodes =
+        !!this.nzVirtualHeight && this.nzHideUnMatched && this.nzSearchValue?.length > 0
+          ? data.filter(d => !d.canHide)
+          : data;
       this.cdr.markForCheck();
     });
 

--- a/components/tree/tree.component.ts
+++ b/components/tree/tree.component.ts
@@ -485,7 +485,7 @@ export class NzTreeComponent
 
   ngOnInit(): void {
     this.nzTreeService.flattenNodes$.pipe(takeUntil(this.destroy$)).subscribe(data => {
-      this.nzFlattenNodes = data;
+      this.nzFlattenNodes = !!this.nzVirtualHeight && this.nzHideUnMatched ? data.filter(d => !d.canHide) : data;
       this.cdr.markForCheck();
     });
 

--- a/components/tree/tree.spec.ts
+++ b/components/tree/tree.spec.ts
@@ -146,25 +146,40 @@ describe('tree', () => {
 
       [
         {
-          title: 'should display 7 nodes when hideUnMatched=false and virtualHeight = undefined',
-          when: { hideUnMatched: false },
-          then: 7
-        },
-        {
-          title: "should display 7 nodes when hideUnMatched=false and virtualHeight = '300px'",
-          when: { hideUnMatched: false, virtualHeight: '300px' },
-          then: 7
-        },
-        {
-          title: 'should display 7 nodes when hideUnMatched=true and virtualHeight = undefined',
-          when: { hideUnMatched: true },
-          then: 7
+          title:
+            "should display 7 nodes when hideUnMatched=false and virtualHeight = undefined and nzSearchValue = '0-1'",
+          when: { hideUnMatched: false, searchValue: '0-1' },
+          then: { matchedNodeList: 3, nzFlattenNodes: 7 }
         },
         {
           title:
-            "should display 4 matched nodes based on nzSearchValue when hideUnMatched=true and virtualHeight = '300px'",
+            "should display 7 nodes when hideUnMatched=false and virtualHeight = '300px' and nzSearchValue = '0-1'",
+          when: { hideUnMatched: false, virtualHeight: '300px', searchValue: '0-1' },
+          then: { matchedNodeList: 3, nzFlattenNodes: 7 }
+        },
+        {
+          title:
+            "'should display 7 nodes when hideUnMatched=true and virtualHeight = undefined and nzSearchValue = '0-1'",
+          when: { hideUnMatched: true, searchValue: '0-1' },
+          then: { matchedNodeList: 3, nzFlattenNodes: 7 }
+        },
+        {
+          title:
+            "should display 4 matched nodes based on nzSearchValue when hideUnMatched=true and virtualHeight = '300px' and nzSearchValue = undefined",
           when: { hideUnMatched: true, virtualHeight: '300px' },
-          then: 4
+          then: { matchedNodeList: 0, nzFlattenNodes: 3 }
+        },
+        {
+          title:
+            "should display 4 matched nodes based on nzSearchValue when hideUnMatched=true and virtualHeight = '300px' and nzSearchValue = ''",
+          when: { hideUnMatched: true, virtualHeight: '300px', searchValue: '' },
+          then: { matchedNodeList: 0, nzFlattenNodes: 3 }
+        },
+        {
+          title:
+            "should display 4 matched nodes based on nzSearchValue when hideUnMatched=true and virtualHeight = '300px' and nzSearchValue = '0-1'",
+          when: { hideUnMatched: true, virtualHeight: '300px', searchValue: '0-1' },
+          then: { matchedNodeList: 3, nzFlattenNodes: 4 }
         }
       ].forEach(({ title, when, then }) => {
         it(
@@ -172,7 +187,7 @@ describe('tree', () => {
           fakeAsync(() => {
             // Given
             const { component, fixture, nativeElement } = testBed;
-            component.searchValue = '0-1';
+            component.searchValue = when.searchValue;
             component.virtualHeight = when.virtualHeight;
             component.hideUnMatched = when.hideUnMatched;
             // When
@@ -182,13 +197,13 @@ describe('tree', () => {
             // Then
             expect(component.treeComponent.getMatchedNodeList().length)
               .withContext('treeComponent.getMatchedNodeList().length')
-              .toBe(3);
+              .toBe(then.matchedNodeList);
             expect(component.treeComponent.nzFlattenNodes.length)
               .withContext('treeComponent.nzFlattenNodes.length')
-              .toBe(then);
+              .toBe(then.nzFlattenNodes);
             expect(nativeElement.querySelectorAll('nz-tree-node').length)
               .withContext('number of displayed nz-tree-node elements')
-              .toBe(then);
+              .toBe(then.nzFlattenNodes);
           })
         );
       });

--- a/components/tree/tree.spec.ts
+++ b/components/tree/tree.spec.ts
@@ -144,6 +144,55 @@ describe('tree', () => {
         expect(component.treeComponent.getMatchedNodeList().length).toEqual(1);
       }));
 
+      [
+        {
+          title: 'should display 7 nodes when hideUnMatched=false and virtualHeight = undefined',
+          when: { hideUnMatched: false },
+          then: 7
+        },
+        {
+          title: "should display 7 nodes when hideUnMatched=false and virtualHeight = '300px'",
+          when: { hideUnMatched: false, virtualHeight: '300px' },
+          then: 7
+        },
+        {
+          title: 'should display 7 nodes when hideUnMatched=true and virtualHeight = undefined',
+          when: { hideUnMatched: true },
+          then: 7
+        },
+        {
+          title:
+            "should display 4 matched nodes based on nzSearchValue when hideUnMatched=true and virtualHeight = '300px'",
+          when: { hideUnMatched: true, virtualHeight: '300px' },
+          then: 4
+        }
+      ].forEach(({ title, when, then }) => {
+        it(
+          title,
+          fakeAsync(() => {
+            // Given
+            const { component, fixture, nativeElement } = testBed;
+            component.searchValue = '0-1';
+            component.virtualHeight = when.virtualHeight;
+            component.hideUnMatched = when.hideUnMatched;
+            // When
+            fixture.detectChanges();
+            tick(300);
+            fixture.detectChanges();
+            // Then
+            expect(component.treeComponent.getMatchedNodeList().length)
+              .withContext('treeComponent.getMatchedNodeList().length')
+              .toBe(3);
+            expect(component.treeComponent.nzFlattenNodes.length)
+              .withContext('treeComponent.nzFlattenNodes.length')
+              .toBe(then);
+            expect(nativeElement.querySelectorAll('nz-tree-node').length)
+              .withContext('number of displayed nz-tree-node elements')
+              .toBe(then);
+          })
+        );
+      });
+
       it('should match nodes based on nzSearchFunc', fakeAsync(() => {
         const { component, fixture, nativeElement } = testBed;
         component.searchFunc = (data: NzTreeNodeOptions): boolean => data.title === component.searchValue;
@@ -588,6 +637,7 @@ describe('tree', () => {
       [nzMultiple]="multiple"
       [nzSearchValue]="searchValue"
       [nzSearchFunc]="searchFunc"
+      [nzVirtualHeight]="virtualHeight"
       [nzHideUnMatched]="hideUnMatched"
       [nzExpandAll]="expandAll"
       [nzExpandedIcon]="expandedIcon"
@@ -619,6 +669,7 @@ export class NzTestTreeBasicControlledComponent {
   defaultExpandedKeys: string[] = [];
   expandedIcon?: TemplateRef<{ $implicit: NzTreeNode; origin: NzTreeNodeOptions }>;
   searchFunc?: (node: NzTreeNodeOptions) => boolean;
+  virtualHeight?: string | boolean = false;
   hideUnMatched = false;
   nodes: NzTreeNodeOptions[] | NzTreeNode[] = [
     {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/NG-ZORRO/ng-zorro-antd/issues/5873


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
For nz-tree component
when nzVirtualHeight is defined and nzHideUnMatched=true
then we should remove node with canHide=true from nzFlattenNodes
In showcase website, for tree select component, i put nzHideUnMatched=true for virtual scroll sample