### PR TITLE
fix(module:upload): remove inline style to resolve CSP issue

### DIFF
--- a/components/upload/upload-btn.component.html
+++ b/components/upload/upload-btn.component.html
@@ -1,3 +1,8 @@
+<!--
+  We explicitly bind `style.display` to avoid using an inline style
+  attribute property (which is not allowed when CSP `unsafe-inline`
+  is not specified).
+-->
 <input
   type="file"
   #file
@@ -6,6 +11,6 @@
   [attr.directory]="options.directory ? 'directory' : null"
   [attr.webkitdirectory]="options.directory ? 'webkitdirectory' : null"
   [multiple]="options.multiple"
-  style="display: none"
+  [style.display]="'none'"
 />
 <ng-content></ng-content>


### PR DESCRIPTION
This commit addresses the CSP issue by removing the inline `style` property from the `input` element within the `nz-upload` component. The use of inline style attributes necessitates the inclusion of `unsafe-inline`.