### PR TITLE
fix(module:select): cannot read properties of null when nzOptions null

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -363,7 +363,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
     this.activatedValue = (activatedItem && activatedItem.nzValue) || null;
     let listOfGroupLabel: Array<string | number | TemplateRef<NzSafeAny> | null> = [];
     if (this.isReactiveDriven) {
-      listOfGroupLabel = [...new Set(this.nzOptions.filter(o => o.groupLabel).map(o => o.groupLabel!))];
+      listOfGroupLabel = [...new Set(this.nzOptions?.filter(o => o.groupLabel).map(o => o.groupLabel!))];
     } else {
       if (this.listOfNzOptionGroupComponent) {
         listOfGroupLabel = this.listOfNzOptionGroupComponent.map(o => o.nzLabel);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`Cannot read properties of null (reading 'filter')  at NzSelectComponent.updateListOfContainerItem`
This error occurs when using `[nzOptions]="(countries | async)!"` and retrive data from api

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
