### PR TITLE
feat(module:image): add scale step

### DIFF
--- a/components/core/config/config.ts
+++ b/components/core/config/config.ts
@@ -354,7 +354,7 @@ export interface ImageConfig {
   nzDisablePreview?: string;
   nzCloseOnNavigation?: boolean;
   nzDirection?: Direction;
-  nzZoomStep?: number;
+  nzScaleStep?: number;
 }
 
 export interface ImageExperimentalConfig {

--- a/components/core/config/config.ts
+++ b/components/core/config/config.ts
@@ -354,6 +354,7 @@ export interface ImageConfig {
   nzDisablePreview?: string;
   nzCloseOnNavigation?: boolean;
   nzDirection?: Direction;
+  nzZoomStep?: number;
 }
 
 export interface ImageExperimentalConfig {

--- a/components/image/demo/controlled-preview.md
+++ b/components/image/demo/controlled-preview.md
@@ -1,0 +1,14 @@
+---
+order: 6
+title:
+  zh-CN: 受控的预览
+  en-US: Controlled Preview
+---
+
+## zh-CN
+
+可以使预览受控。
+
+## en-US
+
+You can make preview controlled.

--- a/components/image/demo/controlled-preview.ts
+++ b/components/image/demo/controlled-preview.ts
@@ -8,7 +8,7 @@ import { NzImageService } from 'ng-zorro-antd/image';
     <div>
       <label>
         <span>scale step:</span>
-        <nz-input-number [(ngModel)]="zoomStep" [nzMin]="0.1" [nzStep]="1"></nz-input-number>
+        <nz-input-number [(ngModel)]="scaleStep" [nzMin]="0.1" [nzStep]="1"></nz-input-number>
       </label>
 
       <button nz-button nzType="primary" (click)="onClick()">Preview</button>
@@ -32,7 +32,7 @@ import { NzImageService } from 'ng-zorro-antd/image';
   ]
 })
 export class NzDemoImageControlledPreviewComponent {
-  zoomStep: number = 0.5;
+  scaleStep: number = 0.5;
 
   constructor(private nzImageService: NzImageService) {}
 
@@ -43,6 +43,6 @@ export class NzDemoImageControlledPreviewComponent {
         alt: ''
       }
     ];
-    this.nzImageService.preview(images, { nzZoom: 1, nzRotate: 0, nzZoomStep: this.zoomStep });
+    this.nzImageService.preview(images, { nzZoom: 1, nzRotate: 0, nzScaleStep: this.scaleStep });
   }
 }

--- a/components/image/demo/controlled-preview.ts
+++ b/components/image/demo/controlled-preview.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+
+import { NzImageService } from 'ng-zorro-antd/image';
+
+@Component({
+  selector: 'nz-demo-image-controlled-preview',
+  template: `
+    <div>
+      <label>
+        <span>scale step:</span>
+        <nz-input-number [(ngModel)]="zoomStep" [nzMin]="0.1" [nzStep]="1"></nz-input-number>
+      </label>
+
+      <button nz-button nzType="primary" (click)="onClick()">Preview</button>
+    </div>
+  `,
+  styles: [
+    `
+      div {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+      }
+
+      label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+    `
+  ]
+})
+export class NzDemoImageControlledPreviewComponent {
+  zoomStep: number = 0.5;
+
+  constructor(private nzImageService: NzImageService) {}
+
+  onClick(): void {
+    const images = [
+      {
+        src: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+        alt: ''
+      }
+    ];
+    this.nzImageService.preview(images, { nzZoom: 1, nzRotate: 0, nzZoomStep: this.zoomStep });
+  }
+}

--- a/components/image/demo/module
+++ b/components/image/demo/module
@@ -1,5 +1,6 @@
 import { NzImageModule } from 'ng-zorro-antd/image';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 
-export const moduleList = [ NzImageModule, NzButtonModule, NzSpaceModule ];
+export const moduleList = [ NzImageModule, NzButtonModule, NzSpaceModule, NzInputNumberModule ];

--- a/components/image/demo/preview-group.ts
+++ b/components/image/demo/preview-group.ts
@@ -5,13 +5,7 @@ import { Component } from '@angular/core';
   template: `
     <nz-image-group>
       <img nz-image width="200px" nzSrc="https://img.alicdn.com/tfs/TB1g.mWZAL0gK0jSZFtXXXQCXXa-200-200.svg" alt="" />
-      <img
-        nz-image
-        [nzZoomStep]="2"
-        width="200px"
-        nzSrc="https://img.alicdn.com/tfs/TB1Z0PywTtYBeNjy1XdXXXXyVXa-186-200.svg"
-        alt=""
-      />
+      <img nz-image width="200px" nzSrc="https://img.alicdn.com/tfs/TB1Z0PywTtYBeNjy1XdXXXXyVXa-186-200.svg" alt="" />
     </nz-image-group>
   `
 })

--- a/components/image/demo/preview-group.ts
+++ b/components/image/demo/preview-group.ts
@@ -4,13 +4,7 @@ import { Component } from '@angular/core';
   selector: 'nz-demo-image-preview-group',
   template: `
     <nz-image-group>
-      <img
-        nz-image
-        [nzZoomStep]="0.2"
-        width="200px"
-        nzSrc="https://img.alicdn.com/tfs/TB1g.mWZAL0gK0jSZFtXXXQCXXa-200-200.svg"
-        alt=""
-      />
+      <img nz-image width="200px" nzSrc="https://img.alicdn.com/tfs/TB1g.mWZAL0gK0jSZFtXXXQCXXa-200-200.svg" alt="" />
       <img
         nz-image
         [nzZoomStep]="2"

--- a/components/image/demo/preview-group.ts
+++ b/components/image/demo/preview-group.ts
@@ -4,8 +4,20 @@ import { Component } from '@angular/core';
   selector: 'nz-demo-image-preview-group',
   template: `
     <nz-image-group>
-      <img nz-image width="200px" nzSrc="https://img.alicdn.com/tfs/TB1g.mWZAL0gK0jSZFtXXXQCXXa-200-200.svg" alt="" />
-      <img nz-image width="200px" nzSrc="https://img.alicdn.com/tfs/TB1Z0PywTtYBeNjy1XdXXXXyVXa-186-200.svg" alt="" />
+      <img
+        nz-image
+        [nzZoomStep]="0.2"
+        width="200px"
+        nzSrc="https://img.alicdn.com/tfs/TB1g.mWZAL0gK0jSZFtXXXQCXXa-200-200.svg"
+        alt=""
+      />
+      <img
+        nz-image
+        [nzZoomStep]="2"
+        width="200px"
+        nzSrc="https://img.alicdn.com/tfs/TB1Z0PywTtYBeNjy1XdXXXXyVXa-186-200.svg"
+        alt=""
+      />
     </nz-image-group>
   `
 })

--- a/components/image/doc/index.en-US.md
+++ b/components/image/doc/index.en-US.md
@@ -20,52 +20,53 @@ import { NzImageModule } from 'ng-zorro-antd/image';
 
 ### [nz-image]
 
-| Property | Description | Type | Default | Global Config |
-| --- | --- | --- | --- | --- |
-| nzSrc | Image path | `string` | - | - |
-| nzFallback | Load failure fault-tolerant src | `string` | - | ✅ |
-| nzPlaceholder | Load placeholder src | `string` | - | ✅ |
-| nzDisablePreview | Whether to disable the preview | `boolean` | `false` | ✅ |
-| nzCloseOnNavigation | Whether to close the image preview when the user goes backwards/forwards in history. Note that this usually doesn't include clicking on links (unless the user is using the HashLocationStrategy). | `boolean` | `false` | ✅ |
-| nzDirection | Text directionality | `Direction` | `'ltr'` | ✅ |
+| Property            | Description                                                                                                                                                                                        | Type        | Default | Global Config |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------- | ------------- |
+| nzSrc               | Image path                                                                                                                                                                                         | `string`    | -       | -             |
+| nzFallback          | Load failure fault-tolerant src                                                                                                                                                                    | `string`    | -       | ✅            |
+| nzPlaceholder       | Load placeholder src                                                                                                                                                                               | `string`    | -       | ✅            |
+| nzDisablePreview    | Whether to disable the preview                                                                                                                                                                     | `boolean`   | `false` | ✅            |
+| nzCloseOnNavigation | Whether to close the image preview when the user goes backwards/forwards in history. Note that this usually doesn't include clicking on links (unless the user is using the HashLocationStrategy). | `boolean`   | `false` | ✅            |
+| nzDirection         | Text directionality                                                                                                                                                                                | `Direction` | `'ltr'` | ✅            |
+| nzScaleStep         | `1 + nzScaleStep` is the step to increase or decrease the scale                                                                                                                                    | `number`    | 0.5     | ✅            |
 
 Other attributes [<img\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
 
-
 ### NzImageService
 
-| Property | Description | Type | Default |
-| --- | --- | --- | --- |
-| images | Preview images | `NzImage[]` | - |
-| options | Preview options | `NzImagePreviewOptions` | - |
+| Property | Description     | Type                    | Default |
+| -------- | --------------- | ----------------------- | ------- |
+| images   | Preview images  | `NzImage[]`             | -       |
+| options  | Preview options | `NzImagePreviewOptions` | -       |
 
 ## Related type definition
 
 ### NzImage
 
-| Property | Description | Type | Default |
-| --- | --- | --- | --- |
-| src | src | `string` | - |
-| alt | alt | `string` | - |
-| width | width | `string` | - |
-| height | height | `string` | - |
+| Property | Description | Type     | Default |
+| -------- | ----------- | -------- | ------- |
+| src      | src         | `string` | -       |
+| alt      | alt         | `string` | -       |
+| width    | width       | `string` | -       |
+| height   | height      | `string` | -       |
 
 ### NzImagePreviewOptions
 
-| Property | Description | Type | Default |
-| --- | --- | --- | --- |
-| nzKeyboard      | Whether support press `esc` to close, press `left` or `right` to switch image | `boolean` | `true` |
-| nzMaskClosable      | Whether to close the image preview when the mask (area outside the image) is clicked | `boolean` | `true` |
-| nzCloseOnNavigation      | Whether to close the image preview when the user goes backwards/forwards in history. Note that this usually doesn't include clicking on links (unless the user is using the HashLocationStrategy). | `boolean` | `true` |
-| nzZIndex      | The z-index of the image preview | `number` | 1000 |
-| nzZoom      | Zoom rate | `number` | 1 |
-| nzRotate      | Rotate rate | `number` | 0 |
+| Property            | Description                                                                                                                                                                                        | Type      | Default |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| nzKeyboard          | Whether support press `esc` to close, press `left` or `right` to switch image                                                                                                                      | `boolean` | `true`  |
+| nzMaskClosable      | Whether to close the image preview when the mask (area outside the image) is clicked                                                                                                               | `boolean` | `true`  |
+| nzCloseOnNavigation | Whether to close the image preview when the user goes backwards/forwards in history. Note that this usually doesn't include clicking on links (unless the user is using the HashLocationStrategy). | `boolean` | `true`  |
+| nzZIndex            | The z-index of the image preview                                                                                                                                                                   | `number`  | 1000    |
+| nzZoom              | Zoom rate                                                                                                                                                                                          | `number`  | 1       |
+| nzRotate            | Rotate rate                                                                                                                                                                                        | `number`  | 0       |
+| nzScaleStep         | `1 + nzScaleStep` is the step to increase or decrease the scale                                                                                                                                    | `number`  | 0.5     |
 
 ### NzImagePreviewRef
 
-| Name | Description |
-| --- | --- |
-| switchTo(index: number): void | Switch to index |
-| prev(): void | Previous image |
-| next(): void | Next image |
-| close(): void | Close image preview |
+| Name                          | Description         |
+| ----------------------------- | ------------------- |
+| switchTo(index: number): void | Switch to index     |
+| prev(): void                  | Previous image      |
+| next(): void                  | Next image          |
+| close(): void                 | Close image preview |

--- a/components/image/doc/index.en-US.md
+++ b/components/image/doc/index.en-US.md
@@ -70,3 +70,9 @@ Other attributes [<img\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Elem
 | prev(): void                  | Previous image      |
 | next(): void                  | Next image          |
 | close(): void                 | Close image preview |
+
+### NzImageGroupComponent
+
+| Property    | Description                                                                                                                     | Type     | Default |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| nzScaleStep | The value of `nzScaleStep` will be applied to all the images inside, unless an image has its own `nzScaleStep` value specified. | `number` | -       |

--- a/components/image/doc/index.zh-CN.md
+++ b/components/image/doc/index.zh-CN.md
@@ -54,14 +54,14 @@ import { NzImageModule } from 'ng-zorro-antd/image';
 ### NzImagePreviewOptions
 
 | 参数                | 说明                                                                                                     | 类型      | 默认值 |
-| ------------------- | -------------------------------------------------------------------------------------------------------- | --------- | ------ | --- |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | --------- | ------ |
 | nzKeyboard          | 是否支持键盘 esc 关闭、左右键切换图片                                                                    | `boolean` | `true` |
 | nzMaskClosable      | 点击蒙层是否允许关闭                                                                                     | `boolean` | `true` |
 | nzCloseOnNavigation | 当用户在历史中前进/后退时是否关闭预览。注意，这通常不包括点击链接（除非用户使用 HashLocationStrategy）。 | `boolean` | `true` |
 | nzZIndex            | 设置预览层的 z-index                                                                                     | `number`  | 1000   |
 | nzZoom              | 缩放比例                                                                                                 | `number`  | 1      |
 | nzRotate            | 旋转角度                                                                                                 | `number`  | 0      |
-| nzScaleStep         | `1 + nzScaleStep` 为缩放放大的每步倍数                                                                   | `number`  | 0.5    | ✅  |
+| nzScaleStep         | `1 + nzScaleStep` 为缩放放大的每步倍数                                                                   | `number`  | 0.5    |
 
 ### NzImagePreviewRef
 
@@ -71,3 +71,9 @@ import { NzImageModule } from 'ng-zorro-antd/image';
 | prev(): void                  | 上一张       |
 | next(): void                  | 下一张       |
 | close(): void                 | 关闭预览     |
+
+### NzImageGroupComponent
+
+| Property    | Description                                                                                                                     | Type | Default |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------- | ---- | ------- |
+| nzScaleStep | The value of `nzScaleStep` will be applied to all the images inside, unless an image has its own `nzScaleStep` value specified. |

--- a/components/image/doc/index.zh-CN.md
+++ b/components/image/doc/index.zh-CN.md
@@ -21,51 +21,53 @@ import { NzImageModule } from 'ng-zorro-antd/image';
 
 ### [nz-image]
 
-| 参数        | 说明                               | 类型             | 默认值 | 支持全局配置  |
-| ----------- | ---------------------------------- | ---------------- | ------ | ----- |
-| nzSrc | 图片地址 | `string` | - | - |
-| nzFallback | 加载失败容错地址 | `string` | - | ✅ |
-| nzPlaceholder | 加载占位地址 | `string` | - | ✅ |
-| nzDisablePreview | 是否禁止预览 | `boolean` | `false` | ✅ |
-| nzCloseOnNavigation | 当用户在历史中前进/后退时是否关闭预览。注意，这通常不包括点击链接（除非用户使用HashLocationStrategy）。 | `boolean` | `false` | ✅ |
-| nzDirection | 文字方向 | `Direction` | `'ltr'` | ✅ |
+| 参数                | 说明                                                                                                     | 类型        | 默认值  | 支持全局配置 |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | ----------- | ------- | ------------ |
+| nzSrc               | 图片地址                                                                                                 | `string`    | -       | -            |
+| nzFallback          | 加载失败容错地址                                                                                         | `string`    | -       | ✅           |
+| nzPlaceholder       | 加载占位地址                                                                                             | `string`    | -       | ✅           |
+| nzDisablePreview    | 是否禁止预览                                                                                             | `boolean`   | `false` | ✅           |
+| nzCloseOnNavigation | 当用户在历史中前进/后退时是否关闭预览。注意，这通常不包括点击链接（除非用户使用 HashLocationStrategy）。 | `boolean`   | `false` | ✅           |
+| nzDirection         | 文字方向                                                                                                 | `Direction` | `'ltr'` | ✅           |
+| nzScaleStep         | `1 + nzScaleStep` 为缩放放大的每步倍数                                                                   | `number`    | 0.5     | ✅           |
 
 其他属性见 [<img\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
 
 ### NzImageService
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| images | 预览图片 | `NzImage[]` | - |
-| options | 预览参数 | `NzImagePreviewOptions` | - |
+| 参数    | 说明     | 类型                    | 默认值 |
+| ------- | -------- | ----------------------- | ------ |
+| images  | 预览图片 | `NzImage[]`             | -      |
+| options | 预览参数 | `NzImagePreviewOptions` | -      |
 
 ## 相关类型定义
 
 ### NzImage
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| src | src | `string` | - |
-| alt | alt | `string` | - |
-| width | 图片宽度 | `string` | - |
-| height | 图片高度 | `string` | - |
+| 参数   | 说明     | 类型     | 默认值 |
+| ------ | -------- | -------- | ------ |
+| src    | src      | `string` | -      |
+| alt    | alt      | `string` | -      |
+| width  | 图片宽度 | `string` | -      |
+| height | 图片高度 | `string` | -      |
 
 ### NzImagePreviewOptions
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| nzKeyboard      | 是否支持键盘 esc 关闭、左右键切换图片 | `boolean` | `true` |
-| nzMaskClosable      | 点击蒙层是否允许关闭 | `boolean` | `true` |
-| nzCloseOnNavigation      | 当用户在历史中前进/后退时是否关闭预览。注意，这通常不包括点击链接（除非用户使用HashLocationStrategy）。 | `boolean` | `true` |
-| nzZIndex      | 设置预览层的 z-index | `number` | 1000 |
-| nzZoom      | 缩放比例 | `number` | 1 |
-| nzRotate      | 旋转角度 | `number` | 0 |
+| 参数                | 说明                                                                                                     | 类型      | 默认值 |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | --------- | ------ | --- |
+| nzKeyboard          | 是否支持键盘 esc 关闭、左右键切换图片                                                                    | `boolean` | `true` |
+| nzMaskClosable      | 点击蒙层是否允许关闭                                                                                     | `boolean` | `true` |
+| nzCloseOnNavigation | 当用户在历史中前进/后退时是否关闭预览。注意，这通常不包括点击链接（除非用户使用 HashLocationStrategy）。 | `boolean` | `true` |
+| nzZIndex            | 设置预览层的 z-index                                                                                     | `number`  | 1000   |
+| nzZoom              | 缩放比例                                                                                                 | `number`  | 1      |
+| nzRotate            | 旋转角度                                                                                                 | `number`  | 0      |
+| nzScaleStep         | `1 + nzScaleStep` 为缩放放大的每步倍数                                                                   | `number`  | 0.5    | ✅  |
 
 ### NzImagePreviewRef
 
-| 名称 | 描述 |
-| --- | --- |
+| 名称                          | 描述         |
+| ----------------------------- | ------------ |
 | switchTo(index: number): void | 设置预览索引 |
-| prev(): void | 上一张 |
-| next(): void | 下一张 |
-| close(): void | 关闭预览 |
+| prev(): void                  | 上一张       |
+| next(): void                  | 下一张       |
+| close(): void                 | 关闭预览     |

--- a/components/image/image-group.component.ts
+++ b/components/image/image-group.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
 import { NzImageDirective } from './image.directive';
 
@@ -16,6 +16,8 @@ import { NzImageDirective } from './image.directive';
   encapsulation: ViewEncapsulation.None
 })
 export class NzImageGroupComponent {
+  @Input() nzZoomStep: number | null = null;
+
   images: NzImageDirective[] = [];
 
   addImage(image: NzImageDirective): void {

--- a/components/image/image-group.component.ts
+++ b/components/image/image-group.component.ts
@@ -16,7 +16,7 @@ import { NzImageDirective } from './image.directive';
   encapsulation: ViewEncapsulation.None
 })
 export class NzImageGroupComponent {
-  @Input() nzZoomStep: number | null = null;
+  @Input() nzScaleStep: number | null = null;
 
   images: NzImageDirective[] = [];
 

--- a/components/image/image-preview-options.ts
+++ b/components/image/image-preview-options.ts
@@ -13,6 +13,7 @@ export class NzImagePreviewOptions {
   nzZIndex?: number;
   nzZoom?: number;
   nzRotate?: number;
+  nzZoomStep?: number;
   nzDirection?: Direction;
 }
 

--- a/components/image/image-preview-options.ts
+++ b/components/image/image-preview-options.ts
@@ -13,7 +13,7 @@ export class NzImagePreviewOptions {
   nzZIndex?: number;
   nzZoom?: number;
   nzRotate?: number;
-  nzZoomStep?: number;
+  nzScaleStep?: number;
   nzDirection?: Direction;
 }
 

--- a/components/image/image-preview.component.ts
+++ b/components/image/image-preview.component.ts
@@ -290,7 +290,9 @@ export class NzImagePreviewComponent implements OnInit {
 
   onZoomOut(): void {
     if (this.zoom > 1) {
-      this.zoom -= this.scaleStep;
+      const zoomStep =
+        this.scaleStepMap.get(this.images[this.index].src ?? this.images[this.index].src) ?? this.scaleStep;
+      this.zoom -= zoomStep;
       this.updatePreviewImageTransform();
       this.updateZoomOutDisabled();
       this.position = { ...initialPosition };

--- a/components/image/image-preview.component.ts
+++ b/components/image/image-preview.component.ts
@@ -43,7 +43,7 @@ const initialPosition = {
   y: 0
 };
 
-export const DEFAULT_NZ_ZOOM_STEP = 0.5;
+export const DEFAULT_NZ_SCALE_STEP = 0.5;
 const DEFAULT_NZ_ZOOM = 1;
 const DEFAULT_NZ_ROTATE = 0;
 
@@ -128,7 +128,7 @@ const DEFAULT_NZ_ROTATE = 0;
 })
 export class NzImagePreviewComponent implements OnInit {
   readonly _defaultNzZoom = DEFAULT_NZ_ZOOM;
-  readonly _defaultNzZoomStep = DEFAULT_NZ_ZOOM_STEP;
+  readonly _defaultNzScaleStep = DEFAULT_NZ_SCALE_STEP;
   readonly _defaultNzRotate = DEFAULT_NZ_ROTATE;
 
   images: NzImage[] = [];
@@ -190,7 +190,7 @@ export class NzImagePreviewComponent implements OnInit {
 
   private zoom: number;
   private rotate: number;
-  private zoomStep: number;
+  private scaleStep: number;
 
   get animationDisabled(): boolean {
     return this.config.nzNoAnimation ?? false;
@@ -212,7 +212,7 @@ export class NzImagePreviewComponent implements OnInit {
     private sanitizer: DomSanitizer
   ) {
     this.zoom = this.config.nzZoom ?? this._defaultNzZoom;
-    this.zoomStep = this.config.nzZoomStep ?? this._defaultNzZoomStep;
+    this.scaleStep = this.config.nzScaleStep ?? this._defaultNzScaleStep;
     this.rotate = this.config.nzRotate ?? this._defaultNzRotate;
     this.updateZoomOutDisabled();
     this.updatePreviewImageTransform();
@@ -279,7 +279,7 @@ export class NzImagePreviewComponent implements OnInit {
   }
 
   onZoomIn(): void {
-    const zoomStep = this.zoomMap.get(this.images[this.index].src ?? this.images[this.index].src) ?? this.zoomStep;
+    const zoomStep = this.zoomMap.get(this.images[this.index].src ?? this.images[this.index].src) ?? this.scaleStep;
     this.zoom += zoomStep;
     this.updatePreviewImageTransform();
     this.updateZoomOutDisabled();
@@ -288,7 +288,7 @@ export class NzImagePreviewComponent implements OnInit {
 
   onZoomOut(): void {
     if (this.zoom > 1) {
-      this.zoom -= this.zoomStep;
+      this.zoom -= this.scaleStep;
       this.updatePreviewImageTransform();
       this.updateZoomOutDisabled();
       this.position = { ...initialPosition };
@@ -401,8 +401,9 @@ export class NzImagePreviewComponent implements OnInit {
   }
 
   private reset(): void {
-    this.zoom = 1;
-    this.rotate = 0;
+    this.zoom = this.config.nzZoom ?? this._defaultNzZoom;
+    this.scaleStep = this.config.nzScaleStep ?? this._defaultNzScaleStep;
+    this.rotate = this.config.nzRotate ?? this._defaultNzRotate;
     this.position = { ...initialPosition };
   }
 }

--- a/components/image/image-preview.component.ts
+++ b/components/image/image-preview.component.ts
@@ -29,6 +29,7 @@ import { isNotNil } from 'ng-zorro-antd/core/util';
 import { FADE_CLASS_NAME_MAP, NZ_CONFIG_MODULE_NAME } from './image-config';
 import { NzImage, NzImagePreviewOptions } from './image-preview-options';
 import { NzImagePreviewRef } from './image-preview-ref';
+import { TImageUrl, TImageScaleStep } from './image.directive';
 import { getClientSize, getFitContentPosition, getOffset } from './utils';
 
 export interface NzImageContainerOperation {
@@ -137,7 +138,7 @@ export class NzImagePreviewComponent implements OnInit {
   visible = true;
   animationState: 'void' | 'enter' | 'leave' = 'enter';
   animationStateChanged = new EventEmitter<AnimationEvent>();
-  zoomMap: Map<string, number> = new Map<string, number>();
+  scaleStepMap: Map<TImageUrl, TImageScaleStep> = new Map<TImageUrl, TImageScaleStep>();
 
   previewImageTransform = '';
   previewImageWrapperTransform = '';
@@ -237,8 +238,8 @@ export class NzImagePreviewComponent implements OnInit {
     });
   }
 
-  setImages(images: NzImage[], zoomMap?: Map<string, number>): void {
-    if (zoomMap) this.zoomMap = zoomMap;
+  setImages(images: NzImage[], scaleStepMap?: Map<string, number>): void {
+    if (scaleStepMap) this.scaleStepMap = scaleStepMap;
     this.images = images;
     this.cdr.markForCheck();
   }
@@ -279,7 +280,8 @@ export class NzImagePreviewComponent implements OnInit {
   }
 
   onZoomIn(): void {
-    const zoomStep = this.zoomMap.get(this.images[this.index].src ?? this.images[this.index].src) ?? this.scaleStep;
+    const zoomStep =
+      this.scaleStepMap.get(this.images[this.index].src ?? this.images[this.index].src) ?? this.scaleStep;
     this.zoom += zoomStep;
     this.updatePreviewImageTransform();
     this.updateZoomOutDisabled();

--- a/components/image/image-preview.component.ts
+++ b/components/image/image-preview.component.ts
@@ -43,9 +43,9 @@ const initialPosition = {
   y: 0
 };
 
-const DEFAULT_NZ_ZOOM = 1;
 export const DEFAULT_NZ_ZOOM_STEP = 0.5;
-const DEFAULT_NZ_ROTATE = 1;
+const DEFAULT_NZ_ZOOM = 1;
+const DEFAULT_NZ_ROTATE = 0;
 
 @Component({
   selector: 'nz-image-preview',
@@ -238,8 +238,8 @@ export class NzImagePreviewComponent implements OnInit {
   }
 
   setImages(images: NzImage[], zoomMap?: Map<string, number>): void {
-    this.images = images;
     if (zoomMap) this.zoomMap = zoomMap;
+    this.images = images;
     this.cdr.markForCheck();
   }
 

--- a/components/image/image.directive.ts
+++ b/components/image/image.directive.ts
@@ -26,7 +26,7 @@ import { InputBoolean } from 'ng-zorro-antd/core/util';
 
 import { NzImageGroupComponent } from './image-group.component';
 // @ts-ignore
-import { DEFAULT_NZ_ZOOM_STEP } from './image-preview.component';
+import { DEFAULT_NZ_SCALE_STEP } from './image-preview.component';
 import { NzImageService } from './image.service';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'image';
@@ -52,7 +52,7 @@ export class NzImageDirective implements OnInit, OnChanges, OnDestroy {
   @Input() @InputBoolean() @WithConfig() nzDisablePreview: boolean = false;
   @Input() @WithConfig() nzFallback: string | null = null;
   @Input() @WithConfig() nzPlaceholder: string | null = null;
-  @Input() @WithConfig() nzZoomStep: number | null = null;
+  @Input() @WithConfig() nzScaleStep: number | null = null;
 
   dir?: Direction;
   backLoadImage!: HTMLImageElement;
@@ -107,7 +107,7 @@ export class NzImageDirective implements OnInit, OnChanges, OnDestroy {
       previewAbleImages.forEach(imageDirective => {
         zoomStepMap.set(
           imageDirective.nzSrc ?? imageDirective.nzSrcset,
-          imageDirective.nzZoomStep ?? this.parentGroup.nzZoomStep ?? this.nzZoomStep ?? DEFAULT_NZ_ZOOM_STEP
+          imageDirective.nzScaleStep ?? this.parentGroup.nzScaleStep ?? this.nzScaleStep ?? DEFAULT_NZ_SCALE_STEP
         );
       });
       const previewRef = this.nzImageService.preview(
@@ -123,7 +123,7 @@ export class NzImageDirective implements OnInit, OnChanges, OnDestroy {
       const previewImages = [{ src: this.nzSrc, srcset: this.nzSrcset }];
       this.nzImageService.preview(previewImages, {
         nzDirection: this.dir,
-        nzZoomStep: this.nzZoomStep ?? DEFAULT_NZ_ZOOM_STEP
+        nzScaleStep: this.nzScaleStep ?? DEFAULT_NZ_SCALE_STEP
       });
     }
   }

--- a/components/image/image.directive.ts
+++ b/components/image/image.directive.ts
@@ -107,14 +107,13 @@ export class NzImageDirective implements OnInit, OnChanges, OnDestroy {
       previewAbleImages.forEach(imageDirective => {
         zoomStepMap.set(
           imageDirective.nzSrc ?? imageDirective.nzSrcset,
-          imageDirective.nzZoomStep ?? DEFAULT_NZ_ZOOM_STEP
+          imageDirective.nzZoomStep ?? this.parentGroup.nzZoomStep ?? this.nzZoomStep ?? DEFAULT_NZ_ZOOM_STEP
         );
       });
       const previewRef = this.nzImageService.preview(
         previewImages,
         {
-          nzDirection: this.dir,
-          nzZoomStep: this.nzZoomStep ?? DEFAULT_NZ_ZOOM_STEP
+          nzDirection: this.dir
         },
         zoomStepMap
       );

--- a/components/image/image.directive.ts
+++ b/components/image/image.directive.ts
@@ -25,15 +25,14 @@ import { BooleanInput, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 
 import { NzImageGroupComponent } from './image-group.component';
-// @ts-ignore
 import { DEFAULT_NZ_SCALE_STEP } from './image-preview.component';
 import { NzImageService } from './image.service';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'image';
 
 export type ImageStatusType = 'error' | 'loading' | 'normal';
-type TImageUrl = string;
-type TImageZoomStep = number;
+export type TImageUrl = string;
+export type TImageScaleStep = number;
 
 @Directive({
   selector: 'img[nz-image]',
@@ -103,9 +102,9 @@ export class NzImageDirective implements OnInit, OnChanges, OnDestroy {
       const previewAbleImages = this.parentGroup.images.filter(e => e.previewable);
       const previewImages = previewAbleImages.map(e => ({ src: e.nzSrc, srcset: e.nzSrcset }));
       const previewIndex = previewAbleImages.findIndex(el => this === el);
-      const zoomStepMap = new Map<TImageUrl, TImageZoomStep>();
+      const scaleStepMap = new Map<TImageUrl, TImageScaleStep>();
       previewAbleImages.forEach(imageDirective => {
-        zoomStepMap.set(
+        scaleStepMap.set(
           imageDirective.nzSrc ?? imageDirective.nzSrcset,
           imageDirective.nzScaleStep ?? this.parentGroup.nzScaleStep ?? this.nzScaleStep ?? DEFAULT_NZ_SCALE_STEP
         );
@@ -115,7 +114,7 @@ export class NzImageDirective implements OnInit, OnChanges, OnDestroy {
         {
           nzDirection: this.dir
         },
-        zoomStepMap
+        scaleStepMap
       );
       previewRef.switchTo(previewIndex);
     } else {

--- a/components/image/image.service.ts
+++ b/components/image/image.service.ts
@@ -28,15 +28,15 @@ export class NzImageService {
     @Optional() private directionality: Directionality
   ) {}
 
-  preview(images: NzImage[], options?: NzImagePreviewOptions): NzImagePreviewRef {
-    return this.display(images, options);
+  preview(images: NzImage[], options?: NzImagePreviewOptions, zoomMap?: Map<string, number>): NzImagePreviewRef {
+    return this.display(images, options, zoomMap);
   }
 
-  private display(images: NzImage[], config?: NzImagePreviewOptions): NzImagePreviewRef {
+  private display(images: NzImage[], config?: NzImagePreviewOptions, zoomMap?: Map<string, number>): NzImagePreviewRef {
     const configMerged = { ...new NzImagePreviewOptions(), ...(config ?? {}) };
     const overlayRef = this.createOverlay(configMerged);
     const previewComponent = this.attachPreviewComponent(overlayRef, configMerged);
-    previewComponent.setImages(images);
+    previewComponent.setImages(images, zoomMap);
     const previewRef = new NzImagePreviewRef(previewComponent, configMerged, overlayRef);
 
     previewComponent.previewRef = previewRef;

--- a/components/image/image.service.ts
+++ b/components/image/image.service.ts
@@ -9,6 +9,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { Injectable, Injector, Optional } from '@angular/core';
 
 import { ImageConfig, NzConfigService } from 'ng-zorro-antd/core/config';
+import { TImageScaleStep, TImageUrl } from 'ng-zorro-antd/image/image.directive';
 
 import { IMAGE_PREVIEW_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME } from './image-config';
 import { NzImage, NzImagePreviewOptions } from './image-preview-options';
@@ -28,15 +29,23 @@ export class NzImageService {
     @Optional() private directionality: Directionality
   ) {}
 
-  preview(images: NzImage[], options?: NzImagePreviewOptions, zoomMap?: Map<string, number>): NzImagePreviewRef {
+  preview(
+    images: NzImage[],
+    options?: NzImagePreviewOptions,
+    zoomMap?: Map<TImageUrl, TImageScaleStep>
+  ): NzImagePreviewRef {
     return this.display(images, options, zoomMap);
   }
 
-  private display(images: NzImage[], config?: NzImagePreviewOptions, zoomMap?: Map<string, number>): NzImagePreviewRef {
+  private display(
+    images: NzImage[],
+    config?: NzImagePreviewOptions,
+    scaleStepMap?: Map<TImageUrl, TImageScaleStep>
+  ): NzImagePreviewRef {
     const configMerged = { ...new NzImagePreviewOptions(), ...(config ?? {}) };
     const overlayRef = this.createOverlay(configMerged);
     const previewComponent = this.attachPreviewComponent(overlayRef, configMerged);
-    previewComponent.setImages(images, zoomMap);
+    previewComponent.setImages(images, scaleStepMap);
     const previewRef = new NzImagePreviewRef(previewComponent, configMerged, overlayRef);
 
     previewComponent.previewRef = previewRef;

--- a/components/image/image.service.ts
+++ b/components/image/image.service.ts
@@ -9,12 +9,12 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { Injectable, Injector, Optional } from '@angular/core';
 
 import { ImageConfig, NzConfigService } from 'ng-zorro-antd/core/config';
-import { TImageScaleStep, TImageUrl } from 'ng-zorro-antd/image/image.directive';
 
 import { IMAGE_PREVIEW_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME } from './image-config';
 import { NzImage, NzImagePreviewOptions } from './image-preview-options';
 import { NzImagePreviewRef } from './image-preview-ref';
 import { NzImagePreviewComponent } from './image-preview.component';
+import { TImageScaleStep, TImageUrl } from './image.directive';
 
 export interface NzImageService {
   preview(images: NzImage[], option?: NzImagePreviewOptions): NzImagePreviewRef;

--- a/components/image/image.spec.ts
+++ b/components/image/image.spec.ts
@@ -28,6 +28,7 @@ import {
   ZoomOutOutline
 } from '@ant-design/icons-angular/icons';
 
+import { NzConfigService } from 'ng-zorro-antd/core/config';
 import { dispatchFakeEvent, dispatchKeyboardEvent } from 'ng-zorro-antd/core/testing';
 import { NzIconModule, NZ_ICONS } from 'ng-zorro-antd/icon';
 import {
@@ -189,6 +190,7 @@ describe('Preview', () => {
   let overlayContainer: OverlayContainer;
   let overlayContainerElement: HTMLElement;
   let previewElement: HTMLElement | null;
+  let configService: NzConfigService;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -212,8 +214,9 @@ describe('Preview', () => {
     TestBed.compileComponents();
   }));
 
-  beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
+  beforeEach(inject([OverlayContainer, NzConfigService], (oc: OverlayContainer, cs: NzConfigService) => {
     overlayContainer = oc;
+    configService = cs;
     overlayContainerElement = oc.getContainerElement();
   }));
 
@@ -308,7 +311,7 @@ describe('Preview', () => {
       expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(1, 1, 1) rotate(0deg)');
       dispatchFakeEvent(zoomIn, 'click');
       tickChanges();
-      expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(2, 2, 1) rotate(0deg)');
+      expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(1.5, 1.5, 1) rotate(0deg)');
       dispatchFakeEvent(zoomOut, 'click');
       tickChanges();
       expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(1, 1, 1) rotate(0deg)');
@@ -316,6 +319,102 @@ describe('Preview', () => {
       tickChanges();
       previewElement = getPreviewElement();
       expect(previewElement).not.toBeTruthy();
+      discardPeriodicTasks();
+      flush();
+    }));
+
+    it('should zoom in/out based on the zoom step value', fakeAsync(() => {
+      context.firstSrc = QUICK_SRC;
+      context.zoomStep = 2;
+      fixture.detectChanges();
+      let image = debugElement.nativeElement.querySelectorAll('img');
+      image[2].click();
+      tickChanges();
+      previewElement = getPreviewElement();
+      let imageElement = getPreviewImageElement();
+      const operations = overlayContainerElement.querySelectorAll('.ant-image-preview-operations-operation');
+      const zoomIn = operations[1];
+      const zoomOut = operations[2];
+      dispatchFakeEvent(zoomIn, 'click');
+      tickChanges();
+      expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(3, 3, 1) rotate(0deg)');
+      dispatchFakeEvent(zoomOut, 'click');
+      tickChanges();
+      expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(1, 1, 1) rotate(0deg)');
+      discardPeriodicTasks();
+      flush();
+    }));
+
+    it('should have a default value of 0.5 for zoomStep', fakeAsync(() => {
+      context.firstSrc = QUICK_SRC;
+      context.zoomStep = null;
+      fixture.detectChanges();
+      let image = debugElement.nativeElement.querySelector('img');
+      image.click();
+      tickChanges();
+      previewElement = getPreviewElement();
+      let imageElement = getPreviewImageElement();
+      const operations = overlayContainerElement.querySelectorAll('.ant-image-preview-operations-operation');
+      const zoomIn = operations[1];
+      dispatchFakeEvent(zoomIn, 'click');
+      tickChanges();
+      expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(1.5, 1.5, 1) rotate(0deg)');
+      discardPeriodicTasks();
+      flush();
+    }));
+
+    it('should the groupZoomStep variable be set for each image"s zoomStep', fakeAsync(() => {
+      context.firstSrc = QUICK_SRC;
+      context.groupZoomStep = 5;
+      fixture.detectChanges();
+      let image = debugElement.nativeElement.querySelectorAll('img');
+      image[0].click();
+      tickChanges();
+      previewElement = getPreviewElement();
+      let imageElement = getPreviewImageElement();
+      const operations = overlayContainerElement.querySelectorAll('.ant-image-preview-operations-operation');
+      const zoomIn = operations[1];
+      dispatchFakeEvent(zoomIn, 'click');
+      tickChanges();
+      expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(6, 6, 1) rotate(0deg)');
+      discardPeriodicTasks();
+      flush();
+    }));
+
+    it('should the groupZoomStep variable be set for each image"s zoomStep Except those that already have a zoomStep value', fakeAsync(() => {
+      context.firstSrc = QUICK_SRC;
+      context.groupZoomStep = 5;
+      context.zoomStep = 3;
+      fixture.detectChanges();
+      let image = debugElement.nativeElement.querySelectorAll('img');
+      image[2].click();
+      tickChanges();
+      previewElement = getPreviewElement();
+      let imageElement = getPreviewImageElement();
+      let operations = overlayContainerElement.querySelectorAll('.ant-image-preview-operations-operation');
+      let zoomIn = operations[1];
+      dispatchFakeEvent(zoomIn, 'click');
+      tickChanges();
+      expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(4, 4, 1) rotate(0deg)');
+      discardPeriodicTasks();
+      flush();
+    }));
+
+    it('should global config work', fakeAsync(() => {
+      configService.set('image', { nzZoomStep: 10 });
+      context.firstSrc = QUICK_SRC;
+      fixture.detectChanges();
+      tickChanges();
+      let image = debugElement.nativeElement.querySelectorAll('img');
+      image[3].click();
+      tickChanges();
+      previewElement = getPreviewElement();
+      let imageElement = getPreviewImageElement();
+      let operations = overlayContainerElement.querySelectorAll('.ant-image-preview-operations-operation');
+      let zoomIn = operations[1];
+      dispatchFakeEvent(zoomIn, 'click');
+      tickChanges();
+      expect(imageElement!.getAttribute('style')).toContain('transform: scale3d(11, 11, 1) rotate(0deg)');
       discardPeriodicTasks();
       flush();
     }));
@@ -571,10 +670,11 @@ export class TestImageFallbackComponent {
 
 @Component({
   template: `
-    <nz-image-group>
-      <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" />
-      <img nz-image [nzSrc]="secondSrc" [nzDisablePreview]="disablePreview" />
+    <nz-image-group [nzZoomStep]="groupZoomStep">
+      <img nz-image id="1" [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" />
+      <img nz-image id="2" [nzSrc]="secondSrc" [nzDisablePreview]="disablePreview" [nzZoomStep]="zoomStep" />
     </nz-image-group>
+    <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" [nzZoomStep]="zoomStep" />
     <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" />
   `
 })
@@ -584,6 +684,8 @@ export class TestImagePreviewGroupComponent {
   secondSrc = '';
   previewRef: NzImagePreviewRef | null = null;
   images: NzImage[] = [];
+  zoomStep: number | null = null;
+  groupZoomStep: number | null = null;
 
   @ViewChild(NzImageGroupComponent) nzImageGroup!: NzImageGroupComponent;
   @ViewChild(NzImageDirective) nzImage!: NzImageDirective;

--- a/components/image/image.spec.ts
+++ b/components/image/image.spec.ts
@@ -401,7 +401,7 @@ describe('Preview', () => {
     }));
 
     it('should global config work', fakeAsync(() => {
-      configService.set('image', { nzZoomStep: 10 });
+      configService.set('image', { nzScaleStep: 10 });
       context.firstSrc = QUICK_SRC;
       fixture.detectChanges();
       tickChanges();
@@ -670,11 +670,11 @@ export class TestImageFallbackComponent {
 
 @Component({
   template: `
-    <nz-image-group [nzZoomStep]="groupZoomStep">
+    <nz-image-group [nzScaleStep]="groupZoomStep">
       <img nz-image id="1" [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" />
-      <img nz-image id="2" [nzSrc]="secondSrc" [nzDisablePreview]="disablePreview" [nzZoomStep]="zoomStep" />
+      <img nz-image id="2" [nzSrc]="secondSrc" [nzDisablePreview]="disablePreview" [nzScaleStep]="zoomStep" />
     </nz-image-group>
-    <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" [nzZoomStep]="zoomStep" />
+    <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" [nzScaleStep]="zoomStep" />
     <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" />
   `
 })

--- a/components/image/image.spec.ts
+++ b/components/image/image.spec.ts
@@ -671,8 +671,8 @@ export class TestImageFallbackComponent {
 @Component({
   template: `
     <nz-image-group [nzScaleStep]="groupZoomStep">
-      <img nz-image id="1" [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" />
-      <img nz-image id="2" [nzSrc]="secondSrc" [nzDisablePreview]="disablePreview" [nzScaleStep]="zoomStep" />
+      <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" />
+      <img nz-image [nzSrc]="secondSrc" [nzDisablePreview]="disablePreview" [nzScaleStep]="zoomStep" />
     </nz-image-group>
     <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" [nzScaleStep]="zoomStep" />
     <img nz-image [nzSrc]="firstSrc" [nzDisablePreview]="disablePreview" />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [✔] Tests for the changes have been added (for bug fixes / features)
- [✔] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[✔] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current version of the image component does not allow customization of the scale step, which is fixed at 1.


## What is the new behavior?
•  The scale step has been updated from `1` to `0.5` to match the default value of the  <a href="https://ant.design/components/image#previewtype">Antd image component</a>.

•  The `nz-image` directive now accepts an input called `nzScaleStep`, which determines the amount of zooming in or out. The default value of `nzScaleStep` is 0.5, and it can be configured globally.

•  The `nz-image-group` component also has an input called `nzScaleStep`, which applies to all the images inside the group. However, if an individual image has its own `nzScaleStep` value, it will override the group value and use its own value instead.


## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The scale step of an image is determined by the following order of priority:
•  The value specified on the image itself, if any.

•  The value specified on the image group, if any.

•  The global value, if any.

•  The default value of `0.5`, if none of the above is provide
