### PR TITLE
fix(module:notification): don't create new messageId for update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ report.*.json
 # System Files
 .DS_Store
 Thumbs.db
+
+monospace.json

--- a/components/message/base.ts
+++ b/components/message/base.ts
@@ -101,7 +101,17 @@ export abstract class NzMNContainerComponent implements OnInit, OnDestroy {
   }
 
   remove(id: string, userAction: boolean = false): void {
-    this.instances.some((instance, index) => {
+    this.instances
+      .map((instance, index) => ({ index, instance }))
+      .filter(({ instance }) => instance.messageId === id)
+      .forEach(({ index, instance }) => {
+        this.instances.splice(index, 1);
+        this.instances = [...this.instances];
+        this.onRemove(instance, userAction);
+        this.readyInstances();
+      });
+
+    /* this.instances.some((instance, index) => {
       if (instance.messageId === id) {
         this.instances.splice(index, 1);
         this.instances = [...this.instances];
@@ -110,7 +120,7 @@ export abstract class NzMNContainerComponent implements OnInit, OnDestroy {
         return true;
       }
       return false;
-    });
+    }); **/
   }
 
   removeAll(): void {

--- a/components/message/base.ts
+++ b/components/message/base.ts
@@ -110,17 +110,6 @@ export abstract class NzMNContainerComponent implements OnInit, OnDestroy {
         this.onRemove(instance, userAction);
         this.readyInstances();
       });
-
-    /* this.instances.some((instance, index) => {
-      if (instance.messageId === id) {
-        this.instances.splice(index, 1);
-        this.instances = [...this.instances];
-        this.onRemove(instance, userAction);
-        this.readyInstances();
-        return true;
-      }
-      return false;
-    }); **/
   }
 
   removeAll(): void {

--- a/components/notification/demo/update.ts
+++ b/components/notification/demo/update.ts
@@ -14,14 +14,16 @@ export class NzDemoNotificationUpdateComponent {
   constructor(private notification: NzNotificationService) {}
 
   createAutoUpdatingNotifications(): void {
-    this.notification.blank('Notification Title', 'Description.', {
+    let notificationRef = this.notification.blank('Notification Title', 'Description.', {
       nzKey: 'key'
     });
+    console.log(notificationRef);
 
     setTimeout(() => {
-      this.notification.blank('New Title', 'New description', {
+      notificationRef = this.notification.blank('New Title', 'New description', {
         nzKey: 'key'
       });
+      console.log(notificationRef);
     }, 1000);
   }
 }

--- a/components/notification/demo/update.ts
+++ b/components/notification/demo/update.ts
@@ -14,16 +14,14 @@ export class NzDemoNotificationUpdateComponent {
   constructor(private notification: NzNotificationService) {}
 
   createAutoUpdatingNotifications(): void {
-    let notificationRef = this.notification.blank('Notification Title', 'Description.', {
+    this.notification.blank('Notification Title', 'Description.', {
       nzKey: 'key'
     });
-    console.log(notificationRef);
 
     setTimeout(() => {
-      notificationRef = this.notification.blank('New Title', 'New description', {
+      this.notification.blank('New Title', 'New description', {
         nzKey: 'key'
       });
-      console.log(notificationRef);
     }, 1000);
   }
 }

--- a/components/notification/notification.service.ts
+++ b/components/notification/notification.service.ts
@@ -70,7 +70,7 @@ export class NzNotificationService extends NzMNService {
       ...message,
       ...{
         createdAt: new Date(),
-        messageId: this.generateMessageId(),
+        messageId: options?.nzKey || this.generateMessageId(),
         options
       }
     });

--- a/components/notification/notification.spec.ts
+++ b/components/notification/notification.spec.ts
@@ -5,7 +5,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { HomeOutline } from '@ant-design/icons-angular/icons';
 
-import { NzConfigService, NZ_CONFIG } from 'ng-zorro-antd/core/config';
+import { NZ_CONFIG, NzConfigService } from 'ng-zorro-antd/core/config';
 import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
 import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 import { NZ_ICONS } from 'ng-zorro-antd/icon';
@@ -218,9 +218,12 @@ describe('NzNotification', () => {
   });
 
   it('should update an existing notification when keys are matched', () => {
-    notificationService.create('', '', 'EXISTS', { nzKey: 'exists' });
+    let messageId: string | null = null;
+    messageId = notificationService.create('', '', 'EXISTS', { nzKey: 'exists' }).messageId;
     expect(overlayContainerElement.textContent).toContain('EXISTS');
-    notificationService.create('success', 'Title', 'SHOULD NOT CHANGE', { nzKey: 'exists' });
+    expect(messageId).toEqual('exists');
+    messageId = notificationService.create('success', 'Title', 'SHOULD NOT CHANGE', { nzKey: 'exists' }).messageId;
+    expect(messageId).toEqual('exists');
     expect(overlayContainerElement.textContent).not.toContain('EXISTS');
     expect(overlayContainerElement.textContent).toContain('Title');
     expect(overlayContainerElement.textContent).toContain('SHOULD NOT CHANGE');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
This PR is a fix for generating a new messageId for updating notification
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

When we update a notification, the service generate a new messageId

Issue Number: 7975


## What is the new behavior?

When we update a notification, the service don't generate a new messageId


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
