### PR TITLE
feat(module:select): add string array support for nzDropdownClassName

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -200,7 +200,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   @Input() nzStatus: NzStatus = '';
   @Input() nzOptionHeightPx = 32;
   @Input() nzOptionOverflowSize = 8;
-  @Input() nzDropdownClassName: string | null = null;
+  @Input() nzDropdownClassName: string[] | string | null = null;
   @Input() nzDropdownMatchSelectWidth = true;
   @Input() nzDropdownStyle: { [key: string]: string } | null = null;
   @Input() nzNotFoundContent: string | TemplateRef<NzSafeAny> | undefined = undefined;

--- a/components/select/style/patch.less
+++ b/components/select/style/patch.less
@@ -15,5 +15,10 @@
     .cdk-virtual-scroll-content-wrapper {
       position: static;
     }
+    .cdk-virtual-scroll-spacer{
+      position: absolute;
+      top: 0;
+      width: 1px;
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
NzDropdownClassName only support string.

Issue Number: [#7611 ](https://github.com/NG-ZORRO/ng-zorro-antd/issues/7611)


## What is the new behavior?
nzDropdownClassName supports both string and string[].

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
