### PR TITLE
docs(module:segmented): add example import

### DIFF
--- a/components/segmented/doc/index.en-US.md
+++ b/components/segmented/doc/index.en-US.md
@@ -10,6 +10,10 @@ cover: https://gw.alipayobjects.com/zos/bmw-prod/a3ff040f-24ba-43e0-92e9-c845df1
 - When displaying multiple options and user can select a single option;
 - When switching the selected option, the content of the associated area changes.
 
+```ts
+import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
+```
+
 ## API
 
 | Property | Description | Type | Default | Global Config |


### PR DESCRIPTION
the segmented component does not have an example import statement, unlike all the other components

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The documentation for the Segmented Component does not included an example import statement, unlike all the other components

Issue Number: N/A


## What is the new behavior?
The documentation for the Segmented Component now includes an example import statement

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
