### PR TITLE
fix(module:table): fix wrong colgroup  when using colspan

### DIFF
--- a/components/table/src/table/table-content.component.ts
+++ b/components/table/src/table/table-content.component.ts
@@ -14,7 +14,9 @@ import { NzTableLayout } from '../table.types';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
-    <col [style.width]="width" [style.minWidth]="width" *ngFor="let width of listOfColWidth" />
+    <colgroup>
+      <col [style.width]="width" [style.minWidth]="width" *ngFor="let width of listOfColWidth" />
+    </colgroup>
     <thead class="ant-table-thead" *ngIf="theadTemplate">
       <ng-template [ngTemplateOutlet]="theadTemplate"></ng-template>
     </thead>

--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -297,10 +297,12 @@ export class NzTableComponent<T> implements OnInit, OnDestroy, OnChanges, AfterV
       this.listOfAutoColWidth = listOfWidth;
       this.cdr.markForCheck();
     });
-    this.nzTableStyleService.manualWidthConfigPx$.pipe(takeUntil(this.destroy$)).subscribe(listOfWidth => {
-      this.listOfManualColWidth = listOfWidth;
-      this.cdr.markForCheck();
-    });
+    this.nzTableStyleService.manualWidthConfigPx$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(({ manualWidth, columnCount }) => {
+        this.listOfManualColWidth = manualWidth.concat(new Array(columnCount - manualWidth.length).fill(null));
+        this.cdr.markForCheck();
+      });
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/components/table/src/testing/thead.spec.ts
+++ b/components/table/src/testing/thead.spec.ts
@@ -59,6 +59,12 @@ describe('nz-thead', () => {
       upButtons[2].click();
       expect(testComponent.sortChange).toHaveBeenCalledTimes(3);
     });
+    it('should show correct colgroup', () => {
+      fixture.detectChanges();
+      const colgroup = table.nativeElement.querySelector('colgroup');
+      const cols = colgroup.querySelectorAll('col');
+      expect(cols.length).toBe(6);
+    })
   });
 });
 
@@ -66,9 +72,12 @@ describe('nz-thead', () => {
   template: `
     <nz-table>
       <thead (nzSortOrderChange)="sortChange($event)">
-        <th nzColumnKey="first" [nzSortFn]="filterFn"></th>
-        <th nzColumnKey="second" [nzSortFn]="filterFn">></th>
-        <th *ngFor="let col of columns" [nzColumnKey]="col" [nzSortFn]="filterFn">></th>
+        <tr>
+          <th nzColumnKey="first" [nzSortFn]="filterFn"></th>
+          <th nzColumnKey="second" [nzSortFn]="filterFn"></th>
+          <th *ngFor="let col of columns" [nzColumnKey]="col" [nzSortFn]="filterFn"></th>
+          <th colspan="2">col with colSpan</th>
+        </tr>
       </thead>
     </nz-table>
   `

--- a/components/table/src/testing/thead.spec.ts
+++ b/components/table/src/testing/thead.spec.ts
@@ -64,7 +64,7 @@ describe('nz-thead', () => {
       const colgroup = table.nativeElement.querySelector('colgroup');
       const cols = colgroup.querySelectorAll('col');
       expect(cols.length).toBe(6);
-    })
+    });
   });
 });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
The table component could not calculate the correct colgroup width when using colspan.
![image](https://user-images.githubusercontent.com/31619017/193493837-66047bd7-1035-4880-861a-0e915595952a.png)
> the list of col width should be ['150px', '150px', '150px', '150px', '150px', '150px', '150px', '150px'], but now is [null, null, null, null], the length of colgroup>cols should be 8.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
thead can calculate correct width for colgroup when using colspan.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

## Other information
