### PR TITLE
fix(module:statistic): remove top-level redundant `div` element

### DIFF
--- a/components/statistic/statistic.component.ts
+++ b/components/statistic/statistic.component.ts
@@ -28,21 +28,23 @@ import { NzStatisticValueType } from './typings';
   selector: 'nz-statistic',
   exportAs: 'nzStatistic',
   template: `
-    <div class="ant-statistic" [class.ant-statistic-rtl]="dir === 'rtl'">
-      <div class="ant-statistic-title">
-        <ng-container *nzStringTemplateOutlet="nzTitle">{{ nzTitle }}</ng-container>
-      </div>
-      <div class="ant-statistic-content" [ngStyle]="nzValueStyle">
-        <span *ngIf="nzPrefix" class="ant-statistic-content-prefix">
-          <ng-container *nzStringTemplateOutlet="nzPrefix">{{ nzPrefix }}</ng-container>
-        </span>
-        <nz-statistic-number [nzValue]="nzValue" [nzValueTemplate]="nzValueTemplate"></nz-statistic-number>
-        <span *ngIf="nzSuffix" class="ant-statistic-content-suffix">
-          <ng-container *nzStringTemplateOutlet="nzSuffix">{{ nzSuffix }}</ng-container>
-        </span>
-      </div>
+    <div class="ant-statistic-title">
+      <ng-container *nzStringTemplateOutlet="nzTitle">{{ nzTitle }}</ng-container>
     </div>
-  `
+    <div class="ant-statistic-content" [ngStyle]="nzValueStyle">
+      <span *ngIf="nzPrefix" class="ant-statistic-content-prefix">
+        <ng-container *nzStringTemplateOutlet="nzPrefix">{{ nzPrefix }}</ng-container>
+      </span>
+      <nz-statistic-number [nzValue]="nzValue" [nzValueTemplate]="nzValueTemplate"></nz-statistic-number>
+      <span *ngIf="nzSuffix" class="ant-statistic-content-suffix">
+        <ng-container *nzStringTemplateOutlet="nzSuffix">{{ nzSuffix }}</ng-container>
+      </span>
+    </div>
+  `,
+  host: {
+    class: 'ant-statistic',
+    '[class.ant-statistic-rtl]': `dir === 'rtl'`
+  }
 })
 export class NzStatisticComponent implements OnDestroy, OnInit {
   @Input() nzPrefix?: string | TemplateRef<void>;

--- a/components/statistic/statistic.spec.ts
+++ b/components/statistic/statistic.spec.ts
@@ -51,11 +51,11 @@ describe('nz-statistic', () => {
 
     it('should className correct on dir change', () => {
       fixture.detectChanges();
-      expect(statisticEl.nativeElement.querySelector('.ant-statistic').classList).toContain('ant-statistic-rtl');
+      expect(statisticEl.nativeElement.classList).toContain('ant-statistic-rtl');
 
       fixture.componentInstance.direction = 'ltr';
       fixture.detectChanges();
-      expect(statisticEl.nativeElement.querySelector('.ant-statistic').classList).not.toContain('ant-statistic-rtl');
+      expect(statisticEl.nativeElement.classList).not.toContain('ant-statistic-rtl');
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://user-images.githubusercontent.com/41798664/193459068-2aa1a40a-b91f-4add-a118-0c7262a1f600.png)

There is a layer of redundant `div` element under the `nz-statistic` element.

Issue Number: N/A

## What is the new behavior?
![image](https://user-images.githubusercontent.com/41798664/193459057-eaee5503-0918-45f2-a687-596f18dff6f3.png)

Remove redundant `div` element.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
DOM structure will change.

## Other information
