### PR TITLE
fix(module:radio): update `touch` status when `focus` and `blur` events

### DIFF
--- a/components/radio/radio.component.ts
+++ b/components/radio/radio.component.ts
@@ -214,6 +214,7 @@ export class NzRadioComponent implements ControlValueAccessor, AfterViewInit, On
             return;
           }
           this.ngZone.run(() => {
+            this.focus();
             this.nzRadioService?.select(this.nzValue);
             if (this.isNgModel) {
               this.isChecked = true;


### PR DESCRIPTION
Fixes #7877.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```


## What is the new behavior?
After clicking on a radio element, the focus monitor for the form state of the `touch` element is started


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
