### PR TITLE
chore: add variable.less to support css variable

### DIFF
--- a/components/core/color/generate.ts
+++ b/components/core/color/generate.ts
@@ -1,0 +1,169 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+/**
+ * Sync from @ant-design/colors(https://github.com/ant-design/ant-design-colors)
+ */
+
+import { rgbToHsv, rgbToHex, inputToRGB } from '@ctrl/tinycolor';
+
+const hueStep = 2; // 色相阶梯
+const saturationStep = 0.16; // 饱和度阶梯，浅色部分
+const saturationStep2 = 0.05; // 饱和度阶梯，深色部分
+const brightnessStep1 = 0.05; // 亮度阶梯，浅色部分
+const brightnessStep2 = 0.15; // 亮度阶梯，深色部分
+const lightColorCount = 5; // 浅色数量，主色上
+const darkColorCount = 4; // 深色数量，主色下
+// 暗色主题颜色映射关系表
+const darkColorMap = [
+  { index: 7, opacity: 0.15 },
+  { index: 6, opacity: 0.25 },
+  { index: 5, opacity: 0.3 },
+  { index: 5, opacity: 0.45 },
+  { index: 5, opacity: 0.65 },
+  { index: 5, opacity: 0.85 },
+  { index: 4, opacity: 0.9 },
+  { index: 3, opacity: 0.95 },
+  { index: 2, opacity: 0.97 },
+  { index: 1, opacity: 0.98 }
+];
+
+interface HsvObject {
+  h: number;
+  s: number;
+  v: number;
+}
+
+interface RgbObject {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// Wrapper function ported from TinyColor.prototype.toHsv
+// Keep it here because of `hsv.h * 360`
+function toHsv({ r, g, b }: RgbObject): HsvObject {
+  const hsv = rgbToHsv(r, g, b);
+  return { h: hsv.h * 360, s: hsv.s, v: hsv.v };
+}
+
+// Wrapper function ported from TinyColor.prototype.toHexString
+// Keep it here because of the prefix `#`
+function toHex({ r, g, b }: RgbObject): string {
+  return `#${rgbToHex(r, g, b, false)}`;
+}
+
+// Wrapper function ported from TinyColor.prototype.mix, not treeshakable.
+// Amount in range [0, 1]
+// Assume color1 & color2 has no alpha, since the following src code did so.
+function mix(rgb1: RgbObject, rgb2: RgbObject, amount: number): RgbObject {
+  const p = amount / 100;
+  const rgb = {
+    r: (rgb2.r - rgb1.r) * p + rgb1.r,
+    g: (rgb2.g - rgb1.g) * p + rgb1.g,
+    b: (rgb2.b - rgb1.b) * p + rgb1.b
+  };
+  return rgb;
+}
+
+function getHue(hsv: HsvObject, i: number, light?: boolean): number {
+  let hue: number;
+  // 根据色相不同，色相转向不同
+  if (Math.round(hsv.h) >= 60 && Math.round(hsv.h) <= 240) {
+    hue = light ? Math.round(hsv.h) - hueStep * i : Math.round(hsv.h) + hueStep * i;
+  } else {
+    hue = light ? Math.round(hsv.h) + hueStep * i : Math.round(hsv.h) - hueStep * i;
+  }
+  if (hue < 0) {
+    hue += 360;
+  } else if (hue >= 360) {
+    hue -= 360;
+  }
+  return hue;
+}
+
+function getSaturation(hsv: HsvObject, i: number, light?: boolean): number {
+  // grey color don't change saturation
+  if (hsv.h === 0 && hsv.s === 0) {
+    return hsv.s;
+  }
+  let saturation: number;
+  if (light) {
+    saturation = hsv.s - saturationStep * i;
+  } else if (i === darkColorCount) {
+    saturation = hsv.s + saturationStep;
+  } else {
+    saturation = hsv.s + saturationStep2 * i;
+  }
+  // 边界值修正
+  if (saturation > 1) {
+    saturation = 1;
+  }
+  // 第一格的 s 限制在 0.06-0.1 之间
+  if (light && i === lightColorCount && saturation > 0.1) {
+    saturation = 0.1;
+  }
+  if (saturation < 0.06) {
+    saturation = 0.06;
+  }
+  return Number(saturation.toFixed(2));
+}
+
+function getValue(hsv: HsvObject, i: number, light?: boolean): number {
+  let value: number;
+  if (light) {
+    value = hsv.v + brightnessStep1 * i;
+  } else {
+    value = hsv.v - brightnessStep2 * i;
+  }
+  if (value > 1) {
+    value = 1;
+  }
+  return Number(value.toFixed(2));
+}
+
+interface Opts {
+  theme?: 'dark' | 'default';
+  backgroundColor?: string;
+}
+
+export function generate(color: string, opts: Opts = {}): string[] {
+  const patterns: string[] = [];
+  const pColor = inputToRGB(color);
+  for (let i = lightColorCount; i > 0; i -= 1) {
+    const hsv = toHsv(pColor);
+    const colorString: string = toHex(
+      inputToRGB({
+        h: getHue(hsv, i, true),
+        s: getSaturation(hsv, i, true),
+        v: getValue(hsv, i, true)
+      })
+    );
+    patterns.push(colorString);
+  }
+  patterns.push(toHex(pColor));
+  for (let i = 1; i <= darkColorCount; i += 1) {
+    const hsv = toHsv(pColor);
+    const colorString: string = toHex(
+      inputToRGB({
+        h: getHue(hsv, i),
+        s: getSaturation(hsv, i),
+        v: getValue(hsv, i)
+      })
+    );
+    patterns.push(colorString);
+  }
+
+  // dark theme patterns
+  if (opts.theme === 'dark') {
+    return darkColorMap.map(({ index, opacity }) => {
+      const darkColorString: string = toHex(
+        mix(inputToRGB(opts.backgroundColor || '#141414'), inputToRGB(patterns[index]), opacity * 100)
+      );
+      return darkColorString;
+    });
+  }
+  return patterns;
+}

--- a/components/core/color/public-api.ts
+++ b/components/core/color/public-api.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './color';
+export * from './generate';

--- a/components/core/config/config.service.ts
+++ b/components/core/config/config.service.ts
@@ -10,10 +10,13 @@ import { filter, mapTo } from 'rxjs/operators';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 import { NzConfig, NzConfigKey, NZ_CONFIG } from './config';
+import { registerTheme } from './css-variables';
 
 const isDefined = function (value?: NzSafeAny): boolean {
   return value !== undefined;
 };
+
+const defaultPrefixCls = 'ant';
 
 @Injectable({
   providedIn: 'root'
@@ -26,6 +29,10 @@ export class NzConfigService {
 
   constructor(@Optional() @Inject(NZ_CONFIG) defaultConfig?: NzConfig) {
     this.config = defaultConfig || {};
+    if (this.config.theme) {
+      // If theme is set with NZ_CONFIG, register theme to make sure css variables work
+      registerTheme(this.getConfig().prefixCls?.prefixCls || defaultPrefixCls, this.config.theme);
+    }
   }
 
   getConfig(): NzConfig {
@@ -45,6 +52,9 @@ export class NzConfigService {
 
   set<T extends NzConfigKey>(componentName: T, value: NzConfig[T]): void {
     this.config[componentName] = { ...this.config[componentName], ...value };
+    if (componentName === 'theme' && this.config.theme) {
+      registerTheme(this.getConfig().prefixCls?.prefixCls || defaultPrefixCls, this.config.theme);
+    }
     this.configUpdated$.next(componentName);
   }
 }

--- a/components/core/config/config.spec.ts
+++ b/components/core/config/config.spec.ts
@@ -99,6 +99,25 @@ describe('nz global config', () => {
       expect(buttonEl.classList).not.toContain('ant-btn-sm');
     });
 
+    it('should dynamic theme colors config work', () => {
+      fixture.detectChanges();
+      testComponent.nzConfigService.set('theme', { primaryColor: '#0000FF' });
+      fixture.detectChanges();
+      expect(getComputedStyle(document.documentElement).getPropertyValue('--ant-primary-color').trim()).toEqual(
+        'rgb(0, 0, 255)'
+      );
+    });
+
+    it('should dynamic theme colors config with custom prefix work', () => {
+      fixture.detectChanges();
+      testComponent.nzConfigService.set('prefixCls', { prefixCls: 'custom-variable' });
+      testComponent.nzConfigService.set('theme', { primaryColor: '#0000FF' });
+      fixture.detectChanges();
+      expect(
+        getComputedStyle(document.documentElement).getPropertyValue('--custom-variable-primary-color').trim()
+      ).toEqual('rgb(0, 0, 255)');
+    });
+
     // It would fail silently. User cannot input a component name wrong - TypeScript comes to help!
     // it('should raise error when the component with given name is not defined', () => {
     //   expect(() => {

--- a/components/core/config/config.ts
+++ b/components/core/config/config.ts
@@ -70,6 +70,23 @@ export interface NzConfig {
   popconfirm?: PopConfirmConfig;
   popover?: PopoverConfig;
   imageExperimental?: ImageExperimentalConfig;
+  theme?: Theme;
+  prefixCls?: PrefixCls;
+}
+
+export interface PrefixCls {
+  prefixCls?: string;
+  iconPrefixCls?: string;
+}
+
+export interface Theme {
+  primaryColor?: string;
+  infoColor?: string;
+  successColor?: string;
+  processingColor?: string;
+  errorColor?: string;
+  warningColor?: string;
+  [key: string]: string | undefined;
 }
 
 export interface SelectConfig {

--- a/components/core/config/css-variables.ts
+++ b/components/core/config/css-variables.ts
@@ -1,0 +1,104 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+/**
+ * Sync from @ant-design/colors(https://github.com/ant-design/ant-design-colors)
+ */
+import { TinyColor } from '@ctrl/tinycolor';
+
+import { generate } from 'ng-zorro-antd/core/color';
+import { warn } from 'ng-zorro-antd/core/logger';
+import { canUseDom, updateCSS } from 'ng-zorro-antd/core/util';
+
+import { Theme } from './config';
+
+const dynamicStyleMark = `-ant-${Date.now()}-${Math.random()}`;
+
+export function getStyle(globalPrefixCls: string, theme: Theme): string {
+  const variables: Record<string, string> = {};
+
+  const formatColor = (color: TinyColor, updater?: (cloneColor: TinyColor) => TinyColor | undefined): string => {
+    let clone = color.clone();
+    clone = updater?.(clone) || clone;
+    return clone.toRgbString();
+  };
+
+  const fillColor = (colorVal: string, type: string): void => {
+    const baseColor = new TinyColor(colorVal);
+    const colorPalettes = generate(baseColor.toRgbString());
+
+    variables[`${type}-color`] = formatColor(baseColor);
+    variables[`${type}-color-disabled`] = colorPalettes[1];
+    variables[`${type}-color-hover`] = colorPalettes[4];
+    variables[`${type}-color-active`] = colorPalettes[7];
+    variables[`${type}-color-outline`] = baseColor.clone().setAlpha(0.2).toRgbString();
+    variables[`${type}-color-deprecated-bg`] = colorPalettes[1];
+    variables[`${type}-color-deprecated-border`] = colorPalettes[3];
+  };
+
+  // ================ Primary Color ================
+  if (theme.primaryColor) {
+    fillColor(theme.primaryColor, 'primary');
+
+    const primaryColor = new TinyColor(theme.primaryColor);
+    const primaryColors = generate(primaryColor.toRgbString());
+
+    // Legacy - We should use semantic naming standard
+    primaryColors.forEach((color, index) => {
+      variables[`primary-${index + 1}`] = color;
+    });
+    // Deprecated
+    variables['primary-color-deprecated-l-35'] = formatColor(primaryColor, c => c.lighten(35));
+    variables['primary-color-deprecated-l-20'] = formatColor(primaryColor, c => c.lighten(20));
+    variables['primary-color-deprecated-t-20'] = formatColor(primaryColor, c => c.tint(20));
+    variables['primary-color-deprecated-t-50'] = formatColor(primaryColor, c => c.tint(50));
+    variables['primary-color-deprecated-f-12'] = formatColor(primaryColor, c => c.setAlpha(c.getAlpha() * 0.12));
+
+    const primaryActiveColor = new TinyColor(primaryColors[0]);
+    variables['primary-color-active-deprecated-f-30'] = formatColor(primaryActiveColor, c =>
+      c.setAlpha(c.getAlpha() * 0.3)
+    );
+    variables['primary-color-active-deprecated-d-02'] = formatColor(primaryActiveColor, c => c.darken(2));
+  }
+
+  // ================ Success Color ================
+  if (theme.successColor) {
+    fillColor(theme.successColor, 'success');
+  }
+
+  // ================ Warning Color ================
+  if (theme.warningColor) {
+    fillColor(theme.warningColor, 'warning');
+  }
+
+  // ================= Error Color =================
+  if (theme.errorColor) {
+    fillColor(theme.errorColor, 'error');
+  }
+
+  // ================= Info Color ==================
+  if (theme.infoColor) {
+    fillColor(theme.infoColor, 'info');
+  }
+
+  // Convert to css variables
+  const cssList = Object.keys(variables).map(key => `--${globalPrefixCls}-${key}: ${variables[key]};`);
+
+  return `
+  :root {
+    ${cssList.join('\n')}
+  }
+  `.trim();
+}
+
+export function registerTheme(globalPrefixCls: string, theme: Theme): void {
+  const style = getStyle(globalPrefixCls, theme);
+
+  if (canUseDom()) {
+    updateCSS(style, `${dynamicStyleMark}-dynamic-theme`);
+  } else {
+    warn(`NzConfigService: SSR do not support dynamic theme with css variables.`);
+  }
+}

--- a/components/core/config/public-api.ts
+++ b/components/core/config/public-api.ts
@@ -5,3 +5,4 @@
 
 export * from './config.service';
 export * from './config';
+export * from './css-variables';

--- a/components/core/util/can-use-dom.ts
+++ b/components/core/util/can-use-dom.ts
@@ -1,0 +1,11 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+/**
+ * Sync from rc-util [https://github.com/react-component/util]
+ */
+export function canUseDom(): boolean {
+  return !!(typeof window !== 'undefined' && window.document && window.document.createElement);
+}

--- a/components/core/util/dynamic-css.ts
+++ b/components/core/util/dynamic-css.ts
@@ -1,0 +1,110 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { NzSafeAny } from 'ng-zorro-antd/core/types';
+
+/**
+ * Sync from rc-util [https://github.com/react-component/util]
+ */
+import { canUseDom } from './can-use-dom';
+
+const MARK_KEY = `rc-util-key` as NzSafeAny;
+
+function getMark({ mark }: Options = {}): string {
+  if (mark) {
+    return mark.startsWith('data-') ? mark : `data-${mark}`;
+  }
+  return MARK_KEY;
+}
+
+interface Options {
+  attachTo?: Element;
+  csp?: { nonce?: string };
+  prepend?: boolean;
+  mark?: string;
+}
+
+function getContainer(option: Options): HTMLElement | Element {
+  if (option.attachTo) {
+    return option.attachTo;
+  }
+
+  const head = document.querySelector('head');
+  return head || document.body;
+}
+
+export function injectCSS(css: string, option: Options = {}): HTMLStyleElement | null {
+  if (!canUseDom()) {
+    return null;
+  }
+
+  const styleNode = document.createElement('style');
+  if (option.csp?.nonce) {
+    styleNode.nonce = option.csp?.nonce;
+  }
+  styleNode.innerHTML = css;
+
+  const container = getContainer(option);
+  const { firstChild } = container;
+
+  if (option.prepend && container.prepend) {
+    // Use `prepend` first
+    container.prepend(styleNode);
+  } else if (option.prepend && firstChild) {
+    // Fallback to `insertBefore` like IE not support `prepend`
+    container.insertBefore(styleNode, firstChild);
+  } else {
+    container.appendChild(styleNode);
+  }
+
+  return styleNode;
+}
+
+const containerCache = new Map<Element, Node & ParentNode>();
+
+function findExistNode(key: string, option: Options = {}): HTMLStyleElement {
+  const container = getContainer(option);
+
+  return Array.from(containerCache.get(container)?.children || []).find(
+    node => node.tagName === 'STYLE' && node.getAttribute(getMark(option)) === key
+  ) as HTMLStyleElement;
+}
+
+export function removeCSS(key: string, option: Options = {}): void {
+  const existNode = findExistNode(key, option);
+
+  existNode?.parentNode?.removeChild(existNode);
+}
+
+export function updateCSS(css: string, key: string, option: Options = {}): HTMLStyleElement | null {
+  const container = getContainer(option);
+
+  // Get real parent
+  if (!containerCache.has(container)) {
+    const placeholderStyle = injectCSS('', option);
+    // @ts-ignore
+    const { parentNode } = placeholderStyle;
+    containerCache.set(container, parentNode);
+    parentNode.removeChild(placeholderStyle);
+  }
+
+  const existNode = findExistNode(key, option);
+
+  if (existNode) {
+    if (option.csp?.nonce && existNode.nonce !== option.csp?.nonce) {
+      existNode.nonce = option.csp?.nonce;
+    }
+
+    if (existNode.innerHTML !== css) {
+      existNode.innerHTML = css;
+    }
+
+    return existNode;
+  }
+
+  const newNode = injectCSS(css, option);
+  newNode?.setAttribute(getMark(option), key);
+  return newNode;
+}

--- a/components/core/util/public-api.ts
+++ b/components/core/util/public-api.ts
@@ -19,4 +19,6 @@ export * from './measure-scrollbar';
 export * from './ensure-in-bounds';
 export * from './tick';
 export * from './observable';
+export * from './can-use-dom';
+export * from './dynamic-css';
 export * from './status-util';

--- a/components/graph/style/index.less
+++ b/components/graph/style/index.less
@@ -6,7 +6,6 @@
 @graph-stroke-width-base: 1px;
 
 @graph-node-background-color: @primary-1;
-@graph-node-border-color: tint(@primary-color, 50%);
 
 @graph-prefix-cls: ~'nz-graph';
 

--- a/components/ng-zorro-antd.less
+++ b/components/ng-zorro-antd.less
@@ -1,4 +1,3 @@
-@root-entry-name: default;
-
-@import './style/entry.less';
+@import './style/default.less';
+@import './style/patch.less';
 @import './components.less';

--- a/components/ng-zorro-antd.variable.less
+++ b/components/ng-zorro-antd.variable.less
@@ -1,2 +1,3 @@
 @import './style/variable.less';
+@import './style/patch.less';
 @import './components.less';

--- a/components/ng-zorro-antd.variable.less
+++ b/components/ng-zorro-antd.variable.less
@@ -1,0 +1,2 @@
+@import './style/variable.less';
+@import './components.less';

--- a/components/style/patch.less
+++ b/components/style/patch.less
@@ -1,4 +1,4 @@
-@import './themes/default.less';
+@import './themes/@{root-entry-name}.less';
 
 // cdk overlay
 .cdk-overlay-container {

--- a/docs/customize-theme-variable.en-US.md
+++ b/docs/customize-theme-variable.en-US.md
@@ -3,12 +3,12 @@ order: 6.1
 title: Dynamic Theme (Experimental)
 ---
 
-Except [less customize theme](/docs/react/customize-theme), We also provide CSS Variable version to enable dynamic theme. You can check on [ConfigProvider](/components/config-provider/#components-config-provider-demo-theme) demo.
+Except [less customize theme](/docs/customize-theme/en), We also provide CSS Variable version to enable dynamic theme.
 
 ## Caveats
 
 - This function depends on CSS Variables. Please check the [browser compatibility](https://caniuse.com/css-variables).
-- This function requires at least `antd@4.17.0-alpha.0`.
+- This function requires at least `ng-zorro-antd@13.2.x`.
 
 ## How to use
 
@@ -17,54 +17,64 @@ Except [less customize theme](/docs/react/customize-theme), We also provide CSS 
 Replace your import style file with CSS Variable version:
 
 ```diff
--- import 'antd/dist/antd.min.css';
-++ import 'antd/dist/antd.variable.min.css';
+-- @import "~ng-zorro-antd/ng-zorro-antd.min.css";
+++ @import "~ng-zorro-antd/ng-zorro-antd.variable.min.css";
 ```
 
 Note: You need remove `babel-plugin-import` for the dynamic theme.
 
 ### Static config
 
-Call ConfigProvider static function to modify theme color:
+In order to provide default configurations in certain components, please pass an object that implements the interface `NzConfig` through the injection token `NZ_CONFIG` in the root injector. For example:
 
-```ts
-import { ConfigProvider } from 'antd';
+```typescript
+import { NzConfig, NZ_CONFIG } from 'ng-zorro-antd/core/config';
 
-ConfigProvider.config({
+const ngZorroConfig: NzConfig = {
   theme: {
-    primaryColor: '#25b864',
-  },
-});
+    primaryColor: '#1890ff'
+  }
+};
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [
+    CommonModule
+  ],
+  providers: [
+    { provide: NZ_CONFIG, useValue:  ngZorroConfig  }
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
 ```
+
+These global configurations would be injected and stored in a service named `NzConfigService`.
+
+### Dynamically Change Configurations
+
+You can alter the global configuration of CSS Variable through the `set` method of `NzConfigService`. For example:
+
+```typescript
+import { NzConfigService } from 'ng-zorro-antd/core/config';
+
+@Component({
+  selector: 'app-change-zorro-config'
+})
+export class ChangeZorroConfigComponent {
+  constructor(private nzConfigService: NzConfigService) {}
+
+  onChangeConfig() {
+    this.nzConfigService.set('theme', { primaryColor: '#1890ff' })
+  }
+}
+```
+
+All component instances is responsive to this configuration change (as long as they are not configured independently).
 
 ## Conflict resolve
 
 CSS Variable use `--ant` prefix by default. When exist multiple antd style file in your project, you can modify prefix to fix it.
-
-### Adjust
-
-Modify `prefixCls` on the root of ConfigProvider:
-
-```tsx
-import { ConfigProvider } from 'antd';
-
-export default () => (
-  <ConfigProvider prefixCls="custom">
-    <MyApp />
-  </ConfigProvider>
-);
-```
-
-Also need call the static function to modify `prefixCls`:
-
-```ts
-ConfigProvider.config({
-  prefixCls: 'custom',
-  theme: {
-    primaryColor: '#25b864',
-  },
-});
-```
 
 ### Compile less
 
@@ -76,6 +86,4 @@ lessc --js --modify-var="ant-prefix=custom" antd/dist/antd.variable.less modifie
 
 ### Related changes
 
-In order to implement CSS Variable and maintain original usage compatibility, we added `@root-entry-name: xxx;` entry injection to the `dist/antd.xxx.less` file to support less dynamic loading of the corresponding less file. Under normal circumstances, you do not need to pay attention to this change. However, if your project directly references the less file in the `lib|es` directory. You need to configure `@root-entry-name: default;` (or `@root-entry-name: variable;`) at the entry of less so that less can find the correct entry.
-
-In addition, we migrated `@import'motion'` and `@import'reset'` in `lib|es/style/minxins/index.less` to `lib|es/style/themes/xxx.less` In, because these two files rely on theme-related variables. If you use the relevant internal method, please adjust it yourself. Of course, we still recommend using the `antd.less` files in the `dist` directory directly instead of calling internal files, because they are often affected by refactoring.
+In order to implement CSS Variable and maintain original usage compatibility, we added `@root-entry-name: xxx;` entry injection to the `ng-zorro-antd.xxx.less` file to support less dynamic loading of the corresponding less file. Under normal circumstances, you do not need to pay attention to this change.

--- a/docs/customize-theme-variable.en-US.md
+++ b/docs/customize-theme-variable.en-US.md
@@ -1,0 +1,81 @@
+---
+order: 6.1
+title: Dynamic Theme (Experimental)
+---
+
+Except [less customize theme](/docs/react/customize-theme), We also provide CSS Variable version to enable dynamic theme. You can check on [ConfigProvider](/components/config-provider/#components-config-provider-demo-theme) demo.
+
+## Caveats
+
+- This function depends on CSS Variables. Please check the [browser compatibility](https://caniuse.com/css-variables).
+- This function requires at least `antd@4.17.0-alpha.0`.
+
+## How to use
+
+### Import antd.variable.min.css
+
+Replace your import style file with CSS Variable version:
+
+```diff
+-- import 'antd/dist/antd.min.css';
+++ import 'antd/dist/antd.variable.min.css';
+```
+
+Note: You need remove `babel-plugin-import` for the dynamic theme.
+
+### Static config
+
+Call ConfigProvider static function to modify theme color:
+
+```ts
+import { ConfigProvider } from 'antd';
+
+ConfigProvider.config({
+  theme: {
+    primaryColor: '#25b864',
+  },
+});
+```
+
+## Conflict resolve
+
+CSS Variable use `--ant` prefix by default. When exist multiple antd style file in your project, you can modify prefix to fix it.
+
+### Adjust
+
+Modify `prefixCls` on the root of ConfigProvider:
+
+```tsx
+import { ConfigProvider } from 'antd';
+
+export default () => (
+  <ConfigProvider prefixCls="custom">
+    <MyApp />
+  </ConfigProvider>
+);
+```
+
+Also need call the static function to modify `prefixCls`:
+
+```ts
+ConfigProvider.config({
+  prefixCls: 'custom',
+  theme: {
+    primaryColor: '#25b864',
+  },
+});
+```
+
+### Compile less
+
+Since prefix modified. Origin `antd.variable.css` should also be replaced:
+
+```bash
+lessc --js --modify-var="ant-prefix=custom" antd/dist/antd.variable.less modified.css
+```
+
+### Related changes
+
+In order to implement CSS Variable and maintain original usage compatibility, we added `@root-entry-name: xxx;` entry injection to the `dist/antd.xxx.less` file to support less dynamic loading of the corresponding less file. Under normal circumstances, you do not need to pay attention to this change. However, if your project directly references the less file in the `lib|es` directory. You need to configure `@root-entry-name: default;` (or `@root-entry-name: variable;`) at the entry of less so that less can find the correct entry.
+
+In addition, we migrated `@import'motion'` and `@import'reset'` in `lib|es/style/minxins/index.less` to `lib|es/style/themes/xxx.less` In, because these two files rely on theme-related variables. If you use the relevant internal method, please adjust it yourself. Of course, we still recommend using the `antd.less` files in the `dist` directory directly instead of calling internal files, because they are often affected by refactoring.

--- a/docs/customize-theme-variable.zh-CN.md
+++ b/docs/customize-theme-variable.zh-CN.md
@@ -1,0 +1,79 @@
+---
+order: 6.1
+title: 动态主题（实验性）
+---
+
+除了 [less 定制主题](/docs/react/customize-theme) 外，我们还提供了 CSS Variable 版本以支持动态切换主题能力。
+
+## 注意事项
+
+- 该功能通过动态修改 CSS Variable 实现，因而在 IE 中页面将无法正常展示。请先确认你的用户环境是否需要支持 IE。
+- 该功能在 `ng-zorro-antd@13.2.x` 版本起支持。
+
+## 如何使用
+
+### 引入 ng-zorro-antd.variable.min.css
+
+替换当前项目引入样式文件为 CSS Variable 版本：
+
+```diff
+-- @import "~ng-zorro-antd/ng-zorro-antd.min.css";
+++ @import "~ng-zorro-antd/ng-zorro-antd.variable.min.css";
+```
+
+注：如果你使用了 `babel-plugin-import`，需要将其去除。
+
+### 静态方法配置
+
+调用 ConfigProvider 配置方法设置主题色：
+
+```ts
+import { ConfigProvider } from 'antd';
+
+ConfigProvider.config({
+  theme: {
+    primaryColor: '#25b864',
+  },
+});
+```
+
+## 冲突解决
+
+默认情况下，CSS Variable 会以 `--ant` 作为前缀。当你的项目中引用多份 css 文件时，可以通过修改前缀的方式避免冲突。
+
+### 代码调整
+
+通过 ConfigProvider 在顶层修改 `prefixCls`：
+
+```tsx
+import { ConfigProvider } from 'antd';
+
+export default () => (
+  <ConfigProvider prefixCls="custom">
+    <MyApp />
+  </ConfigProvider>
+);
+```
+
+通过静态方法设置主题色以及对应 `prefixCls`：
+
+```ts
+ConfigProvider.config({
+  prefixCls: 'custom',
+  theme: {
+    primaryColor: '#25b864',
+  },
+});
+```
+
+### 编译 less
+
+由于前缀变更，你需要重新生成一份对应的 css 文件。
+
+```bash
+lessc --js --modify-var="ant-prefix=custom" ng-zorro-antd/lib/ng-zorro-antd.variable.less modified.css
+```
+
+### 相关变更
+
+为了实现 CSS Variable 并保持原始用法兼容性，我们于 `lib/ng-zorro-antd.xxx.less` 文件中添加了 `@root-entry-name: xxx;` 入口注入以支持 less 动态加载对应的 less 文件。一般情况下，你不需要关注该变化。但是，如果你的项目中直接引用了 `lib|es` 目录下的 less 文件，那么你需要在 less 入口处配置 `@root-entry-name: default;` （或者 `@root-entry-name: variable;`）以使 less 可以找到正确的入口。

--- a/docs/customize-theme-variable.zh-CN.md
+++ b/docs/customize-theme-variable.zh-CN.md
@@ -3,7 +3,7 @@ order: 6.1
 title: 动态主题（实验性）
 ---
 
-除了 [less 定制主题](/docs/react/customize-theme) 外，我们还提供了 CSS Variable 版本以支持动态切换主题能力。
+除了 [less 定制主题](/docs/customize-theme/zh) 外，我们还提供了 CSS Variable 版本以支持动态切换主题能力。
 
 ## 注意事项
 
@@ -25,55 +25,65 @@ title: 动态主题（实验性）
 
 ### 静态方法配置
 
-调用 ConfigProvider 配置方法设置主题色：
+利用全局配置项功能，在根注入器中根据注入令牌 `NZ_CONFIG` 提供一个符合 `NzConfig` 接口的对象，例如：
 
-```ts
-import { ConfigProvider } from 'antd';
+```typescript
+import { NzConfig, NZ_CONFIG } from 'ng-zorro-antd/core/config';
 
-ConfigProvider.config({
+const ngZorroConfig: NzConfig = {
+  // 注意组件名称没有 nz 前缀
   theme: {
-    primaryColor: '#25b864',
-  },
-});
+    primaryColor: '#1890ff'
+  }
+};
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [
+    CommonModule
+  ],
+  providers: [
+    { provide: NZ_CONFIG, useValue:  ngZorroConfig  }
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
 ```
+
+这些全局配置项将会被注入 `NzConfigService` 当中并保存。
+
+### 动态变更
+你可以通过调用 `NzConfigService` 的 `set` 方法来改变 CSS Variable 样式配置项，例如：
+
+```typescript
+import { NzConfigService } from 'ng-zorro-antd/core/config';
+
+@Component({
+  selector: 'app-change-zorro-config'
+})
+export class ChangeZorroConfigComponent {
+  constructor(private nzConfigService: NzConfigService) {}
+
+  onChangeConfig() {
+    this.nzConfigService.set('theme', { primaryColor: '#1890ff' })
+  }
+}
+```
+
+所有的组件实例都会响应这些改变（只要它们没有被单独赋值）。
 
 ## 冲突解决
 
 默认情况下，CSS Variable 会以 `--ant` 作为前缀。当你的项目中引用多份 css 文件时，可以通过修改前缀的方式避免冲突。
-
-### 代码调整
-
-通过 ConfigProvider 在顶层修改 `prefixCls`：
-
-```tsx
-import { ConfigProvider } from 'antd';
-
-export default () => (
-  <ConfigProvider prefixCls="custom">
-    <MyApp />
-  </ConfigProvider>
-);
-```
-
-通过静态方法设置主题色以及对应 `prefixCls`：
-
-```ts
-ConfigProvider.config({
-  prefixCls: 'custom',
-  theme: {
-    primaryColor: '#25b864',
-  },
-});
-```
 
 ### 编译 less
 
 由于前缀变更，你需要重新生成一份对应的 css 文件。
 
 ```bash
-lessc --js --modify-var="ant-prefix=custom" ng-zorro-antd/lib/ng-zorro-antd.variable.less modified.css
+lessc --js --modify-var="ant-prefix=custom" ng-zorro-antd/ng-zorro-antd.variable.less modified.css
 ```
 
 ### 相关变更
 
-为了实现 CSS Variable 并保持原始用法兼容性，我们于 `lib/ng-zorro-antd.xxx.less` 文件中添加了 `@root-entry-name: xxx;` 入口注入以支持 less 动态加载对应的 less 文件。一般情况下，你不需要关注该变化。但是，如果你的项目中直接引用了 `lib|es` 目录下的 less 文件，那么你需要在 less 入口处配置 `@root-entry-name: default;` （或者 `@root-entry-name: variable;`）以使 less 可以找到正确的入口。
+为了实现 CSS Variable 并保持原始用法兼容性，我们于 `ng-zorro-antd.xxx.less` 文件中添加了 `@root-entry-name: xxx;` 入口注入以支持 less 动态加载对应的 less 文件。一般情况下，你不需要关注该变化。

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@angular/cdk": "^13.0.1",
     "@ant-design/icons-angular": "^13.1.0",
+    "@ctrl/tinycolor": "^3.4.1",
     "date-fns": "^2.16.1",
     "ngx-hover-preload": "0.0.3"
   },

--- a/scripts/build/compile-styles.ts
+++ b/scripts/build/compile-styles.ts
@@ -105,6 +105,11 @@ export async function compile(): Promise<void | void[]> {
     await fs.readFile(`${sourcePath}/ng-zorro-antd.compact.less`)
   );
 
+  await fs.writeFile(
+    `${targetPath}/ng-zorro-antd.variable.less`,
+    await fs.readFile(`${sourcePath}/ng-zorro-antd.variable.less`)
+  );
+
   // Compile concentrated less file to CSS file.
   const lessContent = `@import "${path.posix.join(targetPath, 'ng-zorro-antd.less')}";`;
   promiseList.push(compileLess(lessContent, path.join(targetPath, 'ng-zorro-antd.css'), false));
@@ -124,6 +129,11 @@ export async function compile(): Promise<void | void[]> {
   const aliyunLessContent = `@import "${path.posix.join(targetPath, 'ng-zorro-antd.aliyun.less')}";`;
   promiseList.push(compileLess(aliyunLessContent, path.join(targetPath, 'ng-zorro-antd.aliyun.css'), false));
   promiseList.push(compileLess(aliyunLessContent, path.join(targetPath, 'ng-zorro-antd.aliyun.min.css'), true));
+
+  // Compile the aliyun theme less file to CSS file.
+  const variableLessContent = `@import "${path.posix.join(targetPath, 'ng-zorro-antd.variable.less')}";`;
+  promiseList.push(compileLess(variableLessContent, path.join(targetPath, 'ng-zorro-antd.variable.css'), false));
+  promiseList.push(compileLess(variableLessContent, path.join(targetPath, 'ng-zorro-antd.variable.min.css'), true));
 
   // Compile css file that doesn't have component-specific styles.
   const cssIndexPath = path.join(sourcePath, 'style', 'entry.less');

--- a/scripts/site/_site/doc/styles.less
+++ b/scripts/site/_site/doc/styles.less
@@ -1,9 +1,9 @@
 /* You can add global styles to this file, and also import other style files */
-@import "../../components/ng-zorro-antd.less";
-@import "../../components/resizable/style/entry.less";
-@import "../../components/code-editor/style/entry.less";
-@import "../../components/graph/style/entry.less";
-@import "./app/header/header";
-@import "style/index";
-@import "style/patch";
-@import "style/doc-search";
+@import '../../components/ng-zorro-antd.variable.less';
+@import '../../components/resizable/style/entry.less';
+@import '../../components/code-editor/style/entry.less';
+@import '../../components/graph/style/entry.less';
+@import './app/header/header';
+@import 'style/index';
+@import 'style/patch';
+@import 'style/doc-search';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7389


## What is the new behavior?
- add `@ctrl/tinycolor`
- support setting css variable via `NzConfigService`
- sync codes about `css variable` from `ant-design`


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
