### PR TITLE
fix(module:checkbox): chebox group can't be disable initially

### DIFF
--- a/components/checkbox/checkbox-group.component.ts
+++ b/components/checkbox/checkbox-group.component.ts
@@ -70,6 +70,7 @@ export class NzCheckboxGroupComponent implements ControlValueAccessor, OnInit, O
   dir: Direction = 'ltr';
 
   private destroy$ = new Subject<void>();
+  private isNzDisableFirstChange: boolean = true;
 
   trackByOption(_: number, option: NzCheckBoxOptionInterface): string {
     return option.value;
@@ -125,7 +126,8 @@ export class NzCheckboxGroupComponent implements ControlValueAccessor, OnInit, O
   }
 
   setDisabledState(disabled: boolean): void {
-    this.nzDisabled = disabled;
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || disabled;
+    this.isNzDisableFirstChange = false;
     this.cdr.markForCheck();
   }
 }

--- a/components/checkbox/checkbox.spec.ts
+++ b/components/checkbox/checkbox.spec.ts
@@ -284,26 +284,38 @@ describe('checkbox', () => {
   describe('checkbox group form', () => {
     let fixture: ComponentFixture<NzTestCheckboxGroupFormComponent>;
     let testComponent: NzTestCheckboxGroupFormComponent;
-    let checkboxGroup: DebugElement;
-    let inputElement: HTMLInputElement;
-
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(NzTestCheckboxGroupFormComponent);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent = fixture.debugElement.componentInstance;
-      checkboxGroup = fixture.debugElement.query(By.directive(NzCheckboxGroupComponent));
-      inputElement = checkboxGroup.nativeElement.querySelector('input') as HTMLInputElement;
+      testComponent = fixture.componentInstance;
     }));
     it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+      fixture.detectChanges();
       flush();
+      const checkboxGroupComponent: NzCheckboxGroupComponent = fixture.debugElement.query(
+        By.directive(NzCheckboxGroupComponent)
+      ).componentInstance;
       expect(testComponent.formGroup.get('checkboxGroup')!.valid).toBe(true);
       expect(testComponent.formGroup.get('checkboxGroup')!.pristine).toBe(true);
       expect(testComponent.formGroup.get('checkboxGroup')!.touched).toBe(false);
+      expect(checkboxGroupComponent.nzDisabled).toBeFalsy();
+    }));
+    it('should be disable if form is disable and nzDisable set to false initially', fakeAsync(() => {
+      testComponent.formGroup.disable();
+      fixture.detectChanges();
+      flush();
+      const checkboxGroup = fixture.debugElement.query(By.directive(NzCheckboxGroupComponent));
+      expect(checkboxGroup.componentInstance.nzDisabled).toBeTruthy();
     }));
     it('should set disabled work', fakeAsync(() => {
+      testComponent.nzDisabled = true;
+      fixture.detectChanges();
       flush();
+      const checkboxGroup = fixture.debugElement.query(By.directive(NzCheckboxGroupComponent));
+      const inputElement = checkboxGroup.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(checkboxGroup.componentInstance.nzDisabled).toBeTruthy();
+
+      inputElement.click();
+      fixture.detectChanges();
       expect(JSON.stringify(testComponent.formGroup.get('checkboxGroup')!.value)).toBe(
         JSON.stringify([
           { label: 'Apple', value: 'Apple', checked: true },
@@ -311,9 +323,13 @@ describe('checkbox', () => {
           { label: 'Orange', value: 'Orange' }
         ])
       );
-      inputElement.click();
+
+      testComponent.enable();
       fixture.detectChanges();
       flush();
+      expect(checkboxGroup.componentInstance.nzDisabled).toBeFalsy();
+
+      inputElement.click();
       fixture.detectChanges();
       expect(JSON.stringify(testComponent.formGroup.get('checkboxGroup')!.value)).toBe(
         JSON.stringify([
@@ -322,12 +338,13 @@ describe('checkbox', () => {
           { label: 'Orange', value: 'Orange' }
         ])
       );
+
       testComponent.disable();
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
+      expect(checkboxGroup.componentInstance.nzDisabled).toBeTruthy();
+
       inputElement.click();
-      flush();
       fixture.detectChanges();
       expect(JSON.stringify(testComponent.formGroup.get('checkboxGroup')!.value)).toBe(
         JSON.stringify([
@@ -479,12 +496,13 @@ export class NzTestCheckboxFormComponent {
 @Component({
   template: `
     <form [formGroup]="formGroup">
-      <nz-checkbox-group formControlName="checkboxGroup"></nz-checkbox-group>
+      <nz-checkbox-group formControlName="checkboxGroup" [nzDisabled]="nzDisabled"></nz-checkbox-group>
     </form>
   `
 })
 export class NzTestCheckboxGroupFormComponent {
   formGroup: UntypedFormGroup;
+  nzDisabled = false;
 
   constructor(private formBuilder: UntypedFormBuilder) {
     this.formGroup = this.formBuilder.group({
@@ -500,6 +518,10 @@ export class NzTestCheckboxGroupFormComponent {
 
   disable(): void {
     this.formGroup.disable();
+  }
+
+  enable(): void {
+    this.formGroup.enable();
   }
 }
 

--- a/components/radio/radio-group.component.ts
+++ b/components/radio/radio-group.component.ts
@@ -56,6 +56,7 @@ export class NzRadioGroupComponent implements OnInit, ControlValueAccessor, OnDe
 
   private value: NzSafeAny | null = null;
   private destroy$ = new Subject();
+  private isNzDisableFirstChange: boolean = true;
   onChange: OnChangeType = () => {};
   onTouched: OnTouchedType = () => {};
   @Input() @InputBoolean() nzDisabled = false;
@@ -120,8 +121,9 @@ export class NzRadioGroupComponent implements OnInit, ControlValueAccessor, OnDe
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.nzDisabled = isDisabled;
-    this.nzRadioService.setDisabled(isDisabled);
+    this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || isDisabled;
+    this.isNzDisableFirstChange = false;
+    this.nzRadioService.setDisabled(this.nzDisabled);
     this.cdr.markForCheck();
   }
 }

--- a/components/radio/radio.spec.ts
+++ b/components/radio/radio.spec.ts
@@ -302,35 +302,59 @@ describe('radio', () => {
   describe('radio group form', () => {
     let fixture: ComponentFixture<NzTestRadioGroupFormComponent>;
     let testComponent: NzTestRadioGroupFormComponent;
-    let radios: DebugElement[];
 
     beforeEach(fakeAsync(() => {
       fixture = TestBed.createComponent(NzTestRadioGroupFormComponent);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent = fixture.debugElement.componentInstance;
-      radios = fixture.debugElement.queryAll(By.directive(NzRadioComponent));
+      testComponent = fixture.componentInstance;
     }));
     it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
+      fixture.detectChanges();
       flush();
+      const radioGroup: NzRadioGroupComponent = fixture.debugElement.query(
+        By.directive(NzRadioGroupComponent)
+      ).componentInstance;
       expect(testComponent.formGroup.valid).toBe(true);
       expect(testComponent.formGroup.pristine).toBe(true);
       expect(testComponent.formGroup.touched).toBe(false);
+      expect(radioGroup.nzDisabled).toBeFalsy();
+    }));
+    it('should be disable if form is disable and nzDisable set to false initially', fakeAsync(() => {
+      testComponent.formGroup.disable();
+      fixture.detectChanges();
+      flush();
+      const radioGroup: NzRadioGroupComponent = fixture.debugElement.query(
+        By.directive(NzRadioGroupComponent)
+      ).componentInstance;
+      expect(radioGroup.nzDisabled).toBeTruthy();
     }));
     it('should set disabled work', fakeAsync(() => {
+      testComponent.nzDisabled = true;
+      fixture.detectChanges();
       flush();
+      const radios = fixture.debugElement.queryAll(By.directive(NzRadioComponent));
+      const radioGroup: NzRadioGroupComponent = fixture.debugElement.query(
+        By.directive(NzRadioGroupComponent)
+      ).componentInstance;
+      expect(radioGroup.nzDisabled).toBeTruthy();
+      radios[0].nativeElement.click();
+      fixture.detectChanges();
       expect(testComponent.formGroup.get('radioGroup')!.value).toBe('B');
+
+      testComponent.enable();
+      fixture.detectChanges();
+      flush();
+
+      expect(radioGroup.nzDisabled).toBeFalsy();
       radios[0].nativeElement.click();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('radioGroup')!.value).toBe('A');
+
       testComponent.disable();
       fixture.detectChanges();
       flush();
-      fixture.detectChanges();
+
+      expect(radioGroup.nzDisabled).toBeTruthy();
       radios[1].nativeElement.click();
-      fixture.detectChanges();
-      flush();
       fixture.detectChanges();
       expect(testComponent.formGroup.get('radioGroup')!.value).toBe('A');
     }));
@@ -488,7 +512,7 @@ export class NzTestRadioFormComponent {
 @Component({
   template: `
     <form [formGroup]="formGroup">
-      <nz-radio-group formControlName="radioGroup">
+      <nz-radio-group formControlName="radioGroup" [nzDisabled]="nzDisabled">
         <label nz-radio-button nzValue="A">A</label>
         <label nz-radio-button nzValue="B">B</label>
         <label nz-radio-button nzValue="C">C</label>
@@ -499,6 +523,7 @@ export class NzTestRadioFormComponent {
 })
 export class NzTestRadioGroupFormComponent {
   formGroup: UntypedFormGroup;
+  nzDisabled = false;
 
   constructor(private formBuilder: UntypedFormBuilder) {
     this.formGroup = this.formBuilder.group({
@@ -508,6 +533,10 @@ export class NzTestRadioGroupFormComponent {
 
   disable(): void {
     this.formGroup.disable();
+  }
+
+  enable(): void {
+    this.formGroup.enable();
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Fix a regression on disabling radio group and checkbox group initially if form is enable and input nzDisabled is set to true

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Radio Group and Checkbox group is enabled if form is initially enable and input nzDisabled is set to true

Issue Number


## What is the new behavior?
Radio Group and Checkbox group is disabled if form is initially enable and input nzDisabled is set to true

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
