### PR TITLE
fix(module:drawer): drawer not open

### DIFF
--- a/components/drawer/drawer.module.ts
+++ b/components/drawer/drawer.module.ts
@@ -15,19 +15,11 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import { NzDrawerContentDirective } from './drawer-content.directive';
 import { NzDrawerComponent } from './drawer.component';
-import { NzDrawerServiceModule } from './drawer.service.module';
+import { NzDrawerService } from './drawer.service';
 
 @NgModule({
-  imports: [
-    BidiModule,
-    CommonModule,
-    OverlayModule,
-    PortalModule,
-    NzIconModule,
-    NzOutletModule,
-    NzNoAnimationModule,
-    NzDrawerServiceModule
-  ],
+  imports: [BidiModule, CommonModule, OverlayModule, PortalModule, NzIconModule, NzOutletModule, NzNoAnimationModule],
+  providers: [NzDrawerService],
   exports: [NzDrawerComponent, NzDrawerContentDirective],
   declarations: [NzDrawerComponent, NzDrawerContentDirective]
 })

--- a/components/drawer/drawer.service.module.ts
+++ b/components/drawer/drawer.service.module.ts
@@ -1,9 +1,0 @@
-/**
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
- */
-
-import { NgModule } from '@angular/core';
-
-@NgModule()
-export class NzDrawerServiceModule {}

--- a/components/drawer/drawer.service.ts
+++ b/components/drawer/drawer.service.ts
@@ -60,7 +60,7 @@ export class DrawerBuilderForService<T extends {}, R> {
   }
 }
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class NzDrawerService {
   constructor(private overlay: Overlay) {}
 

--- a/components/drawer/public-api.ts
+++ b/components/drawer/public-api.ts
@@ -3,10 +3,9 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-export * from './drawer.component';
 export * from './drawer-content.directive';
-export * from './drawer.module';
-export * from './drawer.service';
-export * from './drawer.service.module';
 export * from './drawer-options';
 export * from './drawer-ref';
+export * from './drawer.component';
+export * from './drawer.module';
+export * from './drawer.service';


### PR DESCRIPTION
Drawer don't open in a lazyload module

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

This pr is a fix.


```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The drawer does not open if the NzDrawerModule is imported into a lazyloader module and one of the components of the lazyloader module injects a service also declared in the lazyloader module.

The fact that the NzDrawerService service was injected into the Root injector prevented the resolution of the Lazyloader service, simply because the parentInjector was not the right one.


Issue Number: #8100

## What is the new behavior?

User can now use the NzDrawerService in a lazyload module


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
