### PR TITLE
docs(module:code-editor): fix monaco editor options deprecated

### DIFF
--- a/components/code-editor/doc/index.en-US.md
+++ b/components/code-editor/doc/index.en-US.md
@@ -92,7 +92,7 @@ You can set the default configuration of the `CodeEditor` component through the 
 | Parameter | Description | Type | Default |
 | --- | --- | --- | --- |
 | `assetsRoot` | Where should the component load resource of monaco editor | `string` \| `SageUrl` | - |
-| `defaultEditorOption` | Default options. [Please refer to the doc of monaco editor](https://microsoft.github.io/monaco-editor/api/enums/monaco.editor.EditorOption.html) | `IEditorConstructionOptions` | `{}` |
+| `defaultEditorOption` | Default options. [Please refer to the doc of monaco editor](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IEditorOptions.html) | `IEditorConstructionOptions` | `{}` |
 | `onLoad` | The hook invoked when the resource of monaco editor is loaded. At this moment and afterwards the global variable `monaco` is usable (`window.MonacoEnvironment = { globalAP: true }` is required if monaco-editor's version is greater or equal to 0.22.0) | `() => void` | - |
 | `onFirstEditorInit` | The hook invoked when the first monaco editor is initialized | `() => void` | - |
 | `onInit` | The hook invoked every time a monaco editor is initialized | `() => void`  | - |

--- a/components/code-editor/doc/index.en-US.md
+++ b/components/code-editor/doc/index.en-US.md
@@ -92,7 +92,7 @@ You can set the default configuration of the `CodeEditor` component through the 
 | Parameter | Description | Type | Default |
 | --- | --- | --- | --- |
 | `assetsRoot` | Where should the component load resource of monaco editor | `string` \| `SageUrl` | - |
-| `defaultEditorOption` | Default options. [Please refer to the doc of monaco editor](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorconstructionoptions.html) | `IEditorConstructionOptions` | `{}` |
+| `defaultEditorOption` | Default options. [Please refer to the doc of monaco editor](https://microsoft.github.io/monaco-editor/api/enums/monaco.editor.EditorOption.html) | `IEditorConstructionOptions` | `{}` |
 | `onLoad` | The hook invoked when the resource of monaco editor is loaded. At this moment and afterwards the global variable `monaco` is usable (`window.MonacoEnvironment = { globalAP: true }` is required if monaco-editor's version is greater or equal to 0.22.0) | `() => void` | - |
 | `onFirstEditorInit` | The hook invoked when the first monaco editor is initialized | `() => void` | - |
 | `onInit` | The hook invoked every time a monaco editor is initialized | `() => void`  | - |

--- a/components/code-editor/doc/index.zh-CN.md
+++ b/components/code-editor/doc/index.zh-CN.md
@@ -80,7 +80,7 @@ npm install monaco-editor
 | `[nzLoading]` | 加载中 | `boolean` | `false` |
 | `[nzOriginalText]` | Diff 模式下，左半边的文本内容 | `boolean` | `false` |
 | `[nzFullControl]` | 完全控制模式，此模式下组件不会帮助用户处理 `TextModel`，用户应当自行管理 monaco editor 实例 | `boolean` | `false` |
-| `[nzEditorOption]` | 编辑器选项，[参考 monaco editor 的定义](https://microsoft.github.io/monaco-editor/api/enums/monaco.editor.EditorOption.html) | `IEditorConstructionOptions` | `{}` |
+| `[nzEditorOption]` | 编辑器选项，[参考 monaco editor 的定义](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IEditorOptions.html) | `IEditorConstructionOptions` | `{}` |
 | `[nzToolkit]` | 暴露快捷操作 | `TemplateRef<void>` | - |
 | `(nzEditorInitialized)` | 当编辑器组件初始化完毕之后派发事件  | `IStandaloneCodeEditor` \| `IStandaloneDiffEditor` | - |
 

--- a/components/code-editor/doc/index.zh-CN.md
+++ b/components/code-editor/doc/index.zh-CN.md
@@ -80,7 +80,7 @@ npm install monaco-editor
 | `[nzLoading]` | 加载中 | `boolean` | `false` |
 | `[nzOriginalText]` | Diff 模式下，左半边的文本内容 | `boolean` | `false` |
 | `[nzFullControl]` | 完全控制模式，此模式下组件不会帮助用户处理 `TextModel`，用户应当自行管理 monaco editor 实例 | `boolean` | `false` |
-| `[nzEditorOption]` | 编辑器选项，[参考 monaco editor 的定义](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorconstructionoptions.html) | `IEditorConstructionOptions` | `{}` |
+| `[nzEditorOption]` | 编辑器选项，[参考 monaco editor 的定义](https://microsoft.github.io/monaco-editor/api/enums/monaco.editor.EditorOption.html) | `IEditorConstructionOptions` | `{}` |
 | `[nzToolkit]` | 暴露快捷操作 | `TemplateRef<void>` | - |
 | `(nzEditorInitialized)` | 当编辑器组件初始化完毕之后派发事件  | `IStandaloneCodeEditor` \| `IStandaloneDiffEditor` | - |
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7502 


## What is the new behavior?
Remove the deprecated monaco editor option link

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
