### PR TITLE
fix: some forms component can't be disable

### DIFF
--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -747,11 +747,11 @@ export class NzCascaderComponent
   }
 
   setDisabledState(isDisabled: boolean): void {
-    if (isDisabled) {
-      this.closeMenu();
-    }
     this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || isDisabled;
     this.isNzDisableFirstChange = false;
+    if (this.nzDisabled) {
+      this.closeMenu();
+    }
   }
 
   closeMenu(): void {

--- a/components/checkbox/checkbox.component.ts
+++ b/components/checkbox/checkbox.component.ts
@@ -82,6 +82,7 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, OnDest
 
   dir: Direction = 'ltr';
   private destroy$ = new Subject<void>();
+  private isNzDisableFirstChange: boolean = true;
 
   onChange: OnChangeType = () => {};
   onTouched: OnTouchedType = () => {};
@@ -119,7 +120,8 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, OnDest
   }
 
   setDisabledState(disabled: boolean): void {
-    this.nzDisabled = disabled;
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || disabled;
+    this.isNzDisableFirstChange = false;
     this.cdr.markForCheck();
   }
 

--- a/components/checkbox/checkbox.spec.ts
+++ b/components/checkbox/checkbox.spec.ts
@@ -237,15 +237,6 @@ describe('checkbox', () => {
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
     }));
-    it('should be disable by default even if form is enable', fakeAsync(() => {
-      testComponent.disabled = true;
-      fixture.detectChanges();
-      flush();
-      const checkbox = fixture.debugElement.query(By.directive(NzCheckboxComponent));
-      const inputElement = checkbox.nativeElement.querySelector('input') as HTMLInputElement;
-      expect(checkbox.nativeElement.firstElementChild!.classList).toContain('ant-checkbox-disabled');
-      expect(inputElement.disabled).toBeTruthy();
-    }));
     it('should be disable if form is disable and nzDisable set to false', fakeAsync(() => {
       testComponent.disable();
       fixture.detectChanges();

--- a/components/checkbox/checkbox.spec.ts
+++ b/components/checkbox/checkbox.spec.ts
@@ -1,7 +1,7 @@
 import { BidiModule, Dir } from '@angular/cdk/bidi';
 import { ApplicationRef, Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
-import { UntypedFormBuilder, UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { NzCheckboxGroupComponent } from './checkbox-group.component';
@@ -21,12 +21,66 @@ describe('checkbox', () => {
           NzTestCheckboxGroupFormComponent,
           NzTestCheckboxWrapperComponent,
           NzTestCheckboxSingleRtlComponent,
-          NzTestCheckboxGroupRtlComponent
+          NzTestCheckboxGroupRtlComponent,
+          NzTestDisablingWithFormComponent
         ]
       });
       TestBed.compileComponents();
     })
   );
+  describe('checkbox disabling with forms', () => {
+    let fixture: ComponentFixture<NzTestDisablingWithFormComponent>;
+    let component: NzTestDisablingWithFormComponent;
+    let checkboxFormModel: DebugElement;
+    let checkboxReactiveForm: DebugElement;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzTestDisablingWithFormComponent);
+      component = fixture.componentInstance;
+      const [checkboxFormModelDebugElement, checkboxReactiveFormDebugElement] = fixture.debugElement.queryAll(
+        By.directive(NzCheckboxComponent)
+      );
+      checkboxFormModel = checkboxFormModelDebugElement;
+      checkboxReactiveForm = checkboxReactiveFormDebugElement;
+    });
+
+    it('should be disable by default even if form is enable', () => {
+      fixture.detectChanges();
+      expect(checkboxFormModel.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')).toBe(true);
+      expect(
+        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
+      ).toBeTruthy();
+    });
+    it('should be enable if form is enable and nzDisable set to false', () => {
+      component.disabled = false;
+      fixture.detectChanges();
+      expect(
+        checkboxFormModel.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
+      ).toBeFalsy();
+      expect(
+        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
+      ).toBeFalsy();
+    });
+    it('should be disable if form is disable and nzDisable set to false', () => {
+      component.disabled = false;
+      component.reactiveFormCheckBox.disable();
+      fixture.detectChanges();
+      expect(
+        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
+      ).toBeTruthy();
+    });
+    it('should be disable first if nzDisabled set to true then enable when enable function is called', () => {
+      fixture.detectChanges();
+      expect(
+        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
+      ).toBeTruthy();
+      component.reactiveFormCheckBox.enable();
+      fixture.detectChanges();
+      expect(
+        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
+      ).toBeFalsy();
+    });
+  });
   describe('checkbox basic', () => {
     let fixture: ComponentFixture<NzTestCheckboxSingleComponent>;
     let testComponent: NzTestCheckboxSingleComponent;
@@ -361,6 +415,18 @@ describe('checkbox', () => {
   });
 });
 
+@Component({
+  selector: 'nz-test-disabling-with-form',
+  template: `
+    <label nz-checkbox [nzDisabled]="disabled" [(ngModel)]="formModelCheckBox"> Checkbox from model </label>
+    <label nz-checkbox [nzDisabled]="disabled" [formControl]="reactiveFormCheckBox"> Checkbox from model </label>
+  `
+})
+export class NzTestDisablingWithFormComponent {
+  reactiveFormCheckBox = new FormControl<boolean>(true);
+  formModelCheckBox = true;
+  disabled = true;
+}
 @Component({
   // eslint-disable-next-line
   selector: 'nz-test-single-checkbox',

--- a/components/checkbox/checkbox.spec.ts
+++ b/components/checkbox/checkbox.spec.ts
@@ -1,7 +1,7 @@
 import { BidiModule, Dir } from '@angular/cdk/bidi';
 import { ApplicationRef, Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
-import { FormControl, FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { NzCheckboxGroupComponent } from './checkbox-group.component';
@@ -21,66 +21,12 @@ describe('checkbox', () => {
           NzTestCheckboxGroupFormComponent,
           NzTestCheckboxWrapperComponent,
           NzTestCheckboxSingleRtlComponent,
-          NzTestCheckboxGroupRtlComponent,
-          NzTestDisablingWithFormComponent
+          NzTestCheckboxGroupRtlComponent
         ]
       });
       TestBed.compileComponents();
     })
   );
-  describe('checkbox disabling with forms', () => {
-    let fixture: ComponentFixture<NzTestDisablingWithFormComponent>;
-    let component: NzTestDisablingWithFormComponent;
-    let checkboxFormModel: DebugElement;
-    let checkboxReactiveForm: DebugElement;
-
-    beforeEach(() => {
-      fixture = TestBed.createComponent(NzTestDisablingWithFormComponent);
-      component = fixture.componentInstance;
-      const [checkboxFormModelDebugElement, checkboxReactiveFormDebugElement] = fixture.debugElement.queryAll(
-        By.directive(NzCheckboxComponent)
-      );
-      checkboxFormModel = checkboxFormModelDebugElement;
-      checkboxReactiveForm = checkboxReactiveFormDebugElement;
-    });
-
-    it('should be disable by default even if form is enable', () => {
-      fixture.detectChanges();
-      expect(checkboxFormModel.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')).toBe(true);
-      expect(
-        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
-      ).toBeTruthy();
-    });
-    it('should be enable if form is enable and nzDisable set to false', () => {
-      component.disabled = false;
-      fixture.detectChanges();
-      expect(
-        checkboxFormModel.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
-      ).toBeFalsy();
-      expect(
-        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
-      ).toBeFalsy();
-    });
-    it('should be disable if form is disable and nzDisable set to false', () => {
-      component.disabled = false;
-      component.reactiveFormCheckBox.disable();
-      fixture.detectChanges();
-      expect(
-        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
-      ).toBeTruthy();
-    });
-    it('should be disable first if nzDisabled set to true then enable when enable function is called', () => {
-      fixture.detectChanges();
-      expect(
-        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
-      ).toBeTruthy();
-      component.reactiveFormCheckBox.enable();
-      fixture.detectChanges();
-      expect(
-        checkboxReactiveForm.nativeElement.firstElementChild!.classList.contains('ant-checkbox-disabled')
-      ).toBeFalsy();
-    });
-  });
   describe('checkbox basic', () => {
     let fixture: ComponentFixture<NzTestCheckboxSingleComponent>;
     let testComponent: NzTestCheckboxSingleComponent;
@@ -275,32 +221,69 @@ describe('checkbox', () => {
   describe('checkbox form', () => {
     let fixture: ComponentFixture<NzTestCheckboxFormComponent>;
     let testComponent: NzTestCheckboxFormComponent;
-    let checkbox: DebugElement;
-    let inputElement: HTMLInputElement;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(NzTestCheckboxFormComponent);
+      testComponent = fixture.componentInstance;
+    });
+    it('should be in pristine, untouched, and valid states and enable initially', fakeAsync(() => {
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
-      testComponent = fixture.debugElement.componentInstance;
-      checkbox = fixture.debugElement.query(By.directive(NzCheckboxComponent));
-      inputElement = checkbox.nativeElement.querySelector('input') as HTMLInputElement;
-    }));
-    it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
-      flush();
+      const checkbox = fixture.debugElement.query(By.directive(NzCheckboxComponent));
+      const inputElement = checkbox.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(checkbox.nativeElement.firstElementChild!.classList).not.toContain('ant-checkbox-disabled');
+      expect(inputElement.disabled).toBeFalsy();
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
     }));
-    it('should set disabled work', fakeAsync(() => {
+    it('should be disable by default even if form is enable', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
       flush();
+      const checkbox = fixture.debugElement.query(By.directive(NzCheckboxComponent));
+      const inputElement = checkbox.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(checkbox.nativeElement.firstElementChild!.classList).toContain('ant-checkbox-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+    }));
+    it('should be disable if form is disable and nzDisable set to false', fakeAsync(() => {
+      testComponent.disable();
+      fixture.detectChanges();
+      flush();
+      const checkbox = fixture.debugElement.query(By.directive(NzCheckboxComponent));
+      const inputElement = checkbox.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(checkbox.nativeElement.firstElementChild!.classList).toContain('ant-checkbox-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+    }));
+    it('should set disabled work', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
+      flush();
+      const checkbox = fixture.debugElement.query(By.directive(NzCheckboxComponent));
+      const inputElement = checkbox.nativeElement.querySelector('input') as HTMLInputElement;
+
+      expect(checkbox.nativeElement.firstElementChild!.classList).toContain('ant-checkbox-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+      inputElement.click();
+      flush();
+      fixture.detectChanges();
       expect(testComponent.formGroup.get('checkbox')!.value).toBe(false);
+
+      testComponent.enable();
+      fixture.detectChanges();
+      flush();
+      expect(checkbox.nativeElement.firstElementChild!.classList).not.toContain('ant-checkbox-disabled');
+      expect(inputElement.disabled).toBeFalsy();
       inputElement.click();
       flush();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('checkbox')!.value).toBe(true);
+
       testComponent.disable();
+      fixture.detectChanges();
+      flush();
+      expect(checkbox.nativeElement.firstElementChild!.classList).toContain('ant-checkbox-disabled');
+      expect(inputElement.disabled).toBeTruthy();
       inputElement.click();
       flush();
       fixture.detectChanges();
@@ -416,18 +399,6 @@ describe('checkbox', () => {
 });
 
 @Component({
-  selector: 'nz-test-disabling-with-form',
-  template: `
-    <label nz-checkbox [nzDisabled]="disabled" [(ngModel)]="formModelCheckBox"> Checkbox from model </label>
-    <label nz-checkbox [nzDisabled]="disabled" [formControl]="reactiveFormCheckBox"> Checkbox from model </label>
-  `
-})
-export class NzTestDisablingWithFormComponent {
-  reactiveFormCheckBox = new FormControl<boolean>(true);
-  formModelCheckBox = true;
-  disabled = true;
-}
-@Component({
   // eslint-disable-next-line
   selector: 'nz-test-single-checkbox',
   template: `
@@ -491,12 +462,13 @@ export class NzTestCheckboxWrapperComponent {
 @Component({
   template: `
     <form [formGroup]="formGroup">
-      <label nz-checkbox formControlName="checkbox"></label>
+      <label nz-checkbox formControlName="checkbox" [nzDisabled]="disabled"></label>
     </form>
   `
 })
 export class NzTestCheckboxFormComponent {
   formGroup: UntypedFormGroup;
+  disabled = false;
 
   constructor(private formBuilder: UntypedFormBuilder) {
     this.formGroup = this.formBuilder.group({
@@ -506,6 +478,10 @@ export class NzTestCheckboxFormComponent {
 
   disable(): void {
     this.formGroup.disable();
+  }
+
+  enable(): void {
+    this.formGroup.enable();
   }
 }
 

--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -6,11 +6,12 @@ import zh from '@angular/common/locales/zh';
 import { ApplicationRef, Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
 import {
+  FormControl,
+  FormsModule,
+  ReactiveFormsModule,
   UntypedFormBuilder,
   UntypedFormControl,
   UntypedFormGroup,
-  FormsModule,
-  ReactiveFormsModule,
   Validators
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -271,22 +272,43 @@ describe('NzDatePickerComponent', () => {
     });
 
     it('should support nzDisabled', fakeAsync(() => {
-      // Make sure picker clear button shown up
-      fixtureInstance.nzAllowClear = true;
-      fixtureInstance.nzValue = new Date();
-
+      fixtureInstance.useSuite = 4;
       fixtureInstance.nzDisabled = true;
+      fixtureInstance.nzAllowClear = true; // Make sure picker clear button shown up
+      fixtureInstance.nzValue = new Date();
+      fixtureInstance.control = new FormControl(new Date());
+      fixture.detectChanges();
+      flush();
+
+      const datePickerElement = fixture.debugElement.query(By.directive(NzDatePickerComponent)).nativeElement;
+      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+
+      expect(datePickerElement.classList).toContain('ant-picker-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+      openPickerByClickTrigger();
+      expect(getPickerContainer()).toBeNull();
+
+      fixtureInstance.control.enable();
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
-      expect(debugElement.query(By.css('.ant-input-disabled'))).not.toBeNull();
-      expect(debugElement.query(By.css('.ant-picker-clear'))).toBeNull();
+      expect(datePickerElement.classList).not.toContain('ant-picker-disabled');
+      expect(inputElement.disabled).toBeFalsy();
+      openPickerByClickTrigger();
+      expect(getPickerContainer()).not.toBeNull();
 
-      fixtureInstance.nzDisabled = false;
+      dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+      fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
-      expect(debugElement.query(By.css('.ant-input-disabled'))).toBeNull();
-      expect(debugElement.query(By.css('.ant-picker-clear'))).not.toBeNull();
+      fixtureInstance.control.disable();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(datePickerElement.classList).toContain('ant-picker-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+      openPickerByClickTrigger();
+      expect(getPickerContainer()).toBeNull();
     }));
 
     it('should support nzInputReadOnly', fakeAsync(() => {
@@ -1199,6 +1221,11 @@ describe('NzDatePickerComponent', () => {
       fixture.detectChanges();
       flush(); // Wait writeValue() tobe done
       fixture.detectChanges();
+      const datePickerElement = fixture.debugElement.query(By.directive(NzDatePickerComponent)).nativeElement;
+      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+
+      expect(datePickerElement.classList).not.toContain('ant-picker-disabled');
+      expect(inputElement.disabled).toBeFalsy();
       expect(getPickerInput(fixture.debugElement).value!.trim()).toBe('2020-04-08');
     }));
 
@@ -1405,7 +1432,7 @@ describe('in form', () => {
       <nz-date-picker *ngSwitchCase="3" nzOpen [(ngModel)]="modelValue"></nz-date-picker>
 
       <!-- Suite 4 -->
-      <nz-date-picker *ngSwitchCase="4" [formControl]="control"></nz-date-picker>
+      <nz-date-picker *ngSwitchCase="4" [formControl]="control" [nzDisabled]="nzDisabled"></nz-date-picker>
 
       <!-- Suite 5 -->
       <ng-container *ngSwitchCase="5">

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -768,7 +768,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, OnDestroy, Afte
   setDisabledState(isDisabled: boolean): void {
     this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || isDisabled;
     this.cdr.markForCheck();
-    this.isNzDisableFirstChange = true;
+    this.isNzDisableFirstChange = false;
   }
 
   // ------------------------------------------------------------------------

--- a/components/input-number/input-number.component.ts
+++ b/components/input-number/input-number.component.ts
@@ -122,6 +122,7 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   private autoStepTimer?: number;
   private parsedValue?: string | number;
   private value?: number;
+  private isNzDisableFirstChange: boolean = true;
   displayValue?: string | number;
   isFocused = false;
   disabled$ = new Subject<boolean>();
@@ -386,8 +387,9 @@ export class NzInputNumberComponent implements ControlValueAccessor, AfterViewIn
   }
 
   setDisabledState(disabled: boolean): void {
-    this.nzDisabled = disabled;
-    this.disabled$.next(disabled);
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || disabled;
+    this.isNzDisableFirstChange = false;
+    this.disabled$.next(this.nzDisabled);
     this.cdr.markForCheck();
   }
 

--- a/components/input-number/input-number.spec.ts
+++ b/components/input-number/input-number.spec.ts
@@ -1,7 +1,7 @@
 import { DOWN_ARROW, ENTER, TAB, UP_ARROW } from '@angular/cdk/keycodes';
 import { ApplicationRef, Component, DebugElement, NgZone, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import { UntypedFormBuilder, UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { take } from 'rxjs/operators';
 
@@ -464,29 +464,36 @@ describe('input number', () => {
   describe('input number form', () => {
     let fixture: ComponentFixture<NzTestInputNumberFormComponent>;
     let testComponent: NzTestInputNumberFormComponent;
-    let inputNumber: DebugElement;
-    let upHandler: HTMLElement;
 
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(NzTestInputNumberFormComponent);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent = fixture.debugElement.componentInstance;
-      inputNumber = fixture.debugElement.query(By.directive(NzInputNumberComponent));
-      upHandler = inputNumber.nativeElement.querySelector('.ant-input-number-handler-up');
+      testComponent = fixture.componentInstance;
     }));
     it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+      fixture.detectChanges();
       flush();
+      fixture.detectChanges();
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
     }));
     it('should set disabled work', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const inputNumber = fixture.debugElement.query(By.directive(NzInputNumberComponent));
+      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      const upHandler = inputNumber.nativeElement.querySelector('.ant-input-number-handler-up');
+      expect(inputNumber.nativeElement.classList).toContain('ant-input-number-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+      testComponent.formGroup.enable();
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('inputNumber')!.value).toBe(1);
+      expect(inputNumber.nativeElement.classList).not.toContain('ant-input-number-disabled');
+      expect(inputElement.disabled).toBeFalsy();
       dispatchFakeEvent(upHandler, 'mousedown');
       fixture.detectChanges();
       flush();
@@ -497,6 +504,8 @@ describe('input number', () => {
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
+      expect(inputNumber.nativeElement.classList).toContain('ant-input-number-disabled');
+      expect(inputElement.disabled).toBeTruthy();
       expect(testComponent.formGroup.get('inputNumber')!.value).toBe(10);
     }));
   });
@@ -598,7 +607,6 @@ describe('input number', () => {
     });
   });
 });
-
 @Component({
   template: `
     <nz-input-number
@@ -648,12 +656,13 @@ export class NzTestReadOnlyInputNumberBasicComponent {
 @Component({
   template: `
     <form [formGroup]="formGroup">
-      <nz-input-number formControlName="inputNumber" nzMax="10" nzMin="-10"></nz-input-number>
+      <nz-input-number formControlName="inputNumber" nzMax="10" nzMin="-10" [nzDisabled]="disabled"></nz-input-number>
     </form>
   `
 })
 export class NzTestInputNumberFormComponent {
   formGroup: UntypedFormGroup;
+  disabled = false;
 
   constructor(private formBuilder: UntypedFormBuilder) {
     this.formGroup = this.formBuilder.group({

--- a/components/input-number/input-number.spec.ts
+++ b/components/input-number/input-number.spec.ts
@@ -465,47 +465,63 @@ describe('input number', () => {
     let fixture: ComponentFixture<NzTestInputNumberFormComponent>;
     let testComponent: NzTestInputNumberFormComponent;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(NzTestInputNumberFormComponent);
       testComponent = fixture.componentInstance;
-    }));
-    it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+    });
+    it('should be in pristine, untouched, and valid states and be enable initially', fakeAsync(() => {
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
+      const inputNumber = fixture.debugElement.query(By.directive(NzInputNumberComponent));
+      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      expect(inputNumber.nativeElement.classList).not.toContain('ant-input-number-disabled');
+      expect(inputElement.disabled).toBeFalsy();
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
+    }));
+    it('should be disable if form disable and nzDisabled set to false initially', fakeAsync(() => {
+      testComponent.disable();
+      fixture.detectChanges();
+      flush();
+      const inputNumber = fixture.debugElement.query(By.directive(NzInputNumberComponent));
+      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      expect(inputNumber.nativeElement.classList).toContain('ant-input-number-disabled');
+      expect(inputElement.disabled).toBeTruthy();
     }));
     it('should set disabled work', fakeAsync(() => {
       testComponent.disabled = true;
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
       const inputNumber = fixture.debugElement.query(By.directive(NzInputNumberComponent));
       const inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
       const upHandler = inputNumber.nativeElement.querySelector('.ant-input-number-handler-up');
       expect(inputNumber.nativeElement.classList).toContain('ant-input-number-disabled');
       expect(inputElement.disabled).toBeTruthy();
-      testComponent.formGroup.enable();
+      expect(testComponent.formGroup.get('inputNumber')!.value).toBe(1);
+      dispatchFakeEvent(upHandler, 'mousedown');
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
       expect(testComponent.formGroup.get('inputNumber')!.value).toBe(1);
+
+      testComponent.enable();
+      fixture.detectChanges();
+      flush();
       expect(inputNumber.nativeElement.classList).not.toContain('ant-input-number-disabled');
       expect(inputElement.disabled).toBeFalsy();
       dispatchFakeEvent(upHandler, 'mousedown');
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
       expect(testComponent.formGroup.get('inputNumber')!.value).toBe(10);
+
       testComponent.disable();
+      fixture.detectChanges();
+      flush();
+      expect(inputNumber.nativeElement.classList).toContain('ant-input-number-disabled');
+      expect(inputElement.disabled).toBeTruthy();
       dispatchFakeEvent(upHandler, 'mousedown');
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
-      expect(inputNumber.nativeElement.classList).toContain('ant-input-number-disabled');
-      expect(inputElement.disabled).toBeTruthy();
       expect(testComponent.formGroup.get('inputNumber')!.value).toBe(10);
     }));
   });
@@ -672,6 +688,10 @@ export class NzTestInputNumberFormComponent {
 
   disable(): void {
     this.formGroup.disable();
+  }
+
+  enable(): void {
+    this.formGroup.enable();
   }
 }
 

--- a/components/radio/radio.component.ts
+++ b/components/radio/radio.component.ts
@@ -86,6 +86,7 @@ export class NzRadioComponent implements ControlValueAccessor, AfterViewInit, On
 
   private isNgModel = false;
   private destroy$ = new Subject<void>();
+  private isNzDisableFirstChange: boolean = true;
   isChecked = false;
   name: string | null = null;
   isRadioButton = !!this.nzRadioButtonDirective;
@@ -118,7 +119,8 @@ export class NzRadioComponent implements ControlValueAccessor, AfterViewInit, On
   ) {}
 
   setDisabledState(disabled: boolean): void {
-    this.nzDisabled = disabled;
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || disabled;
+    this.isNzDisableFirstChange = false;
     this.cdr.markForCheck();
   }
 

--- a/components/radio/radio.spec.ts
+++ b/components/radio/radio.spec.ts
@@ -243,86 +243,69 @@ describe('radio', () => {
   describe('radio form', () => {
     let fixture: ComponentFixture<NzTestRadioFormComponent>;
     let testComponent: NzTestRadioFormComponent;
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(NzTestRadioFormComponent);
       testComponent = fixture.componentInstance;
-    }));
-    it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+    });
+    it('should be in pristine, untouched, and valid states and enable initially', fakeAsync(() => {
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
+      const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
+      const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(radio.nativeElement.firstElementChild!.classList).not.toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeFalsy();
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
     }));
-    it('should be disable by default even if form is enable', fakeAsync(() => {
+    it('should be disable by default even if form is enable initially', fakeAsync(() => {
       testComponent.disabled = true;
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
       const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
       const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
       expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
       expect(inputElement.disabled).toBeTruthy();
     }));
-    it('should be enable if form is enable and nzDisable set to false', fakeAsync(() => {
-      testComponent.disabled = false;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
-      const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
-      expect(radio.nativeElement.firstElementChild!.classList).not.toContain('ant-radio-disabled');
-      expect(inputElement.disabled).toBeFalsy();
-    }));
-    it('should be disable if form is disable and nzDisable set to false', fakeAsync(() => {
-      testComponent.disabled = false;
+    it('should be disable if form is disable and nzDisable set to false initially', fakeAsync(() => {
       testComponent.formGroup.disable();
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
       const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
       const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
       expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
       expect(inputElement.disabled).toBeTruthy();
     }));
-    it('should be disable first if nzDisabled set to true then enable when enable function is called', fakeAsync(() => {
+    it('should set disabled work', fakeAsync(() => {
       testComponent.disabled = true;
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
-      let radio = fixture.debugElement.query(By.directive(NzRadioComponent));
-      let inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
-      expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
-      expect(inputElement.disabled).toBeTruthy();
-      testComponent.formGroup.enable();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      expect(radio.nativeElement.firstElementChild!.classList).not.toContain('ant-radio-disabled');
-      expect(inputElement.disabled).toBeFalsy();
-    }));
-    it('should set disabled work', fakeAsync(() => {
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
       const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
       const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeTruthy();
       expect(testComponent.formGroup.get('radio')!.value).toBe(false);
+      inputElement.click();
+      fixture.detectChanges();
+      expect(testComponent.formGroup.get('radio')!.value).toBe(false);
+
+      testComponent.enable();
+      fixture.detectChanges();
+      flush();
+      expect(radio.nativeElement.firstElementChild!.classList).not.toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeFalsy();
       inputElement.click();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('radio')!.value).toBe(true);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent.formGroup.get('radio')!.setValue(false);
+
       testComponent.disable();
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
+      expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeTruthy();
       inputElement.click();
       fixture.detectChanges();
-      expect(testComponent.formGroup.get('radio')!.value).toBe(false);
+      expect(testComponent.formGroup.get('radio')!.value).toBe(true);
     }));
   });
   describe('radio group form', () => {
@@ -504,6 +487,10 @@ export class NzTestRadioFormComponent {
 
   disable(): void {
     this.formGroup.disable();
+  }
+
+  enable(): void {
+    this.formGroup.enable();
   }
 }
 

--- a/components/radio/radio.spec.ts
+++ b/components/radio/radio.spec.ts
@@ -258,15 +258,6 @@ describe('radio', () => {
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
     }));
-    it('should be disable by default even if form is enable initially', fakeAsync(() => {
-      testComponent.disabled = true;
-      fixture.detectChanges();
-      flush();
-      const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
-      const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
-      expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
-      expect(inputElement.disabled).toBeTruthy();
-    }));
     it('should be disable if form is disable and nzDisable set to false initially', fakeAsync(() => {
       testComponent.formGroup.disable();
       fixture.detectChanges();

--- a/components/radio/radio.spec.ts
+++ b/components/radio/radio.spec.ts
@@ -1,7 +1,7 @@
 import { BidiModule, Dir } from '@angular/cdk/bidi';
 import { ApplicationRef, Component, DebugElement, OnInit, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync } from '@angular/core/testing';
-import { UntypedFormBuilder, UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { createMouseEvent } from 'ng-zorro-antd/core/testing';
@@ -243,25 +243,71 @@ describe('radio', () => {
   describe('radio form', () => {
     let fixture: ComponentFixture<NzTestRadioFormComponent>;
     let testComponent: NzTestRadioFormComponent;
-    let radio: DebugElement;
-    let inputElement: HTMLElement;
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(NzTestRadioFormComponent);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent = fixture.debugElement.componentInstance;
-      radio = fixture.debugElement.query(By.directive(NzRadioComponent));
-      inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
+      testComponent = fixture.componentInstance;
     }));
     it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+      fixture.detectChanges();
       flush();
+      fixture.detectChanges();
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
     }));
-    it('should set disabled work', fakeAsync(() => {
+    it('should be disable by default even if form is enable', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
       flush();
+      fixture.detectChanges();
+      const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
+      const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+    }));
+    it('should be enable if form is enable and nzDisable set to false', fakeAsync(() => {
+      testComponent.disabled = false;
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
+      const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(radio.nativeElement.firstElementChild!.classList).not.toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeFalsy();
+    }));
+    it('should be disable if form is disable and nzDisable set to false', fakeAsync(() => {
+      testComponent.disabled = false;
+      testComponent.formGroup.disable();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
+      const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+    }));
+    it('should be disable first if nzDisabled set to true then enable when enable function is called', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      let radio = fixture.debugElement.query(By.directive(NzRadioComponent));
+      let inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(radio.nativeElement.firstElementChild!.classList).toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeTruthy();
+      testComponent.formGroup.enable();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(radio.nativeElement.firstElementChild!.classList).not.toContain('ant-radio-disabled');
+      expect(inputElement.disabled).toBeFalsy();
+    }));
+    it('should set disabled work', fakeAsync(() => {
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const radio = fixture.debugElement.query(By.directive(NzRadioComponent));
+      const inputElement = radio.nativeElement.querySelector('input') as HTMLInputElement;
       expect(testComponent.formGroup.get('radio')!.value).toBe(false);
       inputElement.click();
       fixture.detectChanges();
@@ -382,7 +428,6 @@ describe('radio', () => {
     });
   });
 });
-
 @Component({
   // eslint-disable-next-line
   selector: 'nz-test-radio-single',
@@ -442,12 +487,14 @@ export class NzTestRadioGroupComponent {
 @Component({
   template: `
     <form [formGroup]="formGroup">
-      <label nz-radio formControlName="radio"></label>
+      <label nz-radio formControlName="radio" [nzDisabled]="disabled"></label>
     </form>
   `
 })
 export class NzTestRadioFormComponent {
   formGroup: UntypedFormGroup;
+
+  disabled = false;
 
   constructor(private formBuilder: UntypedFormBuilder) {
     this.formGroup = this.formBuilder.group({

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -111,6 +111,7 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
   private hoverValue = 0;
   private isFocused = false;
   private _value = 0;
+  private isNzDisableFirstChange: boolean = true;
 
   get nzValue(): number {
     return this._value;
@@ -285,7 +286,8 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.nzDisabled = isDisabled;
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || isDisabled;
+    this.isNzDisableFirstChange = false;
   }
 
   registerOnChange(fn: (_: number) => void): void {

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -288,6 +288,7 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
   setDisabledState(isDisabled: boolean): void {
     this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || isDisabled;
     this.isNzDisableFirstChange = false;
+    this.cdr.markForCheck();
   }
 
   registerOnChange(fn: (_: number) => void): void {

--- a/components/rate/rate.spec.ts
+++ b/components/rate/rate.spec.ts
@@ -206,49 +206,60 @@ describe('rate', () => {
     let fixture: ComponentFixture<NzTestRateFormComponent>;
     let testComponent: NzTestRateFormComponent;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(NzTestRateFormComponent);
       testComponent = fixture.componentInstance;
-    }));
-    it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+    });
+    it('should be in pristine, untouched, and valid states and enable initially', fakeAsync(() => {
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
+      const rate = fixture.debugElement.query(By.directive(NzRateComponent));
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
+      expect(rate.nativeElement.firstElementChild!.classList).not.toContain('ant-rate-disabled');
+    }));
+    it('should be disable if form is enable and nzDisable set to true initially', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
+      flush();
+      const rate = fixture.debugElement.query(By.directive(NzRateComponent));
+      expect(rate.nativeElement.firstElementChild!.classList).toContain('ant-rate-disabled');
+    }));
+    it('should be disable if form is disable and nzDisable set to false initially', fakeAsync(() => {
+      testComponent.disable();
+      fixture.detectChanges();
+      flush();
+      const rate = fixture.debugElement.query(By.directive(NzRateComponent));
+      expect(rate.nativeElement.firstElementChild!.classList).toContain('ant-rate-disabled');
     }));
     it('should set disabled work', fakeAsync(() => {
       testComponent.disabled = true;
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
+
       const rate = fixture.debugElement.query(By.directive(NzRateComponent));
+      expect(rate.nativeElement.firstElementChild!.classList).toContain('ant-rate-disabled');
+      expect(testComponent.formGroup.get('rate')!.value).toBe(1);
       rate.nativeElement.firstElementChild.children[3].firstElementChild.firstElementChild.click();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('rate')!.value).toBe(1);
-      expect(rate.nativeElement.firstElementChild!.classList).toContain('ant-rate-disabled');
-      testComponent.formGroup.enable();
+
+      testComponent.enable();
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
-      expect(testComponent.formGroup.get('rate')!.value).toBe(1);
+      expect(rate.nativeElement.firstElementChild!.classList).not.toContain('ant-rate-disabled');
       rate.nativeElement.firstElementChild.children[3].firstElementChild.firstElementChild.click();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('rate')!.value).toBe(4);
-      expect(rate.nativeElement.firstElementChild!.classList).not.toContain('ant-rate-disabled');
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent.formGroup.get('rate')!.setValue(2);
+
       testComponent.disable();
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
       expect(rate.nativeElement.firstElementChild!.classList).toContain('ant-rate-disabled');
       rate.nativeElement.firstElementChild.children[3].firstElementChild.firstElementChild.click();
       fixture.detectChanges();
-      expect(testComponent.formGroup.get('rate')!.value).toBe(2);
+      expect(testComponent.formGroup.get('rate')!.value).toBe(4);
     }));
   });
   describe('RTL', () => {
@@ -344,6 +355,10 @@ export class NzTestRateFormComponent {
 
   disable(): void {
     this.formGroup.disable();
+  }
+
+  enable(): void {
+    this.formGroup.enable();
   }
 }
 @Component({

--- a/components/rate/rate.spec.ts
+++ b/components/rate/rate.spec.ts
@@ -2,7 +2,7 @@ import { BidiModule, Dir } from '@angular/cdk/bidi';
 import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import { Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
-import { UntypedFormBuilder, UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { dispatchFakeEvent, dispatchKeyboardEvent } from 'ng-zorro-antd/core/testing';
@@ -205,28 +205,38 @@ describe('rate', () => {
   describe('rate form', () => {
     let fixture: ComponentFixture<NzTestRateFormComponent>;
     let testComponent: NzTestRateFormComponent;
-    let rate: DebugElement;
 
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(NzTestRateFormComponent);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent = fixture.debugElement.componentInstance;
-      rate = fixture.debugElement.query(By.directive(NzRateComponent));
+      testComponent = fixture.componentInstance;
     }));
     it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+      fixture.detectChanges();
       flush();
+      fixture.detectChanges();
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
     }));
     it('should set disabled work', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
       flush();
+      fixture.detectChanges();
+      const rate = fixture.debugElement.query(By.directive(NzRateComponent));
+      rate.nativeElement.firstElementChild.children[3].firstElementChild.firstElementChild.click();
+      fixture.detectChanges();
+      expect(testComponent.formGroup.get('rate')!.value).toBe(1);
+      expect(rate.nativeElement.firstElementChild!.classList).toContain('ant-rate-disabled');
+      testComponent.formGroup.enable();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
       expect(testComponent.formGroup.get('rate')!.value).toBe(1);
       rate.nativeElement.firstElementChild.children[3].firstElementChild.firstElementChild.click();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('rate')!.value).toBe(4);
+      expect(rate.nativeElement.firstElementChild!.classList).not.toContain('ant-rate-disabled');
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
@@ -235,12 +245,12 @@ describe('rate', () => {
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
+      expect(rate.nativeElement.firstElementChild!.classList).toContain('ant-rate-disabled');
       rate.nativeElement.firstElementChild.children[3].firstElementChild.firstElementChild.click();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('rate')!.value).toBe(2);
     }));
   });
-
   describe('RTL', () => {
     let fixture: ComponentFixture<NzTestRateRtlComponent>;
     let rate: DebugElement;
@@ -260,7 +270,6 @@ describe('rate', () => {
       expect(rate.nativeElement.firstElementChild!.classList).not.toContain('ant-rate-rtl');
     }));
   });
-
   describe('rate character', () => {
     let fixture: ComponentFixture<NzTestRateCharacterComponent>;
     let rate: DebugElement;
@@ -281,7 +290,6 @@ describe('rate', () => {
     });
   });
 });
-
 @Component({
   // eslint-disable-next-line
   selector: 'nz-test-rate',
@@ -319,12 +327,14 @@ export class NzTestRateBasicComponent {
 @Component({
   template: `
     <form [formGroup]="formGroup">
-      <nz-rate formControlName="rate"></nz-rate>
+      <nz-rate formControlName="rate" [nzDisabled]="disabled"></nz-rate>
     </form>
   `
 })
 export class NzTestRateFormComponent {
   formGroup: UntypedFormGroup;
+
+  disabled = false;
 
   constructor(private formBuilder: UntypedFormBuilder) {
     this.formGroup = this.formBuilder.group({

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -279,6 +279,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   private value: NzSafeAny | NzSafeAny[];
   private _nzShowArrow: boolean | undefined;
   private requestId: number = -1;
+  private isNzDisableFirstChange: boolean = true;
   onChange: OnChangeType = () => {};
   onTouched: OnTouchedType = () => {};
   dropDownPosition: NzSelectPlacementType = 'bottomLeft';
@@ -600,8 +601,9 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   }
 
   setDisabledState(disabled: boolean): void {
-    this.nzDisabled = disabled;
-    if (disabled) {
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || disabled;
+    this.isNzDisableFirstChange = false;
+    if (this.nzDisabled) {
       this.setOpenState(false);
     }
     this.cdr.markForCheck();

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -1403,43 +1403,20 @@ describe('select', () => {
     let component: TestSelectInFormComponent;
     let fixture: ComponentFixture<TestSelectInFormComponent>;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       testBed = createComponentBed(TestSelectInFormComponent, {
         imports: [NzSelectModule, NzIconTestModule, NzFormModule, ReactiveFormsModule]
       });
       component = testBed.component;
       fixture = testBed.fixture;
-    }));
-    it('should be disable by default even if form is enable', fakeAsync(() => {
-      component.disabled = true;
-      fixture.detectChanges();
-      flush();
+    });
+    it('should classname correct and be disable initially', () => {
       fixture.detectChanges();
       const selectElement = testBed.debugElement.query(By.directive(NzSelectComponent)).nativeElement;
       const inputElement = testBed.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
-      expect(inputElement.disabled).toBeTruthy();
-      expect(selectElement.classList).toContain('ant-select-disabled');
-    }));
-    it('should be enable if form is enable and nzDisable set to false', () => {
-      fixture.detectChanges();
-      const selectElement = testBed.debugElement.query(By.directive(NzSelectComponent)).nativeElement;
-      const inputElement = testBed.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+
       expect(inputElement.disabled).toBeFalsy();
       expect(selectElement.classList).not.toContain('ant-select-disabled');
-    });
-    it('should be disable if form is disabled and nzDisabled set to false', fakeAsync(() => {
-      component.disable();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      const selectElement = testBed.debugElement.query(By.directive(NzSelectComponent)).nativeElement;
-      const inputElement = testBed.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
-      expect(inputElement.disabled).toBeTruthy();
-      expect(selectElement.classList).toContain('ant-select-disabled');
-    }));
-    it('should classname correct', () => {
-      fixture.detectChanges();
-      const selectElement = testBed.debugElement.query(By.directive(NzSelectComponent)).nativeElement;
       expect(selectElement.classList).toContain('ant-select-status-error');
       expect(selectElement.classList).toContain('ant-select-in-form-item');
       expect(selectElement.querySelector('nz-form-item-feedback-icon')).toBeTruthy();
@@ -1456,6 +1433,26 @@ describe('select', () => {
       fixture.detectChanges();
       expect(selectElement.querySelector('nz-form-item-feedback-icon')).toBeNull();
     });
+    it('should be disable by default even if form is enable', fakeAsync(() => {
+      component.disabled = true;
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const selectElement = testBed.debugElement.query(By.directive(NzSelectComponent)).nativeElement;
+      const inputElement = testBed.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      expect(inputElement.disabled).toBeTruthy();
+      expect(selectElement.classList).toContain('ant-select-disabled');
+    }));
+    it('should be disable if form is disabled and nzDisabled set to false', fakeAsync(() => {
+      component.disable();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const selectElement = testBed.debugElement.query(By.directive(NzSelectComponent)).nativeElement;
+      const inputElement = testBed.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      expect(inputElement.disabled).toBeTruthy();
+      expect(selectElement.classList).toContain('ant-select-disabled');
+    }));
   });
   describe('placement', () => {
     let testBed: ComponentBed<TestSelectTemplateDefaultComponent>;

--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -235,6 +235,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
     this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || isDisabled;
     this.isNzDisableFirstChange = false;
     this.toggleDragDisabled(isDisabled);
+    this.cdr.markForCheck();
   }
 
   /**

--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -168,6 +168,7 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
   private dragMove_?: Subscription | null;
   private dragEnd_?: Subscription | null;
   private destroy$ = new Subject();
+  private isNzDisableFirstChange = true;
 
   constructor(
     private sliderService: NzSliderService,
@@ -231,7 +232,8 @@ export class NzSliderComponent implements ControlValueAccessor, OnInit, OnChange
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.nzDisabled = isDisabled;
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || isDisabled;
+    this.isNzDisableFirstChange = false;
     this.toggleDragDisabled(isDisabled);
   }
 

--- a/components/slider/slider.spec.ts
+++ b/components/slider/slider.spec.ts
@@ -5,10 +5,10 @@ import { Component, DebugElement, OnInit, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, inject, tick } from '@angular/core/testing';
 import {
   AbstractControl,
-  UntypedFormBuilder,
-  UntypedFormGroup,
   FormsModule,
-  ReactiveFormsModule
+  ReactiveFormsModule,
+  UntypedFormBuilder,
+  UntypedFormGroup
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -790,70 +790,77 @@ describe('nz-slider', () => {
         imports: [NzSliderModule, FormsModule, ReactiveFormsModule, NoopAnimationsModule]
       });
       fixture = testBed.fixture;
-      fixture.detectChanges();
-
-      testComponent = fixture.debugElement.componentInstance;
-
-      getReferenceFromFixture(fixture);
+      testComponent = fixture.componentInstance;
       sliderControl = testComponent.form.controls.slider;
+      getReferenceFromFixture(fixture);
     });
 
-    it('should have correct initial value', () => {
+    it('should have correct initial value', fakeAsync(() => {
+      fixture.detectChanges();
+      const firstElementChildSlider = sliderDebugElement.nativeElement.firstElementChild;
       expect(sliderInstance.value).toBe(42);
-    });
+      expect(firstElementChildSlider!.classList).not.toContain('ant-slider-disabled');
+    }));
 
     it('should not update the control when the value is updated', () => {
       expect(sliderControl.value).toBe(42);
 
       sliderInstance.value = 11;
       fixture.detectChanges();
-
       expect(sliderControl.value).toBe(42);
     });
 
-    it('should update the control on click', () => {
+    it('should update the control', () => {
       expect(sliderControl.value).toBe(42);
 
       dispatchClickEventSequence(sliderNativeElement, 0.76);
       fixture.detectChanges();
-
       expect(sliderControl.value).toBe(76);
-    });
-
-    it('should update the control on slide', () => {
-      expect(sliderControl.value).toBe(42);
 
       dispatchSlideEventSequence(sliderNativeElement, 0.42, 0.19);
       fixture.detectChanges();
-
       expect(sliderControl.value).toBe(19);
-    });
-
-    it('should update the value when the control is set', () => {
-      expect(sliderInstance.value).toBe(42);
 
       sliderControl.setValue(7);
       fixture.detectChanges();
-
+      expect(sliderControl.value).toBe(7);
       expect(sliderInstance.value).toBe(7);
     });
-
-    it('should update the disabled state when control is disabled', () => {
-      expect(sliderInstance.nzDisabled).toBe(false);
-
-      sliderControl.disable();
+    it('should be disable initially even if nzDisable is set to false', () => {
+      testComponent.disable();
       fixture.detectChanges();
+      const firstElementChildSlider = sliderDebugElement.nativeElement.firstElementChild;
 
+      expect(firstElementChildSlider!.classList).toContain('ant-slider-disabled');
       expect(sliderInstance.nzDisabled).toBe(true);
     });
-
-    it('should update the disabled state when the control is enabled', () => {
-      sliderInstance.nzDisabled = true;
-
-      sliderControl.enable();
+    it('should disable work', () => {
+      testComponent.disabled = true;
       fixture.detectChanges();
+      const firstElementChildSlider = sliderDebugElement.nativeElement.firstElementChild;
 
+      expect(firstElementChildSlider!.classList).toContain('ant-slider-disabled');
+      expect(sliderInstance.nzDisabled).toBe(true);
+      expect(sliderControl.value).toBe(42);
+      dispatchClickEventSequence(sliderNativeElement, 0.76);
+      fixture.detectChanges();
+      expect(sliderControl.value).toBe(42);
+
+      testComponent.enable();
+      fixture.detectChanges();
+      expect(firstElementChildSlider!.classList).not.toContain('ant-slider-disabled');
       expect(sliderInstance.nzDisabled).toBe(false);
+      dispatchClickEventSequence(sliderNativeElement, 0.76);
+      fixture.detectChanges();
+      expect(sliderControl.value).toBe(76);
+
+      testComponent.disable();
+      fixture.detectChanges();
+      expect(firstElementChildSlider!.classList).toContain('ant-slider-disabled');
+      expect(sliderInstance.nzDisabled).toBe(true);
+      dispatchSlideEventSequence(sliderNativeElement, 0.42, 0.19);
+      fixture.detectChanges();
+      expect(sliderControl.value).toBe(76);
     });
 
     it('should have the correct control state initially and after interaction', () => {
@@ -1155,7 +1162,7 @@ class MixedSliderComponent {
 @Component({
   template: `
     <form [formGroup]="form">
-      <nz-slider formControlName="slider"></nz-slider>
+      <nz-slider formControlName="slider" [nzDisabled]="disabled"></nz-slider>
     </form>
   `,
   styles: [styles]
@@ -1169,6 +1176,16 @@ class SliderWithFormControlComponent implements OnInit {
     this.form = this.fb.group({
       slider: [42]
     });
+  }
+
+  disabled = false;
+
+  disable(): void {
+    this.form.disable();
+  }
+
+  enable(): void {
+    this.form.enable();
   }
 }
 

--- a/components/switch/switch.component.ts
+++ b/components/switch/switch.component.ts
@@ -97,6 +97,7 @@ export class NzSwitchComponent implements ControlValueAccessor, AfterViewInit, O
   dir: Direction = 'ltr';
 
   private destroy$ = new Subject<void>();
+  private isNzDisableFirstChange = true;
 
   updateValue(value: boolean): void {
     if (this.isChecked !== value) {
@@ -207,7 +208,8 @@ export class NzSwitchComponent implements ControlValueAccessor, AfterViewInit, O
   }
 
   setDisabledState(disabled: boolean): void {
-    this.nzDisabled = disabled;
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || disabled;
+    this.isNzDisableFirstChange = false;
     this.cdr.markForCheck();
   }
 }

--- a/components/switch/switch.spec.ts
+++ b/components/switch/switch.spec.ts
@@ -244,83 +244,71 @@ describe('switch', () => {
     let fixture: ComponentFixture<NzTestSwitchFormComponent>;
     let testComponent: NzTestSwitchFormComponent;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(NzTestSwitchFormComponent);
       testComponent = fixture.debugElement.componentInstance;
-    }));
-    it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+    });
+    it('should be in pristine, untouched, and valid states and enable initially', fakeAsync(() => {
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
+      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
+      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
+      expect(buttonElement.disabled).toBeFalsy();
+      expect(buttonElement.classList).not.toContain('ant-switch-disabled');
     }));
     it('should be disable by default even if form is enable', fakeAsync(() => {
       testComponent.disabled = true;
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
       const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
       const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
       expect(buttonElement.disabled).toBeTruthy();
       expect(buttonElement.classList).toContain('ant-switch-disabled');
     }));
-    it('should be enable if form is enable and nzDisable set to false', fakeAsync(() => {
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
-      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
-      expect(buttonElement.disabled).toBeFalsy();
-      expect(buttonElement.classList).not.toContain('ant-switch-disabled');
-    }));
-    it('should be disable if form is disable and nzDisable set to false', fakeAsync(() => {
-      testComponent.formGroup.disable();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
-      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
-      expect(buttonElement.disabled).toBeTruthy();
-      expect(buttonElement.classList).toContain('ant-switch-disabled');
-    }));
-    it('should be disable first if nzDisabled set to true then enable when enable function is called', fakeAsync(() => {
-      testComponent.disabled = true;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
-      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
-      expect(buttonElement.disabled).toBeTruthy();
-      expect(buttonElement.classList).toContain('ant-switch-disabled');
-      testComponent.formGroup.enable();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      expect(buttonElement.disabled).toBeFalsy();
-      expect(buttonElement.classList).not.toContain('ant-switch-disabled');
-    }));
-    it('should set disabled work', fakeAsync(() => {
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
-      expect(testComponent.formGroup.get('switchValue')!.value).toBe(true);
-      switchElement.nativeElement.click();
-      fixture.detectChanges();
-      expect(testComponent.formGroup.get('switchValue')!.value).toBe(false);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent.formGroup.get('switchValue')!.setValue(true);
+    it('should be disable if form is disable and nzDisable set to false initially', fakeAsync(() => {
       testComponent.disable();
       fixture.detectChanges();
       flush();
+      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
+      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
+      expect(buttonElement.disabled).toBeTruthy();
+      expect(buttonElement.classList).toContain('ant-switch-disabled');
+    }));
+    it('should set disabled work', fakeAsync(() => {
+      testComponent.disabled = true;
       fixture.detectChanges();
+      flush();
+      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
+      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
+
+      expect(buttonElement.disabled).toBeTruthy();
+      expect(buttonElement.classList).toContain('ant-switch-disabled');
+      expect(testComponent.formGroup.get('switchValue')!.value).toBe(true);
+
       switchElement.nativeElement.click();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('switchValue')!.value).toBe(true);
+
+      testComponent.enable();
+      fixture.detectChanges();
+      flush();
+      expect(buttonElement.disabled).toBeFalsy();
+      expect(buttonElement.classList).not.toContain('ant-switch-disabled');
+      switchElement.nativeElement.click();
+      fixture.detectChanges();
+      expect(testComponent.formGroup.get('switchValue')!.value).toBe(false);
+
+      testComponent.disable();
+      fixture.detectChanges();
+      flush();
+      expect(buttonElement.disabled).toBeTruthy();
+      expect(buttonElement.classList).toContain('ant-switch-disabled');
+      switchElement.nativeElement.click();
+      fixture.detectChanges();
+      expect(testComponent.formGroup.get('switchValue')!.value).toBe(false);
     }));
   });
   describe('RTL', () => {
@@ -398,6 +386,10 @@ export class NzTestSwitchFormComponent {
 
   disable(): void {
     this.formGroup.disable();
+  }
+
+  enable(): void {
+    this.formGroup.enable();
   }
 }
 

--- a/components/switch/switch.spec.ts
+++ b/components/switch/switch.spec.ts
@@ -2,7 +2,7 @@ import { BidiModule, Dir } from '@angular/cdk/bidi';
 import { ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 import { ApplicationRef, Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
-import { UntypedFormBuilder, UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { dispatchKeyboardEvent } from 'ng-zorro-antd/core/testing';
@@ -26,6 +26,7 @@ describe('switch', () => {
       TestBed.compileComponents();
     })
   );
+
   describe('basic switch', () => {
     let fixture: ComponentFixture<NzTestSwitchBasicComponent>;
     let testComponent: NzTestSwitchBasicComponent;
@@ -242,24 +243,69 @@ describe('switch', () => {
   describe('switch form', () => {
     let fixture: ComponentFixture<NzTestSwitchFormComponent>;
     let testComponent: NzTestSwitchFormComponent;
-    let switchElement: DebugElement;
 
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(NzTestSwitchFormComponent);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
       testComponent = fixture.debugElement.componentInstance;
-      switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
     }));
     it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+      fixture.detectChanges();
       flush();
+      fixture.detectChanges();
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
     }));
-    it('should set disabled work', fakeAsync(() => {
+    it('should be disable by default even if form is enable', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
       flush();
+      fixture.detectChanges();
+      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
+      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
+      expect(buttonElement.disabled).toBeTruthy();
+      expect(buttonElement.classList).toContain('ant-switch-disabled');
+    }));
+    it('should be enable if form is enable and nzDisable set to false', fakeAsync(() => {
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
+      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
+      expect(buttonElement.disabled).toBeFalsy();
+      expect(buttonElement.classList).not.toContain('ant-switch-disabled');
+    }));
+    it('should be disable if form is disable and nzDisable set to false', fakeAsync(() => {
+      testComponent.formGroup.disable();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
+      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
+      expect(buttonElement.disabled).toBeTruthy();
+      expect(buttonElement.classList).toContain('ant-switch-disabled');
+    }));
+    it('should be disable first if nzDisabled set to true then enable when enable function is called', fakeAsync(() => {
+      testComponent.disabled = true;
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
+      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
+      expect(buttonElement.disabled).toBeTruthy();
+      expect(buttonElement.classList).toContain('ant-switch-disabled');
+      testComponent.formGroup.enable();
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(buttonElement.disabled).toBeFalsy();
+      expect(buttonElement.classList).not.toContain('ant-switch-disabled');
+    }));
+    it('should set disabled work', fakeAsync(() => {
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
       expect(testComponent.formGroup.get('switchValue')!.value).toBe(true);
       switchElement.nativeElement.click();
       fixture.detectChanges();
@@ -290,7 +336,6 @@ describe('switch', () => {
     });
   });
 });
-
 @Component({
   template: `
     <ng-template #checkedChildrenTemplate><span nz-icon nzType="check"></span></ng-template>
@@ -336,12 +381,14 @@ export class NzTestSwitchTemplateComponent {}
 @Component({
   template: `
     <form [formGroup]="formGroup">
-      <nz-switch formControlName="switchValue"></nz-switch>
+      <nz-switch formControlName="switchValue" [nzDisabled]="disabled"></nz-switch>
     </form>
   `
 })
 export class NzTestSwitchFormComponent {
   formGroup: UntypedFormGroup;
+
+  disabled = false;
 
   constructor(private formBuilder: UntypedFormBuilder) {
     this.formGroup = this.formBuilder.group({

--- a/components/switch/switch.spec.ts
+++ b/components/switch/switch.spec.ts
@@ -259,15 +259,6 @@ describe('switch', () => {
       expect(buttonElement.disabled).toBeFalsy();
       expect(buttonElement.classList).not.toContain('ant-switch-disabled');
     }));
-    it('should be disable by default even if form is enable', fakeAsync(() => {
-      testComponent.disabled = true;
-      fixture.detectChanges();
-      flush();
-      const switchElement = fixture.debugElement.query(By.directive(NzSwitchComponent));
-      const buttonElement = switchElement.nativeElement.firstElementChild! as HTMLButtonElement;
-      expect(buttonElement.disabled).toBeTruthy();
-      expect(buttonElement.classList).toContain('ant-switch-disabled');
-    }));
     it('should be disable if form is disable and nzDisable set to false initially', fakeAsync(() => {
       testComponent.disable();
       fixture.detectChanges();

--- a/components/time-picker/time-picker.component.ts
+++ b/components/time-picker/time-picker.component.ts
@@ -149,6 +149,7 @@ export class NzTimePickerComponent implements ControlValueAccessor, OnInit, Afte
   private _onChange?: (value: Date | null) => void;
   private _onTouched?: () => void;
   private destroy$ = new Subject<void>();
+  private isNzDisableFirstChange: boolean = true;
   isInit = false;
   focused = false;
   inputValue: string = '';
@@ -440,7 +441,8 @@ export class NzTimePickerComponent implements ControlValueAccessor, OnInit, Afte
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.nzDisabled = isDisabled;
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || isDisabled;
+    this.isNzDisableFirstChange = false;
     this.cdr.markForCheck();
   }
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ngx-quicklink": "^0.3.0"
   },
   "devDependencies": {
-    "@angular-builders/custom-webpack": "^15.0.0-beta.0",
+    "@angular-builders/custom-webpack": "^15.0.0",
     "@angular-devkit/build-angular": "~15.0.1",
     "@angular-devkit/core": "~15.0.1",
     "@angular-devkit/schematics": "~15.0.1",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

if the component is bind to a formControl and the property nzDisable is set to true initially the form element will stay enable. This is not the correct behavior. Form component should be disable

Issue Number: 7726 (release v15)


## What is the new behavior?

Form component bind by ngModel and property nzDisable set to true are now disable initially (this was the behavior in version 14) 


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
