### PR TITLE
fix: inline external css

### DIFF
--- a/components/style/patch.less
+++ b/components/style/patch.less
@@ -1,5 +1,5 @@
 @import './themes/@{root-entry-name}.less';
-@import '~@angular/cdk/overlay-prebuilt.css';
+@import (inline) '../../node_modules/@angular/cdk/overlay-prebuilt.css';
 
 .cdk-visually-hidden {
   border: 0;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8119 #8106


## What is the new behavior?

我们不能通过简单的删除 `~` 符号来修复这一问题：

```less
@import '~@angular/cdk/overlay-prebuilt.css';
```

修改为

```less
@import '@angular/cdk/overlay-prebuilt.css';
```

这会导致 ZORRO 文档构建失败，因为编译器将该路径视为本地路径，而非外部依赖路径（node_modules）。

此修改通过使用 `@import (inline)` 内联导入语句，将外部 CSS 直接内联到文件，解决上述问题。

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
