### PR TITLE
fix #fff border in text button when apply ghost mode

### DIFF
--- a/components/button/style/mixin.less
+++ b/components/button/style/mixin.less
@@ -389,6 +389,7 @@
 .btn-text() {
   .button-variant-other(@text-color, transparent, transparent);
   box-shadow: none;
+  border-color: transparent !important;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

For this code: 
![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/92224087/6ec4a333-3dd2-4dce-88de-2dc999584dce)


Before:
![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/92224087/2b822ef2-a900-4119-82fb-bbf60ee6bf7e)


After:
![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/92224087/0b61dfa5-b11c-42f1-9e9a-5b2dfb51ea25)

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/92224087/57702865-a39c-465a-993e-e05d09290eb4)
