### PR TITLE
fix(module:mention): page not loading entirely

### DIFF
--- a/components/mention/demo/form.ts
+++ b/components/mention/demo/form.ts
@@ -43,7 +43,7 @@ import { NzMentionComponent } from 'ng-zorro-antd/mention';
   ]
 })
 export class NzDemoMentionFormComponent {
-  suggestions = ['afc163', 'benjycui', 'yiminghe', 'RaoHai', '中文', 'にほんご'];
+  suggestions = ['afc163', 'benjycui', 'yiminghe', 'RaoHai', '中文', 'にほんご', 'ParsaArvaneh'];
   validateForm: FormGroup<{ mention: FormControl<string | null> }>;
   @ViewChild('mentions', { static: true }) mentionChild!: NzMentionComponent;
 

--- a/components/mention/demo/form.ts
+++ b/components/mention/demo/form.ts
@@ -25,13 +25,22 @@ import { NzMentionComponent } from 'ng-zorro-antd/mention';
       </nz-form-item>
       <nz-form-item nz-row style="margin-bottom:8px;">
         <nz-form-control [nzSpan]="14" [nzOffset]="6">
-          <button type="button" nz-button nzType="primary" (click)="submitForm()">Submit</button>
-          &nbsp;&nbsp;&nbsp;
-          <button type="button" nz-button (click)="resetForm()">Reset</button>
+          <div class="cta-wrapper">
+            <button type="button" nz-button nzType="primary" (click)="submitForm()">Submit</button>
+            <button type="button" nz-button (click)="resetForm()">Reset</button>
+          </div>
         </nz-form-control>
       </nz-form-item>
     </form>
-  `
+  `,
+  styles: [
+    `
+      .cta-wrapper {
+        display: flex;
+        gap: 1rem;
+      }
+    `
+  ]
 })
 export class NzDemoMentionFormComponent {
   suggestions = ['afc163', 'benjycui', 'yiminghe', 'RaoHai', '中文', 'にほんご'];
@@ -51,7 +60,7 @@ export class NzDemoMentionFormComponent {
   mentionValidator: ValidatorFn = (control: AbstractControl) => {
     if (!control.value) {
       return { required: true };
-    } else if (this.mentionChild.getMentions().length < 2) {
+    } else if (this.mentionChild?.getMentions().length < 2) {
       return { confirm: true, error: true };
     }
     return {};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when you navigate to <a href="https://ng.ant.design/components/mention/en">mention component</a>, you'll notice that mention page does not load at all. This behaviour is caused by a logical error in `form.ts`. 
At line number 54, `this.mentionChild` is equal to `undefined`. I just added an optional chain so if it is undefined it won't throw an error.

Issue Number: N/A


## What is the new behavior?
Mention page can now be loaded and viewed, and `form.ts` has the same functionality as intended (checked with version 15 of ng-zorro).

## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Image of `mention component` not working:

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/62149413/245949aa-ea2c-4c94-9327-c908f31fc4b9)

