### PR TITLE
refactor(module:breadcrumb): remove redundant dom nodes

### DIFF
--- a/components/breadcrumb/breadcrumb-item.component.ts
+++ b/components/breadcrumb/breadcrumb-item.component.ts
@@ -19,7 +19,7 @@ import { NzBreadcrumb } from './breadcrumb';
     <ng-container *ngIf="!!nzOverlay; else noMenuTpl">
       <span class="ant-breadcrumb-overlay-link" nz-dropdown [nzDropdownMenu]="nzOverlay">
         <ng-template [ngTemplateOutlet]="noMenuTpl"></ng-template>
-        <span *ngIf="!!nzOverlay" nz-icon nzType="down"></span>
+        <span nz-icon nzType="down"></span>
       </span>
     </ng-container>
 
@@ -29,11 +29,11 @@ import { NzBreadcrumb } from './breadcrumb';
       </span>
     </ng-template>
 
-    <span class="ant-breadcrumb-separator" *ngIf="nzBreadCrumbComponent.nzSeparator">
+    <nz-breadcrumb-separator *ngIf="nzBreadCrumbComponent.nzSeparator">
       <ng-container *nzStringTemplateOutlet="nzBreadCrumbComponent.nzSeparator">
         {{ nzBreadCrumbComponent.nzSeparator }}
       </ng-container>
-    </span>
+    </nz-breadcrumb-separator>
   `
 })
 export class NzBreadCrumbItemComponent {

--- a/components/breadcrumb/breadcrumb-separator.component.ts
+++ b/components/breadcrumb/breadcrumb-separator.component.ts
@@ -8,10 +8,9 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'nz-breadcrumb-separator',
   exportAs: 'nzBreadcrumbSeparator',
-  template: `
-    <span class="ant-breadcrumb-separator">
-      <ng-content></ng-content>
-    </span>
-  `
+  template: `<ng-content></ng-content>`,
+  host: {
+    class: 'ant-breadcrumb-separator'
+  }
 })
 export class NzBreadCrumbSeparatorComponent {}

--- a/components/breadcrumb/doc/index.en-US.md
+++ b/components/breadcrumb/doc/index.en-US.md
@@ -46,7 +46,7 @@ For lazy loading modules, you should write `data` in parent module like this:
 ```ts
 {
   path: 'first',
-  loadChildren: './first/first.module#FirstModule',
+  loadChildren: () => import('./first/first.module').then(m => m.FirstModule),
   data: {
     breadcrumb: 'First'
   },

--- a/components/breadcrumb/doc/index.zh-CN.md
+++ b/components/breadcrumb/doc/index.zh-CN.md
@@ -46,7 +46,7 @@ import { NzBreadCrumbModule } from 'ng-zorro-antd/breadcrumb';
 ```ts
 {
   path: 'first',
-  loadChildren: './first/first.module#FirstModule',
+  loadChildren: () => import('./first/first.module').then(m => m.FirstModule),
   data: {
     breadcrumb: 'First'
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `nz-breadcrumb-separator` has extra dom nodes.

<img width="388" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/41798664/9d8f3ef0-f166-4295-ade8-d60bc3f7eded">


Issue Number: N/A


## What is the new behavior?

Remove redundant dom nodes in `nz-breadcrumb-separator`.

<img width="648" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/41798664/817e0f54-a6f8-4806-b629-2fbe4ef4006e">

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This may break user custom styles, which may be rare:

```css
nz-breadcrumb-separator .ant-breadcrumb-separator { }
nz-breadcrumb-separator > .ant-breadcrumb-separator { }
nz-breadcrumb-separator span { }
nz-breadcrumb-separator > span { }
```


## Other information

This commit also fixes the documentation and simplifies some code.

