### PR TITLE
fix(module:tabs): fix @animation-duration-slow not applied to .ant-tabs-tab-btn with

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -145,7 +145,7 @@
 
     &-btn {
       outline: none;
-      transition: all 0.3s;
+      transition: all @animation-duration-slow;
     }
 
     &-remove {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
Override `@animation-duration-slow` in style.less will not applied to the `.ant-tabs-tab-btn` element


## What is the new behavior?
Override `@animation-duration-slow` in style.less do applied to the `.ant-tabs-tab-btn` element


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
