### PR TITLE
fix(module:tree-select): 修复节点为禁用状态时，back快捷键能删除bug

### DIFF
--- a/components/tree-select/tree-select.component.ts
+++ b/components/tree-select/tree-select.component.ts
@@ -545,7 +545,9 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
       e.preventDefault();
       if (this.selectedNodes.length) {
         const removeNode = this.selectedNodes[this.selectedNodes.length - 1];
-        this.removeSelected(removeNode);
+        if (!removeNode.isDisabled) {
+          this.removeSelected(removeNode);
+        }
       }
     }
   }

--- a/components/tree-select/tree-select.component.ts
+++ b/components/tree-select/tree-select.component.ts
@@ -545,7 +545,7 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
       e.preventDefault();
       if (this.selectedNodes.length) {
         const removeNode = this.selectedNodes[this.selectedNodes.length - 1];
-        if (!removeNode.isDisabled) {
+        if (removeNode && !removeNode.isDisabled) {
           this.removeSelected(removeNode);
         }
       }
@@ -558,8 +558,10 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
   }
 
   setInputValue(value: string): void {
-    this.inputValue = value;
-    this.updatePosition();
+    if (!this.isComposing) {
+      this.inputValue = value;
+      this.updatePosition();
+    }
   }
 
   removeSelected(node: NzTreeNode, emit: boolean = true): void {


### PR DESCRIPTION
修复，当节点为禁用状态时，通过快捷键能删除禁用状态节点问题