### PR TITLE
fix(module:select): activated value resetting during load on scroll

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -355,6 +355,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
     }
     const activatedItem =
       listOfContainerItem.find(item => item.nzLabel === this.searchValue) ||
+      listOfContainerItem.find(item => this.compareWith(item.nzValue, this.activatedValue)) ||
       listOfContainerItem.find(item => this.compareWith(item.nzValue, this.listOfValue[0])) ||
       listOfContainerItem[0];
     this.activatedValue = (activatedItem && activatedItem.nzValue) || null;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- Load on Scroll - Activated Value resets to zero position after the adding of new page of data
- Multiple Selection - After selecting an item Activated Value resets to the first selected element instead of staying the same. And one have to navigate through all the list again to continue selection. It's significant for selecting by keyboard.

Issue Number: N/A


## What is the new behavior?
- Load on Scroll - Activated Value shifts to the next item of the list
- Multiple Selection - After selecting an item Activated Value stays the same 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
