### PR TITLE
fix(module:message): clean up DOM after usage

### DIFF
--- a/components/core/services/singleton.ts
+++ b/components/core/services/singleton.ts
@@ -47,6 +47,12 @@ export class NzSingletonService {
     }
   }
 
+  unregisterSingletonWithKey(key: string): void {
+    if (this.singletonRegistry.has(key)) {
+      this.singletonRegistry.delete(key);
+    }
+  }
+
   getSingletonWithKey<T>(key: string): T | null {
     return this.singletonRegistry.has(key) ? (this.singletonRegistry.get(key)!.target as T) : null;
   }

--- a/components/message/message.spec.ts
+++ b/components/message/message.spec.ts
@@ -13,10 +13,11 @@ import { NzMessageService } from './message.service';
 describe('message', () => {
   let testBed: ComponentBed<NzTestMessageComponent>;
   let messageService: NzMessageService;
+  let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let fixture: ComponentFixture<NzTestMessageComponent>;
   let testComponent: NzTestMessageComponent;
-  let nzConfigService: NzConfigService;
+  let configService: NzConfigService;
 
   beforeEach(fakeAsync(() => {
     testBed = createComponentBed(NzTestMessageComponent, {
@@ -38,17 +39,14 @@ describe('message', () => {
     testComponent = testBed.component;
   }));
 
-  beforeEach(inject([NzMessageService, OverlayContainer], (m: NzMessageService, oc: OverlayContainer) => {
-    messageService = m;
-    // need init before testing
-    const message = messageService.success('init');
-    messageService.remove(message.messageId);
-    // @ts-ignore
-    nzConfigService = messageService.container.nzConfigService;
-    if (!overlayContainerElement) {
-      overlayContainerElement = oc.getContainerElement();
+  beforeEach(inject(
+    [NzMessageService, OverlayContainer, NzConfigService],
+    (m: NzMessageService, oc: OverlayContainer, c: NzConfigService) => {
+      messageService = m;
+      overlayContainer = oc;
+      configService = c;
     }
-  }));
+  ));
 
   afterEach(() => {
     messageService.remove();
@@ -57,6 +55,7 @@ describe('message', () => {
   it('should open a message box with success', () => {
     messageService.success('SUCCESS');
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
 
     expect((overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement).style.zIndex).toBe('1010');
     expect(overlayContainerElement.textContent).toContain('SUCCESS');
@@ -66,6 +65,7 @@ describe('message', () => {
   it('should open a message box with error', () => {
     messageService.error('ERROR');
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
     expect(overlayContainerElement.textContent).toContain('ERROR');
     expect(overlayContainerElement.querySelector('.anticon-close-circle')).not.toBeNull();
   });
@@ -73,6 +73,7 @@ describe('message', () => {
   it('should open a message box with warning', () => {
     messageService.warning('WARNING');
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
 
     expect(overlayContainerElement.textContent).toContain('WARNING');
     expect(overlayContainerElement.querySelector('.anticon-exclamation-circle')).not.toBeNull();
@@ -81,6 +82,7 @@ describe('message', () => {
   it('should open a message box with info', () => {
     messageService.info('INFO');
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
 
     expect(overlayContainerElement.textContent).toContain('INFO');
     expect(overlayContainerElement.querySelector('.anticon-info-circle')).not.toBeNull();
@@ -89,6 +91,7 @@ describe('message', () => {
   it('should open a message box with loading', () => {
     messageService.loading('LOADING');
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
 
     expect(overlayContainerElement.textContent).toContain('LOADING');
     expect(overlayContainerElement.querySelector('.anticon-loading')).not.toBeNull();
@@ -97,6 +100,7 @@ describe('message', () => {
   it('should support template', fakeAsync(() => {
     messageService.info(testComponent.template);
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
 
     expect(overlayContainerElement.textContent).toContain('Content in template');
     tick(10000);
@@ -105,6 +109,7 @@ describe('message', () => {
   it('should auto closed by 1s', fakeAsync(() => {
     messageService.create('', 'EXISTS', { nzDuration: 1000 });
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
 
     expect(overlayContainerElement.textContent).toContain('EXISTS');
 
@@ -115,6 +120,7 @@ describe('message', () => {
   it('should not destroy when hovered', fakeAsync(() => {
     messageService.create('', 'EXISTS', { nzDuration: 3000 });
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
 
     const messageElement = overlayContainerElement.querySelector('.ant-message-notice')!;
     dispatchMouseEvent(messageElement, 'mouseenter');
@@ -129,6 +135,7 @@ describe('message', () => {
   it('should not destroyed automatically but manually', fakeAsync(() => {
     const filledMessage = messageService.success('SUCCESS', { nzDuration: 0 });
     fixture.detectChanges();
+    overlayContainerElement = overlayContainer.getContainerElement();
 
     tick(50000);
     expect(overlayContainerElement.textContent).toContain('SUCCESS');
@@ -145,6 +152,7 @@ describe('message', () => {
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
+      overlayContainerElement = overlayContainer.getContainerElement();
 
       expect(overlayContainerElement.textContent).toContain(content);
       if (id === 3) {
@@ -156,7 +164,7 @@ describe('message', () => {
     messageService.remove();
     fixture.detectChanges();
     expect(overlayContainerElement.textContent).not.toContain('SUCCESS-3');
-    expect((messageService as any).container.instances.length).toBe(0); // eslint-disable-line @typescript-eslint/no-explicit-any
+    expect((messageService as any).container).toBeUndefined(); // eslint-disable-line @typescript-eslint/no-explicit-any
   }));
 
   it('should destroy without animation', fakeAsync(() => {
@@ -167,10 +175,11 @@ describe('message', () => {
   }));
 
   it('should reset default config from config service', fakeAsync(() => {
-    nzConfigService.set('message', { nzDuration: 0 });
+    configService.set('message', { nzDuration: 0 });
     messageService.create('loading', 'EXISTS');
     fixture.detectChanges();
     tick(10000);
+    overlayContainerElement = overlayContainer.getContainerElement();
     expect(overlayContainerElement.textContent).toContain('EXISTS');
   }));
 
@@ -190,6 +199,7 @@ describe('message', () => {
     messageService.create('top', 'CHANGE');
     fixture.detectChanges();
 
+    overlayContainerElement = overlayContainer.getContainerElement();
     const messageContainerElement = overlayContainerElement.querySelector('.ant-message') as HTMLElement;
     expect(messageContainerElement.style.top).toBe('24px');
 
@@ -198,9 +208,10 @@ describe('message', () => {
 
   describe('RTL', () => {
     it('should apply classname', () => {
-      nzConfigService.set('message', { nzDirection: 'rtl' });
+      configService.set('message', { nzDirection: 'rtl' });
       messageService.info('INFO');
       fixture.detectChanges();
+      overlayContainerElement = overlayContainer.getContainerElement();
       expect(overlayContainerElement.textContent).toContain('INFO');
       expect(overlayContainerElement.querySelector('.ant-message-rtl')).not.toBeNull();
     });


### PR DESCRIPTION
Call `overlayRef.dispose()` when all instances of messages have disappeared

Resolves #7772

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

The current implementation of the message service leaves a `nz-message-container` element in the DOM even after all messages have been removed. This PR introduces a small change so that the DOM is cleaned up when all messages are removed, so no extra elements remain in the DOM

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7772 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
