### PR TITLE
fix(module:message): fix the z-index of overlay

### DIFF
--- a/components/message/base.ts
+++ b/components/message/base.ts
@@ -54,8 +54,8 @@ export abstract class NzMNService {
     });
     const componentPortal = new ComponentPortal(ctor, null, this.injector);
     const componentRef = overlayRef.attach(componentPortal);
-    const overlayPane = overlayRef.overlayElement;
-    overlayPane.style.zIndex = '1010';
+    const overlayWrapper = overlayRef.hostElement;
+    overlayWrapper.style.zIndex = '1010';
 
     if (!containerInstance) {
       this.container = containerInstance = componentRef.instance;

--- a/components/message/message.spec.ts
+++ b/components/message/message.spec.ts
@@ -3,7 +3,7 @@ import { Component, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, inject, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { NzConfigService, NZ_CONFIG } from 'ng-zorro-antd/core/config';
+import { NZ_CONFIG, NzConfigService } from 'ng-zorro-antd/core/config';
 import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
 import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 
@@ -58,7 +58,9 @@ describe('message', () => {
     messageService.success('SUCCESS');
     fixture.detectChanges();
 
-    expect((overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement).style.zIndex).toBe('1010');
+    expect((overlayContainerElement.querySelector('.cdk-global-overlay-wrapper') as HTMLElement).style.zIndex).toBe(
+      '1010'
+    );
     expect(overlayContainerElement.textContent).toContain('SUCCESS');
     expect(overlayContainerElement.querySelector('.anticon-check-circle')).not.toBeNull();
   });

--- a/components/style/patch.less
+++ b/components/style/patch.less
@@ -1,15 +1,5 @@
 @import './themes/@{root-entry-name}.less';
-
-// cdk overlay
-.cdk-overlay-container {
-  pointer-events: none;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  position: fixed;
-  z-index: 1000;
-}
+@import '~@angular/cdk/overlay-prebuilt.css';
 
 .cdk-visually-hidden {
   border: 0;
@@ -25,59 +15,8 @@
   -moz-appearance: none;
 }
 
-.cdk-overlay-backdrop {
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  -webkit-tap-highlight-color: transparent;
-  transition: opacity 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
-  opacity: 0;
-  position: absolute;
-  pointer-events: auto;
-  z-index: 1000;
-
-  &.ant-modal-mask {
-    opacity: 1;
-  }
-}
-
-.cdk-overlay-pane {
-  position: absolute;
-  pointer-events: auto;
-  z-index: 1000; // Give an opportunity to the content own to manage their z-index such as Modal
-}
-
-.cdk-overlay-connected-position-bounding-box {
-  position: absolute;
-  z-index: 1000;
-  display: flex;
-  flex-direction: column;
-  min-width: 1px;
-  min-height: 1px;
-}
-
-// Used when disabling global scrolling.
-.cdk-global-scrollblock {
-  position: fixed;
-
-  // Necessary for the content not to lose its width. Note that we're using 100%, instead of
-  // 100vw, because 100vw includes the width plus the scrollbar, whereas 100% is the width
-  // that the element had before we made it `fixed`.
-  width: 100%;
-
-  // Note: this will always add a scrollbar to whatever element it is on, which can
-  // potentially result in double scrollbars. It shouldn't be an issue, because we won't
-  // block scrolling on a page that doesn't have a scrollbar in the first place.
-  overflow-y: scroll;
-
-  // https://github.com/angular/material2/issues/15051
-  body {
-    overflow-x: visible;
-  }
-}
-
 .nz-overlay-transparent-backdrop {
+
   &,
   &.cdk-overlay-backdrop-showing {
     opacity: 0;
@@ -85,6 +24,7 @@
 }
 
 .nz-animate-disabled {
+
   // badge
   &.ant-scroll-number-only {
     animation: none;
@@ -98,7 +38,7 @@
       transition: none;
     }
 
-    & > * {
+    &>* {
       transition: none;
     }
   }
@@ -131,7 +71,7 @@
     .ant-menu-submenu-title .anticon {
       transition: none;
 
-      & + span {
+      &+span {
         transition: none;
       }
     }
@@ -139,10 +79,11 @@
 
   // tabs
   &.ant-tabs {
+
     .ant-tabs-top-content.ant-tabs-content-animated,
     .ant-tabs-bottom-content.ant-tabs-content-animated,
-    .ant-tabs-top-content > .ant-tabs-tabpane,
-    .ant-tabs-bottom-content > .ant-tabs-tabpane,
+    .ant-tabs-top-content>.ant-tabs-tabpane,
+    .ant-tabs-bottom-content>.ant-tabs-tabpane,
     &.ant-tabs-left .ant-tabs-ink-bar-animated,
     &.ant-tabs-right .ant-tabs-ink-bar-animated,
     &.ant-tabs-top .ant-tabs-ink-bar-animated,
@@ -152,7 +93,7 @@
   }
 
   // collapse
-  &.ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-arrow svg {
+  &.ant-collapse>.ant-collapse-item>.ant-collapse-header .ant-collapse-arrow svg {
     transition: none;
   }
 }

--- a/docs/getting-started.en-US.md
+++ b/docs/getting-started.en-US.md
@@ -157,6 +157,10 @@ Then use the component inside the template:
 <button nz-button nzType="primary">Primary</button>
 ```
 
+# Precautions
+
+- `ng-zorro-antd` already contains `@angular/cdk/overlay-prebuilt.css` overlay style, no additional import is required.
+
 ## Other
 
 - [I18n](/docs/i18n/en)

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -153,6 +153,10 @@ export class AppModule { }
 <button nz-button nzType="primary">Primary</button>
 ```
 
+# 注意事项
+
+- `ng-zorro-antd` 已经包含了 `@angular/cdk/overlay-prebuilt.css` 浮层样式，无需额外导入。
+
 ## 其他
 
 - [国际化配置](/docs/i18n/zh)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8010

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/41798664/a859292a-e536-44ff-acf0-e6f3f9f19550)

由于 `.cdk-global-overlay-wrapper` 是绝对定位，给 `.cdk-global-overlay-wrapper` 的子元素设置 `z-index` 是无效的。


## What is the new behavior?

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/41798664/6e9914b5-5759-4699-8420-f32c2cc42b43)

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/41798664/2f323b9b-21bc-413d-bfe0-b046d71766a5)

将 `z-index` 样式设置到 `.cdk-global-overlay-wrapper` 上。

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

在此之前的 nz 的 cdk-overlay 预建样式是不完整的，此 PR 将导入完整的 `@angular/cdk/overlay-prebuilt.css`，用户不再需要自行导入该样式，**我希望这点会在 CHANGELOG 中特别指出**。
