### PR TITLE
fix: gulp file read endless waiting

### DIFF
--- a/scripts/build-config.ts
+++ b/scripts/build-config.ts
@@ -22,6 +22,11 @@ export function findBuildConfig(): string {
   let currentDir = process.cwd();
 
   while (!existsSync(resolve(currentDir, BUILD_CONFIG_FILENAME))) {
+    if (currentDir === '/') {
+      console.error('Can not find build-config.js');
+      break;
+    }
+
     currentDir = dirname(currentDir);
   }
 

--- a/scripts/build-config.ts
+++ b/scripts/build-config.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { dirname, join, parse, resolve } from 'path';
 
 export interface BuildConfig {
   projectVersion: string;
@@ -22,8 +22,8 @@ export function findBuildConfig(): string {
   let currentDir = process.cwd();
 
   while (!existsSync(resolve(currentDir, BUILD_CONFIG_FILENAME))) {
-    if (currentDir === '/') {
-      console.error('Can not find build-config.js');
+    if (currentDir === parse(process.cwd()).root) {
+      console.error(`Can not find ${BUILD_CONFIG_FILENAME}`);
       break;
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If build-config.js does not exist, the gulp command will cause endless waiting


## What is the new behavior?

When the search reaches the end of the file system and still does not find the target file, then throw an error

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
