### PR TITLE
feat(module:dropdown): close context menu on escape

### DIFF
--- a/components/dropdown/context-menu.service.spec.ts
+++ b/components/dropdown/context-menu.service.spec.ts
@@ -1,3 +1,4 @@
+import { ESCAPE } from '@angular/cdk/keycodes';
 import { OverlayContainer, ScrollDispatcher } from '@angular/cdk/overlay';
 import { ApplicationRef, Component, Provider, Type, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, inject, tick } from '@angular/core/testing';
@@ -5,7 +6,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Subject } from 'rxjs';
 
-import { createMouseEvent } from 'ng-zorro-antd/core/testing';
+import { createKeyboardEvent, createMouseEvent, dispatchEvent } from 'ng-zorro-antd/core/testing';
 import { NzMenuModule } from 'ng-zorro-antd/menu';
 
 import { NzContextMenuService } from './context-menu.service';
@@ -114,6 +115,27 @@ describe('context-menu', () => {
       fixture.detectChanges();
       expect(overlayContainerElement.textContent).toContain('1st menu item');
       document.body.click();
+      fixture.detectChanges();
+      tick(1000);
+      fixture.detectChanges();
+      expect(overlayContainerElement.textContent).toBe('');
+    }).not.toThrowError();
+  }));
+  it('should backdrop work with keyboard event ESCAPE', fakeAsync(() => {
+    const fixture = createComponent(NzTestDropdownContextMenuComponent, [], []);
+    const keyboardEvent = createKeyboardEvent('keydown', ESCAPE, undefined, 'Escape');
+    fixture.detectChanges();
+    expect(overlayContainerElement.textContent).toBe('');
+    fixture.detectChanges();
+    expect(() => {
+      const fakeEvent = createMouseEvent('contextmenu', 300, 300);
+      const component = fixture.componentInstance;
+      component.nzContextMenuService.create(fakeEvent, component.nzDropdownMenuComponent);
+      fixture.detectChanges();
+      tick(1000);
+      fixture.detectChanges();
+      expect(overlayContainerElement.textContent).toContain('1st menu item');
+      dispatchEvent(document.body, keyboardEvent);
       fixture.detectChanges();
       tick(1000);
       fixture.detectChanges();

--- a/components/dropdown/context-menu.service.ts
+++ b/components/dropdown/context-menu.service.ts
@@ -6,8 +6,8 @@
 import { ConnectionPositionPair, Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { Injectable, NgZone } from '@angular/core';
-import { fromEvent, Subscription } from 'rxjs';
-import { filter, take } from 'rxjs/operators';
+import { fromEvent, merge, Subscription } from 'rxjs';
+import { filter, first, take } from 'rxjs/operators';
 
 import { NzContextMenuServiceModule } from './context-menu.service.module';
 import { NzDropdownMenuComponent } from './dropdown-menu.component';
@@ -51,14 +51,18 @@ export class NzContextMenuService {
 
     this.closeSubscription.add(
       this.ngZone.runOutsideAngular(() =>
-        fromEvent<MouseEvent>(document, 'click')
-          .pipe(
+        merge(
+          fromEvent<MouseEvent>(document, 'click').pipe(
             filter(event => !!this.overlayRef && !this.overlayRef.overlayElement.contains(event.target as HTMLElement)),
             /** handle firefox contextmenu event **/
             filter(event => event.button !== 2),
             take(1)
+          ),
+          fromEvent<KeyboardEvent>(document, 'keydown').pipe(
+            filter(event => event.key === 'Escape'),
+            first()
           )
-          .subscribe(() => this.ngZone.run(() => this.close()))
+        ).subscribe(() => this.ngZone.run(() => this.close()))
       )
     );
 

--- a/components/dropdown/context-menu.service.ts
+++ b/components/dropdown/context-menu.service.ts
@@ -7,7 +7,7 @@ import { ConnectionPositionPair, Overlay, OverlayRef } from '@angular/cdk/overla
 import { TemplatePortal } from '@angular/cdk/portal';
 import { Injectable, NgZone } from '@angular/core';
 import { fromEvent, merge, Subscription } from 'rxjs';
-import { filter, first, take } from 'rxjs/operators';
+import { filter, first } from 'rxjs/operators';
 
 import { NzContextMenuServiceModule } from './context-menu.service.module';
 import { NzDropdownMenuComponent } from './dropdown-menu.component';
@@ -55,14 +55,12 @@ export class NzContextMenuService {
           fromEvent<MouseEvent>(document, 'click').pipe(
             filter(event => !!this.overlayRef && !this.overlayRef.overlayElement.contains(event.target as HTMLElement)),
             /** handle firefox contextmenu event **/
-            filter(event => event.button !== 2),
-            take(1)
+            filter(event => event.button !== 2)
           ),
-          fromEvent<KeyboardEvent>(document, 'keydown').pipe(
-            filter(event => event.key === 'Escape'),
-            first()
-          )
-        ).subscribe(() => this.ngZone.run(() => this.close()))
+          fromEvent<KeyboardEvent>(document, 'keydown').pipe(filter(event => event.key === 'Escape'))
+        )
+          .pipe(first())
+          .subscribe(() => this.ngZone.run(() => this.close()))
       )
     );
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently on dropwdown context menu it's only possible to close the context menu if the user click outside of this context menu or clikcon an item of this context menu

Issue Number: #7911


## What is the new behavior?

Now it's possible to close the context menu on pressing the button key espcape


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
