### PR TITLE
fix(module:modal): hide close button in confirm

### DIFF
--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -7,6 +7,10 @@
     display: none;
   }
 
+  .@{ant-prefix}-modal-close {
+    display: none;
+  }
+
   .@{ant-prefix}-modal-body {
     padding: @modal-confirm-body-padding;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

modal should hide close button in confirm mode, but it visible now(^10.x.y still work successfully)
modal 在确认模式下应该隐藏关闭按钮，但是现在出现了。（^10.x.y版本正常）

## What is the new behavior?

close button hide in confirm mode
关闭按钮在确认模式下正确隐藏

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
