### PR TITLE
fix(module: tree): nz-tree-drop-indicator for custom tree node templates

### DIFF
--- a/components/tree/tree-node-title.component.ts
+++ b/components/tree/tree-node-title.component.ts
@@ -41,12 +41,12 @@ import { NzTreeNode, NzTreeNodeOptions } from 'ng-zorro-antd/core/tree';
         </span>
       </span>
       <span class="ant-tree-title" [innerHTML]="title | nzHighlight: matchedValue:'i':'font-highlight'"></span>
-      <nz-tree-drop-indicator
-        *ngIf="showIndicator"
-        [dropPosition]="dragPosition"
-        [level]="context.level"
-      ></nz-tree-drop-indicator>
     </ng-container>
+    <nz-tree-drop-indicator
+      *ngIf="showIndicator"
+      [dropPosition]="dragPosition"
+      [level]="context.level"
+    ></nz-tree-drop-indicator>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `nz-tree-drop-indicator` is only rendered for tree nodes if no custom `treeTemplate` is provided

Issue Number: N/A


## What is the new behavior?
The `nz-tree-drop-indicator` is also rendered for tree nodes with a custom `treeTemplate`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
In this screenshot you can see the new behaviour: https://www.awesomescreenshot.com/video/10188107
The first tree uses a custom node template, the other tree does not
In both trees you can now see the drop-indicator

The tree was taken from https://ng.ant.design/components/tree/en