### PR TITLE
fix(module:table): fix vertical scroll bar in table header

### DIFF
--- a/components/table/src/cell/cell-fixed.directive.ts
+++ b/components/table/src/cell/cell-fixed.directive.ts
@@ -26,6 +26,10 @@ export class NzCellFixedDirective implements OnChanges {
   isFixedRight = false;
   isFixed = false;
 
+  isInsideTableThead(): boolean {
+    return this.elementRef.nativeElement.closest('thead')?.contains(this.elementRef.nativeElement);
+  }
+
   setAutoLeftWidth(autoLeft: string | null): void {
     this.renderer.setStyle(this.elementRef.nativeElement, 'left', autoLeft);
   }

--- a/components/table/src/table-style.service.ts
+++ b/components/table/src/table-style.service.ts
@@ -29,10 +29,12 @@ export class NzTableStyleService {
   listOfListOfThWidthPx$ = merge(
     /** init with manual width **/
     this.manualWidthConfigPx$,
-    combineLatest([this.listOfAutoWidthPx$, this.manualWidthConfigPx$]).pipe(
-      map(([autoWidth, manualWidth]) => {
+    combineLatest([this.listOfAutoWidthPx$, this.manualWidthConfigPx$, this.columnCount$]).pipe(
+      map(([autoWidth, manualWidth, columnCount]) => {
         /** use autoWidth until column length match **/
-        if (autoWidth.length === manualWidth.length) {
+        if (manualWidth.every(width => width === null)) {
+          return autoWidth;
+        } else if (autoWidth.length === manualWidth.length) {
           return autoWidth.map((width, index) => {
             if (width === '0px') {
               return manualWidth[index] || null;
@@ -41,7 +43,7 @@ export class NzTableStyleService {
             }
           });
         } else {
-          return manualWidth;
+          return [...manualWidth, ...new Array(columnCount - manualWidth.length).fill(null)];
         }
       })
     )

--- a/components/table/src/table-style.service.ts
+++ b/components/table/src/table-style.service.ts
@@ -14,6 +14,7 @@ import { NzThMeasureDirective } from './cell/th-measure.directive';
 @Injectable()
 export class NzTableStyleService {
   theadTemplate$ = new ReplaySubject<TemplateRef<NzSafeAny>>(1);
+  hasVerticalScrollBar$ = new ReplaySubject<boolean>(1);
   hasFixLeft$ = new ReplaySubject<boolean>(1);
   hasFixRight$ = new ReplaySubject<boolean>(1);
   hostWidth$ = new ReplaySubject<number>(1);
@@ -62,6 +63,10 @@ export class NzTableStyleService {
 
   setHasFixRight(hasFixRight: boolean): void {
     this.hasFixRight$.next(hasFixRight);
+  }
+
+  setHasVerticalScrollBar(hasVerticalScrollBar: boolean): void {
+    this.hasVerticalScrollBar$.next(hasVerticalScrollBar);
   }
 
   setTableWidthConfig(widthConfig: ReadonlyArray<string | null>): void {

--- a/components/table/src/table/table-content.component.ts
+++ b/components/table/src/table/table-content.component.ts
@@ -3,7 +3,16 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnChanges,
+  Renderer2,
+  SimpleChanges,
+  TemplateRef,
+  ViewEncapsulation
+} from '@angular/core';
 
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
@@ -14,7 +23,10 @@ import { NzTableLayout } from '../table.types';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
-    <col [style.width]="width" [style.minWidth]="width" *ngFor="let width of listOfColWidth" />
+    <colgroup>
+      <col [style.width]="width" [style.minWidth]="width" *ngFor="let width of listOfColWidth" />
+      <col *ngIf="hasVerticalScrollBar && scrollbarWidth" [style.width]="scrollbarWidth + 'px'" />
+    </colgroup>
     <thead class="ant-table-thead" *ngIf="theadTemplate">
       <ng-template [ngTemplateOutlet]="theadTemplate"></ng-template>
     </thead>
@@ -28,10 +40,41 @@ import { NzTableLayout } from '../table.types';
     '[style.min-width]': `scrollX ? '100%': null`
   }
 })
-export class NzTableContentComponent {
+export class NzTableContentComponent implements OnChanges {
   @Input() tableLayout: NzTableLayout = 'auto';
   @Input() theadTemplate: TemplateRef<NzSafeAny> | null = null;
   @Input() contentTemplate: TemplateRef<NzSafeAny> | null = null;
   @Input() listOfColWidth: ReadonlyArray<string | null> = [];
+  @Input() hasVerticalScrollBar: boolean | null = null;
   @Input() scrollX: string | null = null;
+  @Input() hasFixRight: boolean | null = null;
+  @Input() scrollbarWidth: number = 0;
+
+  constructor(private renderer: Renderer2) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const { hasVerticalScrollBar, hasFixRight, theadTemplate } = changes;
+    // If the table has vertical scrollbar, we should add an extra column to fix the width of table header.
+    if (hasVerticalScrollBar || hasFixRight || theadTemplate) {
+      if (this.hasVerticalScrollBar && this.hasFixRight !== null && this.theadTemplate) {
+        const thead = this.theadTemplate!.createEmbeddedView(this).rootNodes;
+        if (thead?.length) {
+          const scrollBarCell = this.renderer.createElement('th');
+          this.renderer.addClass(scrollBarCell, 'ant-table-cell');
+          this.renderer.addClass(scrollBarCell, 'ant-table-cell-scrollbar');
+          // If the table has fixed right column, we should add 'ant-table-cell-fix-right' class, set right to 0 and position to sticky.
+          if (this.hasFixRight) {
+            this.renderer.addClass(scrollBarCell, 'ant-table-cell-fix-right');
+            this.renderer.setStyle(scrollBarCell, 'right', '0');
+            this.renderer.setStyle(scrollBarCell, 'position', 'sticky');
+          }
+          // if the row num of table header is not equal to 1, we should add rowspan to the cell.
+          if (thead.length > 1) {
+            this.renderer.setAttribute(scrollBarCell, 'rowspan', `${thead.length}`);
+          }
+          this.renderer.appendChild(thead[0], scrollBarCell);
+        }
+      }
+    }
+  }
 }

--- a/components/table/src/table/table-inner-scroll.component.ts
+++ b/components/table/src/table/table-inner-scroll.component.ts
@@ -33,11 +33,14 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
   encapsulation: ViewEncapsulation.None,
   template: `
     <ng-container *ngIf="scrollY">
-      <div #tableHeaderElement [ngStyle]="headerStyleMap" class="ant-table-header nz-table-hide-scrollbar">
+      <div #tableHeaderElement class="ant-table-header nz-table-hide-scrollbar">
         <table
           nz-table-content
           tableLayout="fixed"
           [scrollX]="scrollX"
+          [hasVerticalScrollBar]="hasVerticalScrollBar"
+          [hasFixRight]="hasFixRight"
+          [scrollbarWidth]="verticalScrollBarWidth"
           [listOfColWidth]="listOfColWidth"
           [theadTemplate]="theadTemplate"
         ></table>
@@ -90,6 +93,8 @@ export class NzTableInnerScrollComponent<T> implements OnChanges, AfterViewInit,
   @Input() scrollY: string | null = null;
   @Input() contentTemplate: TemplateRef<NzSafeAny> | null = null;
   @Input() widthConfig: string[] = [];
+  @Input() hasFixRight: boolean | null = null;
+  @Input() hasVerticalScrollBar: boolean | null = null;
   @Input() listOfColWidth: ReadonlyArray<string | null> = [];
   @Input() theadTemplate: TemplateRef<NzSafeAny> | null = null;
   @Input() virtualTemplate: TemplateRef<NzSafeAny> | null = null;
@@ -102,7 +107,6 @@ export class NzTableInnerScrollComponent<T> implements OnChanges, AfterViewInit,
   @ViewChild('tableBodyElement', { read: ElementRef }) tableBodyElement!: ElementRef;
   @ViewChild(CdkVirtualScrollViewport, { read: CdkVirtualScrollViewport })
   cdkVirtualScrollViewport?: CdkVirtualScrollViewport;
-  headerStyleMap = {};
   bodyStyleMap = {};
   @Input() verticalScrollBarWidth = 0;
   noDateVirtualHeight = '182px';
@@ -139,18 +143,13 @@ export class NzTableInnerScrollComponent<T> implements OnChanges, AfterViewInit,
   ngOnChanges(changes: SimpleChanges): void {
     const { scrollX, scrollY, data } = changes;
     if (scrollX || scrollY) {
-      const hasVerticalScrollBar = this.verticalScrollBarWidth !== 0;
-      this.headerStyleMap = {
-        overflowX: 'hidden',
-        overflowY: this.scrollY && hasVerticalScrollBar ? 'scroll' : 'hidden'
-      };
       this.bodyStyleMap = {
         overflowY: this.scrollY ? 'scroll' : 'hidden',
         overflowX: this.scrollX ? 'auto' : null,
         maxHeight: this.scrollY
       };
-      // Caretaker note: we have to emit the value outside of the Angular zone, thus DOM timer (`delay(0)`) and `scroll`
-      // event listener will be also added outside of the Angular zone.
+      // Caretaker note: we have to emit the value outside the Angular zone, thus DOM timer (`delay(0)`) and `scroll`
+      // event listener will be also added outside the Angular zone.
       this.ngZone.runOutsideAngular(() => this.scroll$.next());
     }
     if (data) {

--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -79,6 +79,8 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
           [data]="data"
           [scrollX]="scrollX"
           [scrollY]="scrollY"
+          [hasVerticalScrollBar]="hasVerticalScrollBar"
+          [hasFixRight]="hasFixRight"
           [contentTemplate]="contentTemplate"
           [listOfColWidth]="listOfAutoColWidth"
           [theadTemplate]="theadTemplate"
@@ -192,6 +194,7 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
   theadTemplate: TemplateRef<NzSafeAny> | null = null;
   listOfAutoColWidth: ReadonlyArray<string | null> = [];
   listOfManualColWidth: ReadonlyArray<string | null> = [];
+  hasVerticalScrollBar: boolean | null = null;
   hasFixLeft = false;
   hasFixRight = false;
   showPagination = true;
@@ -361,6 +364,8 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
     this.scrollX = (this.nzScroll && this.nzScroll.x) || null;
     this.scrollY = (this.nzScroll && this.nzScroll.y) || null;
     this.nzTableStyleService.setScroll(this.scrollX, this.scrollY);
+    this.hasVerticalScrollBar = !!this.scrollY;
+    this.nzTableStyleService.setHasVerticalScrollBar(!!this.scrollY);
   }
 
   private updateShowPagination(): void {

--- a/components/table/src/testing/table.spec.ts
+++ b/components/table/src/testing/table.spec.ts
@@ -192,10 +192,21 @@ describe('nz-table', () => {
       expect(table.nativeElement.querySelector('.ant-table-scroll')).toBeDefined();
     });
     it('should show a scrollBar cell in table header when has vertical scroll', () => {
+      testComponent.fixHeader = false;
       fixture.detectChanges();
       expect(table.nativeElement.querySelector('.ant-table-cell-scrollbar')).toBeNull();
       testComponent.fixHeader = true;
+      fixture.detectChanges();
       expect(table.nativeElement.querySelector('.ant-table-cell-scrollbar')).toBeDefined();
+    });
+    it('should the col width for scrollBar cell in thead be 15px and no this column in tbody', () => {
+      testComponent.fixHeader = false;
+      fixture.detectChanges();
+      expect(table.nativeElement.querySelectorAll('col').length).toBe(4);
+      testComponent.fixHeader = true;
+      fixture.detectChanges();
+      const cols = table.nativeElement.querySelectorAll('col')
+      expect(cols[cols.length - 1].style.width).toBe('15px');
     });
     it('should width config', () => {
       fixture.detectChanges();

--- a/components/table/src/testing/table.spec.ts
+++ b/components/table/src/testing/table.spec.ts
@@ -191,6 +191,12 @@ describe('nz-table', () => {
       testComponent.fixHeader = true;
       expect(table.nativeElement.querySelector('.ant-table-scroll')).toBeDefined();
     });
+    it('should show a scrollBar cell in table header when has vertical scroll', () => {
+      fixture.detectChanges();
+      expect(table.nativeElement.querySelector('.ant-table-cell-scrollbar')).toBeNull();
+      testComponent.fixHeader = true;
+      expect(table.nativeElement.querySelector('.ant-table-cell-scrollbar')).toBeDefined();
+    });
     it('should width config', () => {
       fixture.detectChanges();
       expect(table.nativeElement.querySelectorAll('col').length).toBe(4);

--- a/components/table/src/testing/thead.spec.ts
+++ b/components/table/src/testing/thead.spec.ts
@@ -67,8 +67,8 @@ describe('nz-thead', () => {
     <nz-table>
       <thead (nzSortOrderChange)="sortChange($event)">
         <th nzColumnKey="first" [nzSortFn]="filterFn"></th>
-        <th nzColumnKey="second" [nzSortFn]="filterFn">></th>
-        <th *ngFor="let col of columns" [nzColumnKey]="col" [nzSortFn]="filterFn">></th>
+        <th nzColumnKey="second" [nzSortFn]="filterFn"></th>
+        <th *ngFor="let col of columns" [nzColumnKey]="col" [nzSortFn]="filterFn"></th>
       </thead>
     </nz-table>
   `

--- a/components/table/style/patch.less
+++ b/components/table/style/patch.less
@@ -25,24 +25,8 @@ nz-filter-trigger {
   }
 }
 
-cdk-virtual-scroll-viewport.ant-table-body {
-  overflow-y: scroll;
-}
-
 .nz-table-hide-scrollbar {
-  scrollbar-color: @table-header-bg @table-header-bg;
-  &::-webkit-scrollbar {
-    background-color: @table-header-bg;
-  }
-}
-
-.@{table-prefix-cls}.@{table-prefix-cls}-small {
-  .nz-table-hide-scrollbar {
-    scrollbar-color: @table-header-bg-sm @table-header-bg-sm;
-    &::-webkit-scrollbar {
-      background-color: transparent;
-    }
-  }
+  overflow: hidden;
 }
 
 .ant-table-wrapper-rtl .ant-table thead > tr > th.ant-table-selection-column {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The table component of ng-zorro used to display a vertical scroll bar in the header, and modified its scroll bar style under webkit to achieve a similar display effect to Ant Design React, but this implementation uses styles that are only valid under webkit, Not compatible with firefox.
Issue Number: #7656 

## What is the new behavior?

After this modification, when the table has vertical scrolling, the header will add a scroll bar cell with the same width as the scroll bar of the table body in the last column of the first row and the last column of the table header like Ant Design React. If the column is fixed on the right, then this column is also fixed at the same time, and the corresponding right style is set for the other fixed columns on the right.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
no