### PR TITLE
refactor(module:modal): :recycle: refactor the way to retrieve params

### DIFF
--- a/components/modal/demo/service.ts
+++ b/components/modal/demo/service.ts
@@ -1,8 +1,8 @@
 /* declarations: NzModalCustomComponent */
 
-import { Component, Input, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Component, Inject, TemplateRef, ViewContainerRef } from '@angular/core';
 
-import { NzModalRef, NzModalService } from 'ng-zorro-antd/modal';
+import { NzModalRef, NzModalService, NZ_MODAL_DATA } from 'ng-zorro-antd/modal';
 
 @Component({
   selector: 'nz-demo-modal-service',
@@ -102,7 +102,7 @@ export class NzDemoModalServiceComponent {
         {
           label: 'change component title from outside',
           onClick: componentInstance => {
-            componentInstance!.title = 'title in inner component is changed';
+            componentInstance!.componentParams.title = 'title in inner component is changed';
           }
         }
       ]
@@ -114,7 +114,7 @@ export class NzDemoModalServiceComponent {
 
     // delay until modal instance created
     setTimeout(() => {
-      instance.subtitle = 'sub title is changed';
+      instance.componentParams.subtitle = 'sub title is changed';
     }, 2000);
   }
 
@@ -180,8 +180,8 @@ export class NzDemoModalServiceComponent {
   selector: 'nz-modal-custom-component',
   template: `
     <div>
-      <h2>{{ title }}</h2>
-      <h4>{{ subtitle }}</h4>
+      <h2>{{ componentParams.title }}</h2>
+      <h4>{{ componentParams.subtitle }}</h4>
       <p>
         <span>Get Modal instance in component</span>
         <button nz-button [nzType]="'primary'" (click)="destroyModal()">destroy modal in the component</button>
@@ -190,10 +190,13 @@ export class NzDemoModalServiceComponent {
   `
 })
 export class NzModalCustomComponent {
-  @Input() title?: string;
-  @Input() subtitle?: string;
+  //@Input() title?: string;
+  //@Input() subtitle?: string;
 
-  constructor(private modal: NzModalRef) {}
+  constructor(
+    private modal: NzModalRef,
+    @Inject(NZ_MODAL_DATA) public componentParams: { title?: string; subtitle?: string }
+  ) {}
 
   destroyModal(): void {
     this.modal.destroy({ data: 'this the result data' });

--- a/components/modal/doc/index.en-US.md
+++ b/components/modal/doc/index.en-US.md
@@ -125,11 +125,11 @@ The dialog created by the service method `NzModalService.xxx()` will return a `N
 | updateConfig(config: ModalOptions): void   | Update the config |
 
 
-#### NZ_MODAL_COMPONENT_PARAMS
+#### NZ_MODAL_DATA
 
-> NZ_MODAL_COMPONENT_PARAMS injection token is used to retrieve `nzContentParams` in the custom component.
+> NZ_MODAL_DATA injection token is used to retrieve `nzContentParams` in the custom component.
 
-The dialog created by the service method `NzModalService.xxx()` inject a `NZ_MODAL_COMPONENT_PARAMS` token (if `nzContent` is used as Component) to retrieve the parameters that have used to the '`nzContent` component'
+The dialog created by the service method `NzModalService.xxx()` inject a `NZ_MODAL_DATA` token (if `nzContent` is used as Component) to retrieve the parameters that have used to the '`nzContent` component'
 
 ### ModalButtonOptions (used to customize the bottom button)
 

--- a/components/modal/doc/index.en-US.md
+++ b/components/modal/doc/index.en-US.md
@@ -60,13 +60,9 @@ The dialog is currently divided into 2 modes, `normal mode` and `confirm box mod
 | nzOnCancel        | Specify a function that will be called when a user clicks mask, close button on top right or Cancel button (If nzContent is Component, the Component instance will be put in as an argument). <i>Note: When created with `NzModalService.create`, this parameter should be passed into the type of function (callback function). This function returns a promise, which is automatically closed when the execution is complete or the promise ends (return `false` to prevent closing)</i> | EventEmitter | - |
 | nzOnOk            | Specify a EventEmitter that will be emitted when a user clicks the OK button (If nzContent is Component, the Component instance will be put in as an argument). <i>Note: When created with `NzModalService.create`, this parameter should be passed into the type of function (callback function). This function returns a promise, which is automatically closed when the execution is complete or the promise ends (return `false` to prevent closing)</i> | EventEmitter | - |
 | nzContent         | Content | string / TemplateRef / Component / ng-content | - |
-| nzComponentParams | Will be instance property when `nzContent` is a component，will be template variable when `nzContent` is `TemplateRef`  | `object` | - |
+| nzComponentParams | Will be data pass through the `NZ_MODAL_DATA` injection token when `nzContent` is a component，will be template variable when `nzContent` is `TemplateRef`  | `object` | - |
 | nzIconType        | Icon type of the Icon component. <i>Only valid in confirm box mode</i> | `string` | question-circle |
 | nzAutofocus        | autofocus and the position，disabled when is `null` | `'ok' \| 'cancel' \| 'auto' \| null` | `'auto'` |
-
-#### Attentions
-
-> The creation or modification of the `nzComponentParams` property does not trigger the `ngOnChanges` life cycle hook of the `nzContent` component.
 
 #### Using service to create Normal Mode modal
 
@@ -127,6 +123,13 @@ The dialog created by the service method `NzModalService.xxx()` will return a `N
 | triggerOk()               | Manually trigger nzOnOk |
 | triggerCancel()           | Manually trigger nzOnCancel |
 | updateConfig(config: ModalOptions): void   | Update the config |
+
+
+#### NZ_MODAL_COMPONENT_PARAMS
+
+> NZ_MODAL_COMPONENT_PARAMS injection token is used to retrieve `nzContentParams` in the custom component.
+
+The dialog created by the service method `NzModalService.xxx()` inject a `NZ_MODAL_COMPONENT_PARAMS` token (if `nzContent` is used as Component) to retrieve the parameters that have used to the '`nzContent` component'
 
 ### ModalButtonOptions (used to customize the bottom button)
 

--- a/components/modal/modal-config.ts
+++ b/components/modal/modal-config.ts
@@ -3,6 +3,8 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { InjectionToken } from '@angular/core';
+
 import { NzConfigKey } from 'ng-zorro-antd/core/config';
 
 export const ZOOM_CLASS_NAME_MAP = {
@@ -21,3 +23,5 @@ export const FADE_CLASS_NAME_MAP = {
 
 export const MODAL_MASK_CLASS_NAME = 'ant-modal-mask';
 export const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'modal';
+
+export const NZ_MODAL_DATA = new InjectionToken('NZ__MODAL_DATA');

--- a/components/modal/modal-types.ts
+++ b/components/modal/modal-types.ts
@@ -21,7 +21,7 @@ export interface StyleObjectLike {
 
 const noopFun = () => void 0;
 
-export class ModalOptions<T = NzSafeAny, R = NzSafeAny> {
+export class ModalOptions<T = NzSafeAny, D = NzSafeAny, R = NzSafeAny> {
   nzCentered?: boolean = false;
   nzClosable?: boolean = true;
   nzOkLoading?: boolean = false;
@@ -41,7 +41,7 @@ export class ModalOptions<T = NzSafeAny, R = NzSafeAny> {
   nzModalType?: ModalTypes = 'default';
   nzOnCancel?: EventEmitter<T> | OnClickCallback<T> = noopFun;
   nzOnOk?: EventEmitter<T> | OnClickCallback<T> = noopFun;
-  nzComponentParams?: Partial<T>;
+  nzComponentParams?: D;
   nzMaskStyle?: StyleObjectLike;
   nzBodyStyle?: StyleObjectLike;
   nzWrapClassName?: string;

--- a/components/modal/modal.service.ts
+++ b/components/modal/modal.service.ts
@@ -15,13 +15,13 @@ import { warn } from 'ng-zorro-antd/core/logger';
 import { IndexableObject, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { isNotNil } from 'ng-zorro-antd/core/util';
 
-import { MODAL_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME } from './modal-config';
+import { MODAL_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME, NZ_MODAL_DATA } from './modal-config';
 import { NzModalConfirmContainerComponent } from './modal-confirm-container.component';
 import { NzModalContainerComponent } from './modal-container.component';
 import { BaseModalContainerComponent } from './modal-container.directive';
 import { NzModalRef } from './modal-ref';
 import { ConfirmType, ModalOptions } from './modal-types';
-import { applyConfigDefaults, getValueWithConfig, setContentInstanceParams } from './utils';
+import { applyConfigDefaults, getValueWithConfig } from './utils';
 
 type ContentType<T> = ComponentType<T> | TemplateRef<T> | string;
 
@@ -188,7 +188,6 @@ export class NzModalService implements OnDestroy {
       const contentRef = modalContainer.attachComponentPortal<T>(
         new ComponentPortal(componentOrTemplateRef, config.nzViewContainerRef, injector)
       );
-      setContentInstanceParams<T>(contentRef.instance, config.nzComponentParams);
       modalRef.componentInstance = contentRef.instance;
     } else {
       modalContainer.attachStringContent();
@@ -201,7 +200,10 @@ export class NzModalService implements OnDestroy {
 
     return Injector.create({
       parent: userInjector || this.injector,
-      providers: [{ provide: NzModalRef, useValue: modalRef }]
+      providers: [
+        { provide: NzModalRef, useValue: modalRef },
+        { provide: NZ_MODAL_DATA, useValue: config.nzComponentParams }
+      ]
     });
   }
 

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -7,8 +7,8 @@ import {
   ChangeDetectionStrategy,
   Component,
   Directive,
+  Inject,
   Injector,
-  Input,
   NgModule,
   TemplateRef,
   ViewChild,
@@ -25,7 +25,9 @@ import {
   dispatchKeyboardEvent,
   dispatchMouseEvent
 } from 'ng-zorro-antd/core/testing';
+import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
+import { NZ_MODAL_DATA } from './modal-config';
 import { NzModalRef, NzModalState } from './modal-ref';
 import { NzModalComponent } from './modal.component';
 import { NzModalModule } from './modal.module';
@@ -1702,15 +1704,17 @@ class TestWithServiceComponent {
 
 @Component({
   template: `
-    <div class="modal-content">Hello {{ value }}</div>
+    <div class="modal-content">Hello {{ params?.value }}</div>
     <input />
     <button (click)="destroyModal()">destroy</button>
   `
 })
 class TestWithModalContentComponent {
-  @Input() value?: string;
-
-  constructor(public modalRef: NzModalRef, public modalInjector: Injector) {}
+  constructor(
+    public modalRef: NzModalRef,
+    public modalInjector: Injector,
+    @Inject(NZ_MODAL_DATA) public params: NzSafeAny
+  ) {}
 
   destroyModal(): void {
     this.modalRef.destroy();


### PR DESCRIPTION
BREAKING_CHANGES:

To retrieve the parameters of the nzContent component, it is no longer necessary to retrieve them using the @Input annotation. The token NZ_MODAL_COMPONENT_PARAMS allows to retrieve these parameters

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Refactor the way to retrieve nzContentParameters when nzContent is used as Component

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

To retrieve  nzContentParamters when nzContent is used as Component, we have to used annotation @Input() in our custom component

Issue Number:


## What is the new behavior?

To retrieve  nzContentParamters when nzContent is used as Component, we have to used the new injection token `NZ_MODAL_COMPONENT_PARAMS` in the nzContent component

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Replace @Input() annotation in the nzContent component by injecting the new injection token `NZ_MODAL_COMPONENT_PARAMS`


## Other information
