### PR TITLE
fix(module:select): fix broken CDK virtual scroll integration

### DIFF
--- a/components/select/style/patch.less
+++ b/components/select/style/patch.less
@@ -15,5 +15,10 @@
     .cdk-virtual-scroll-content-wrapper {
       position: static;
     }
+    .cdk-virtual-scroll-spacer{
+      position: absolute;
+      top: 0;
+      width: 1px;
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
when set [nzDropdownMatchSelectWidth]="false", there is always a blank area at the bottom of the dropdown.

Issue Number: [#7625](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7625)


## What is the new behavior?
make [nzDropdownMatchSelectWidth]="false" behaviar normoal

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
It's related to this PR [https://github.com/angular/components/pull/24394](https://github.com/angular/components/pull/24394)