### PR TITLE
feat(module:input): hide stepper for type number

### DIFF
--- a/components/affix/affix.spec.ts
+++ b/components/affix/affix.spec.ts
@@ -1,6 +1,6 @@
 import { BidiModule, Dir } from '@angular/cdk/bidi';
 import { Component, DebugElement, ViewChild } from '@angular/core';
-import { ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { NzScrollService } from 'ng-zorro-antd/core/services';

--- a/components/input/demo/basic.ts
+++ b/components/input/demo/basic.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'nz-demo-input-basic',
   template: `
-    <input nz-input placeholder="Basic usage" [(ngModel)]="value" />
+    <input nz-input placeholder="Basic usage" [(ngModel)]="value" type="number" />
     <br />
     <br />
     <input nz-input placeholder="Basic usage" [(ngModel)]="value" [disabled]="true" />

--- a/components/input/doc/index.en-US.md
+++ b/components/input/doc/index.en-US.md
@@ -29,7 +29,7 @@ All props of input supported by [w3c standards](https://www.w3schools.com/tags/t
 | `[nzAutosize]` | Only used for `textarea`, height autosize feature, can be set to `boolean` or an object `{ minRows: 2, maxRows: 6 }` | `boolean \| { minRows: number, maxRows: number }` | `false` |
 | `[nzBorderless]` | Whether hide border | `boolean` | `false` |
 | `[nzStatus]` | Set validation status | `'error' \| 'warning'` | - |
-| `[nzStepperless]` | Whether hide stepper when input type is number | `'boolean' \| 'false'` | - |
+| `[nzStepperless]` | Whether hide stepper when input type is number | `'boolean' \| 'true'` | - |
 
 ### nz-input-group
 

--- a/components/input/doc/index.en-US.md
+++ b/components/input/doc/index.en-US.md
@@ -29,6 +29,7 @@ All props of input supported by [w3c standards](https://www.w3schools.com/tags/t
 | `[nzAutosize]` | Only used for `textarea`, height autosize feature, can be set to `boolean` or an object `{ minRows: 2, maxRows: 6 }` | `boolean \| { minRows: number, maxRows: number }` | `false` |
 | `[nzBorderless]` | Whether hide border | `boolean` | `false` |
 | `[nzStatus]` | Set validation status | `'error' \| 'warning'` | - |
+| `[nzStepperless]` | Whether hide stepper when input type is number | `'boolean' \| 'false'` | - |
 
 ### nz-input-group
 

--- a/components/input/input.directive.ts
+++ b/components/input/input.directive.ts
@@ -24,7 +24,7 @@ import { distinctUntilChanged, filter, takeUntil } from 'rxjs/operators';
 
 import { NzFormItemFeedbackIconComponent, NzFormNoStatusService, NzFormStatusService } from 'ng-zorro-antd/core/form';
 import { BooleanInput, NgClassInterface, NzSizeLDSType, NzStatus, NzValidateStatus } from 'ng-zorro-antd/core/types';
-import { getStatusClassNames, InputBoolean } from 'ng-zorro-antd/core/util';
+import { InputBoolean, getStatusClassNames } from 'ng-zorro-antd/core/util';
 
 @Directive({
   selector: 'input[nz-input],textarea[nz-input]',
@@ -36,7 +36,8 @@ import { getStatusClassNames, InputBoolean } from 'ng-zorro-antd/core/util';
     '[class.ant-input-lg]': `nzSize === 'large'`,
     '[class.ant-input-sm]': `nzSize === 'small'`,
     '[attr.disabled]': 'disabled || null',
-    '[class.ant-input-rtl]': `dir=== 'rtl'`
+    '[class.ant-input-rtl]': `dir=== 'rtl'`,
+    '[class.ant-input-stepperless]': `!nzStepperless`
   }
 })
 export class NzInputDirective implements OnChanges, OnInit, OnDestroy {
@@ -44,6 +45,7 @@ export class NzInputDirective implements OnChanges, OnInit, OnDestroy {
   static ngAcceptInputType_nzBorderless: BooleanInput;
   @Input() @InputBoolean() nzBorderless = false;
   @Input() nzSize: NzSizeLDSType = 'default';
+  @Input() @InputBoolean() nzStepperless: boolean = false;
   @Input() nzStatus: NzStatus = '';
   @Input()
   get disabled(): boolean {

--- a/components/input/input.directive.ts
+++ b/components/input/input.directive.ts
@@ -37,7 +37,7 @@ import { InputBoolean, getStatusClassNames } from 'ng-zorro-antd/core/util';
     '[class.ant-input-sm]': `nzSize === 'small'`,
     '[attr.disabled]': 'disabled || null',
     '[class.ant-input-rtl]': `dir=== 'rtl'`,
-    '[class.ant-input-stepperless]': `!nzStepperless`
+    '[class.ant-input-stepperless]': `nzStepperless`
   }
 })
 export class NzInputDirective implements OnChanges, OnInit, OnDestroy {
@@ -45,7 +45,7 @@ export class NzInputDirective implements OnChanges, OnInit, OnDestroy {
   static ngAcceptInputType_nzBorderless: BooleanInput;
   @Input() @InputBoolean() nzBorderless = false;
   @Input() nzSize: NzSizeLDSType = 'default';
-  @Input() @InputBoolean() nzStepperless: boolean = false;
+  @Input() @InputBoolean() nzStepperless: boolean = true;
   @Input() nzStatus: NzStatus = '';
   @Input()
   get disabled(): boolean {

--- a/components/input/input.spec.ts
+++ b/components/input/input.spec.ts
@@ -65,7 +65,7 @@ describe('input', () => {
       it('should nzStepperLess work', () => {
         fixture.detectChanges();
         expect(inputElement.nativeElement.classList).toContain('ant-input-stepperless');
-        testComponent.showStepper = true;
+        testComponent.stepperless = false;
         fixture.detectChanges();
         expect(inputElement.nativeElement.classList).not.toContain('ant-input-stepperless');
       });
@@ -211,12 +211,12 @@ export class NzTestInputWithDirComponent {
 }
 
 @Component({
-  template: ` <input nz-input [nzSize]="size" [disabled]="disabled" [nzStepperless]="showStepper" /> `
+  template: ` <input nz-input [nzSize]="size" [disabled]="disabled" [nzStepperless]="stepperless" /> `
 })
 export class NzTestInputWithInputComponent {
   size = 'default';
   disabled = false;
-  showStepper = false;
+  stepperless = true;
 }
 
 @Component({

--- a/components/input/input.spec.ts
+++ b/components/input/input.spec.ts
@@ -1,7 +1,7 @@
 import { BidiModule, Direction } from '@angular/cdk/bidi';
 import { Component, DebugElement } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
-import { UntypedFormBuilder, UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ComponentFixture, TestBed, fakeAsync, flush, waitForAsync } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { NzStatus } from 'ng-zorro-antd/core/types';
@@ -61,6 +61,13 @@ describe('input', () => {
         fixture.detectChanges();
         expect(inputElement.nativeElement.classList).toContain('ant-input');
         expect(inputElement.nativeElement.classList).toContain('ant-input-lg');
+      });
+      it('should nzStepperLess work', () => {
+        fixture.detectChanges();
+        expect(inputElement.nativeElement.classList).toContain('ant-input-stepperless');
+        testComponent.showStepper = true;
+        fixture.detectChanges();
+        expect(inputElement.nativeElement.classList).not.toContain('ant-input-stepperless');
       });
     });
 
@@ -204,11 +211,12 @@ export class NzTestInputWithDirComponent {
 }
 
 @Component({
-  template: ` <input nz-input [nzSize]="size" [disabled]="disabled" /> `
+  template: ` <input nz-input [nzSize]="size" [disabled]="disabled" [nzStepperless]="showStepper" /> `
 })
 export class NzTestInputWithInputComponent {
   size = 'default';
   disabled = false;
+  showStepper = false;
 }
 
 @Component({

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -23,8 +23,7 @@
     border-color: @hoverBorderColor;
   }
   & when not (@theme = variable) {
-    box-shadow: @input-outline-offset @outline-blur-size @outline-width
-      fade(@borderColor, @outline-fade);
+    box-shadow: @input-outline-offset @outline-blur-size @outline-width fade(@borderColor, @outline-fade);
   }
   & when (@theme = variable) {
     border-color: @hoverBorderColor;
@@ -97,6 +96,15 @@
       background-color: transparent;
       border: none;
       box-shadow: none;
+    }
+  }
+
+  &-stepperless[type='number'] {
+    -moz-appearance: textfield;
+    &::-webkit-inner-spin-button,
+    ::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
     }
   }
 
@@ -200,8 +208,7 @@
     .@{ant-prefix}-select {
       margin: -(@input-padding-vertical-base + 1px) (-@input-padding-horizontal-base);
 
-      &.@{ant-prefix}-select-single:not(.@{ant-prefix}-select-customize-input)
-        .@{ant-prefix}-select-selector {
+      &.@{ant-prefix}-select-single:not(.@{ant-prefix}-select-customize-input) .@{ant-prefix}-select-selector {
         background-color: inherit;
         border: @border-width-base @border-style-base transparent;
         box-shadow: none;

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -99,15 +99,6 @@
     }
   }
 
-  &-stepperless[type='number'] {
-    -moz-appearance: textfield;
-    &::-webkit-inner-spin-button,
-    ::-webkit-outer-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-  }
-
   // Reset height for `textarea`s
   textarea& {
     max-width: 100%; // prevent textearea resize from coming out of its container

--- a/components/input/style/patch.less
+++ b/components/input/style/patch.less
@@ -62,3 +62,14 @@ nz-form-item-feedback-icon.@{ant-prefix}-input {
   position: relative;
 }
 
+.input() {
+  &-stepperless[type='number'] {
+    -moz-appearance: textfield;
+    &::-webkit-inner-spin-button,
+    ::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+  }
+}
+


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

have the possibility to hide or show  native stepper for input of type number

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7956


## What is the new behavior?

It's now possible to have the possibility to hide or show the stepper with the directive nz-input and the type number


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
