### PR TITLE
docs(module:typography): remove undesired tag

### DIFF
--- a/components/typography/demo/text.ts
+++ b/components/typography/demo/text.ts
@@ -16,9 +16,7 @@ import { Component } from '@angular/core';
     <span nz-typography><del>Ant Design (delete)</del></span>
     <span nz-typography><strong>Ant Design (strong)</strong></span>
     <span nz-typography>
-      <a href="https://ng.ant.design/" target="_blank">
-        Ant Design
-      </a>
+      <a href="https://ng.ant.design/" target="_blank">Ant Design</a>
     </span>
   `,
   styles: [

--- a/components/typography/demo/text.ts
+++ b/components/typography/demo/text.ts
@@ -18,7 +18,6 @@ import { Component } from '@angular/core';
     <span nz-typography>
       <a href="https://ng.ant.design/" target="_blank">
         Ant Design
-        <Link />
       </a>
     </span>
   `,


### PR DESCRIPTION
Remove mistakenly placed `<Link />` tag in typography docs

https://github.com/NG-ZORRO/ng-zorro-antd/issues/7832

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
