### PR TITLE
feat(module:type): support string literal union and auto complete

### DIFF
--- a/components/badge/badge.component.ts
+++ b/components/badge/badge.component.ts
@@ -26,7 +26,7 @@ import { takeUntil } from 'rxjs/operators';
 import { zoomBadgeMotion } from 'ng-zorro-antd/core/animation';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
-import { BooleanInput, NzSafeAny, NzSizeDSType } from 'ng-zorro-antd/core/types';
+import { BooleanInput, NzSafeAny, NzSizeDSType, NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 
 import { badgePresetColors } from './preset-colors';
@@ -93,7 +93,7 @@ export class NzBadgeComponent implements OnChanges, OnDestroy, OnInit {
   @Input() nzStyle: { [key: string]: string } | null = null;
   @Input() nzText?: string | TemplateRef<void> | null = null;
   @Input() nzTitle?: string | null | undefined;
-  @Input() nzStatus?: NzBadgeStatusType | string;
+  @Input() nzStatus?: NzStringLiteralUnion<NzBadgeStatusType>;
   @Input() nzCount?: number | TemplateRef<NzSafeAny>;
   @Input() nzOffset?: [number, number];
   @Input() nzSize: NzSizeDSType = 'default';

--- a/components/card/card.component.ts
+++ b/components/card/card.component.ts
@@ -22,7 +22,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
-import { BooleanInput, NgStyleInterface, NzSizeDSType } from 'ng-zorro-antd/core/types';
+import { BooleanInput, NgStyleInterface, NzSizeDSType, NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 
 import { NzCardGridDirective } from './card-grid.directive';
@@ -93,7 +93,7 @@ export class NzCardComponent implements OnDestroy, OnInit {
   @Input() nzBodyStyle: NgStyleInterface | null = null;
   @Input() nzCover?: TemplateRef<void>;
   @Input() nzActions: Array<TemplateRef<void>> = [];
-  @Input() nzType: string | 'inner' | null = null;
+  @Input() nzType: NzStringLiteralUnion<'inner'> | null = null;
   @Input() @WithConfig() nzSize: NzSizeDSType = 'default';
   @Input() nzTitle?: string | TemplateRef<void>;
   @Input() nzExtra?: string | TemplateRef<void>;

--- a/components/carousel/typings.ts
+++ b/components/carousel/typings.ts
@@ -6,11 +6,13 @@
 import { Direction } from '@angular/cdk/bidi';
 import { InjectionToken, NgZone, QueryList } from '@angular/core';
 
+import { NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
+
 import { NzCarouselContentDirective } from './carousel-content.directive';
 import { NzCarouselBaseStrategy } from './strategies/base-strategy';
 
-export type NzCarouselEffects = 'fade' | 'scrollx' | string;
-export type NzCarouselDotPosition = 'top' | 'bottom' | 'left' | 'right' | string;
+export type NzCarouselEffects = NzStringLiteralUnion<'fade' | 'scrollx'>;
+export type NzCarouselDotPosition = NzStringLiteralUnion<'top' | 'bottom' | 'left' | 'right'>;
 
 export interface NzCarouselComponentAsSource {
   carouselContents: QueryList<NzCarouselContentDirective>;

--- a/components/core/types/type.ts
+++ b/components/core/types/type.ts
@@ -4,3 +4,6 @@
  */
 
 export const tuple = <T extends string[]>(...args: T): T => args;
+
+// https://github.com/Microsoft/TypeScript/issues/29729
+export type NzStringLiteralUnion<T extends string> = T | (string & {});

--- a/components/empty/empty.component.ts
+++ b/components/empty/empty.component.ts
@@ -18,10 +18,11 @@ import {
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
+import { NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 import { NzEmptyI18nInterface, NzI18nService } from 'ng-zorro-antd/i18n';
 
 const NzEmptyDefaultImages = ['default', 'simple'] as const;
-type NzEmptyNotFoundImageType = typeof NzEmptyDefaultImages[number] | null | string | TemplateRef<void>;
+type NzEmptyNotFoundImageType = NzStringLiteralUnion<typeof NzEmptyDefaultImages[number]> | null | TemplateRef<void>;
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/components/graph/graph-edge.component.ts
+++ b/components/graph/graph-edge.component.ts
@@ -19,6 +19,8 @@ import { take } from 'rxjs/operators';
 
 import { curveBasis, curveLinear, line } from 'd3-shape';
 
+import { NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
+
 import { NzGraphEdge, NzGraphEdgeType } from './interface';
 
 @Component({
@@ -40,7 +42,7 @@ import { NzGraphEdge, NzGraphEdgeType } from './interface';
 })
 export class NzGraphEdgeComponent implements OnInit, OnChanges {
   @Input() edge!: NzGraphEdge;
-  @Input() edgeType?: NzGraphEdgeType | string;
+  @Input() edgeType?: NzStringLiteralUnion<NzGraphEdgeType>;
 
   @Input() customTemplate?: TemplateRef<{
     $implicit: NzGraphEdge;

--- a/components/graph/interface.ts
+++ b/components/graph/interface.ts
@@ -14,8 +14,9 @@ import {
   LayoutConfig
 } from 'dagre-compound';
 
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { NzSafeAny, NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 
+// TODO: Convert to string literal type
 export enum NzGraphEdgeType {
   LINE = 'line',
   CURVE = 'curve'
@@ -87,7 +88,7 @@ export interface NzGraphBaseLayout {
     maxLabelWidth: number;
   };
   defaultEdge: {
-    type: NzGraphEdgeType | string; // Need to support extensions
+    type: NzStringLiteralUnion<NzGraphEdgeType>; // Need to support extensions
   };
 }
 

--- a/components/message/message.service.ts
+++ b/components/message/message.service.ts
@@ -7,11 +7,12 @@ import { Overlay } from '@angular/cdk/overlay';
 import { Injectable, Injector, TemplateRef } from '@angular/core';
 
 import { NzSingletonService } from 'ng-zorro-antd/core/services';
+import { NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 
 import { NzMNService } from './base';
 import { NzMessageContainerComponent } from './message-container.component';
 import { NzMessageServiceModule } from './message.service.module';
-import { NzMessageData, NzMessageDataOptions, NzMessageRef } from './typings';
+import { NzMessageData, NzMessageDataOptions, NzMessageRef, NzMessageType } from './typings';
 
 @Injectable({
   providedIn: NzMessageServiceModule
@@ -45,7 +46,7 @@ export class NzMessageService extends NzMNService {
   }
 
   create(
-    type: 'success' | 'info' | 'warning' | 'error' | 'loading' | string,
+    type: NzStringLiteralUnion<NzMessageType>,
     content: string | TemplateRef<void>,
     options?: NzMessageDataOptions
   ): NzMessageRef {

--- a/components/message/typings.ts
+++ b/components/message/typings.ts
@@ -6,6 +6,8 @@
 import { TemplateRef } from '@angular/core';
 import { Subject } from 'rxjs';
 
+import { NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
+
 export type NzMessageType = 'success' | 'info' | 'warning' | 'error' | 'loading';
 
 export interface NzMessageDataOptions {
@@ -15,7 +17,7 @@ export interface NzMessageDataOptions {
 }
 
 export interface NzMessageData {
-  type?: NzMessageType | string;
+  type?: NzStringLiteralUnion<NzMessageType>;
   content?: string | TemplateRef<void>;
   messageId?: string;
   createdAt?: Date;

--- a/components/notification/notification.service.ts
+++ b/components/notification/notification.service.ts
@@ -7,11 +7,12 @@ import { Overlay } from '@angular/cdk/overlay';
 import { Injectable, Injector, TemplateRef } from '@angular/core';
 
 import { NzSingletonService } from 'ng-zorro-antd/core/services';
+import { NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 import { NzMNService } from 'ng-zorro-antd/message';
 
 import { NzNotificationContainerComponent } from './notification-container.component';
 import { NzNotificationServiceModule } from './notification.service.module';
-import { NzNotificationData, NzNotificationDataOptions, NzNotificationRef } from './typings';
+import { NzNotificationData, NzNotificationDataOptions, NzNotificationRef, NzNotificationType } from './typings';
 
 let notificationId = 0;
 
@@ -47,7 +48,7 @@ export class NzNotificationService extends NzMNService {
   }
 
   create(
-    type: 'success' | 'info' | 'warning' | 'error' | 'blank' | string,
+    type: NzStringLiteralUnion<NzNotificationType>,
     title: string,
     content: string,
     options?: NzNotificationDataOptions

--- a/components/notification/typings.ts
+++ b/components/notification/typings.ts
@@ -6,8 +6,9 @@
 import { TemplateRef } from '@angular/core';
 import { Subject } from 'rxjs';
 
-import { NgClassInterface, NgStyleInterface } from 'ng-zorro-antd/core/types';
+import { NgClassInterface, NgStyleInterface, NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 
+export type NzNotificationType = 'success' | 'info' | 'warning' | 'error' | 'blank';
 export type NzNotificationPlacement = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight' | 'top' | 'bottom';
 
 export interface NzNotificationDataOptions<T = {}> {
@@ -30,7 +31,7 @@ export interface NzNotificationData {
   state?: 'enter' | 'leave';
   template?: TemplateRef<{}>;
   title?: string;
-  type?: 'success' | 'info' | 'warning' | 'error' | 'blank' | string;
+  type?: NzStringLiteralUnion<NzNotificationType>;
 
   // observables exposed to users
   onClose?: Subject<boolean>;

--- a/components/pagination/pagination-item.component.ts
+++ b/components/pagination/pagination-item.component.ts
@@ -15,7 +15,7 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { NzSafeAny, NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 import { NzPaginationI18nInterface } from 'ng-zorro-antd/i18n';
 import { PaginationItemRenderContext, PaginationItemType } from './pagination.types';
 
@@ -79,7 +79,7 @@ import { PaginationItemRenderContext, PaginationItemType } from './pagination.ty
   }
 })
 export class NzPaginationItemComponent implements OnChanges {
-  static ngAcceptInputType_type: PaginationItemType | string | null | undefined;
+  static ngAcceptInputType_type: NzStringLiteralUnion<PaginationItemType> | null | undefined;
   static ngAcceptInputType_index: number | null | undefined;
 
   @Input() active = false;
@@ -87,7 +87,7 @@ export class NzPaginationItemComponent implements OnChanges {
   @Input() index: number | null = null;
   @Input() disabled = false;
   @Input() direction = 'ltr';
-  @Input() type: PaginationItemType | string | null = null;
+  @Input() type: NzStringLiteralUnion<PaginationItemType> | null = null;
   @Input() itemRender: TemplateRef<PaginationItemRenderContext> | null = null;
   @Output() readonly diffIndex = new EventEmitter<number>();
   @Output() readonly gotoIndex = new EventEmitter<number>();

--- a/components/table/src/table.types.ts
+++ b/components/table/src/table.types.ts
@@ -3,14 +3,14 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { NzSafeAny, NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 
 export type NzTableLayout = 'fixed' | 'auto';
 export type NzTablePaginationPosition = 'top' | 'bottom' | 'both';
 export type NzTablePaginationType = 'default' | 'small';
 export type NzTableSize = 'middle' | 'default' | 'small';
 export type NzTableFilterList = Array<{ text: string; value: NzSafeAny; byDefault?: boolean }>;
-export type NzTableSortOrder = string | 'ascend' | 'descend' | null;
+export type NzTableSortOrder = NzStringLiteralUnion<'ascend' | 'descend'> | null;
 export type NzTableSortFn<T = unknown> = (a: T, b: T, sortOrder?: NzTableSortOrder) => number;
 export type NzTableFilterValue = NzSafeAny[] | NzSafeAny;
 export type NzTableFilterFn<T = unknown> = (value: NzTableFilterValue, data: T) => boolean;

--- a/components/tag/tag.component.ts
+++ b/components/tag/tag.component.ts
@@ -31,7 +31,7 @@ import {
   presetColors,
   statusColors
 } from 'ng-zorro-antd/core/color';
-import { BooleanInput } from 'ng-zorro-antd/core/types';
+import { BooleanInput, NzStringLiteralUnion } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 
 @Component({
@@ -65,7 +65,7 @@ export class NzTagComponent implements OnChanges, OnDestroy, OnInit {
   static ngAcceptInputType_nzChecked: BooleanInput;
   isPresetColor = false;
   @Input() nzMode: 'default' | 'closeable' | 'checkable' = 'default';
-  @Input() nzColor?: string | NzStatusColor | NzPresetColor;
+  @Input() nzColor?: NzStringLiteralUnion<NzStatusColor | NzPresetColor>;
   @Input() @InputBoolean() nzChecked = false;
   @Output() readonly nzOnClose = new EventEmitter<MouseEvent>();
   @Output() readonly nzCheckedChange = new EventEmitter<boolean>();

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -25,7 +25,7 @@ import {
 import { zoomBigMotion } from 'ng-zorro-antd/core/animation';
 import { isPresetColor, NzPresetColor } from 'ng-zorro-antd/core/color';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
-import { BooleanInput, NgStyleInterface, NzTSType } from 'ng-zorro-antd/core/types';
+import { BooleanInput, NgStyleInterface, NzStringLiteralUnion, NzTSType } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 
 import {
@@ -130,7 +130,7 @@ export class NzToolTipComponent extends NzTooltipBaseComponent {
   override nzTitle: NzTSType | null = null;
   nzTitleContext: Object | null = null;
 
-  nzColor?: string | NzPresetColor;
+  nzColor?: NzStringLiteralUnion<NzPresetColor>;
 
   _contentStyleMap: NgStyleInterface = {};
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "An enterprise-class UI components based on Ant Design and Angular",
   "engines": {
-    "node": "^14.20.0 || ˆ16.13.0 || >=18.10.0"
+    "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
   },
   "scripts": {
     "start": "NODE_ENV=development gulp start:dev",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

不能出现智能提示，原因是联合类型将父子类型合并只保留了最高类型:

![image](https://user-images.githubusercontent.com/51586637/212276961-b4f6e6c6-e6f6-4b67-9146-540811c8c2ad.png)

## What is the new behavior?

支持智能提示:

![image](https://user-images.githubusercontent.com/51586637/212277175-e5dd01e8-4c3d-4216-ba38-affb7ae5ce8c.png)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

主要是实现一个类型。

这个类型的功能是，将字符串字面量类型和字符串类型进行联合，而不是合并简化：

```ts
type NzStringLiteralUnion<T extends string> = T | (string & {});
```

以前有考虑过这么做吗？

Reference: https://github.com/Microsoft/TypeScript/issues/29729