### PR TITLE
docs(module:table): add missing nzShowSort to English documentation (#7736)

### DIFF
--- a/components/table/doc/index.en-US.md
+++ b/components/table/doc/index.en-US.md
@@ -123,6 +123,7 @@ Sort property
 
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
+| `[nzShowSort]` | Whether to display sorting | `boolean` | - |
 | `[nzSortFn]` | Sort function used to sort the data on client side (ref to Array.sort compareFunction). Should be set to `true` when using server side sorting  | `NzTableSortFn<T> \| boolean` | - |
 | `[nzSortOrder]` | Sort direction | `'ascend' \| 'descend' \| null` | - |
 | `[nzSortDirections]` | Supported sort order, could be `'ascend'`, `'descend'`, `null` | `Array<'ascend' \| 'descend' \| null>` | `['ascend', 'descend', null]` |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
nzShowSort is missing in English documentation

Issue Number: #7736 


## What is the new behavior?
nzShowSort is added to English documentation

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
