### PR TITLE
fix: add error handler for style file load failed

### DIFF
--- a/scripts/site/_site/doc/app/app.component.ts
+++ b/scripts/site/_site/doc/app/app.component.ts
@@ -116,10 +116,16 @@ export class AppComponent implements OnInit {
       style.rel = 'stylesheet';
       style.id = `site-theme-${theme}`;
       style.href = `assets/${theme}.css`;
+      document.body.append(style);
+
       style.onload = () => {
         successLoaded();
       };
-      document.body.append(style);
+      style.onerror = () => {
+        this.nzMessageService.remove(loading?.messageId);
+        this.nzMessageService.error(this.language === 'en' ? `Switching theme failed` : `切换主题失败`);
+        document.getElementById(style.id)?.remove();
+      };
     } else {
       successLoaded();
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

when theme style file load failed (not exists or other causes), <link...${theme}...> will  always be added in DOM and useless.
and the message component will always display with processing UI.

## What is the new behavior?
If theme style file load failed, show error message with "Switching theme failed" and will not add multi-same <link> in DOM

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
