### PR TITLE
docs(module:popconfirm): fix `nzPopconfirmTrigger` default value to `click`

### DIFF
--- a/components/popconfirm/doc/index.en-US.md
+++ b/components/popconfirm/doc/index.en-US.md
@@ -25,7 +25,7 @@ import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
 | ----- | ----------- | ---- | ------------- |
 | `[nzPopconfirmArrowPointAtCenter]` | Arrow point at center of the origin | `boolean` | `false` |
 | `[nzPopconfirmTitle]` | Title of the confirmation box | `string \| TemplateRef<void>` | - |
-| `[nzPopconfirmTrigger]` | Popconfirm trigger mode. If set to `null` it would not be triggered | `'click' \| 'focus' \| 'hover' \| null` | `'hover'` |
+| `[nzPopconfirmTrigger]` | Popconfirm trigger mode. If set to `null` it would not be triggered | `'click' \| 'focus' \| 'hover' \| null` | `'click'` |
 | `[nzPopconfirmPlacement]` | The position of the popconfirm relative to the target | `'top' \| 'left' \| 'right' \| 'bottom' \| 'topLeft' \| 'topRight' \| 'bottomLeft' \| 'bottomRight' \| 'leftTop' \| 'leftBottom' \| 'rightTop' \| 'rightBottom' \| Array<string>` | `'top'` |
 | `[nzPopconfirmOrigin]` | Origin of the popconfirm | `ElementRef` | - |
 | `[nzPopconfirmVisible]` | Show or hide popconfirm | `boolean` | `false` |

--- a/components/popconfirm/doc/index.zh-CN.md
+++ b/components/popconfirm/doc/index.zh-CN.md
@@ -26,7 +26,7 @@ import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
 | --- | --- | --- | --- |
 | `[nzPopconfirmArrowPointAtCenter]` | 箭头指向锚点的中心 | `boolean` | `false` |
 | `[nzPopconfirmTitle]` | 确认框的描述 | `string \| TemplateRef<void>` | - |
-| `[nzPopconfirmTrigger]` | 触发行为，为 `null` 时不响应光标事件 | `'click' \| 'focus' \| 'hover' \| null` | `'hover'` |
+| `[nzPopconfirmTrigger]` | 触发行为，为 `null` 时不响应光标事件 | `'click' \| 'focus' \| 'hover' \| null` | `'click'` |
 | `[nzPopconfirmPlacement]` | 气泡框位置 | `'top' \| 'left' \| 'right' \| 'bottom' \| 'topLeft' \| 'topRight' \| 'bottomLeft' \| 'bottomRight' \| 'leftTop' \| 'leftBottom' \| 'rightTop' \| 'rightBottom' \| Array<string>` | `'top'` |
 | `[nzPopconfirmOrigin]` | 气泡框定位元素 | `ElementRef` | - |
 | `[nzPopconfirmVisible]` | 显示隐藏气泡框 | `boolean` | `false` |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
<img width="734" alt="image" src="https://user-images.githubusercontent.com/39730999/182843592-b010f7b8-38e1-4afd-a0cc-fced6f096fa6.png">

[code line](https://github.com/NG-ZORRO/ng-zorro-antd/blob/797b2617f08394b56fe0a7903dc69e2d75984219/components/popconfirm/popconfirm.ts#L61)
