### PR TITLE
fix(module:transfer): `submit` behavior for button inside form

### DIFF
--- a/components/transfer/transfer.component.ts
+++ b/components/transfer/transfer.component.ts
@@ -69,6 +69,7 @@ import { NzTransferListComponent } from './transfer-list.component';
     <div *ngIf="dir !== 'rtl'" class="ant-transfer-operation">
       <button
         nz-button
+        type="button"
         (click)="moveToLeft()"
         [disabled]="nzDisabled || !leftActive"
         [nzType]="'primary'"
@@ -79,6 +80,7 @@ import { NzTransferListComponent } from './transfer-list.component';
       </button>
       <button
         nz-button
+        type="button"
         (click)="moveToRight()"
         [disabled]="nzDisabled || !rightActive"
         [nzType]="'primary'"
@@ -91,6 +93,7 @@ import { NzTransferListComponent } from './transfer-list.component';
     <div *ngIf="dir === 'rtl'" class="ant-transfer-operation">
       <button
         nz-button
+        type="button"
         (click)="moveToRight()"
         [disabled]="nzDisabled || !rightActive"
         [nzType]="'primary'"
@@ -101,6 +104,7 @@ import { NzTransferListComponent } from './transfer-list.component';
       </button>
       <button
         nz-button
+        type="button"
         (click)="moveToLeft()"
         [disabled]="nzDisabled || !leftActive"
         [nzType]="'primary'"


### PR DESCRIPTION
Fixes #7410.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Inside the form, the `transfer` component is triggered by moving to the `right/left` on the `enter` command.

Issue Number: https://github.com/NG-ZORRO/ng-zorro-antd/issues/7410


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->