### PR TITLE
docs(module:*): debug demos

### DIFF
--- a/components/progress/demo/dashboard-layout.md
+++ b/components/progress/demo/dashboard-layout.md
@@ -1,0 +1,15 @@
+---
+order: 8
+debug: true
+title:
+  zh-CN: 仪表盘样式
+  en-US: Dashboard Layout
+---
+
+## zh-CN
+
+仪表盘展示样式
+
+## en-US
+
+Dashboard layout

--- a/components/progress/demo/dashboard-layout.ts
+++ b/components/progress/demo/dashboard-layout.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'nz-demo-progress-dashboard-layout',
+  template: `<nz-progress [nzPercent]="1" nzType="dashboard" [nzGapDegree]="90"></nz-progress>
+    <nz-progress [nzPercent]="75" nzType="dashboard" [nzGapDegree]="180"></nz-progress>
+    <nz-progress [nzPercent]="75" nzType="dashboard" [nzGapDegree]="295"></nz-progress>
+    <nz-progress [nzPercent]="1" nzType="dashboard" [nzGapDegree]="340"></nz-progress>`
+})
+export class NzDemoProgressDashboardLayoutComponent {}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
   },
   "scripts": {
-    "start": "gulp start:dev",
+    "start": "NODE_ENV=development gulp start:dev",
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI --code-coverage",
     "test:watch": "gulp test:watch --tags",
     "test:schematics": "gulp build:schematics && gulp test:schematics",

--- a/scripts/site/utils/get-meta.js
+++ b/scripts/site/utils/get-meta.js
@@ -35,7 +35,7 @@ module.exports = function getMeta(file) {
     .reduce((a, b) => [...a, ...b], []);
   let description = '';
   if (meta.subtitle) {
-    description = `Angular ${meta.subtitle}组件，`;
+    description = `Angular ${meta.subtitle} 组件，`;
   } else if (meta.title) {
     description = `Angular ${meta.title} Component, `;
   }


### PR DESCRIPTION
Add `debug: true` in the yaml meta, we could me a demo only visible in local development. It would be convenient to debug reproductions from the community.

允许在 demo 中增加 `debug: true` 属性，来让这个 demo 只出现在本地开发环境中，这样调试用户提供的复现时就会方便一些。

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
