### PR TITLE
fix(module:date-picker): ng-untouched when loose focus

### DIFF
--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -330,6 +330,21 @@ describe('NzDatePickerComponent', () => {
       expect(getPickerContainer()).toBeNull();
     }));
 
+    it('should mark the control touched when user loseFocus of datePicker', fakeAsync(() => {
+      fixtureInstance.useSuite = 4;
+      fixtureInstance.control = new FormControl<Date | null>(null);
+      fixture.detectChanges();
+      flush();
+      const datePickerElement = fixture.debugElement.query(By.directive(NzDatePickerComponent)).nativeElement;
+      openPickerByClickTrigger();
+      expect(datePickerElement.classList).toContain('ng-untouched');
+      triggerInputBlur();
+      fixture.detectChanges();
+      flush();
+      expect(datePickerElement.classList).toContain('ng-touched');
+      expect(fixtureInstance.control.touched).toBeTruthy();
+    }));
+
     it('should support nzInputReadOnly', fakeAsync(() => {
       fixtureInstance.nzInputReadOnly = true;
       fixture.detectChanges();

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -435,6 +435,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, AfterViewInit, 
   // blur event has not the relatedTarget in IE11, use focusout instead.
   onFocusout(event: FocusEvent): void {
     event.preventDefault();
+    this.onTouchedFn();
     if (!this.elementRef.nativeElement.contains(<Node>event.relatedTarget)) {
       this.checkAndClose();
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
This PR introduce a bug fix. 


```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Before this PR, when the user  loose the focus without selected a value of date-picker input, datapicker control stay untouched

Issue Number: #7879


## What is the new behavior?

When the user loose the focus without selected a date, datePicker control become touched


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

