### PR TITLE
fix(module:tabs): update active router tab after tabs changed

### DIFF
--- a/components/tabs/demo/link-router.ts
+++ b/components/tabs/demo/link-router.ts
@@ -1,4 +1,3 @@
-import { CommonModule, NgForOf } from '@angular/common';
 import { Component } from '@angular/core';
 import { Params, RouterLink } from '@angular/router';
 
@@ -7,7 +6,7 @@ import { NzTabsModule } from 'ng-zorro-antd/tabs';
 
 @Component({
   selector: 'nz-demo-tabs-link-router',
-  imports: [RouterLink, NzTabsModule, NgForOf, NzButtonModule, CommonModule],
+  imports: [RouterLink, NzTabsModule, NzButtonModule],
   template: `
     <div style="margin-bottom: 16px;">
       <button nz-button (click)="newTab()">ADD</button>

--- a/components/tabs/demo/link-router.ts
+++ b/components/tabs/demo/link-router.ts
@@ -1,12 +1,17 @@
+import { CommonModule, NgForOf } from '@angular/common';
 import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Params, RouterLink } from '@angular/router';
 
+import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzTabsModule } from 'ng-zorro-antd/tabs';
 
 @Component({
   selector: 'nz-demo-tabs-link-router',
-  imports: [RouterLink, NzTabsModule],
+  imports: [RouterLink, NzTabsModule, NgForOf, NzButtonModule, CommonModule],
   template: `
+    <div style="margin-bottom: 16px;">
+      <button nz-button (click)="newTab()">ADD</button>
+    </div>
     <nz-tabset nzLinkRouter>
       <nz-tab>
         <a *nzTabLink nz-tab-link [routerLink]="['.']" [queryParams]="{ tab: 'one' }" queryParamsHandling="merge">
@@ -32,7 +37,40 @@ import { NzTabsModule } from 'ng-zorro-antd/tabs';
         </a>
         Four.
       </nz-tab>
+      @for (tab of dynamicTabs; track tab.title) {
+        <nz-tab>
+          <a
+            *nzTabLink
+            nz-tab-link
+            [routerLink]="tab.routerLink"
+            [queryParams]="tab.queryParams ?? {}"
+            queryParamsHandling="merge"
+          >
+            {{ tab.title }}
+          </a>
+          {{ tab.content }}
+        </nz-tab>
+      }
     </nz-tabset>
   `
 })
-export class NzDemoTabsLinkRouterComponent {}
+export class NzDemoTabsLinkRouterComponent {
+  dynamicTabs: Array<{ title: string; content: string; queryParams?: Params; routerLink: string[] }> = [];
+
+  newTab(): void {
+    const { length } = this.dynamicTabs;
+    const newTabId = length + 1;
+    const title = `NewTab${newTabId}`;
+    this.dynamicTabs = [
+      ...this.dynamicTabs,
+      {
+        title,
+        content: title,
+        routerLink: ['.'],
+        queryParams: {
+          tab: newTabId
+        }
+      }
+    ];
+  }
+}

--- a/components/tabs/tabset.component.spec.ts
+++ b/components/tabs/tabset.component.spec.ts
@@ -5,12 +5,12 @@
 
 import { ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { AsyncPipe, CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, DebugElement, OnInit, QueryList, ViewChild, ViewChildren, ViewEncapsulation } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { provideRouter, Router, RouterLink, RouterModule, RouterOutlet, Routes } from '@angular/router';
+import { provideRouter, Router, RouterLink, RouterOutlet, Routes } from '@angular/router';
 import { Observable } from 'rxjs';
 
 import { dispatchFakeEvent, dispatchKeyboardEvent } from 'ng-zorro-antd/core/testing';
@@ -936,7 +936,6 @@ describe('NzTabSet', () => {
       tick();
 
       expect(comp.selectedIdx).toBe(2);
-
       flush();
     }));
   });
@@ -1201,7 +1200,8 @@ export class RouterTabsTestComponent {
 }
 
 @Component({
-  template: ` <nz-tabset nzLinkRouter [(nzSelectedIndex)]="selectedIdx" [nzLinkExact]="false">
+  template: `
+    <nz-tabset nzLinkRouter [(nzSelectedIndex)]="selectedIdx" [nzLinkExact]="false">
       @for (tab of tabs; track tab.title) {
         <nz-tab>
           <a *nzTabLink nz-tab-link [routerLink]="tab.route">{{ tab.title }}</a>
@@ -1209,8 +1209,9 @@ export class RouterTabsTestComponent {
         </nz-tab>
       }
     </nz-tabset>
-    <router-outlet></router-outlet>`,
-  imports: [CommonModule, RouterModule, NzTabsModule],
+    <router-outlet></router-outlet>
+  `,
+  imports: [RouterLink, RouterOutlet, NzTabsModule],
   standalone: true
 })
 export class DynamicRouterTabsTestComponent {

--- a/components/tabs/tabset.component.ts
+++ b/components/tabs/tabset.component.ts
@@ -51,6 +51,7 @@ import {
 } from './interfaces';
 import { NzTabBodyComponent } from './tab-body.component';
 import { NzTabCloseButtonComponent } from './tab-close-button.component';
+import { NzTabLinkDirective } from './tab-link.directive';
 import { NzTabNavBarComponent } from './tab-nav-bar.component';
 import { NzTabNavItemDirective } from './tab-nav-item.directive';
 import { NZ_TAB_SET, NzTabComponent } from './tab.component';
@@ -251,6 +252,8 @@ export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy
   // We filter out only the tabs that belong to this tab set in `tabs`.
   @ContentChildren(NzTabComponent, { descendants: true })
   allTabs: QueryList<NzTabComponent> = new QueryList<NzTabComponent>();
+  @ContentChildren(NzTabLinkDirective, { descendants: true })
+  tabLinks: QueryList<NzTabLinkDirective> = new QueryList<NzTabLinkDirective>();
   @ViewChild(NzTabNavBarComponent, { static: false }) tabNavBarRef!: NzTabNavBarComponent;
 
   // All the direct tabs for this tab set
@@ -475,13 +478,14 @@ export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy
       if (!this.router) {
         throw new Error(`${PREFIX} you should import 'RouterModule' if you want to use 'nzLinkRouter'!`);
       }
-      this.router.events
-        .pipe(
-          takeUntil(this.destroy$),
+      merge(
+        this.router.events.pipe(
           filter(e => e instanceof NavigationEnd),
-          startWith(true),
           delay(0)
-        )
+        ),
+        this.tabLinks.changes
+      )
+        .pipe(takeUntil(this.destroy$), startWith(true))
         .subscribe(() => {
           this.updateRouterActive();
           this.cdr.markForCheck();
@@ -495,7 +499,7 @@ export class NzTabSetComponent implements OnInit, AfterContentChecked, OnDestroy
       if (index !== this.selectedIndex) {
         this.setSelectedIndex(index);
       }
-      this.nzHideAll = index === -1;
+      Promise.resolve().then(() => (this.nzHideAll = index === -1));
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[x] Application (the showcase website)
```

## What is the current behavior?

Tabs with Router always select the first tab after a refresh 

Issue Number: #4773

## What is the new behavior?

Tabs with Router will select the tab match the route after a refresh

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

I have added an `ADD` button to the demo of link router tab which will add a new tab after click; you can try refresh demo page with query params `tab=1` (the full path should be `/components/tabs/en?tab=1`), and click the `ADD` button on link router demo, the active tab should switch to the newly added tab with title `NewTab1`
