### PR TITLE
feat(module:datepicker): date-adapter support for other calendars

### DIFF
--- a/components/calendar/calendar-header.component.ts
+++ b/components/calendar/calendar-header.component.ts
@@ -15,7 +15,13 @@ import {
 } from '@angular/core';
 
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
-import { DateHelperService, NzI18nService as I18n } from 'ng-zorro-antd/i18n';
+import {
+  DateHelperService,
+  mergeDateConfig,
+  NZ_DATE_CONFIG,
+  NzDateConfig,
+  NzI18nService as I18n
+} from 'ng-zorro-antd/i18n';
 import { NzSelectSizeType } from 'ng-zorro-antd/select';
 
 @Component({
@@ -77,6 +83,8 @@ export class NzCalendarHeaderComponent implements OnInit {
   years: Array<{ label: string; value: number }> = [];
   months: Array<{ label: string; value: number }> = [];
 
+  config: NzDateConfig;
+
   get activeYear(): number {
     return this.activeDate.getYear();
   }
@@ -100,8 +108,11 @@ export class NzCalendarHeaderComponent implements OnInit {
   constructor(
     private i18n: I18n,
     private dateHelper: DateHelperService,
-    @Inject(CandyDate) private candyDate: CandyDateFac
-  ) {}
+    @Inject(CandyDate) private candyDate: CandyDateFac,
+    @Inject(NZ_DATE_CONFIG) config: NzDateConfig
+  ) {
+    this.config = mergeDateConfig(config);
+  }
 
   ngOnInit(): void {
     this.setUpYears();
@@ -128,7 +139,7 @@ export class NzCalendarHeaderComponent implements OnInit {
 
     for (let i = 0; i < 12; i++) {
       const dateInMonth = this.activeDate.setMonth(i);
-      const monthText = this.dateHelper.format(dateInMonth.nativeDate, 'MMM');
+      const monthText = this.dateHelper.format(dateInMonth.nativeDate, this.config.displayFormats?.monthLabel!);
       this.months.push({ label: monthText, value: i });
     }
   }

--- a/components/calendar/calendar-header.component.ts
+++ b/components/calendar/calendar-header.component.ts
@@ -15,13 +15,7 @@ import {
 } from '@angular/core';
 
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
-import {
-  DateHelperService,
-  mergeDateConfig,
-  NZ_DATE_CONFIG,
-  NzDateConfig,
-  NzI18nService as I18n
-} from 'ng-zorro-antd/i18n';
+import { DateHelperService, NZ_DATE_FORMATS, NzDateDisplayFormats, NzI18nService as I18n } from 'ng-zorro-antd/i18n';
 import { NzSelectSizeType } from 'ng-zorro-antd/select';
 
 @Component({
@@ -83,8 +77,6 @@ export class NzCalendarHeaderComponent implements OnInit {
   years: Array<{ label: string; value: number }> = [];
   months: Array<{ label: string; value: number }> = [];
 
-  config: NzDateConfig;
-
   get activeYear(): number {
     return this.activeDate.getYear();
   }
@@ -109,10 +101,8 @@ export class NzCalendarHeaderComponent implements OnInit {
     private i18n: I18n,
     private dateHelper: DateHelperService,
     @Inject(CandyDate) private candyDate: CandyDateFac,
-    @Inject(NZ_DATE_CONFIG) config: NzDateConfig
-  ) {
-    this.config = mergeDateConfig(config);
-  }
+    @Inject(NZ_DATE_FORMATS) private displayFormats: NzDateDisplayFormats
+  ) {}
 
   ngOnInit(): void {
     this.setUpYears();
@@ -139,7 +129,7 @@ export class NzCalendarHeaderComponent implements OnInit {
 
     for (let i = 0; i < 12; i++) {
       const dateInMonth = this.activeDate.setMonth(i);
-      const monthText = this.dateHelper.format(dateInMonth.nativeDate, this.config.displayFormats?.monthLabel!);
+      const monthText = this.dateHelper.format(dateInMonth.nativeDate, this.displayFormats.monthLabel!);
       this.months.push({ label: monthText, value: i });
     }
   }

--- a/components/calendar/calendar-header.component.ts
+++ b/components/calendar/calendar-header.component.ts
@@ -7,13 +7,14 @@ import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
+  Inject,
   Input,
   OnInit,
   Output,
   ViewEncapsulation
 } from '@angular/core';
 
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { DateHelperService, NzI18nService as I18n } from 'ng-zorro-antd/i18n';
 import { NzSelectSizeType } from 'ng-zorro-antd/select';
 
@@ -64,7 +65,7 @@ import { NzSelectSizeType } from 'ng-zorro-antd/select';
 export class NzCalendarHeaderComponent implements OnInit {
   @Input() mode: 'month' | 'year' = 'month';
   @Input() fullscreen: boolean = true;
-  @Input() activeDate: CandyDate = new CandyDate();
+  @Input() activeDate: CandyDate = this.candyDate();
 
   @Output() readonly modeChange: EventEmitter<'month' | 'year'> = new EventEmitter();
   @Output() readonly yearChange: EventEmitter<number> = new EventEmitter();
@@ -96,7 +97,11 @@ export class NzCalendarHeaderComponent implements OnInit {
     return this.i18n.getLocale().Calendar.lang.month;
   }
 
-  constructor(private i18n: I18n, private dateHelper: DateHelperService) {}
+  constructor(
+    private i18n: I18n,
+    private dateHelper: DateHelperService,
+    @Inject(CandyDate) private candyDate: CandyDateFac
+  ) {}
 
   ngOnInit(): void {
     this.setUpYears();

--- a/components/calendar/calendar-header.spec.ts
+++ b/components/calendar/calendar-header.spec.ts
@@ -1,12 +1,12 @@
 import { registerLocaleData } from '@angular/common';
 import zh from '@angular/common/locales/zh';
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule, NgModel } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 
 import { NzI18nModule } from '../i18n/nz-i18n.module';
 import { NzRadioGroupComponent as RadioGroup, NzRadioModule } from '../radio/index';
@@ -219,7 +219,9 @@ class NzTestCalendarHeaderFullscreenComponent {
   `
 })
 class NzTestCalendarHeaderActiveDateComponent {
-  activeDate = new CandyDate(new Date(2001, 1, 3));
+  constructor(@Inject(CandyDate) private candyDate: CandyDateFac) {}
+
+  activeDate = this.candyDate(new Date(2001, 1, 3));
 }
 
 @Component({

--- a/components/calendar/calendar.component.ts
+++ b/components/calendar/calendar.component.ts
@@ -11,6 +11,7 @@ import {
   ContentChild,
   EventEmitter,
   forwardRef,
+  Inject,
   Input,
   OnChanges,
   OnDestroy,
@@ -25,7 +26,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { BooleanInput } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 
@@ -97,7 +98,7 @@ type NzCalendarDateTemplate = TemplateRef<{ $implicit: Date }>;
 export class NzCalendarComponent implements ControlValueAccessor, OnChanges, OnInit, OnDestroy {
   static ngAcceptInputType_nzFullscreen: BooleanInput;
 
-  activeDate: CandyDate = new CandyDate();
+  activeDate: CandyDate = this.candyDate();
   prefixCls: string = 'ant-picker-calendar';
   private destroy$ = new Subject<void>();
   dir: Direction = 'ltr';
@@ -144,7 +145,11 @@ export class NzCalendarComponent implements ControlValueAccessor, OnChanges, OnI
 
   @Input() @InputBoolean() nzFullscreen: boolean = true;
 
-  constructor(private cdr: ChangeDetectorRef, @Optional() private directionality: Directionality) {}
+  constructor(
+    private cdr: ChangeDetectorRef,
+    @Optional() private directionality: Directionality,
+    @Inject(CandyDate) private candyDate: CandyDateFac
+  ) {}
 
   ngOnInit(): void {
     this.dir = this.directionality.value;
@@ -175,7 +180,7 @@ export class NzCalendarComponent implements ControlValueAccessor, OnChanges, OnI
   }
 
   writeValue(value: Date | null): void {
-    this.updateDate(new CandyDate(value as Date), false);
+    this.updateDate(this.candyDate(value as Date), false);
     this.cdr.markForCheck();
   }
 
@@ -200,7 +205,7 @@ export class NzCalendarComponent implements ControlValueAccessor, OnChanges, OnI
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.nzValue) {
-      this.updateDate(new CandyDate(this.nzValue), false);
+      this.updateDate(this.candyDate(this.nzValue), false);
     }
   }
 

--- a/components/calendar/calendar.spec.ts
+++ b/components/calendar/calendar.spec.ts
@@ -7,8 +7,7 @@ import { FormsModule, NgModel } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { CandyDate } from 'ng-zorro-antd/core/time';
-import { NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
+import { CandyDate, NzDateAdapter } from 'ng-zorro-antd/core/time';
 
 import { NZ_DATE_CONFIG } from '../i18n/date-config';
 import { NzCalendarHeaderComponent as CalendarHeader } from './calendar-header.component';

--- a/components/calendar/calendar.spec.ts
+++ b/components/calendar/calendar.spec.ts
@@ -8,6 +8,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { CandyDate } from 'ng-zorro-antd/core/time';
+import { NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
 
 import { NZ_DATE_CONFIG } from '../i18n/date-config';
 import { NzCalendarHeaderComponent as CalendarHeader } from './calendar-header.component';
@@ -132,12 +133,12 @@ describe('Calendar', () => {
 
       const calendar = fixture.debugElement.queryAll(By.directive(Calendar))[1].injector.get(Calendar);
 
-      expect(calendar.activeDate.nativeDate).toBe(component.date0);
+      expect(calendar.activeDate.nativeDate).toEqual(component.date0);
 
-      calendar.onDateSelect(new CandyDate(now));
+      calendar.onDateSelect(new CandyDate(fixture.debugElement.injector.get(NzDateAdapter), now));
       fixture.detectChanges();
 
-      expect(component.date0).toBe(now);
+      expect(component.date0).toEqual(now);
     });
 
     it('should support model binding', fakeAsync(() => {
@@ -151,12 +152,12 @@ describe('Calendar', () => {
       flush();
       fixture.detectChanges();
 
-      expect(calendar.activeDate.nativeDate).toBe(component.date1);
+      expect(calendar.activeDate.nativeDate).toEqual(component.date1);
 
       model.viewToModelUpdate(now);
       fixture.detectChanges();
 
-      expect(component.date1).toBe(now);
+      expect(component.date1).toEqual(now);
     }));
 
     it('should update value when year changed', () => {

--- a/components/calendar/doc/index.en-US.md
+++ b/components/calendar/doc/index.en-US.md
@@ -16,7 +16,7 @@ When data is in the form of dates, such as schedules, timetables, prices calenda
 import { NzCalendarModule } from 'ng-zorro-antd/calendar';
 ```
 
-providing custom date adapter for Jalali and Hijri calendars [here](/docs/i18n/en#Provide%20Custom%20Date%20Adapter)
+providing custom date adapter for Jalali and Hijri calendars [here](/docs/i18n/en#provide-custom-dateadapter)
 
 ## API
 

--- a/components/calendar/doc/index.en-US.md
+++ b/components/calendar/doc/index.en-US.md
@@ -16,6 +16,7 @@ When data is in the form of dates, such as schedules, timetables, prices calenda
 import { NzCalendarModule } from 'ng-zorro-antd/calendar';
 ```
 
+providing custom date adapter for Jalali and Hijri calendars [here](/docs/i18n/en#Provide%20Custom%20Date%20Adapter)
 
 ## API
 

--- a/components/core/time/candy-date.spec.ts
+++ b/components/core/time/candy-date.spec.ts
@@ -1,94 +1,99 @@
 import differenceInCalendarMonths from 'date-fns/differenceInCalendarMonths';
 
+import { DateFnsDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
+
 import { CandyDate, normalizeRangeValue, SingleValue } from './candy-date';
 
+export const dateAdapter = new DateFnsDateAdapter();
+export const candyDateFac = (date?: Date | number | string): CandyDate => new CandyDate(dateAdapter, date);
+
 describe('candy-date coverage supplements', () => {
-  const date = new CandyDate('2018-5-5 12:12:12');
+  const date = candyDateFac('2018-5-5 12:12:12');
 
   it('support getTime', () => expect(date.getTime()).toBe(date.nativeDate.getTime()));
 
   it('support getMilliseconds', () => expect(date.getMilliseconds()).toBe(date.nativeDate.getMilliseconds()));
 
   it('support isSame', () => {
-    expect(date.isSame(new CandyDate('2018'), 'year')).toBeTruthy();
+    expect(date.isSame(candyDateFac('2018'), 'year')).toBeTruthy();
 
-    expect(date.isSameMonth(new CandyDate('2018-5-5 12:00:00'))).toBeTruthy();
+    expect(date.isSameMonth(candyDateFac('2018-5-5 12:00:00'))).toBeTruthy();
 
-    expect(date.isSame(new CandyDate('2018-5-5 12:00:00'), 'hour')).toBeTruthy();
-    expect(date.isSameHour(new CandyDate('2019-5-5 12:00:00'))).toBeFalsy();
+    expect(date.isSame(candyDateFac('2018-5-5 12:00:00'), 'hour')).toBeTruthy();
+    expect(date.isSameHour(candyDateFac('2019-5-5 12:00:00'))).toBeFalsy();
 
-    expect(date.isSame(new CandyDate('2018-5-5 12:12:00'), 'minute')).toBeTruthy();
-    expect(date.isSameMinute(new CandyDate('2019-5-5 12:12:00'))).toBeFalsy();
+    expect(date.isSame(candyDateFac('2018-5-5 12:12:00'), 'minute')).toBeTruthy();
+    expect(date.isSameMinute(candyDateFac('2019-5-5 12:12:00'))).toBeFalsy();
 
-    expect(date.isSame(new CandyDate('2018-5-5 12:12:12'), 'second')).toBeTruthy();
-    expect(date.isSameSecond(new CandyDate('2019-5-5 12:12:12'))).toBeFalsy();
+    expect(date.isSame(candyDateFac('2018-5-5 12:12:12'), 'second')).toBeTruthy();
+    expect(date.isSameSecond(candyDateFac('2019-5-5 12:12:12'))).toBeFalsy();
   });
 
   it('support isBefore', () => {
     expect(date.isBeforeYear(null)).toBeFalsy();
 
-    expect(date.isBeforeYear(new CandyDate('2100'))).toBeTruthy();
+    expect(date.isBeforeYear(candyDateFac('2100'))).toBeTruthy();
 
-    expect(date.isBeforeMonth(new CandyDate('2100-5-5 12:12:12'))).toBeTruthy();
-    expect(date.isBeforeMonth(new CandyDate('2018-6-5 12:12:12'))).toBeTruthy();
+    expect(date.isBeforeMonth(candyDateFac('2100-5-5 12:12:12'))).toBeTruthy();
+    expect(date.isBeforeMonth(candyDateFac('2018-6-5 12:12:12'))).toBeTruthy();
 
-    expect(date.isBeforeDay(new CandyDate('2018-6-5 12:12:12'))).toBeTruthy();
+    expect(date.isBeforeDay(candyDateFac('2018-6-5 12:12:12'))).toBeTruthy();
   });
 
   it('should throw error while putting invalid date input', () => {
     const errorMessage = 'The input date type is not supported ("Date" is now recommended)';
-    expect(() => new CandyDate({} as any)).toThrowError(errorMessage); // eslint-disable-line @typescript-eslint/no-explicit-any
+    expect(() => candyDateFac({} as any)).toThrowError(errorMessage); // eslint-disable-line @typescript-eslint/no-explicit-any
   });
 
   it('should normalizeRangeValue work', () => {
-    const randomDay = new CandyDate('2020-09-17');
+    const randomDay = candyDateFac('2020-09-17');
     const now = new Date();
     let result: SingleValue[];
-    result = normalizeRangeValue([null, randomDay], false);
+    result = normalizeRangeValue(dateAdapter, [null, randomDay], false);
     expect(result[0]!.getMonth()).toEqual(7);
     expect(result[1]!.getMonth()).toEqual(8);
 
-    result = normalizeRangeValue([randomDay, null], false);
+    result = normalizeRangeValue(dateAdapter, [randomDay, null], false);
     expect(result[0]!.getMonth()).toEqual(8);
     expect(result[1]!.getMonth()).toEqual(9);
 
-    result = normalizeRangeValue([randomDay, null], true);
+    result = normalizeRangeValue(dateAdapter, [randomDay, null], true);
     expect(result[0]!.getMonth()).toEqual(8);
     expect(result[1]!.getMonth()).toEqual(8);
 
-    result = normalizeRangeValue([null, null], false);
+    result = normalizeRangeValue(dateAdapter, [null, null], false);
     expect(result[0]!.getMonth()).toEqual(now.getMonth());
     expect(differenceInCalendarMonths(result[1]!.nativeDate, now)).toEqual(1);
 
-    result = normalizeRangeValue([null, null], true);
+    result = normalizeRangeValue(dateAdapter, [null, null], true);
     expect(result[0]!.getMonth()).toEqual(now.getMonth());
     expect(result[1]!.getMonth()).toEqual(now.getMonth());
 
-    result = normalizeRangeValue([randomDay, new CandyDate()], false, 'month', 'left');
+    result = normalizeRangeValue(dateAdapter, [randomDay, candyDateFac()], false, 'month', 'left');
     expect(result[0]!.getMonth()).toEqual(randomDay.getMonth());
     expect(differenceInCalendarMonths(result[1]!.nativeDate, randomDay.nativeDate)).toEqual(1);
 
-    result = normalizeRangeValue([randomDay, new CandyDate()], false, 'month', 'right');
+    result = normalizeRangeValue(dateAdapter, [randomDay, candyDateFac()], false, 'month', 'right');
     expect(result[1]!.getMonth()).toEqual(now.getMonth());
     expect(differenceInCalendarMonths(result[0]!.nativeDate, now)).toEqual(-1);
 
-    result = normalizeRangeValue([new CandyDate(), new CandyDate()], false, 'month', 'left');
+    result = normalizeRangeValue(dateAdapter, [candyDateFac(), candyDateFac()], false, 'month', 'left');
     expect(result[0]!.getMonth()).toEqual(now.getMonth());
     expect(differenceInCalendarMonths(result[1]!.nativeDate, now)).toEqual(1);
 
-    result = normalizeRangeValue([new CandyDate(), new CandyDate()], false, 'month', 'right');
+    result = normalizeRangeValue(dateAdapter, [candyDateFac(), candyDateFac()], false, 'month', 'right');
     expect(result[0]!.getMonth()).toEqual(now.getMonth());
     expect(differenceInCalendarMonths(result[1]!.nativeDate, now)).toEqual(1);
 
-    result = normalizeRangeValue([new CandyDate(), new CandyDate()], true);
+    result = normalizeRangeValue(dateAdapter, [candyDateFac(), candyDateFac()], true);
     expect(result[0]!.getMonth()).toEqual(now.getMonth());
     expect(result[1]!.getMonth()).toEqual(now.getMonth());
 
-    result = normalizeRangeValue([new CandyDate(), new CandyDate()], false, 'year');
+    result = normalizeRangeValue(dateAdapter, [candyDateFac(), candyDateFac()], false, 'year');
     expect(result[0]!.getYear()).toEqual(now.getFullYear());
     expect(result[1]!.getYear()).toEqual(now.getFullYear() + 1);
 
-    result = normalizeRangeValue([new CandyDate(), new CandyDate()], true, 'year');
+    result = normalizeRangeValue(dateAdapter, [candyDateFac(), candyDateFac()], true, 'year');
     expect(result[0]!.getYear()).toEqual(now.getFullYear());
     expect(result[1]!.getYear()).toEqual(now.getFullYear());
   });

--- a/components/core/time/candy-date.spec.ts
+++ b/components/core/time/candy-date.spec.ts
@@ -1,8 +1,7 @@
 import differenceInCalendarMonths from 'date-fns/differenceInCalendarMonths';
 
-import { DateFnsDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
-
 import { CandyDate, normalizeRangeValue, SingleValue } from './candy-date';
+import { DateFnsDateAdapter } from './date-adapter';
 
 export const dateAdapter = new DateFnsDateAdapter();
 export const candyDateFac = (date?: Date | number | string): CandyDate => new CandyDate(dateAdapter, date);

--- a/components/core/time/candy-date.ts
+++ b/components/core/time/candy-date.ts
@@ -109,39 +109,39 @@ export class CandyDate<D = Date> implements IndexableObject {
   // -----------------------------------------------------------------------------\
 
   getYear(): number {
-    return this.dateAdapter.getYear(this.date);
+    return this.dateAdapter.getYear(this.nativeDate);
   }
 
   getMonth(): number {
-    return this.dateAdapter.getMonth(this.date);
+    return this.dateAdapter.getMonth(this.nativeDate);
   }
 
   getDay(): number {
-    return this.dateAdapter.getDay(this.date);
+    return this.dateAdapter.getDay(this.nativeDate);
   }
 
   getTime(): number {
-    return this.dateAdapter.getTime(this.date);
+    return this.dateAdapter.getTime(this.nativeDate);
   }
 
   getDate(): number {
-    return this.dateAdapter.getDate(this.date);
+    return this.dateAdapter.getDate(this.nativeDate);
   }
 
   getHours(): number {
-    return this.dateAdapter.getHours(this.date);
+    return this.dateAdapter.getHours(this.nativeDate);
   }
 
   getMinutes(): number {
-    return this.dateAdapter.getMinutes(this.date);
+    return this.dateAdapter.getMinutes(this.nativeDate);
   }
 
   getSeconds(): number {
-    return this.dateAdapter.getSeconds(this.date);
+    return this.dateAdapter.getSeconds(this.nativeDate);
   }
 
   getMilliseconds(): number {
-    return this.dateAdapter.getMilliseconds(this.date);
+    return this.dateAdapter.getMilliseconds(this.nativeDate);
   }
 
   // ---------------------------------------------------------------------

--- a/components/core/time/candy-date.ts
+++ b/components/core/time/candy-date.ts
@@ -6,12 +6,12 @@
 import { Injectable } from '@angular/core';
 
 import { NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
-import { IndexableObject, NzSafeAny } from 'ng-zorro-antd/core/types';
+import { IndexableObject } from 'ng-zorro-antd/core/types';
 
 export type CandyDateMode = 'decade' | 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
 export type NormalizedMode = 'decade' | 'year' | 'month';
 export type WeekDayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-export type CandyDateType = CandyDate | Date | null;
+export type CandyDateType<D = Date> = CandyDate<D> | null;
 export type SingleValue = CandyDate | null;
 export type CompatibleValue = SingleValue | SingleValue[];
 export type CandyDateFac = (date?: Date | string | number) => CandyDate;
@@ -110,39 +110,39 @@ export class CandyDate<D = Date> implements IndexableObject {
   // -----------------------------------------------------------------------------\
 
   getYear(): number {
-    return this.dateAdapter.getYear(this.nativeDate);
+    return this.dateAdapter.getYear(this.date);
   }
 
   getMonth(): number {
-    return this.dateAdapter.getMonth(this.nativeDate);
+    return this.dateAdapter.getMonth(this.date);
   }
 
   getDay(): number {
-    return this.dateAdapter.getDay(this.nativeDate);
+    return this.dateAdapter.getDay(this.date);
   }
 
   getTime(): number {
-    return this.dateAdapter.getTime(this.nativeDate);
+    return this.dateAdapter.getTime(this.date);
   }
 
   getDate(): number {
-    return this.dateAdapter.getDate(this.nativeDate);
+    return this.dateAdapter.getDate(this.date);
   }
 
   getHours(): number {
-    return this.dateAdapter.getHours(this.nativeDate);
+    return this.dateAdapter.getHours(this.date);
   }
 
   getMinutes(): number {
-    return this.dateAdapter.getMinutes(this.nativeDate);
+    return this.dateAdapter.getMinutes(this.date);
   }
 
   getSeconds(): number {
-    return this.dateAdapter.getSeconds(this.nativeDate);
+    return this.dateAdapter.getSeconds(this.date);
   }
 
   getMilliseconds(): number {
-    return this.dateAdapter.getMilliseconds(this.nativeDate);
+    return this.dateAdapter.getMilliseconds(this.date);
   }
 
   // ---------------------------------------------------------------------
@@ -200,47 +200,51 @@ export class CandyDate<D = Date> implements IndexableObject {
     }
   }
 
-  isSame(date: CandyDateType, grain: CandyDateMode = 'day'): boolean {
-    return this.dateAdapter.isSame(this.date, this.toNativeDate(date), grain);
+  isSame(candyDate: CandyDateType<D>, grain: CandyDateMode = 'day'): boolean {
+    if (!candyDate) return false;
+
+    return this.dateAdapter.isSame(this.date, candyDate.date, grain);
   }
 
-  isSameYear(date: CandyDateType): boolean {
+  isSameYear(date: CandyDateType<D>): boolean {
     return this.isSame(date, 'year');
   }
 
-  isSameMonth(date: CandyDateType): boolean {
+  isSameMonth(date: CandyDateType<D>): boolean {
     return this.isSame(date, 'month');
   }
 
-  isSameDay(date: CandyDateType): boolean {
+  isSameDay(date: CandyDateType<D>): boolean {
     return this.isSame(date, 'day');
   }
 
-  isSameHour(date: CandyDateType): boolean {
+  isSameHour(date: CandyDateType<D>): boolean {
     return this.isSame(date, 'hour');
   }
 
-  isSameMinute(date: CandyDateType): boolean {
+  isSameMinute(date: CandyDateType<D>): boolean {
     return this.isSame(date, 'minute');
   }
 
-  isSameSecond(date: CandyDateType): boolean {
+  isSameSecond(date: CandyDateType<D>): boolean {
     return this.isSame(date, 'second');
   }
 
-  isBefore(date: CandyDateType, grain: CandyDateMode = 'day'): boolean {
-    return this.dateAdapter.isBefore(this.date, this.toNativeDate(date), grain);
+  isBefore(candyDate: CandyDateType<D>, grain: CandyDateMode = 'day'): boolean {
+    if (!candyDate) return false;
+
+    return this.dateAdapter.isBefore(this.date, candyDate.date, grain);
   }
 
-  isBeforeYear(date: CandyDateType): boolean {
+  isBeforeYear(date: CandyDateType<D>): boolean {
     return this.isBefore(date, 'year');
   }
 
-  isBeforeMonth(date: CandyDateType): boolean {
+  isBeforeMonth(date: CandyDateType<D>): boolean {
     return this.isBefore(date, 'month');
   }
 
-  isBeforeDay(date: CandyDateType): boolean {
+  isBeforeDay(date: CandyDateType<D>): boolean {
     return this.isBefore(date, 'day');
   }
 
@@ -259,9 +263,5 @@ export class CandyDate<D = Date> implements IndexableObject {
 
   isLastDayOfMonth(): boolean {
     return this.dateAdapter.isLastDayOfMonth(this.date);
-  }
-
-  private toNativeDate(date: NzSafeAny): D {
-    return date instanceof CandyDate ? date.nativeDate : date;
   }
 }

--- a/components/core/time/candy-date.ts
+++ b/components/core/time/candy-date.ts
@@ -60,6 +60,10 @@ export function cloneDate(value: CompatibleValue): CompatibleValue {
   }
 }
 
+export function CANDY_DATE_FACTORY(adapter: NzDateAdapter): CandyDateFac {
+  return (date?: Date | string | number): CandyDate => new CandyDate(adapter, date);
+}
+
 /**
  * Wrapping kind APIs for date operating and unify
  * NOTE: every new API return new CandyDate object without side effects to the former Date object
@@ -68,10 +72,7 @@ export function cloneDate(value: CompatibleValue): CompatibleValue {
  */
 @Injectable({
   providedIn: 'root',
-  useFactory:
-    (adapter: NzDateAdapter): CandyDateFac =>
-    (date?: Date | string | number): CandyDate =>
-      new CandyDate(adapter, date),
+  useFactory: CANDY_DATE_FACTORY,
   deps: [NzDateAdapter]
 })
 export class CandyDate<D = Date> implements IndexableObject {

--- a/components/core/time/candy-date.ts
+++ b/components/core/time/candy-date.ts
@@ -5,8 +5,9 @@
 
 import { Injectable } from '@angular/core';
 
-import { NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
 import { IndexableObject } from 'ng-zorro-antd/core/types';
+
+import { NzDateAdapter } from './date-adapter';
 
 export type CandyDateMode = 'decade' | 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
 export type NormalizedMode = 'decade' | 'year' | 'month';

--- a/components/core/time/date-adapter.spec.ts
+++ b/components/core/time/date-adapter.spec.ts
@@ -1,0 +1,190 @@
+import { dateAdapter } from 'ng-zorro-antd/core/time/candy-date.spec';
+import { DateFnsDateAdapter, isCustomAdapter, NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
+
+describe('date-adapter', () => {
+  let dateAdapter: NzDateAdapter;
+
+  beforeAll(() => {
+    dateAdapter = new DateFnsDateAdapter();
+  });
+
+  it('should support today', () => {
+    const today = dateAdapter.today().getDate();
+    expect(today).toEqual(new Date().getDate());
+  });
+
+  it('should support deserialize', () => {
+    const input = '2020-06-12 12:12:12';
+    const date = dateAdapter.deserialize(input);
+    expect(date).toEqual(new Date(input));
+  });
+
+  it('should support parse', () => {
+    const input = '2020-06';
+    const date = dateAdapter.parse(input, 'yyyy-MM');
+    expect(date).toEqual(new Date(2020, 5));
+  });
+
+  it('should support toNativeDate', function () {
+    const date = new Date();
+    expect(date).toEqual(new Date());
+  });
+
+  it('should support calendarStartOfWeek', function () {
+    const date = new Date(2020, 5, 12);
+    const startOfWeek = new Date(2020, 5, 7);
+    expect(dateAdapter.calendarStartOfWeek(date)).toEqual(startOfWeek);
+  });
+
+  it('should support calendarStartOfWeek with different weekStartsOn', function () {
+    const date = new Date(2020, 5, 12);
+    const startOfWeek = new Date(2020, 5, 8);
+    expect(dateAdapter.calendarStartOfWeek(date, { weekStartsOn: 1 })).toEqual(startOfWeek);
+  });
+
+  it('should support calendarStartOfMonth', function () {
+    const date = new Date(2020, 5, 12);
+    const startOfMonth = new Date(2020, 5, 1);
+    expect(dateAdapter.calendarStartOfMonth(date)).toEqual(startOfMonth);
+  });
+
+  it('should support required getters', function () {
+    const date = new Date(2020, 5, 12, 12, 12, 12, 12);
+
+    expect(dateAdapter.getYear(date)).toBe(2020);
+    expect(dateAdapter.getMonth(date)).toBe(5);
+    expect(dateAdapter.getDay(date)).toBe(5);
+    expect(dateAdapter.getDate(date)).toBe(12);
+    expect(dateAdapter.getTime(date)).toBe(1591947732012);
+    expect(dateAdapter.getHours(date)).toBe(12);
+    expect(dateAdapter.getMinutes(date)).toBe(12);
+    expect(dateAdapter.getSeconds(date)).toBe(12);
+    expect(dateAdapter.getMilliseconds(date)).toBe(12);
+    expect(dateAdapter.getISOWeek(date)).toBe(24);
+  });
+
+  it('should support clone', () => {
+    const date = new Date();
+    expect(dateAdapter.clone(date)).toEqual(new Date());
+  });
+
+  it('should support setHms', () => {
+    const date = new Date('2020-06-12 12:12:12');
+
+    const result = dateAdapter.setHms(date, 13, 13, 13);
+
+    expect(result).toEqual(new Date('2020-06-12 13:13:13'));
+  });
+
+  it('should support addYears', () => {
+    const date = new Date('2020-06-12');
+
+    const addYears = dateAdapter.addYears(date, 5);
+
+    expect(addYears).toEqual(new Date('2025-06-12'));
+  });
+
+  it('should support addMonth', () => {
+    const date = new Date('2020-06-12');
+
+    const addMonths = dateAdapter.addMonths(date, 12);
+
+    expect(addMonths).toEqual(new Date('2021-06-12'));
+  });
+
+  it('should support addDays', () => {
+    const date = new Date('2020-06-12');
+
+    const addDays = dateAdapter.addDays(date, 20);
+
+    expect(addDays).toEqual(new Date('2020-07-02'));
+  });
+
+  it('should support setDate', () => {
+    const date = new Date('2020-06-12');
+
+    const setDate = dateAdapter.setDate(date, 20);
+
+    expect(setDate).toEqual(new Date('2020-06-20'));
+  });
+
+  it('should support setDay', () => {
+    const date = new Date('2020-06-12');
+
+    const setDay = dateAdapter.setDay(date, 2);
+
+    expect(setDay).toEqual(new Date('2020-06-09'));
+  });
+
+  it('should support setMonth', () => {
+    const date = new Date(2020, 6, 12);
+
+    const setMonth = dateAdapter.setMonth(date, 2);
+
+    expect(setMonth).toEqual(new Date(2020, 2, 12));
+  });
+
+  it('should support isSame', () => {
+    const first = new Date('2020-06-12 12:12:12');
+    const second = new Date('2020-07-12 12:12:12');
+
+    expect(dateAdapter.isSame(first, second, 'year')).toBeTrue();
+    expect(dateAdapter.isSame(first, second, 'month')).toBeFalse();
+
+    expect(dateAdapter.isSame(first, second, 'hour')).toBeFalse();
+    expect(dateAdapter.isSame(first, second, 'minute')).toBeFalse();
+  });
+
+  it('should support isBefore', () => {
+    const date = new Date('2020-06-12');
+
+    expect(dateAdapter.isBefore(date, new Date(), 'year')).toBeTrue();
+    expect(dateAdapter.isBefore(date, new Date('2018-06-12'), 'year')).toBeFalse();
+    expect(dateAdapter.isBefore(date, new Date('2020-07-12'), 'month')).toBeTrue();
+    expect(dateAdapter.isBefore(date, new Date('2020-06-13'), 'day')).toBeTrue();
+  });
+
+  it('should support isToday', () => {
+    const date = new Date('2020-06-12');
+
+    expect(dateAdapter.isToday(date)).toBeFalse();
+    expect(dateAdapter.isToday(new Date())).toBeTrue();
+  });
+
+  it('should support isValid', () => {
+    expect(dateAdapter.isValid(new Date())).toBeTrue();
+    expect(dateAdapter.isValid({} as never)).toBeFalse();
+  });
+
+  it('should support isFirstDayOfMonth', () => {
+    const firstDayOfMonth = new Date('2020-06-01');
+    const secondDayOfMonth = new Date('2020-06-02');
+
+    expect(dateAdapter.isFirstDayOfMonth(firstDayOfMonth)).toBeTrue();
+    expect(dateAdapter.isFirstDayOfMonth(secondDayOfMonth)).toBeFalse();
+  });
+
+  it('should support isLastDayOfMonth', () => {
+    const lastDayOfMonth = new Date('2020-06-30');
+    const anotherDayOfMonth = new Date('2020-06-12');
+
+    expect(dateAdapter.isLastDayOfMonth(lastDayOfMonth)).toBeTrue();
+    expect(dateAdapter.isLastDayOfMonth(anotherDayOfMonth)).toBeFalse();
+  });
+
+  it('should support format', () => {
+    const date = new Date('2020-06-12');
+
+    expect(dateAdapter.format(date, 'yyyy-dd-MM')).toBe('2020-12-06');
+  });
+});
+
+// @ts-ignore
+class CustomAdapter extends NzDateAdapter<Date> {}
+
+describe('date adapter utility functions', () => {
+  it('should returns true when custom adapter provided', function () {
+    expect(isCustomAdapter(dateAdapter)).toBeFalse();
+    expect(isCustomAdapter(new CustomAdapter())).toBeTrue();
+  });
+});

--- a/components/core/time/date-adapter.spec.ts
+++ b/components/core/time/date-adapter.spec.ts
@@ -1,5 +1,6 @@
 import { dateAdapter } from 'ng-zorro-antd/core/time/candy-date.spec';
-import { DateFnsDateAdapter, isCustomAdapter, NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
+
+import { DateFnsDateAdapter, isCustomAdapter, NzDateAdapter } from './date-adapter';
 
 describe('date-adapter', () => {
   let dateAdapter: NzDateAdapter;

--- a/components/core/time/date-adapter.spec.ts
+++ b/components/core/time/date-adapter.spec.ts
@@ -56,7 +56,10 @@ describe('date-adapter', () => {
     expect(dateAdapter.getMonth(date)).toBe(5);
     expect(dateAdapter.getDay(date)).toBe(5);
     expect(dateAdapter.getDate(date)).toBe(12);
-    expect(dateAdapter.getTime(date)).toBe(1591947732012);
+
+    const now = new Date();
+    expect(dateAdapter.getTime(now)).toBe(now.getTime());
+
     expect(dateAdapter.getHours(date)).toBe(12);
     expect(dateAdapter.getMinutes(date)).toBe(12);
     expect(dateAdapter.getSeconds(date)).toBe(12);

--- a/components/core/time/date-adapter.ts
+++ b/components/core/time/date-adapter.ts
@@ -123,8 +123,8 @@ export class DateFnsDateAdapter extends NzDateAdapter<Date> {
     return input;
   }
 
-  calendarStartOfWeek(date: Date): Date {
-    return startOfWeek(date);
+  calendarStartOfWeek(date: Date, options?: { weekStartsOn: WeekDayIndex | undefined }): Date {
+    return startOfWeek(date, options);
   }
 
   calendarStartOfMonth(date: Date): Date {
@@ -196,8 +196,8 @@ export class DateFnsDateAdapter extends NzDateAdapter<Date> {
     return new Date(newDate.setDate(amount));
   }
 
-  setDay(date: Date, day: number): Date {
-    return setDay(date, day);
+  setDay(date: Date, day: number, options?: { weekStartsOn: WeekDayIndex | undefined }): Date {
+    return setDay(date, day, options);
   }
 
   setMonth(date: Date, month: number): Date {

--- a/components/core/time/date-adapter.ts
+++ b/components/core/time/date-adapter.ts
@@ -304,3 +304,7 @@ export class DateFnsDateAdapter extends NzDateAdapter<Date> {
     return format(date, displayFormat, options);
   }
 }
+
+export function isCustomAdapter(adapter: NzDateAdapter): boolean {
+  return !(adapter instanceof DateFnsDateAdapter);
+}

--- a/components/core/time/date-adapter.ts
+++ b/components/core/time/date-adapter.ts
@@ -57,23 +57,23 @@ export abstract class NzDateAdapter<D = Date> {
 
   abstract today(): D;
 
-  abstract getYear(date: Date): number;
+  abstract getYear(date: D): number;
 
-  abstract getMonth(date: Date): number;
+  abstract getMonth(date: D): number;
 
-  abstract getDay(date: Date): number;
+  abstract getDay(date: D): number;
 
-  abstract getTime(date: Date): number;
+  abstract getTime(date: D): number;
 
-  abstract getDate(date: Date): number;
+  abstract getDate(date: D): number;
 
-  abstract getHours(date: Date): number;
+  abstract getHours(date: D): number;
 
-  abstract getMinutes(date: Date): number;
+  abstract getMinutes(date: D): number;
 
-  abstract getSeconds(date: Date): number;
+  abstract getSeconds(date: D): number;
 
-  abstract getMilliseconds(date: Date): number;
+  abstract getMilliseconds(date: D): number;
 
   abstract getISOWeek(date: Date): number;
 
@@ -254,9 +254,6 @@ export class DateFnsDateAdapter extends NzDateAdapter<Date> {
   }
 
   isBefore(first: Date, second: Date, mode: CandyDateMode): boolean {
-    if (second === null) {
-      return false;
-    }
     let fn;
     switch (mode) {
       case 'year':

--- a/components/core/time/date-adapter.ts
+++ b/components/core/time/date-adapter.ts
@@ -16,6 +16,7 @@ import {
   differenceInMinutes,
   differenceInSeconds,
   format,
+  getISOWeek,
   isFirstDayOfMonth,
   isLastDayOfMonth,
   isSameDay,
@@ -30,10 +31,12 @@ import {
   setMonth,
   setYear,
   startOfMonth,
-  startOfWeek
+  startOfWeek,
+  parse as fnsParse
 } from 'date-fns';
 
 import { CandyDateMode, WeekDayIndex } from 'ng-zorro-antd/core/time/candy-date';
+import { DateLocale } from 'ng-zorro-antd/i18n';
 
 export type DateMode = CandyDateMode;
 
@@ -48,27 +51,31 @@ export abstract class NzDateAdapter<D = Date> {
 
   abstract deserialize(input: D | Date | string | number | never): D;
 
+  abstract parse(text: string, formatStr: string, options?: { locale: DateLocale; weekStartsOn: number }): D;
+
   abstract toNativeDate(input: D): Date;
 
   abstract today(): D;
 
-  abstract getYear(date: D): number;
+  abstract getYear(date: Date): number;
 
-  abstract getMonth(date: D): number;
+  abstract getMonth(date: Date): number;
 
-  abstract getDay(date: D): number;
+  abstract getDay(date: Date): number;
 
-  abstract getTime(date: D): number;
+  abstract getTime(date: Date): number;
 
-  abstract getDate(date: D): number;
+  abstract getDate(date: Date): number;
 
-  abstract getHours(date: D): number;
+  abstract getHours(date: Date): number;
 
-  abstract getMinutes(date: D): number;
+  abstract getMinutes(date: Date): number;
 
-  abstract getSeconds(date: D): number;
+  abstract getSeconds(date: Date): number;
 
-  abstract getMilliseconds(date: D): number;
+  abstract getMilliseconds(date: Date): number;
+
+  abstract getISOWeek(date: Date): number;
 
   abstract clone(date: D): D;
 
@@ -100,7 +107,7 @@ export abstract class NzDateAdapter<D = Date> {
 
   abstract isLastDayOfMonth(date: D): boolean;
 
-  abstract format(date: D, displayFormat: string): string;
+  abstract format(date: Date, displayFormat: string, options?: { locale: DateLocale }): string;
 }
 
 @Injectable({
@@ -117,6 +124,13 @@ export class DateFnsDateAdapter extends NzDateAdapter<Date> {
     }
 
     throw new Error('The input date type is not supported ("Date" is now recommended)');
+  }
+
+  parse(text: string, formatStr: string, options: { locale: DateLocale; weekStartsOn: WeekDayIndex }): Date {
+    return fnsParse(text, formatStr, new Date(), {
+      locale: options?.locale,
+      weekStartsOn: options?.weekStartsOn
+    });
   }
 
   toNativeDate(input: Date): Date {
@@ -165,6 +179,10 @@ export class DateFnsDateAdapter extends NzDateAdapter<Date> {
 
   getMilliseconds(date: Date): number {
     return date.getMilliseconds();
+  }
+
+  getISOWeek(date: Date): number {
+    return getISOWeek(date);
   }
 
   clone(date: Date): Date {
@@ -282,7 +300,7 @@ export class DateFnsDateAdapter extends NzDateAdapter<Date> {
     return isLastDayOfMonth(date);
   }
 
-  format(date: Date, displayFormat: string): string {
-    return format(date, displayFormat as string);
+  format(date: Date, displayFormat: string, options?: { locale: DateLocale }): string {
+    return format(date, displayFormat, options);
   }
 }

--- a/components/core/time/date-adapter.ts
+++ b/components/core/time/date-adapter.ts
@@ -1,0 +1,288 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { forwardRef, Injectable } from '@angular/core';
+
+import {
+  addDays,
+  addMonths,
+  addYears,
+  differenceInCalendarDays,
+  differenceInCalendarMonths,
+  differenceInCalendarYears,
+  differenceInHours,
+  differenceInMinutes,
+  differenceInSeconds,
+  format,
+  isFirstDayOfMonth,
+  isLastDayOfMonth,
+  isSameDay,
+  isSameHour,
+  isSameMinute,
+  isSameMonth,
+  isSameSecond,
+  isSameYear,
+  isToday,
+  isValid,
+  setDay,
+  setMonth,
+  setYear,
+  startOfMonth,
+  startOfWeek
+} from 'date-fns';
+
+import { CandyDateMode, WeekDayIndex } from 'ng-zorro-antd/core/time/candy-date';
+
+export type DateMode = CandyDateMode;
+
+@Injectable({
+  providedIn: 'root',
+  useExisting: forwardRef(() => DateFnsDateAdapter)
+})
+export abstract class NzDateAdapter<D = Date> {
+  abstract calendarStartOfWeek(date: D, options?: { weekStartsOn: WeekDayIndex | undefined }): D;
+
+  abstract calendarStartOfMonth(date: D): D;
+
+  abstract deserialize(input: D | Date | string | number | never): D;
+
+  abstract toNativeDate(input: D): Date;
+
+  abstract today(): D;
+
+  abstract getYear(date: D): number;
+
+  abstract getMonth(date: D): number;
+
+  abstract getDay(date: D): number;
+
+  abstract getTime(date: D): number;
+
+  abstract getDate(date: D): number;
+
+  abstract getHours(date: D): number;
+
+  abstract getMinutes(date: D): number;
+
+  abstract getSeconds(date: D): number;
+
+  abstract getMilliseconds(date: D): number;
+
+  abstract clone(date: D): D;
+
+  abstract setHms(date: D, hour: number, minute: number, second: number): D;
+
+  abstract setYear(date: D, year: number): D;
+
+  abstract addYears(date: D, amount: number): D;
+
+  abstract setMonth(date: D, amount: number): D;
+
+  abstract addMonths(date: D, amount: number): D;
+
+  abstract setDay(date: D, day: number, options?: { weekStartsOn: WeekDayIndex | undefined }): D;
+
+  abstract setDate(date: D, amount: number): D;
+
+  abstract addDays(date: D, amount: number): D;
+
+  abstract isSame(first: D, second: D, mode: DateMode): boolean;
+
+  abstract isBefore(first: D, second: D, mode: DateMode): boolean;
+
+  abstract isToday(date: D): boolean;
+
+  abstract isValid(date: D): boolean;
+
+  abstract isFirstDayOfMonth(date: D): boolean;
+
+  abstract isLastDayOfMonth(date: D): boolean;
+
+  abstract format(date: D, displayFormat: string): string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DateFnsDateAdapter extends NzDateAdapter<Date> {
+  today(): Date {
+    return new Date();
+  }
+
+  deserialize(input: Date | string | number | never): Date {
+    if (input instanceof Date || typeof input === 'string' || typeof input === 'number') {
+      return new Date(input);
+    }
+
+    throw new Error('The input date type is not supported ("Date" is now recommended)');
+  }
+
+  toNativeDate(input: Date): Date {
+    return input;
+  }
+
+  calendarStartOfWeek(date: Date): Date {
+    return startOfWeek(date);
+  }
+
+  calendarStartOfMonth(date: Date): Date {
+    return startOfMonth(date);
+  }
+
+  getYear(date: Date): number {
+    return date.getFullYear();
+  }
+
+  getMonth(date: Date): number {
+    return date.getMonth();
+  }
+
+  getDay(date: Date): number {
+    return date.getDay();
+  }
+
+  getTime(date: Date): number {
+    return date.getTime();
+  }
+
+  getDate(date: Date): number {
+    return date.getDate();
+  }
+
+  getHours(date: Date): number {
+    return date.getHours();
+  }
+
+  getMinutes(date: Date): number {
+    return date.getMinutes();
+  }
+
+  getSeconds(date: Date): number {
+    return date.getSeconds();
+  }
+
+  getMilliseconds(date: Date): number {
+    return date.getMilliseconds();
+  }
+
+  clone(date: Date): Date {
+    return new Date(date);
+  }
+
+  setHms(date: Date, hour: number, minute: number, second: number): Date {
+    return new Date(date.setHours(hour, minute, second));
+  }
+
+  setYear(date: Date, year: number): Date {
+    return setYear(date, year);
+  }
+
+  addYears(date: Date, amount: number): Date {
+    return addYears(date, amount);
+  }
+
+  addDays(date: Date, amount: number): Date {
+    return addDays(date, amount);
+  }
+
+  addMonths(date: Date, amount: number): Date {
+    return addMonths(date, amount);
+  }
+
+  setDate(date: Date, amount: number): Date {
+    const newDate = new Date(date);
+    return new Date(newDate.setDate(amount));
+  }
+
+  setDay(date: Date, day: number): Date {
+    return setDay(date, day);
+  }
+
+  setMonth(date: Date, month: number): Date {
+    return setMonth(date, month);
+  }
+
+  isSame(first: Date, second: Date, mode: DateMode): boolean {
+    let fn;
+    switch (mode) {
+      case 'decade':
+        fn = (pre: Date, next: Date) => Math.abs(pre.getFullYear() - next.getFullYear()) < 11;
+        break;
+      case 'year':
+        fn = isSameYear;
+        break;
+      case 'month':
+        fn = isSameMonth;
+        break;
+      case 'day':
+        fn = isSameDay;
+        break;
+      case 'hour':
+        fn = isSameHour;
+        break;
+      case 'minute':
+        fn = isSameMinute;
+        break;
+      case 'second':
+        fn = isSameSecond;
+        break;
+      default:
+        fn = isSameDay;
+        break;
+    }
+    return fn(first, second);
+  }
+
+  isBefore(first: Date, second: Date, mode: CandyDateMode): boolean {
+    if (second === null) {
+      return false;
+    }
+    let fn;
+    switch (mode) {
+      case 'year':
+        fn = differenceInCalendarYears;
+        break;
+      case 'month':
+        fn = differenceInCalendarMonths;
+        break;
+      case 'day':
+        fn = differenceInCalendarDays;
+        break;
+      case 'hour':
+        fn = differenceInHours;
+        break;
+      case 'minute':
+        fn = differenceInMinutes;
+        break;
+      case 'second':
+        fn = differenceInSeconds;
+        break;
+      default:
+        fn = differenceInCalendarDays;
+        break;
+    }
+    return fn(first, second) < 0;
+  }
+
+  isToday(date: Date): boolean {
+    return isToday(date);
+  }
+
+  isValid(date: Date): boolean {
+    return isValid(date);
+  }
+
+  isFirstDayOfMonth(date: Date): boolean {
+    return isFirstDayOfMonth(date);
+  }
+
+  isLastDayOfMonth(date: Date): boolean {
+    return isLastDayOfMonth(date);
+  }
+
+  format(date: Date, displayFormat: string): string {
+    return format(date, displayFormat as string);
+  }
+}

--- a/components/core/time/date-adapter.ts
+++ b/components/core/time/date-adapter.ts
@@ -32,11 +32,13 @@ import {
   setYear,
   startOfMonth,
   startOfWeek,
-  parse as fnsParse
+  parse as fnsParse,
+  Locale
 } from 'date-fns';
 
-import { CandyDateMode, WeekDayIndex } from 'ng-zorro-antd/core/time/candy-date';
-import { DateLocale } from 'ng-zorro-antd/i18n';
+export type DateLocale = Locale;
+
+import { CandyDateMode, WeekDayIndex } from './candy-date';
 
 export type DateMode = CandyDateMode;
 

--- a/components/core/time/public-api.ts
+++ b/components/core/time/public-api.ts
@@ -4,5 +4,6 @@
  */
 
 export * from './candy-date';
+export * from './date-adapter';
 export * from './time';
 export { NgTimeParser as ɵNgTimeParser, TimeResult as ɵTimeResult } from './time-parser';

--- a/components/date-picker/calendar-footer.component.ts
+++ b/components/date-picker/calendar-footer.component.ts
@@ -7,6 +7,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
+  Inject,
   Input,
   OnChanges,
   Output,
@@ -15,7 +16,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { isNonEmptyString, isTemplateRef } from 'ng-zorro-antd/core/util';
 import { DateHelperService, NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
@@ -94,7 +95,7 @@ export class CalendarFooterComponent implements OnChanges {
   isTodayDisabled: boolean = false;
   todayTitle: string = '';
 
-  constructor(private dateHelper: DateHelperService) {}
+  constructor(private dateHelper: DateHelperService, @Inject(CandyDate) private candyDate: CandyDateFac) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     const now: Date = new Date();
@@ -109,7 +110,7 @@ export class CalendarFooterComponent implements OnChanges {
   }
 
   onClickToday(): void {
-    const now: CandyDate = new CandyDate();
+    const now: CandyDate = this.candyDate();
     this.clickToday.emit(now.clone()); // To prevent the "now" being modified from outside, we use clone
   }
 }

--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -19,9 +19,9 @@ import {
   dispatchMouseEvent,
   typeInElement
 } from 'ng-zorro-antd/core/testing';
+import { NzI18nModule, NzI18nService, NZ_DATE_LOCALE, NZ_DATE_CONFIG } from 'ng-zorro-antd/i18n';
 import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 import { NgStyleInterface, NzStatus } from 'ng-zorro-antd/core/types';
-import { NzI18nModule, NzI18nService, NZ_DATE_LOCALE } from 'ng-zorro-antd/i18n';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import en_US from '../i18n/languages/en_US';
@@ -1210,6 +1210,57 @@ describe('status', () => {
     fixture.detectChanges();
     expect(datePickerElement.classList).not.toContain('ant-picker-status-warning');
   });
+});
+
+describe('custom date display formats testing', () => {
+  let fixture: ComponentFixture<NzTestDatePickerComponent>;
+  let fixtureInstance: NzTestDatePickerComponent;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsModule, NoopAnimationsModule, NzDatePickerModule, NzI18nModule],
+      providers: [
+        { provide: NZ_DATE_LOCALE, useValue: enUS },
+        {
+          provide: NZ_DATE_CONFIG,
+          useValue: {
+            displayFormats: {
+              dateInput: 'yyyy/dd/MM',
+              veryShortWeekLabel: 'EEEE'
+            }
+          }
+        }
+      ],
+      declarations: [NzTestDatePickerComponent]
+    });
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NzTestDatePickerComponent);
+    fixtureInstance = fixture.componentInstance;
+    fixtureInstance.useSuite = 1;
+  });
+
+  it('should show header week label according to provided value', fakeAsync(() => {
+    fixture.componentInstance.nzInline = true;
+    fixture.detectChanges();
+    tick(500);
+
+    const firstWeekName = fixture.debugElement.nativeElement.querySelector('.ant-picker-content thead th:first-child');
+
+    expect(firstWeekName.innerHTML).toBe(' S ');
+  }));
+
+  it('should format input from provided value', fakeAsync(() => {
+    fixture.componentInstance.nzValue = new Date('2020-06-12');
+    fixture.detectChanges();
+    tick(500);
+
+    const input = getPickerInput(fixture.debugElement);
+
+    expect(input.value).toBe('2020/12/06');
+  }));
 });
 
 @Component({

--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -19,9 +19,9 @@ import {
   dispatchMouseEvent,
   typeInElement
 } from 'ng-zorro-antd/core/testing';
-import { NzI18nModule, NzI18nService, NZ_DATE_LOCALE, NZ_DATE_CONFIG } from 'ng-zorro-antd/i18n';
 import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 import { NgStyleInterface, NzStatus } from 'ng-zorro-antd/core/types';
+import { NzI18nModule, NzI18nService, NZ_DATE_LOCALE, NZ_DATE_CONFIG } from 'ng-zorro-antd/i18n';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import en_US from '../i18n/languages/en_US';

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -48,7 +48,6 @@ import { slideMotion } from 'ng-zorro-antd/core/animation';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { CandyDate, CandyDateFac, cloneDate, CompatibleValue, wrongSortOrder } from 'ng-zorro-antd/core/time';
-import { InputBoolean, toBoolean, valueFunctionProp } from 'ng-zorro-antd/core/util';
 import {
   BooleanInput,
   FunctionProp,
@@ -61,9 +60,8 @@ import {
 import { getStatusClassNames, InputBoolean, toBoolean, valueFunctionProp } from 'ng-zorro-antd/core/util';
 import {
   DateHelperService,
-  mergeDateConfig,
-  NZ_DATE_CONFIG,
-  NzDateConfig,
+  NZ_DATE_FORMATS,
+  NzDateDisplayFormats,
   NzDatePickerI18nInterface,
   NzDatePickerLangI18nInterface,
   NzI18nService
@@ -274,7 +272,6 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
   private isCustomPlaceHolder: boolean = false;
   private isCustomFormat: boolean = false;
   private showTime: SupportTimeOptions | boolean = false;
-  private config: NzDateConfig;
 
   // --- Common API
   @Input() @InputBoolean() nzAllowClear: boolean = true;
@@ -616,12 +613,11 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
     @Inject(DOCUMENT) doc: NzSafeAny,
     @Optional() private directionality: Directionality,
     @Inject(CandyDate) private candyDate: CandyDateFac,
-    @Inject(NZ_DATE_CONFIG) config: NzDateConfig,
+    @Inject(NZ_DATE_FORMATS) private dateFormats: NzDateDisplayFormats,
     @Host() @Optional() public noAnimation?: NzNoAnimationDirective
   ) {
     this.document = doc;
     this.origin = new CdkOverlayOrigin(this.elementRef);
-    this.config = mergeDateConfig(config);
   }
 
   ngOnInit(): void {
@@ -710,10 +706,10 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
 
   setModeAndFormat(): void {
     const inputFormats: { [key in NzDateMode]?: string } = {
-      year: this.config.displayFormats?.yearLabel,
-      month: this.config.displayFormats?.monthYearLabel,
-      week: this.i18n.getDateLocale() ? 'RRRR-II' : this.config.displayFormats?.weekYearLabel, // Format for week
-      date: this.nzShowTime ? this.config.displayFormats?.dateTimeInput : this.config.displayFormats?.dateInput
+      year: this.dateFormats.yearLabel,
+      month: this.dateFormats.monthYearLabel,
+      week: this.i18n.getDateLocale() ? 'RRRR-II' : this.dateFormats.weekYearLabel, // Format for week
+      date: this.nzShowTime ? this.dateFormats.dateTimeInput : this.dateFormats.dateInput
     };
 
     if (!this.nzMode) {

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -61,6 +61,9 @@ import {
 import { getStatusClassNames, InputBoolean, toBoolean, valueFunctionProp } from 'ng-zorro-antd/core/util';
 import {
   DateHelperService,
+  mergeDateConfig,
+  NZ_DATE_CONFIG,
+  NzDateConfig,
   NzDatePickerI18nInterface,
   NzDatePickerLangI18nInterface,
   NzI18nService
@@ -271,6 +274,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
   private isCustomPlaceHolder: boolean = false;
   private isCustomFormat: boolean = false;
   private showTime: SupportTimeOptions | boolean = false;
+  private config: NzDateConfig;
 
   // --- Common API
   @Input() @InputBoolean() nzAllowClear: boolean = true;
@@ -612,10 +616,12 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
     @Inject(DOCUMENT) doc: NzSafeAny,
     @Optional() private directionality: Directionality,
     @Inject(CandyDate) private candyDate: CandyDateFac,
+    @Inject(NZ_DATE_CONFIG) config: NzDateConfig,
     @Host() @Optional() public noAnimation?: NzNoAnimationDirective
   ) {
     this.document = doc;
     this.origin = new CdkOverlayOrigin(this.elementRef);
+    this.config = mergeDateConfig(config);
   }
 
   ngOnInit(): void {
@@ -704,10 +710,10 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
 
   setModeAndFormat(): void {
     const inputFormats: { [key in NzDateMode]?: string } = {
-      year: 'yyyy',
-      month: 'yyyy-MM',
-      week: this.i18n.getDateLocale() ? 'RRRR-II' : 'yyyy-ww', // Format for week
-      date: this.nzShowTime ? 'yyyy-MM-dd HH:mm:ss' : 'yyyy-MM-dd'
+      year: this.config.displayFormats?.yearLabel,
+      month: this.config.displayFormats?.monthYearLabel,
+      week: this.i18n.getDateLocale() ? 'RRRR-II' : this.config.displayFormats?.weekYearLabel, // Format for week
+      date: this.nzShowTime ? this.config.displayFormats?.dateTimeInput : this.config.displayFormats?.dateInput
     };
 
     if (!this.nzMode) {

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -47,7 +47,8 @@ import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
 import { slideMotion } from 'ng-zorro-antd/core/animation';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
-import { CandyDate, cloneDate, CompatibleValue, wrongSortOrder } from 'ng-zorro-antd/core/time';
+import { CandyDate, CandyDateFac, cloneDate, CompatibleValue, wrongSortOrder } from 'ng-zorro-antd/core/time';
+import { InputBoolean, toBoolean, valueFunctionProp } from 'ng-zorro-antd/core/util';
 import {
   BooleanInput,
   FunctionProp,
@@ -564,7 +565,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
   }
 
   private checkValidDate(value: string): CandyDate | null {
-    const date = new CandyDate(this.dateHelper.parseDate(value, this.nzFormat));
+    const date = this.candyDate(this.dateHelper.parseDate(value, this.nzFormat));
 
     if (!date.isValid() || value !== this.dateHelper.format(date.nativeDate, this.nzFormat)) {
       return null;
@@ -610,6 +611,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
     private platform: Platform,
     @Inject(DOCUMENT) doc: NzSafeAny,
     @Optional() private directionality: Directionality,
+    @Inject(CandyDate) private candyDate: CandyDateFac,
     @Host() @Optional() public noAnimation?: NzNoAnimationDirective
   ) {
     this.document = doc;

--- a/components/date-picker/date-picker.service.ts
+++ b/components/date-picker/date-picker.service.ts
@@ -12,9 +12,9 @@ import {
   cloneDate,
   CompatibleValue,
   NormalizedMode,
-  normalizeRangeValue
+  normalizeRangeValue,
+  NzDateAdapter
 } from 'ng-zorro-antd/core/time';
-import { NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
 
 import { CompatibleDate, NzDateMode, RangePartType } from './standard-types';
 

--- a/components/date-picker/date-picker.service.ts
+++ b/components/date-picker/date-picker.service.ts
@@ -3,10 +3,18 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Injectable, OnDestroy } from '@angular/core';
+import { Inject, Injectable, OnDestroy } from '@angular/core';
 import { ReplaySubject, Subject } from 'rxjs';
 
-import { CandyDate, cloneDate, CompatibleValue, NormalizedMode, normalizeRangeValue } from 'ng-zorro-antd/core/time';
+import {
+  CandyDate,
+  CandyDateFac,
+  cloneDate,
+  CompatibleValue,
+  NormalizedMode,
+  normalizeRangeValue
+} from 'ng-zorro-antd/core/time';
+import { NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
 
 import { CompatibleDate, NzDateMode, RangePartType } from './standard-types';
 
@@ -22,6 +30,8 @@ export class DatePickerService implements OnDestroy {
   valueChange$ = new ReplaySubject<CompatibleValue>(1);
   emitValue$ = new Subject<void>();
   inputPartChange$ = new Subject<RangePartType>();
+
+  constructor(private dateAdapter: NzDateAdapter, @Inject(CandyDate) private candyDate: CandyDateFac) {}
 
   initValue(reset: boolean = false): void {
     if (reset) {
@@ -41,9 +51,9 @@ export class DatePickerService implements OnDestroy {
 
   makeValue(value?: CompatibleDate): CompatibleValue {
     if (this.isRange) {
-      return value ? (value as Date[]).map(val => new CandyDate(val)) : [];
+      return value ? (value as Date[]).map(val => this.candyDate(val)) : [];
     } else {
-      return value ? new CandyDate(value as Date) : null;
+      return value ? this.candyDate(value as Date) : null;
     }
   }
 
@@ -54,7 +64,13 @@ export class DatePickerService implements OnDestroy {
       year: 'decade'
     };
     if (this.isRange) {
-      this.activeDate = normalizeRangeValue(value as CandyDate[], hasTimePicker, parentPanels[mode], this.activeInput);
+      this.activeDate = normalizeRangeValue(
+        this.dateAdapter,
+        value as CandyDate[],
+        hasTimePicker,
+        parentPanels[mode],
+        this.activeInput
+      );
     } else {
       this.activeDate = cloneDate(value);
     }

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -10,6 +10,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  Inject,
   Input,
   NgZone,
   OnChanges,
@@ -25,6 +26,7 @@ import { takeUntil } from 'rxjs/operators';
 
 import {
   CandyDate,
+  CandyDateFac,
   cloneDate,
   CompatibleValue,
   NormalizedMode,
@@ -183,7 +185,8 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
     public datePickerService: DatePickerService,
     public cdr: ChangeDetectorRef,
     private ngZone: NgZone,
-    private host: ElementRef<HTMLElement>
+    private host: ElementRef<HTMLElement>,
+    @Inject(CandyDate) private candyDate: CandyDateFac
   ) {}
 
   ngOnInit(): void {
@@ -432,7 +435,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
   onClickPresetRange(val: PresetRanges[keyof PresetRanges]): void {
     const value = typeof val === 'function' ? val() : val;
     if (value) {
-      this.datePickerService.setValue([new CandyDate(value[0]), new CandyDate(value[1])]);
+      this.datePickerService.setValue([this.candyDate(value[0]), this.candyDate(value[1])]);
       this.datePickerService.emitValue$.next();
     }
   }
@@ -443,7 +446,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
 
   onHoverPresetRange(val: PresetRanges[keyof PresetRanges]): void {
     if (typeof val !== 'function') {
-      this.hoverValue = [new CandyDate(val[0]), new CandyDate(val[1])];
+      this.hoverValue = [this.candyDate(val[0]), this.candyDate(val[1])];
     }
   }
 
@@ -492,8 +495,8 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private overrideHms(newValue: CandyDate | null, oldValue: CandyDate | null): CandyDate {
-    newValue = newValue || new CandyDate();
-    oldValue = oldValue || new CandyDate();
+    newValue = newValue || this.candyDate();
+    oldValue = oldValue || this.candyDate();
     return oldValue.setHms(newValue.getHours(), newValue.getMinutes(), newValue.getSeconds());
   }
 }

--- a/components/date-picker/doc/index.en-US.md
+++ b/components/date-picker/doc/index.en-US.md
@@ -28,6 +28,8 @@ registerLocaleData(en);
 
 **Note:** All input and output date objects are [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), you can manipulate it with [date-fns](https://date-fns.org/).
 
+providing custom date adapter for Jalali and Hijri calendars [here](/docs/i18n/en#Provide%20Custom%20Date%20Adapter)
+
 ### Common API
 
 The following APIs are shared by nz-date-picker, nz-range-picker.

--- a/components/date-picker/doc/index.en-US.md
+++ b/components/date-picker/doc/index.en-US.md
@@ -28,7 +28,7 @@ registerLocaleData(en);
 
 **Note:** All input and output date objects are [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), you can manipulate it with [date-fns](https://date-fns.org/).
 
-providing custom date adapter for Jalali and Hijri calendars [here](/docs/i18n/en#Provide%20Custom%20Date%20Adapter)
+providing custom date adapter for Jalali and Hijri calendars [here](/docs/i18n/en#provide-custom-dateadapter)
 
 ### Common API
 

--- a/components/date-picker/inner-popup.component.ts
+++ b/components/date-picker/inner-popup.component.ts
@@ -7,6 +7,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
+  Inject,
   Input,
   OnChanges,
   Output,
@@ -15,7 +16,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { FunctionProp } from 'ng-zorro-antd/core/types';
 import { NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
 
@@ -176,6 +177,8 @@ export class InnerPopupComponent implements OnChanges {
 
   prefixCls: string = PREFIX_CLASS;
 
+  constructor(@Inject(CandyDate) private candyDate: CandyDateFac) {}
+
   /**
    * Hide "next" arrow in left panel,
    * hide "prev" arrow in right panel
@@ -192,12 +195,12 @@ export class InnerPopupComponent implements OnChanges {
   }
 
   onSelectTime(date: Date): void {
-    this.selectTime.emit(new CandyDate(date));
+    this.selectTime.emit(this.candyDate(date));
   }
 
   // The value real changed to outside
-  onSelectDate(date: CandyDate | Date): void {
-    const value = date instanceof CandyDate ? date : new CandyDate(date);
+  onSelectDate(date: CandyDate): void {
+    const value = date;
     const timeValue = this.timeOptions && this.timeOptions.nzDefaultOpenValue;
 
     // Display timeValue when value is null
@@ -243,7 +246,7 @@ export class InnerPopupComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.activeDate && !changes.activeDate.currentValue) {
-      this.activeDate = new CandyDate();
+      this.activeDate = this.candyDate();
     }
     // New Antd vesion has merged 'date' ant 'time' to one panel,
     // So there is not 'time' panel

--- a/components/date-picker/lib/abstract-panel-header.ts
+++ b/components/date-picker/lib/abstract-panel-header.ts
@@ -3,9 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Directive, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { Directive, EventEmitter, Inject, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
+
 import { NzDateMode } from '../standard-types';
 import { PanelSelector } from './interface';
 
@@ -26,6 +28,8 @@ export abstract class AbstractPanelHeader implements OnInit, OnChanges {
   @Output() readonly valueChange = new EventEmitter<CandyDate>();
 
   abstract getSelectors(): PanelSelector[];
+
+  constructor(@Inject(CandyDate) protected candyDate: CandyDateFac) {}
 
   superPreviousTitle(): string {
     return this.locale.previousYear;
@@ -79,7 +83,7 @@ export abstract class AbstractPanelHeader implements OnInit, OnChanges {
 
   ngOnInit(): void {
     if (!this.value) {
-      this.value = new CandyDate(); // Show today by default
+      this.value = this.candyDate(); // Show today by default
     }
     this.selectors = this.getSelectors();
   }

--- a/components/date-picker/lib/abstract-table.ts
+++ b/components/date-picker/lib/abstract-table.ts
@@ -19,7 +19,7 @@ import {
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { FunctionProp, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { isNonEmptyString, isTemplateRef } from 'ng-zorro-antd/core/util';
-import { NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
+import {mergeDateConfig, NZ_DATE_CONFIG, NzCalendarI18nInterface, NzDateConfig} from 'ng-zorro-antd/i18n';
 
 import { DateBodyRow, DateCell } from './interface';
 
@@ -32,6 +32,8 @@ export abstract class AbstractTable implements OnInit, OnChanges {
   bodyRows: DateBodyRow[] = [];
   MAX_ROW = 6;
   MAX_COL = 7;
+
+  config: NzDateConfig;
 
   @Input() prefixCls: string = 'ant-picker';
   @Input() value!: CandyDate;
@@ -47,7 +49,12 @@ export abstract class AbstractTable implements OnInit, OnChanges {
   @Output() readonly valueChange = new EventEmitter<CandyDate>();
   @Output() readonly cellHover = new EventEmitter<CandyDate>(); // Emitted when hover on a day by mouse enter
 
-  constructor(@Inject(CandyDate) protected candyDate: CandyDateFac) {}
+  constructor(
+    @Inject(CandyDate) protected candyDate: CandyDateFac,
+    @Inject(NZ_DATE_CONFIG) config: NzDateConfig,
+  ) {
+    this.config = mergeDateConfig(config);
+  }
 
   protected render(): void {
     if (this.activeDate) {

--- a/components/date-picker/lib/abstract-table.ts
+++ b/components/date-picker/lib/abstract-table.ts
@@ -19,7 +19,7 @@ import {
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { FunctionProp, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { isNonEmptyString, isTemplateRef } from 'ng-zorro-antd/core/util';
-import {mergeDateConfig, NZ_DATE_CONFIG, NzCalendarI18nInterface, NzDateConfig} from 'ng-zorro-antd/i18n';
+import { NZ_DATE_FORMATS, NzCalendarI18nInterface, NzDateDisplayFormats } from 'ng-zorro-antd/i18n';
 
 import { DateBodyRow, DateCell } from './interface';
 
@@ -32,8 +32,6 @@ export abstract class AbstractTable implements OnInit, OnChanges {
   bodyRows: DateBodyRow[] = [];
   MAX_ROW = 6;
   MAX_COL = 7;
-
-  config: NzDateConfig;
 
   @Input() prefixCls: string = 'ant-picker';
   @Input() value!: CandyDate;
@@ -51,10 +49,8 @@ export abstract class AbstractTable implements OnInit, OnChanges {
 
   constructor(
     @Inject(CandyDate) protected candyDate: CandyDateFac,
-    @Inject(NZ_DATE_CONFIG) config: NzDateConfig,
-  ) {
-    this.config = mergeDateConfig(config);
-  }
+    @Inject(NZ_DATE_FORMATS) protected dateFormats: NzDateDisplayFormats
+  ) {}
 
   protected render(): void {
     if (this.activeDate) {

--- a/components/date-picker/lib/abstract-table.ts
+++ b/components/date-picker/lib/abstract-table.ts
@@ -3,11 +3,24 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Directive, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChange, SimpleChanges, TemplateRef } from '@angular/core';
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import {
+  Directive,
+  EventEmitter,
+  Inject,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChange,
+  SimpleChanges,
+  TemplateRef
+} from '@angular/core';
+
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { FunctionProp, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { isNonEmptyString, isTemplateRef } from 'ng-zorro-antd/core/util';
 import { NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
+
 import { DateBodyRow, DateCell } from './interface';
 
 @Directive()
@@ -23,7 +36,7 @@ export abstract class AbstractTable implements OnInit, OnChanges {
   @Input() prefixCls: string = 'ant-picker';
   @Input() value!: CandyDate;
   @Input() locale!: NzCalendarI18nInterface;
-  @Input() activeDate: CandyDate = new CandyDate();
+  @Input() activeDate: CandyDate = this.candyDate();
   @Input() showWeek: boolean = false;
   @Input() selectedValue: CandyDate[] = []; // Range ONLY
   @Input() hoverValue: CandyDate[] = []; // Range ONLY
@@ -33,6 +46,8 @@ export abstract class AbstractTable implements OnInit, OnChanges {
 
   @Output() readonly valueChange = new EventEmitter<CandyDate>();
   @Output() readonly cellHover = new EventEmitter<CandyDate>(); // Emitted when hover on a day by mouse enter
+
+  constructor(@Inject(CandyDate) protected candyDate: CandyDateFac) {}
 
   protected render(): void {
     if (this.activeDate) {
@@ -83,7 +98,7 @@ export abstract class AbstractTable implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.activeDate && !changes.activeDate.currentValue) {
-      this.activeDate = new CandyDate();
+      this.activeDate = this.candyDate();
     }
 
     if (

--- a/components/date-picker/lib/date-header.component.ts
+++ b/components/date-picker/lib/date-header.component.ts
@@ -3,9 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, ViewEncapsulation } from '@angular/core';
 
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { DateHelperService } from 'ng-zorro-antd/i18n';
+
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
 import { transCompatFormat } from './util';
@@ -18,8 +20,8 @@ import { transCompatFormat } from './util';
   templateUrl: './abstract-panel-header.html'
 })
 export class DateHeaderComponent extends AbstractPanelHeader {
-  constructor(private dateHelper: DateHelperService) {
-    super();
+  constructor(private dateHelper: DateHelperService, @Inject(CandyDate) candyDate: CandyDateFac) {
+    super(candyDate);
   }
 
   getSelectors(): PanelSelector[] {

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -3,11 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
-import { CandyDate } from 'ng-zorro-antd/core/time';
-import { valueFunctionProp } from 'ng-zorro-antd/core/util';
+import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
 
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
+import { valueFunctionProp } from 'ng-zorro-antd/core/util';
 import { DateHelperService, NzCalendarI18nInterface, NzI18nService } from 'ng-zorro-antd/i18n';
+
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell } from './interface';
 import { transCompatFormat } from './util';
@@ -23,8 +24,12 @@ import { transCompatFormat } from './util';
 export class DateTableComponent extends AbstractTable implements OnChanges, OnInit {
   @Input() override locale!: NzCalendarI18nInterface;
 
-  constructor(private i18n: NzI18nService, private dateHelper: DateHelperService) {
-    super();
+  constructor(
+    private i18n: NzI18nService,
+    private dateHelper: DateHelperService,
+    @Inject(CandyDate) candyDate: CandyDateFac
+  ) {
+    super(candyDate);
   }
 
   private changeValueFromInside(value: CandyDate): void {
@@ -44,8 +49,8 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
       const day = start.addDays(colIndex);
       weekDays.push({
         trackByIndex: null,
-        value: day.nativeDate,
-        title: this.dateHelper.format(day.nativeDate, 'E'), // eg. Tue
+        value: day,
+        title: this.dateHelper.format(day.nativeDate, 'e'), // eg. Tue
         content: this.dateHelper.format(day.nativeDate, this.getVeryShortWeekFormat()), // eg. Tu,
         isSelected: false,
         isDisabled: false,
@@ -79,7 +84,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
         const label = this.dateHelper.format(date.nativeDate, 'dd');
         const cell: DateCell = {
           trackByIndex: day,
-          value: date.nativeDate,
+          value: date,
           label,
           isSelected: false,
           isDisabled: false,
@@ -147,7 +152,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
   }
 
   override getClassMap(cell: DateCell): { [key: string]: boolean } {
-    const date = new CandyDate(cell.value);
+    const date = cell.value.clone();
     return {
       ...super.getClassMap(cell),
       [`ant-picker-cell-today`]: !!cell.isToday,

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -7,7 +7,13 @@ import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges, OnInit, V
 
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
-import { DateHelperService, NzCalendarI18nInterface, NzI18nService } from 'ng-zorro-antd/i18n';
+import {
+  DateHelperService,
+  NZ_DATE_CONFIG,
+  NzCalendarI18nInterface,
+  NzDateConfig,
+  NzI18nService
+} from 'ng-zorro-antd/i18n';
 
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell } from './interface';
@@ -27,9 +33,10 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
   constructor(
     private i18n: NzI18nService,
     private dateHelper: DateHelperService,
-    @Inject(CandyDate) candyDate: CandyDateFac
+    @Inject(CandyDate) candyDate: CandyDateFac,
+    @Inject(NZ_DATE_CONFIG) config: NzDateConfig
   ) {
-    super(candyDate);
+    super(candyDate, config);
   }
 
   private changeValueFromInside(value: CandyDate): void {
@@ -50,7 +57,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
       weekDays.push({
         trackByIndex: null,
         value: day,
-        title: this.dateHelper.format(day.nativeDate, 'e'), // eg. Tue
+        title: this.dateHelper.format(day.nativeDate, this.config.displayFormats?.weekLabel!), // eg. Tue
         content: this.dateHelper.format(day.nativeDate, this.getVeryShortWeekFormat()), // eg. Tu,
         isSelected: false,
         isDisabled: false,
@@ -62,7 +69,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
   }
 
   private getVeryShortWeekFormat(): string {
-    return this.i18n.getLocaleId().toLowerCase().indexOf('zh') === 0 ? 'EEEEE' : 'EEEEEE'; // Use extreme short for chinese
+    return this.i18n.getLocaleId().toLowerCase().indexOf('zh') === 0 ? 'EEEEE' : this.config.displayFormats?.veryShortWeekLabel!; // Use extreme short for chinese
   }
 
   makeBodyRows(): DateBodyRow[] {
@@ -81,7 +88,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
         const date = weekStart.addDays(day);
         const dateFormat = transCompatFormat(this.i18n.getLocaleData('DatePicker.lang.dateFormat', 'YYYY-MM-DD'));
         const title = this.dateHelper.format(date.nativeDate, dateFormat);
-        const label = this.dateHelper.format(date.nativeDate, 'dd');
+        const label = this.dateHelper.format(date.nativeDate, this.config.displayFormats?.dayLabel!);
         const cell: DateCell = {
           trackByIndex: day,
           value: date,

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -9,9 +9,9 @@ import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
 import {
   DateHelperService,
-  NZ_DATE_CONFIG,
+  NZ_DATE_FORMATS,
   NzCalendarI18nInterface,
-  NzDateConfig,
+  NzDateDisplayFormats,
   NzI18nService
 } from 'ng-zorro-antd/i18n';
 
@@ -34,9 +34,9 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
     private i18n: NzI18nService,
     private dateHelper: DateHelperService,
     @Inject(CandyDate) candyDate: CandyDateFac,
-    @Inject(NZ_DATE_CONFIG) config: NzDateConfig
+    @Inject(NZ_DATE_FORMATS) dateFormats: NzDateDisplayFormats
   ) {
-    super(candyDate, config);
+    super(candyDate, dateFormats);
   }
 
   private changeValueFromInside(value: CandyDate): void {
@@ -57,7 +57,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
       weekDays.push({
         trackByIndex: null,
         value: day,
-        title: this.dateHelper.format(day.nativeDate, this.config.displayFormats?.weekLabel!), // eg. Tue
+        title: this.dateHelper.format(day.nativeDate, this.dateFormats.weekLabel!), // eg. Tue
         content: this.dateHelper.format(day.nativeDate, this.getVeryShortWeekFormat()), // eg. Tu,
         isSelected: false,
         isDisabled: false,
@@ -69,7 +69,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
   }
 
   private getVeryShortWeekFormat(): string {
-    return this.i18n.getLocaleId().toLowerCase().indexOf('zh') === 0 ? 'EEEEE' : this.config.displayFormats?.veryShortWeekLabel!; // Use extreme short for chinese
+    return this.i18n.getLocaleId().toLowerCase().indexOf('zh') === 0 ? 'EEEEE' : this.dateFormats.veryShortWeekLabel!; // Use extreme short for chinese
   }
 
   makeBodyRows(): DateBodyRow[] {
@@ -88,7 +88,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
         const date = weekStart.addDays(day);
         const dateFormat = transCompatFormat(this.i18n.getLocaleData('DatePicker.lang.dateFormat', 'YYYY-MM-DD'));
         const title = this.dateHelper.format(date.nativeDate, dateFormat);
-        const label = this.dateHelper.format(date.nativeDate, this.config.displayFormats?.dayLabel!);
+        const label = this.dateHelper.format(date.nativeDate, this.dateFormats.dayLabel!);
         const cell: DateCell = {
           trackByIndex: day,
           value: date,

--- a/components/date-picker/lib/decade-table.component.ts
+++ b/components/date-picker/lib/decade-table.component.ts
@@ -52,7 +52,7 @@ export class DecadeTableComponent extends AbstractTable implements OnChanges {
 
         const cell: DecadeCell = {
           trackByIndex: colIndex,
-          value: this.activeDate.setYear(start).nativeDate,
+          value: this.activeDate.setYear(start),
           content,
           title: content,
           isDisabled: false,

--- a/components/date-picker/lib/interface.ts
+++ b/components/date-picker/lib/interface.ts
@@ -4,6 +4,8 @@
  */
 
 import { TemplateRef } from '@angular/core';
+
+import { CandyDate } from 'ng-zorro-antd/core/time';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 export interface PanelSelector {
@@ -15,7 +17,7 @@ export interface PanelSelector {
 
 export interface DateCell {
   trackByIndex: NzSafeAny;
-  value: Date;
+  value: CandyDate;
   content: TemplateRef<Date> | string;
   onClick(): void;
   onMouseEnter(): void;

--- a/components/date-picker/lib/lib-packer.spec.ts
+++ b/components/date-picker/lib/lib-packer.spec.ts
@@ -1,9 +1,9 @@
 import { registerLocaleData } from '@angular/common';
 import zh from '@angular/common/locales/zh';
-
 import { fakeAsync, inject, TestBed } from '@angular/core/testing';
 
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { candyDateFac } from 'ng-zorro-antd/core/time/candy-date.spec';
+
 import { DateHelperService } from '../../i18n/date-helper.service';
 import { NzI18nService } from '../../i18n/nz-i18n.service';
 import { DateTableComponent } from './date-table.component';
@@ -79,11 +79,11 @@ describe('Coverage supplements', () => {
   // TODO: Unit test of date-table and month-table
   describe('DateTable', () => {
     beforeEach(() => {
-      componentInstance = new DateTableComponent(i18n, dateHelper);
+      componentInstance = new DateTableComponent(i18n, dateHelper, candyDateFac);
     });
 
     it('should cover untouched branches', () => {
-      componentInstance.value = new CandyDate('2018-11-11');
+      componentInstance.value = candyDateFac('2018-11-11');
       componentInstance.showWeek = true;
       const weekRows = componentInstance.makeBodyRows();
       expect(weekRows.length > 0).toBeTruthy();
@@ -92,11 +92,11 @@ describe('Coverage supplements', () => {
 
   describe('MonthTable', () => {
     beforeEach(() => {
-      componentInstance = new MonthTableComponent(dateHelper);
+      componentInstance = new MonthTableComponent(dateHelper, candyDateFac);
     });
 
     it('should cover untouched branches', () => {
-      componentInstance.value = new CandyDate();
+      componentInstance.value = candyDateFac();
       spyOn(componentInstance, 'render');
       componentInstance.ngOnChanges({ disabledDate: true }); // Fake
       expect(componentInstance.render).toHaveBeenCalled();

--- a/components/date-picker/lib/lib-packer.spec.ts
+++ b/components/date-picker/lib/lib-packer.spec.ts
@@ -3,13 +3,13 @@ import zh from '@angular/common/locales/zh';
 import { fakeAsync, inject, TestBed } from '@angular/core/testing';
 
 import { candyDateFac } from 'ng-zorro-antd/core/time/candy-date.spec';
+import { NZ_DATE_CONFIG_DEFAULT } from 'ng-zorro-antd/i18n';
 
 import { DateHelperService } from '../../i18n/date-helper.service';
 import { NzI18nService } from '../../i18n/nz-i18n.service';
 import { DateTableComponent } from './date-table.component';
 import { LibPackerModule } from './lib-packer.module';
 import { MonthTableComponent } from './month-table.component';
-import {NZ_DATE_CONFIG_DEFAULT} from "ng-zorro-antd/i18n";
 
 registerLocaleData(zh);
 
@@ -80,7 +80,12 @@ describe('Coverage supplements', () => {
   // TODO: Unit test of date-table and month-table
   describe('DateTable', () => {
     beforeEach(() => {
-      componentInstance = new DateTableComponent(i18n, dateHelper, candyDateFac, NZ_DATE_CONFIG_DEFAULT);
+      componentInstance = new DateTableComponent(
+        i18n,
+        dateHelper,
+        candyDateFac,
+        NZ_DATE_CONFIG_DEFAULT.displayFormats!
+      );
     });
 
     it('should cover untouched branches', () => {
@@ -93,7 +98,7 @@ describe('Coverage supplements', () => {
 
   describe('MonthTable', () => {
     beforeEach(() => {
-      componentInstance = new MonthTableComponent(dateHelper, candyDateFac, NZ_DATE_CONFIG_DEFAULT);
+      componentInstance = new MonthTableComponent(dateHelper, candyDateFac, NZ_DATE_CONFIG_DEFAULT.displayFormats!);
     });
 
     it('should cover untouched branches', () => {

--- a/components/date-picker/lib/lib-packer.spec.ts
+++ b/components/date-picker/lib/lib-packer.spec.ts
@@ -9,6 +9,7 @@ import { NzI18nService } from '../../i18n/nz-i18n.service';
 import { DateTableComponent } from './date-table.component';
 import { LibPackerModule } from './lib-packer.module';
 import { MonthTableComponent } from './month-table.component';
+import {NZ_DATE_CONFIG_DEFAULT} from "ng-zorro-antd/i18n";
 
 registerLocaleData(zh);
 
@@ -79,7 +80,7 @@ describe('Coverage supplements', () => {
   // TODO: Unit test of date-table and month-table
   describe('DateTable', () => {
     beforeEach(() => {
-      componentInstance = new DateTableComponent(i18n, dateHelper, candyDateFac);
+      componentInstance = new DateTableComponent(i18n, dateHelper, candyDateFac, NZ_DATE_CONFIG_DEFAULT);
     });
 
     it('should cover untouched branches', () => {
@@ -92,7 +93,7 @@ describe('Coverage supplements', () => {
 
   describe('MonthTable', () => {
     beforeEach(() => {
-      componentInstance = new MonthTableComponent(dateHelper, candyDateFac);
+      componentInstance = new MonthTableComponent(dateHelper, candyDateFac, NZ_DATE_CONFIG_DEFAULT);
     });
 
     it('should cover untouched branches', () => {

--- a/components/date-picker/lib/month-header.component.ts
+++ b/components/date-picker/lib/month-header.component.ts
@@ -3,9 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, ViewEncapsulation } from '@angular/core';
 
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { DateHelperService } from 'ng-zorro-antd/i18n';
+
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
 import { transCompatFormat } from './util';
@@ -18,8 +20,8 @@ import { transCompatFormat } from './util';
   templateUrl: './abstract-panel-header.html'
 })
 export class MonthHeaderComponent extends AbstractPanelHeader {
-  constructor(private dateHelper: DateHelperService) {
-    super();
+  constructor(private dateHelper: DateHelperService, @Inject(CandyDate) candyDate: CandyDateFac) {
+    super(candyDate);
   }
 
   getSelectors(): PanelSelector[] {

--- a/components/date-picker/lib/month-table.component.ts
+++ b/components/date-picker/lib/month-table.component.ts
@@ -3,10 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { ChangeDetectionStrategy, Component, Inject, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
+
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
 import { DateHelperService } from 'ng-zorro-antd/i18n';
+
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell } from './interface';
 
@@ -22,8 +24,8 @@ export class MonthTableComponent extends AbstractTable implements OnChanges, OnI
   override MAX_ROW = 4;
   override MAX_COL = 3;
 
-  constructor(private dateHelper: DateHelperService) {
-    super();
+  constructor(private dateHelper: DateHelperService, @Inject(CandyDate) candyDate: CandyDateFac) {
+    super(candyDate);
   }
 
   makeHeadRow(): DateCell[] {
@@ -46,7 +48,7 @@ export class MonthTableComponent extends AbstractTable implements OnChanges, OnI
         const content = this.dateHelper.format(month.nativeDate, 'MMM');
         const cell: DateCell = {
           trackByIndex: colIndex,
-          value: month.nativeDate,
+          value: month,
           isDisabled,
           isSelected: month.isSameMonth(this.value),
           content,

--- a/components/date-picker/lib/month-table.component.ts
+++ b/components/date-picker/lib/month-table.component.ts
@@ -7,7 +7,7 @@ import { ChangeDetectionStrategy, Component, Inject, OnChanges, OnInit, ViewEnca
 
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
-import { DateHelperService } from 'ng-zorro-antd/i18n';
+import { DateHelperService, mergeDateConfig, NZ_DATE_CONFIG, NzDateConfig} from 'ng-zorro-antd/i18n';
 
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell } from './interface';
@@ -24,8 +24,13 @@ export class MonthTableComponent extends AbstractTable implements OnChanges, OnI
   override MAX_ROW = 4;
   override MAX_COL = 3;
 
-  constructor(private dateHelper: DateHelperService, @Inject(CandyDate) candyDate: CandyDateFac) {
-    super(candyDate);
+  constructor(
+    private dateHelper: DateHelperService,
+    @Inject(CandyDate) candyDate: CandyDateFac,
+    @Inject(NZ_DATE_CONFIG) config: NzDateConfig
+) {
+    super(candyDate, config);
+    this.config = mergeDateConfig(config);
   }
 
   makeHeadRow(): DateCell[] {
@@ -45,7 +50,7 @@ export class MonthTableComponent extends AbstractTable implements OnChanges, OnI
       for (let colIndex = 0; colIndex < this.MAX_COL; colIndex++) {
         const month = this.activeDate.setMonth(monthValue);
         const isDisabled = this.isDisabledMonth(month);
-        const content = this.dateHelper.format(month.nativeDate, 'MMM');
+        const content = this.dateHelper.format(month.nativeDate, this.config.displayFormats?.monthLabel!);
         const cell: DateCell = {
           trackByIndex: colIndex,
           value: month,

--- a/components/date-picker/lib/month-table.component.ts
+++ b/components/date-picker/lib/month-table.component.ts
@@ -7,7 +7,7 @@ import { ChangeDetectionStrategy, Component, Inject, OnChanges, OnInit, ViewEnca
 
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
-import { DateHelperService, mergeDateConfig, NZ_DATE_CONFIG, NzDateConfig} from 'ng-zorro-antd/i18n';
+import { DateHelperService, NZ_DATE_FORMATS, NzDateDisplayFormats } from 'ng-zorro-antd/i18n';
 
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell } from './interface';
@@ -27,10 +27,9 @@ export class MonthTableComponent extends AbstractTable implements OnChanges, OnI
   constructor(
     private dateHelper: DateHelperService,
     @Inject(CandyDate) candyDate: CandyDateFac,
-    @Inject(NZ_DATE_CONFIG) config: NzDateConfig
-) {
-    super(candyDate, config);
-    this.config = mergeDateConfig(config);
+    @Inject(NZ_DATE_FORMATS) dateFormats: NzDateDisplayFormats
+  ) {
+    super(candyDate, dateFormats);
   }
 
   makeHeadRow(): DateCell[] {
@@ -50,7 +49,7 @@ export class MonthTableComponent extends AbstractTable implements OnChanges, OnI
       for (let colIndex = 0; colIndex < this.MAX_COL; colIndex++) {
         const month = this.activeDate.setMonth(monthValue);
         const isDisabled = this.isDisabledMonth(month);
-        const content = this.dateHelper.format(month.nativeDate, this.config.displayFormats?.monthLabel!);
+        const content = this.dateHelper.format(month.nativeDate, this.dateFormats.monthLabel!);
         const cell: DateCell = {
           trackByIndex: colIndex,
           value: month,

--- a/components/date-picker/lib/year-table.component.ts
+++ b/components/date-picker/lib/year-table.component.ts
@@ -3,10 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { CandyDate } from 'ng-zorro-antd/core/time';
+import { ChangeDetectionStrategy, Component, Inject, ViewEncapsulation } from '@angular/core';
+
+import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
 import { DateHelperService } from 'ng-zorro-antd/i18n';
+
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell, YearCell } from './interface';
 
@@ -22,8 +24,8 @@ export class YearTableComponent extends AbstractTable {
   override MAX_ROW = 4;
   override MAX_COL = 3;
 
-  constructor(private dateHelper: DateHelperService) {
-    super();
+  constructor(private dateHelper: DateHelperService, @Inject(CandyDate) candyDate: CandyDateFac) {
+    super(candyDate);
   }
 
   makeHeadRow(): DateCell[] {
@@ -50,7 +52,7 @@ export class YearTableComponent extends AbstractTable {
         const isDisabled = this.isDisabledYear(year);
         const cell: YearCell = {
           trackByIndex: colIndex,
-          value: year.nativeDate,
+          value: year,
           isDisabled,
           isSameDecade: yearNum >= startYear && yearNum <= endYear,
           isSelected: yearNum === (this.value && this.value.getYear()),
@@ -61,7 +63,7 @@ export class YearTableComponent extends AbstractTable {
           isFirstCellInPanel: year.getYear() === startYear,
           cellRender: valueFunctionProp(this.cellRender!, year), // Customized content
           fullCellRender: valueFunctionProp(this.fullCellRender!, year),
-          onClick: () => this.chooseYear(cell.value.getFullYear()), // don't use yearValue here,
+          onClick: () => this.chooseYear(cell.value.getYear()), // don't use yearValue here,
           onMouseEnter: () => this.cellHover.emit(year)
         };
 

--- a/components/date-picker/lib/year-table.component.ts
+++ b/components/date-picker/lib/year-table.component.ts
@@ -7,7 +7,7 @@ import { ChangeDetectionStrategy, Component, Inject, ViewEncapsulation } from '@
 
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
-import { DateHelperService, NZ_DATE_CONFIG, NzDateConfig} from 'ng-zorro-antd/i18n';
+import { DateHelperService, NZ_DATE_FORMATS, NzDateDisplayFormats } from 'ng-zorro-antd/i18n';
 
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell, YearCell } from './interface';
@@ -27,9 +27,9 @@ export class YearTableComponent extends AbstractTable {
   constructor(
     private dateHelper: DateHelperService,
     @Inject(CandyDate) candyDate: CandyDateFac,
-    @Inject(NZ_DATE_CONFIG) config: NzDateConfig
+    @Inject(NZ_DATE_FORMATS) dateFormats: NzDateDisplayFormats
   ) {
-    super(candyDate, config);
+    super(candyDate, dateFormats);
   }
 
   makeHeadRow(): DateCell[] {
@@ -52,7 +52,7 @@ export class YearTableComponent extends AbstractTable {
       for (let colIndex = 0; colIndex < this.MAX_COL; colIndex++) {
         const yearNum = previousYear + yearValue;
         const year = this.activeDate.setYear(yearNum);
-        const content = this.dateHelper.format(year.nativeDate, this.config.displayFormats?.yearLabel!);
+        const content = this.dateHelper.format(year.nativeDate, this.dateFormats.yearLabel!);
         const isDisabled = this.isDisabledYear(year);
         const cell: YearCell = {
           trackByIndex: colIndex,

--- a/components/date-picker/lib/year-table.component.ts
+++ b/components/date-picker/lib/year-table.component.ts
@@ -7,7 +7,7 @@ import { ChangeDetectionStrategy, Component, Inject, ViewEncapsulation } from '@
 
 import { CandyDate, CandyDateFac } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
-import { DateHelperService } from 'ng-zorro-antd/i18n';
+import { DateHelperService, NZ_DATE_CONFIG, NzDateConfig} from 'ng-zorro-antd/i18n';
 
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell, YearCell } from './interface';
@@ -24,8 +24,12 @@ export class YearTableComponent extends AbstractTable {
   override MAX_ROW = 4;
   override MAX_COL = 3;
 
-  constructor(private dateHelper: DateHelperService, @Inject(CandyDate) candyDate: CandyDateFac) {
-    super(candyDate);
+  constructor(
+    private dateHelper: DateHelperService,
+    @Inject(CandyDate) candyDate: CandyDateFac,
+    @Inject(NZ_DATE_CONFIG) config: NzDateConfig
+  ) {
+    super(candyDate, config);
   }
 
   makeHeadRow(): DateCell[] {
@@ -48,7 +52,7 @@ export class YearTableComponent extends AbstractTable {
       for (let colIndex = 0; colIndex < this.MAX_COL; colIndex++) {
         const yearNum = previousYear + yearValue;
         const year = this.activeDate.setYear(yearNum);
-        const content = this.dateHelper.format(year.nativeDate, 'yyyy');
+        const content = this.dateHelper.format(year.nativeDate, this.config.displayFormats?.yearLabel!);
         const isDisabled = this.isDisabledYear(year);
         const cell: YearCell = {
           trackByIndex: colIndex,

--- a/components/date-picker/util.spec.ts
+++ b/components/date-picker/util.spec.ts
@@ -1,5 +1,4 @@
-import { CandyDate } from 'ng-zorro-antd/core/time';
-import { DateFnsDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
+import { CandyDate, DateFnsDateAdapter } from 'ng-zorro-antd/core/time';
 
 import { isAllowedDate } from './util';
 

--- a/components/date-picker/util.spec.ts
+++ b/components/date-picker/util.spec.ts
@@ -1,11 +1,15 @@
 import { CandyDate } from 'ng-zorro-antd/core/time';
+import { DateFnsDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
 
 import { isAllowedDate } from './util';
+
+const dateAdapter = new DateFnsDateAdapter();
+const candyDateFac = (date?: Date | number | string): CandyDate => new CandyDate(dateAdapter, date);
 
 describe('util.ts coverage supplements', () => {
   it('should cover untouched branches', () => {
     const disabledDate = (): boolean => true;
-    expect(isAllowedDate(new CandyDate(), disabledDate)).toBeFalsy();
+    expect(isAllowedDate(candyDateFac(), disabledDate)).toBeFalsy();
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const disabledTime = () => ({
@@ -13,8 +17,8 @@ describe('util.ts coverage supplements', () => {
       nzDisabledMinutes: () => [2],
       nzDisabledSeconds: () => [3]
     });
-    expect(isAllowedDate(new CandyDate('2000-11-11 01:11:11'), undefined, disabledTime)).toBeFalsy();
-    expect(isAllowedDate(new CandyDate('2000-11-11 02:02:11'), undefined, disabledTime)).toBeFalsy();
-    expect(isAllowedDate(new CandyDate('2000-11-11 02:03:03'), undefined, disabledTime)).toBeFalsy();
+    expect(isAllowedDate(candyDateFac('2000-11-11 01:11:11'), undefined, disabledTime)).toBeFalsy();
+    expect(isAllowedDate(candyDateFac('2000-11-11 02:02:11'), undefined, disabledTime)).toBeFalsy();
+    expect(isAllowedDate(candyDateFac('2000-11-11 02:03:03'), undefined, disabledTime)).toBeFalsy();
   });
 });

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -3,27 +3,29 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { InjectionToken } from '@angular/core';
+import { inject, InjectionToken } from '@angular/core';
 
 import { WeekDayIndex } from 'ng-zorro-antd/core/time';
+
+export interface NzDateDisplayFormats {
+  dateInput?: string;
+  dateTimeInput?: string;
+  dayLabel?: string;
+  weekLabel?: string;
+  monthLabel?: string;
+  yearLabel?: string;
+  weekYearLabel?: string;
+  monthYearLabel?: string;
+  shortWeekLabel?: string;
+  veryShortWeekLabel?: string;
+}
 
 export interface NzDateConfig {
   /** Customize the first day of a week */
   firstDayOfWeek?: WeekDayIndex;
 
   /** Customize display formats */
-  displayFormats?: {
-    dateInput?: string;
-    dateTimeInput?: string;
-    dayLabel?: string;
-    weekLabel?: string;
-    monthLabel?: string;
-    yearLabel?: string;
-    weekYearLabel?: string;
-    monthYearLabel?: string;
-    shortWeekLabel?: string;
-    veryShortWeekLabel?: string;
-  };
+  displayFormats?: NzDateDisplayFormats;
 }
 
 export const NZ_DATE_CONFIG = new InjectionToken<NzDateConfig>('date-config', {
@@ -37,7 +39,7 @@ export const NZ_DATE_CONFIG_DEFAULT: NzDateConfig = {
     dateInput: 'yyyy-MM-dd',
     dateTimeInput: 'yyyy-MM-dd HH:mm:ss',
     dayLabel: 'dd',
-    weekLabel: 'e',
+    weekLabel: 'EEEE',
     monthLabel: 'MMM',
     yearLabel: 'yyyy',
     weekYearLabel: 'yyyy-ww',
@@ -57,3 +59,8 @@ export function mergeDateConfig(config: NzDateConfig): NzDateConfig {
     }
   };
 }
+
+export const NZ_DATE_FORMATS = new InjectionToken<NzDateDisplayFormats>('display formats', {
+  providedIn: 'root',
+  factory: () => mergeDateConfig(inject(NZ_DATE_CONFIG)).displayFormats!
+});

--- a/components/i18n/date-config.ts
+++ b/components/i18n/date-config.ts
@@ -10,14 +10,50 @@ import { WeekDayIndex } from 'ng-zorro-antd/core/time';
 export interface NzDateConfig {
   /** Customize the first day of a week */
   firstDayOfWeek?: WeekDayIndex;
+
+  /** Customize display formats */
+  displayFormats?: {
+    dateInput?: string;
+    dateTimeInput?: string;
+    dayLabel?: string;
+    weekLabel?: string;
+    monthLabel?: string;
+    yearLabel?: string;
+    weekYearLabel?: string;
+    monthYearLabel?: string;
+    shortWeekLabel?: string;
+    veryShortWeekLabel?: string;
+  };
 }
 
-export const NZ_DATE_CONFIG = new InjectionToken<NzDateConfig>('date-config');
+export const NZ_DATE_CONFIG = new InjectionToken<NzDateConfig>('date-config', {
+  providedIn: 'root',
+  factory: () => NZ_DATE_CONFIG_DEFAULT
+});
 
 export const NZ_DATE_CONFIG_DEFAULT: NzDateConfig = {
-  firstDayOfWeek: undefined
+  firstDayOfWeek: undefined,
+  displayFormats: {
+    dateInput: 'yyyy-MM-dd',
+    dateTimeInput: 'yyyy-MM-dd HH:mm:ss',
+    dayLabel: 'dd',
+    weekLabel: 'e',
+    monthLabel: 'MMM',
+    yearLabel: 'yyyy',
+    weekYearLabel: 'yyyy-ww',
+    monthYearLabel: 'yyyy-MM',
+    shortWeekLabel: 'EEEEE',
+    veryShortWeekLabel: 'EEEEEE'
+  }
 };
 
 export function mergeDateConfig(config: NzDateConfig): NzDateConfig {
-  return { ...NZ_DATE_CONFIG_DEFAULT, ...config };
+  return {
+    ...NZ_DATE_CONFIG_DEFAULT,
+    ...config,
+    displayFormats: {
+      ...NZ_DATE_CONFIG_DEFAULT.displayFormats,
+      ...config.displayFormats
+    }
+  };
 }

--- a/components/i18n/date-helper.service.ts
+++ b/components/i18n/date-helper.service.ts
@@ -6,8 +6,7 @@
 import { formatDate } from '@angular/common';
 import { Inject, Injectable, Injector, Optional } from '@angular/core';
 
-import { WeekDayIndex, ɵNgTimeParser } from 'ng-zorro-antd/core/time';
-import { isCustomAdapter, NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
+import { WeekDayIndex, ɵNgTimeParser, isCustomAdapter, NzDateAdapter } from 'ng-zorro-antd/core/time';
 
 import { mergeDateConfig, NzDateConfig, NZ_DATE_CONFIG } from './date-config';
 import { NzI18nService } from './nz-i18n.service';

--- a/components/i18n/date-helper.service.ts
+++ b/components/i18n/date-helper.service.ts
@@ -7,14 +7,10 @@ import { formatDate } from '@angular/common';
 import { Inject, Injectable, Injector, Optional } from '@angular/core';
 
 import { WeekDayIndex, ɵNgTimeParser } from 'ng-zorro-antd/core/time';
-import { DateFnsDateAdapter, NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
+import { isCustomAdapter, NzDateAdapter } from 'ng-zorro-antd/core/time/date-adapter';
 
 import { mergeDateConfig, NzDateConfig, NZ_DATE_CONFIG } from './date-config';
 import { NzI18nService } from './nz-i18n.service';
-
-function isCustomAdapter(adapter: NzDateAdapter): boolean {
-  return !(adapter instanceof DateFnsDateAdapter);
-}
 
 export function DATE_HELPER_SERVICE_FACTORY(injector: Injector, config: NzDateConfig): DateHelperService {
   const i18n = injector.get(NzI18nService);

--- a/components/i18n/nz-i18n.interface.ts
+++ b/components/i18n/nz-i18n.interface.ts
@@ -3,8 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Locale } from 'date-fns';
-
 export interface NzPaginationI18nInterface {
   items_per_page: string;
   jump_to: string;
@@ -146,5 +144,3 @@ export interface NzI18nInterface {
   Empty: NzEmptyI18nInterface;
   Text?: NzTextI18nInterface;
 }
-
-export type DateLocale = Locale;

--- a/components/i18n/nz-i18n.service.ts
+++ b/components/i18n/nz-i18n.service.ts
@@ -7,11 +7,12 @@ import { Inject, Injectable, Optional } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { warn } from 'ng-zorro-antd/core/logger';
+import { DateLocale } from 'ng-zorro-antd/core/time';
 import { IndexableObject, NzSafeAny } from 'ng-zorro-antd/core/types';
 
 import en_US from './languages/en_US';
 import zh_CN from './languages/zh_CN';
-import { DateLocale, NzI18nInterface } from './nz-i18n.interface';
+import { NzI18nInterface } from './nz-i18n.interface';
 import { NZ_DATE_LOCALE, NZ_I18N } from './nz-i18n.token';
 
 @Injectable({

--- a/components/i18n/nz-i18n.token.ts
+++ b/components/i18n/nz-i18n.token.ts
@@ -5,7 +5,9 @@
 
 import { InjectionToken } from '@angular/core';
 
-import { DateLocale, NzI18nInterface } from './nz-i18n.interface';
+import { DateLocale } from 'ng-zorro-antd/core/time';
+
+import { NzI18nInterface } from './nz-i18n.interface';
 
 export const NZ_I18N = new InjectionToken<NzI18nInterface>('nz-i18n');
 

--- a/docs/i18n.en-US.md
+++ b/docs/i18n.en-US.md
@@ -219,7 +219,7 @@ The default configuration is as follows:
 
 [https://date-fns.org/docs/I18n#supported-languages](https://date-fns.org/docs/I18n#supported-languages)
 
-## Provide Custom Date Adapter
+## Provide custom DateAdapter
 If you need to present another calendar like [Jalali](https://en.wikipedia.org/wiki/Jalali_calendar) or [Hijri](https://en.wikipedia.org/wiki/Islamic_calendar), you can provide a custom NzDateAdapter which implements required methods to deal with native date object.
 
 ### Example

--- a/docs/i18n.en-US.md
+++ b/docs/i18n.en-US.md
@@ -194,16 +194,51 @@ registerLocaleData(en);
 ### NZ_DATE_CONFIG (Date global configuration)
 
 The default configuration is as follows:
-```js
+```ts
 {
   /** Specify which day is the beginning of the week (null for default, 0 for Sunday, 1 for Monday, and so on) */
-  firstDayOfWeek: null
+  firstDayOfWeek: null,
+
+  /** Specify custom date display formats in datepicker and calendar components */
+  displayFormats: {
+    dateInput: 'yyyy-MM-dd',
+    dateTimeInput: 'yyyy-MM-dd HH:mm:ss',
+    dayLabel: 'dd',
+    weekLabel: 'EEEE',
+    monthLabel: 'MMM',
+    yearLabel: 'yyyy',
+    weekYearLabel: 'yyyy-ww',
+    monthYearLabel: 'yyyy-MM',
+    shortWeekLabel: 'EEEEE',
+    veryShortWeekLabel: 'EEEEEE'
+  }
 }
 ```
 
 ## Language supported by date-fns
 
 [https://date-fns.org/docs/I18n#supported-languages](https://date-fns.org/docs/I18n#supported-languages)
+
+## Provide Custom Date Adapter
+If you need to present another calendar like [Jalali](https://en.wikipedia.org/wiki/Jalali_calendar) or [Hijri](https://en.wikipedia.org/wiki/Islamic_calendar), you can provide a custom NzDateAdapter which implements required methods to deal with native date object.
+
+### Example
+```ts
+import { NzDateAdapter } from 'ng-zorro-antd/core/time';
+
+export class CustomDateAdapter extends NzDateAdapter<any> {
+    // implementation of abstract methods
+}
+
+@NgModule({
+  providers: [
+    {provide: NzDateAdapter, useClass: CustomDateAdapter}
+  ]
+})
+export class AppModule {}
+```
+#### Sample
+[Jalali-Moment date adapter](https://gist.github.com/moein459/768318ccb67a0daaf8234d742753cb46)
 
 ## How to override internationalization configuration
 The text of some components in `ng-zorro` depends on the internationalized text, such as the `size changer` in `nz-pagination`. At this time, you can modify the internationalization configuration to change the text content in the `size changer`:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6270


## What is the new behavior?
CandyDate utility functions moved to a separate date adapter class which can be provided by its token. now users are able to provide custom date adapters to represent other calendars like Jalali or Hijri and deal with native Date objects differently.

### Example
[jalali-moment date adapter example](https://gist.github.com/moein459/768318ccb67a0daaf8234d742753cb46)
![jalali-date-picker](https://user-images.githubusercontent.com/42533472/171279996-75478af5-7977-4845-bf56-846c448308ae.gif)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
