### PR TITLE
fix(module:select): fix input width in tags mode

### DIFF
--- a/components/select/select-search.component.ts
+++ b/components/select/select-search.component.ts
@@ -79,8 +79,10 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
     const hostDOM = this.elementRef.nativeElement;
     const inputDOM = this.inputElement.nativeElement;
     this.renderer.removeStyle(hostDOM, 'width');
-    mirrorDOM.innerHTML = this.renderer.createText(`${inputDOM.value}&nbsp;`);
+    const textnode = this.renderer.createText(`${inputDOM.value}&nbsp;`);
+    mirrorDOM.appendChild(textnode);
     this.renderer.setStyle(hostDOM, 'width', `${mirrorDOM.scrollWidth}px`);
+    this.renderer.removeChild(mirrorDOM, textnode);
   }
 
   focus(): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

when searching in a select in tags mode, the input field has a constant width to 75px, making the input scrolling when the text take more than 75px.


## What is the new behavior?

The input element is correctly resized depending the search text.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
