### PR TITLE
feat(module:table): add `nzLabel` to include aria-label in checkboxes

### DIFF
--- a/components/table/demo/row-selection-and-operation.ts
+++ b/components/table/demo/row-selection-and-operation.ts
@@ -32,7 +32,12 @@ export interface Data {
     >
       <thead>
         <tr>
-          <th [nzChecked]="checked" [nzIndeterminate]="indeterminate" (nzCheckedChange)="onAllChecked($event)"></th>
+          <th
+            [nzChecked]="checked"
+            [nzIndeterminate]="indeterminate"
+            nzLabel="Select all"
+            (nzCheckedChange)="onAllChecked($event)"
+          ></th>
           <th>Name</th>
           <th>Age</th>
           <th>Address</th>
@@ -43,6 +48,7 @@ export interface Data {
           <td
             [nzChecked]="setOfCheckedId.has(data.id)"
             [nzDisabled]="data.disabled"
+            [nzLabel]="data.name"
             (nzCheckedChange)="onItemChecked(data.id, $event)"
           ></td>
           <td>{{ data.name }}</td>

--- a/components/table/doc/index.en-US.md
+++ b/components/table/doc/index.en-US.md
@@ -109,6 +109,7 @@ Checkbox property
 | `[nzShowCheckbox]` | Whether `nz-checkbox` should be shown in the header | `boolean` | - |
 | `[nzDisabled]` | Whether the `nz-checkbox` is disabled | `boolean` | - |
 | `[nzIndeterminate]` | `nz-checkbox` indeterminate status | `boolean` | - |
+| `[nzLabel]` | ARIA label for the `nz-checkbox` | `string` | - |
 | `[nzChecked]` | Checked status, double binding | `boolean` | - |
 | `(nzCheckedChange)` | Callback when checked status changes | `EventEmitter<boolean>` | - |
 
@@ -170,6 +171,7 @@ Checkbox property
 | `[nzShowCheckbox]` | Whether add nz-checkbox | `boolean` | - |
 | `[nzDisabled]` | Whether disable checkbox | `boolean` | - |
 | `[nzIndeterminate]` | Indeterminate status | `boolean` | - |
+| `[nzLabel]` | ARIA label for the `nz-checkbox` | `string` | - |
 | `[nzChecked]` | Checked status, double binding | `boolean` | - |
 | `(nzCheckedChange)` | Checked status change callback | `EventEmitter<boolean>` | - |
 | `[colSpan]` | how many columns the cell extends | `number` | `null` |

--- a/components/table/doc/index.zh-CN.md
+++ b/components/table/doc/index.zh-CN.md
@@ -110,6 +110,7 @@ Table 组件同时具备了易用性和高度可定制性
 | `[nzShowCheckbox]` | 是否添加checkbox | `boolean` | - |
 | `[nzDisabled]` | checkbox 是否禁用 | `boolean` | - |
 | `[nzIndeterminate]` | checkbox indeterminate 状态 | `boolean` | - |
+| `[nzLabel]` | checkbox 的可访问性标签 | `string` | - |
 | `[nzChecked]` | checkbox 是否被选中，可双向绑定 | `boolean` | - |
 | `(nzCheckedChange)` | 选中的回调 | `EventEmitter<boolean>` | - |
 
@@ -170,6 +171,7 @@ Table 组件同时具备了易用性和高度可定制性
 | `[nzShowCheckbox]` | 是否添加checkbox | `boolean` | - |
 | `[nzDisabled]` | checkbox 是否禁用 | `boolean` | - |
 | `[nzIndeterminate]` | checkbox indeterminate 状态 | `boolean` | - |
+| `[nzLabel]` | checkbox 的可访问性标签 | `string` | - |
 | `[nzChecked]` | checkbox 是否被选中，可双向绑定 | `boolean` | - |
 | `(nzCheckedChange)` | 选中的回调 | `EventEmitter<boolean>` | - |
 

--- a/components/table/src/addon/selection.component.ts
+++ b/components/table/src/addon/selection.component.ts
@@ -20,6 +20,7 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
       [ngModel]="checked"
       [nzDisabled]="disabled"
       [nzIndeterminate]="indeterminate"
+      [attr.aria-label]="label"
       (ngModelChange)="onCheckedChange($event)"
     ></label>
     <div class="ant-table-selection-extra" *ngIf="showRowSelection">
@@ -42,6 +43,7 @@ export class NzTableSelectionComponent {
   @Input() checked = false;
   @Input() disabled = false;
   @Input() indeterminate = false;
+  @Input() label: string | null = null;
   @Input() showCheckbox = false;
   @Input() showRowSelection = false;
   @Output() readonly checkedChange = new EventEmitter<boolean>();

--- a/components/table/src/cell/td-addon.component.ts
+++ b/components/table/src/cell/td-addon.component.ts
@@ -42,6 +42,7 @@ import { InputBoolean } from 'ng-zorro-antd/core/util';
       [nzDisabled]="nzDisabled"
       [ngModel]="nzChecked"
       [nzIndeterminate]="nzIndeterminate"
+      [attr.aria-label]="nzLabel"
       (ngModelChange)="onCheckedChange($event)"
     ></label>
     <ng-content></ng-content>
@@ -59,6 +60,7 @@ export class NzTdAddOnComponent implements OnChanges {
   @Input() nzChecked = false;
   @Input() nzDisabled = false;
   @Input() nzIndeterminate = false;
+  @Input() nzLabel: string | null = null;
   @Input() nzIndentSize = 0;
   @Input() @InputBoolean() nzShowExpand = false;
   @Input() @InputBoolean() nzShowCheckbox = false;

--- a/components/table/src/cell/th-selection.component.ts
+++ b/components/table/src/cell/th-selection.component.ts
@@ -29,6 +29,7 @@ import { InputBoolean } from 'ng-zorro-antd/core/util';
       [checked]="nzChecked"
       [disabled]="nzDisabled"
       [indeterminate]="nzIndeterminate"
+      [label]="nzLabel"
       [listOfSelections]="nzSelections"
       [showCheckbox]="nzShowCheckbox"
       [showRowSelection]="nzShowRowSelection"
@@ -46,6 +47,7 @@ export class NzThSelectionComponent implements OnChanges {
   @Input() nzChecked = false;
   @Input() nzDisabled = false;
   @Input() nzIndeterminate = false;
+  @Input() nzLabel: string | null = null;
   @Input() @InputBoolean() nzShowCheckbox = false;
   @Input() @InputBoolean() nzShowRowSelection = false;
   @Output() readonly nzCheckedChange = new EventEmitter<boolean>();

--- a/components/table/src/testing/td.spec.ts
+++ b/components/table/src/testing/td.spec.ts
@@ -137,6 +137,12 @@ describe('nz-td', () => {
         }).createComponent(NzTestDisableTdComponent);
       }).toThrow();
     });
+    it('should add aria-label', () => {
+      testComponent.label = 'test-label';
+      fixture.detectChanges();
+      console.log(td.nativeElement.querySelector('label').attributes.getNamedItem('aria-label').value);
+      expect(td.nativeElement.querySelector('label').attributes.getNamedItem('aria-label').value).toBe('test-label'); //toContain('test-label');
+    });
   });
 });
 
@@ -145,6 +151,7 @@ describe('nz-td', () => {
     <td
       [(nzChecked)]="checked"
       [nzIndeterminate]="indeterminate"
+      [nzLabel]="label"
       (nzCheckedChange)="checkedChange($event)"
       [nzDisabled]="disabled"
       [(nzExpand)]="expand"
@@ -165,6 +172,7 @@ export class NzTestTdComponent {
   indentSize?: number;
   left?: string | number;
   right?: string | number;
+  label?: string | null;
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It's impossible to add an accessible label to the built-in checkboxes in tables, making screen readers just read "checkbox" over and over again when tabbing through a table.

## What is the new behavior?

It is possible to set an `aria-label` on checkboxes in `th`s and `td`s with `nzShowCheckbox` (or `nzChecked`, etc.)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
