### PR TITLE
fix(module:table): remove empty space in custom columns

### DIFF
--- a/components/table/src/cell/custom-column.directive.ts
+++ b/components/table/src/cell/custom-column.directive.ts
@@ -33,7 +33,7 @@ export class NzCustomColumnDirective<T> implements OnInit, OnDestroy {
             if (!v?.fixWidth) {
               this.renderer.setStyle(this.el.nativeElement, 'flex', `1 1 ${v.width}px`);
             } else {
-              this.renderer.setStyle(this.el.nativeElement, 'flex', `0 0 ${v.width}px`);
+              this.renderer.setStyle(this.el.nativeElement, 'flex', `1 0 ${v.width}px`);
             }
           }
         });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://stackblitz.com/edit/angular-z9xssu

Issue Number: N/A


## What is the new behavior?
When using custom fixed-width columns, empty space appears between columns if the total width of the columns is less than the width of the table

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
