### PR TITLE
fix(showcase): ui bug in rtl mode inside the doc site

### DIFF
--- a/scripts/site/_site/doc/style/responsive.less
+++ b/scripts/site/_site/doc/style/responsive.less
@@ -10,7 +10,8 @@
 }
 
 @media only screen and (max-width: @screen-lg) {
-  .main-container {
+  .main-container,
+  .ant-row-rtl .main-container {
     padding-right: 48px;
     padding-left: 48px;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Go to the current <a href="https://ng.ant.design/docs/introduce/en"> document site </a>,  follow these steps to reproduce the bug:
- click on the RTL button in the header
- start minimizing your window until you reach 993px
- when entering 992px, you will see that although the affix is gone, the main container doesn't take up the freed space

## What is the new behavior?
The problem was with the specificity of CSS rules, with that corrected now when you reach the specified media query size, the main container will reduce its padding so that it can take up the space left behind by the said affix.


## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
