### PR TITLE
feat(module:color-picker): disable alpha

### DIFF
--- a/components/color-picker/color-format.component.ts
+++ b/components/color-picker/color-format.component.ts
@@ -20,6 +20,8 @@ import { debounceTime, filter, takeUntil } from 'rxjs/operators';
 
 import { generateColor } from 'ng-antd-color-picker';
 
+import { InputBoolean } from 'ng-zorro-antd/core/util';
+
 import { NzColorPickerFormatType } from './typings';
 
 @Component({
@@ -103,17 +105,19 @@ import { NzColorPickerFormatType } from './typings';
         </div>
       </div>
 
-      <div class="ant-color-picker-steppers ant-color-picker-alpha-input">
-        <nz-input-number
-          formControlName="roundA"
-          [nzMin]="0"
-          [nzMax]="100"
-          [nzStep]="1"
-          [nzFormatter]="formatterPercent"
-          [nzParser]="parserPercent"
-          nzSize="small"
-        ></nz-input-number>
-      </div>
+      <ng-container *ngIf="!nzDisabledAlpha">
+        <div class="ant-color-picker-steppers ant-color-picker-alpha-input">
+          <nz-input-number
+            formControlName="roundA"
+            [nzMin]="0"
+            [nzMax]="100"
+            [nzStep]="1"
+            [nzFormatter]="formatterPercent"
+            [nzParser]="parserPercent"
+            nzSize="small"
+          ></nz-input-number>
+        </div>
+      </ng-container>
     </div>
   `
 })
@@ -121,6 +125,7 @@ export class NzColorFormatComponent implements OnChanges, OnInit, OnDestroy {
   @Input() format: NzColorPickerFormatType | null = null;
   @Input() colorValue: string = '';
   @Input() clearColor: boolean = false;
+  @Input() @InputBoolean() nzDisabledAlpha: boolean = false;
   @Output() readonly formatChange = new EventEmitter<{ color: string; format: NzColorPickerFormatType }>();
   @Output() readonly nzOnFormatChange = new EventEmitter<NzColorPickerFormatType>();
 

--- a/components/color-picker/color-picker.component.spec.ts
+++ b/components/color-picker/color-picker.component.spec.ts
@@ -194,6 +194,36 @@ describe('nz-color-picker', () => {
       expect(testComponent.colorChange?.color.toHsbString()).toBe('hsb(215, 91%, 100%)');
       discardPeriodicTasks();
     }));
+
+    it('color-picker disableAlpha', fakeAsync(() => {
+      testComponent.nzAlphaDisabled = true;
+      fixture.detectChanges();
+      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+      dispatchMouseEvent(dom, 'click');
+      waitingForTooltipToggling();
+      const alphaSlider = overlayContainerElement.querySelector('.ant-color-picker-slider-alpha') as Element;
+      expect(alphaSlider).toBeFalsy();
+      discardPeriodicTasks();
+    }));
+
+    it('nz-color-format disableAlpha', fakeAsync(() => {
+      testComponent.nzAlphaDisabled = true;
+      fixture.detectChanges();
+      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+      dispatchMouseEvent(dom, 'click');
+      waitingForTooltipToggling();
+      const select = overlayContainerElement.querySelector('nz-select') as Element;
+      dispatchMouseEvent(select, 'click');
+      waitingForTooltipToggling();
+      const items = overlayContainerElement.querySelectorAll('nz-option-item');
+      items.forEach(item => {
+        dispatchMouseEvent(item, 'click');
+        waitingForTooltipToggling();
+        let alphaInputElement = overlayContainerElement.querySelector('.ant-color-picker-alpha-input') as Element;
+        expect(alphaInputElement).toBeFalsy();
+      });
+      discardPeriodicTasks();
+    }));
   });
 });
 
@@ -209,6 +239,7 @@ describe('nz-color-picker', () => {
       [nzFormat]="nzFormat"
       [nzAllowClear]="nzAllowClear"
       [nzOpen]="nzOpen"
+      [nzDisabledAlpha]="nzAlphaDisabled"
       (nzOnChange)="nzOnChange($event)"
       (nzOnFormatChange)="nzOnFormatChange($event)"
       (nzOnClear)="nzOnClear($event)"
@@ -230,6 +261,7 @@ export class NzTestColorPickerComponent {
   nzShowText: boolean = false;
   nzAllowClear: boolean = false;
   nzDisabled: boolean = false;
+  nzAlphaDisabled: boolean = false;
   nzOpen: boolean = false;
 
   isFlipFlop = false;

--- a/components/color-picker/color-picker.component.ts
+++ b/components/color-picker/color-picker.component.ts
@@ -60,6 +60,7 @@ import { NzColor, NzColorPickerTriggerType, NzColorPickerFormatType } from './ty
         [disabled]="nzDisabled"
         [panelRenderHeader]="nzPanelRenderHeader"
         [panelRenderFooter]="nzPanelRenderFooter"
+        [disabledAlpha]="nzDisabledAlpha"
         (nzOnChange)="colorChange($event)"
       ></ng-antd-color-picker>
     </ng-template>
@@ -83,6 +84,7 @@ import { NzColor, NzColorPickerTriggerType, NzColorPickerFormatType } from './ty
         [colorValue]="blockColor"
         [clearColor]="clearColor"
         [format]="nzFormat"
+        [nzDisabledAlpha]="nzDisabledAlpha"
         (formatChange)="formatChange($event)"
         (nzOnFormatChange)="nzOnFormatChange.emit($event)"
       ></nz-color-format>
@@ -117,6 +119,7 @@ export class NzColorPickerComponent implements OnInit, OnChanges, ControlValueAc
   @Input() @InputBoolean() nzOpen: boolean = false;
   @Input() @InputBoolean() nzAllowClear: boolean = false;
   @Input() @InputBoolean() nzDisabled: boolean = false;
+  @Input() @InputBoolean() nzDisabledAlpha: boolean = false;
   @Output() readonly nzOnChange = new EventEmitter<{ color: NzColor; format: string }>();
   @Output() readonly nzOnFormatChange = new EventEmitter<NzColorPickerFormatType>();
   @Output() readonly nzOnClear = new EventEmitter<boolean>();

--- a/components/color-picker/doc/index.en-US.md
+++ b/components/color-picker/doc/index.en-US.md
@@ -35,7 +35,7 @@ npm install ng-antd-color-picker
 | `[nzShowText]`       | Show color text                       | `boolean`                                          | `false`   |
 | `[nzOpen]`           | Whether to show popups                | `boolean`                                          | `false`   |
 | `[nzDisabled]`       | Disable ColorPicker                   | `boolean`                                          | `false`   |
-| `[disabledAlpha]`    | Disable Alpha                         | `boolean`                                          | `false`   |
+| `[nzDisabledAlpha]`  | Disable Alpha                         | `boolean`                                          | `false`   |
 | `[nzTitle]`          | Setting the title of the color picker | `TemplateRef<void>`｜`string`                      | -         |
 | `(nzOnChange)`       | Callback when value is changed        | `EventEmitter<{ color: NzColor; format: string }>` | -         |
 | `(nzOnClear)`        | Called when clear                     | `EventEmitter<boolean>`                            | -         |

--- a/components/color-picker/doc/index.en-US.md
+++ b/components/color-picker/doc/index.en-US.md
@@ -24,38 +24,39 @@ npm install ng-antd-color-picker
 
 ### nz-color-picker
 
-| Parameter                 | Description         | Type                                | Default       |
-|--------------------|------------|-----------------------------------|-----------|
-| `[nzFormat]`       | Format of color       | `rgb`｜`hex`｜`hsb`                 | `hex`     |
-| `[nzValue]`        | Value of color       | `string`｜`NzColor`                  | -         |
-| `[nzSize]`         | Setting the trigger size    | `large`｜`default`｜`small`         | `default` |
-| `[nzDefaultValue]` | Default value of color     | `string`｜`NzColor`                  | `false`   |
-| `[nzAllowClear]`   | Allow clearing color selected  | `boolean`                         | `false`   |
-| `[nzTrigger]`      | ColorPicker trigger mode | `hover`｜`click`                   | `click`   |
-| `[nzShowText]`      | Show color text     | `boolean`                         | `false`   |
-| `[nzOpen]`      | Whether to show popups     | `boolean`                         | `false`  |
-| `[nzDisabled]`     | Disable ColorPicker    | `boolean`                         | `false`   |
-| `[nzTitle]`      | Setting the title of the color picker | `TemplateRef<void>`｜`string`      | -         |
-| `(nzOnChange)`     | Callback when value is changed    | `EventEmitter<{ color: NzColor; format: string }>`            | -         |
-| `(nzOnClear)`      | 	Called when clear      | `EventEmitter<boolean>`           | -         |
-| `(nzOnFormatChange)`      | Callback when `format` is changed      | `EventEmitter<'rgb'｜'hex'｜'hsb'>` | -         |
-| `(nzOnOpenChange)`      | Callback for opening the color panel  | `EventEmitter<boolean>` | -        |
+| Parameter            | Description                           | Type                                               | Default   |
+| -------------------- | ------------------------------------- | -------------------------------------------------- | --------- |
+| `[nzFormat]`         | Format of color                       | `rgb`｜`hex`｜`hsb`                                | `hex`     |
+| `[nzValue]`          | Value of color                        | `string`｜`NzColor`                                | -         |
+| `[nzSize]`           | Setting the trigger size              | `large`｜`default`｜`small`                        | `default` |
+| `[nzDefaultValue]`   | Default value of color                | `string`｜`NzColor`                                | `false`   |
+| `[nzAllowClear]`     | Allow clearing color selected         | `boolean`                                          | `false`   |
+| `[nzTrigger]`        | ColorPicker trigger mode              | `hover`｜`click`                                   | `click`   |
+| `[nzShowText]`       | Show color text                       | `boolean`                                          | `false`   |
+| `[nzOpen]`           | Whether to show popups                | `boolean`                                          | `false`   |
+| `[nzDisabled]`       | Disable ColorPicker                   | `boolean`                                          | `false`   |
+| `[disabledAlpha]`    | Disable Alpha                         | `boolean`                                          | `false`   |
+| `[nzTitle]`          | Setting the title of the color picker | `TemplateRef<void>`｜`string`                      | -         |
+| `(nzOnChange)`       | Callback when value is changed        | `EventEmitter<{ color: NzColor; format: string }>` | -         |
+| `(nzOnClear)`        | Called when clear                     | `EventEmitter<boolean>`                            | -         |
+| `(nzOnFormatChange)` | Callback when `format` is changed     | `EventEmitter<'rgb'｜'hex'｜'hsb'>`                | -         |
+| `(nzOnOpenChange)`   | Callback for opening the color panel  | `EventEmitter<boolean>`                            | -         |
 
 ### nz-color-block
 
-| Parameter    | Description   | Type  | Default       |
-|--------------|----------|------------|-----------|
-| `[nzColor]` | Module colors | `string` | `#1677ff` |
-| `[nzSize]` | Color block size | `large`｜`default`｜`small` | `default` |
-| `[nzOnClick]` | Callbacks for clicking on color blocks | `EventEmitter<boolean>`   | - |
+| Parameter     | Description                            | Type                        | Default   |
+| ------------- | -------------------------------------- | --------------------------- | --------- |
+| `[nzColor]`   | Module colors                          | `string`                    | `#1677ff` |
+| `[nzSize]`    | Color block size                       | `large`｜`default`｜`small` | `default` |
+| `[nzOnClick]` | Callbacks for clicking on color blocks | `EventEmitter<boolean>`     | -         |
 
 ### NzColor
 
-| Parameter         | Description                                                                       | Type                                  | Default |
-| ------------ |-----------------------------------------------------------------------------------| ------------------------------------- |-----|
-| `toHex`      | Convert to `hex` format characters, the return type like: `1677ff`                | `() => string`                              | -   |
-| `toHexString`   | Convert to `hex` format color string, the return type like: `#1677ff`             | `() => string`                              | -   |
-| `toHsb` | Convert to `hsb` object                                                           | `() => ({ h: number, s: number, b: number, a number })` | -   |
-| `toHsbString` | Convert to `hsb` format color string, the return type like: `hsb(215, 91%, 100%)` | `() => string`                              | -   |
-| `toRgb`  | Convert to `rgb` object                                                           | `() => ({ r: number, g: number, b: number, a number })` | -   |
-| `toRgbString`  | Convert to `rgb` format color string, the return type like: `rgb(22, 119, 255)`       | `() => string` | -   |
+| Parameter     | Description                                                                       | Type                                                    | Default |
+| ------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------- | ------- |
+| `toHex`       | Convert to `hex` format characters, the return type like: `1677ff`                | `() => string`                                          | -       |
+| `toHexString` | Convert to `hex` format color string, the return type like: `#1677ff`             | `() => string`                                          | -       |
+| `toHsb`       | Convert to `hsb` object                                                           | `() => ({ h: number, s: number, b: number, a number })` | -       |
+| `toHsbString` | Convert to `hsb` format color string, the return type like: `hsb(215, 91%, 100%)` | `() => string`                                          | -       |
+| `toRgb`       | Convert to `rgb` object                                                           | `() => ({ r: number, g: number, b: number, a number })` | -       |
+| `toRgbString` | Convert to `rgb` format color string, the return type like: `rgb(22, 119, 255)`   | `() => string`                                          | -       |

--- a/components/color-picker/doc/index.zh-CN.md
+++ b/components/color-picker/doc/index.zh-CN.md
@@ -25,38 +25,39 @@ npm install ng-antd-color-picker
 
 ### nz-color-picker
 
-| 参数                 | 说明         | 类型                                | 默认值      |
-|--------------------|------------|-----------------------------------|----------|
-| `[nzFormat]`       | 颜色格式       | `rgb`｜`hex`｜`hsb`                 | `hex`    |
-| `[nzValue]`        | 颜色的值       | `string`｜`NzColor`                  | -        |
-| `[nzSize]`         | 设置触发器大小    | `large`｜`default`｜`small`         | `default` |
-| `[nzDefaultValue]` | 颜色默认的值     | `string`｜`NzColor`                  | -        |
-| `[nzAllowClear]`   | 允许清除选择的颜色  | `boolean`                         | `false`  |
-| `[nzTrigger]`      | 颜色选择器的触发模式 | `hover`｜`click`                   | `click`  |
-| `[nzShowText]`      | 显示颜色文本     | `boolean`                         | `false`  |
-| `[nzOpen]`      | 是否显示弹出窗口     | `boolean`                         | `false`  |
-| `[nzDisabled]`     | 禁用颜色选择器    | `boolean`                         | `false`  |
-| `[nzTitle]`      | 设置颜色选择器的标题 | `TemplateRef<void>`｜`string`      | -        |
-| `(nzOnChange)`     | 颜色变化的回调    | `EventEmitter<{ color: NzColor; format: string }>` | -        |
-| `(nzOnClear)`      | 清除的回调      | `EventEmitter<boolean>`           | -        |
-| `(nzOnFormatChange)`      | 颜色格式变化的回调  | `EventEmitter<'rgb'｜'hex'｜'hsb'>` | -        |
-| `(nzOnOpenChange)`      | 打开颜色面板的回调  | `EventEmitter<boolean>` | -        |
+| 参数                 | 说明                 | 类型                                               | 默认值    |
+| -------------------- | -------------------- | -------------------------------------------------- | --------- |
+| `[nzFormat]`         | 颜色格式             | `rgb`｜`hex`｜`hsb`                                | `hex`     |
+| `[nzValue]`          | 颜色的值             | `string`｜`NzColor`                                | -         |
+| `[nzSize]`           | 设置触发器大小       | `large`｜`default`｜`small`                        | `default` |
+| `[nzDefaultValue]`   | 颜色默认的值         | `string`｜`NzColor`                                | -         |
+| `[nzAllowClear]`     | 允许清除选择的颜色   | `boolean`                                          | `false`   |
+| `[nzTrigger]`        | 颜色选择器的触发模式 | `hover`｜`click`                                   | `click`   |
+| `[nzShowText]`       | 显示颜色文本         | `boolean`                                          | `false`   |
+| `[nzOpen]`           | 是否显示弹出窗口     | `boolean`                                          | `false`   |
+| `[nzDisabled]`       | 禁用颜色选择器       | `boolean`                                          | `false`   |
+| `[disabledAlpha]`    | 禁用透明度           | `boolean`                                          | `false`   |
+| `[nzTitle]`          | 设置颜色选择器的标题 | `TemplateRef<void>`｜`string`                      | -         |
+| `(nzOnChange)`       | 颜色变化的回调       | `EventEmitter<{ color: NzColor; format: string }>` | -         |
+| `(nzOnClear)`        | 清除的回调           | `EventEmitter<boolean>`                            | -         |
+| `(nzOnFormatChange)` | 颜色格式变化的回调   | `EventEmitter<'rgb'｜'hex'｜'hsb'>`                | -         |
+| `(nzOnOpenChange)`   | 打开颜色面板的回调   | `EventEmitter<boolean>`                            | -         |
 
 ### nz-color-block
 
-| 参数                 | 说明       | 类型                | 默认值       |
-|--------------------|----------|-------------------|-----------|
-| `[nzColor]`       | 模块的颜色    | `string`          | `#1677ff` |
-| `[nzSize]`       | 色彩块的大小    | `large`｜`default`｜`small` | `default` |
-| `[nzOnClick]`       | 点击色彩块的回调 | `EventEmitter<boolean>`   | -         |
+| 参数          | 说明             | 类型                        | 默认值    |
+| ------------- | ---------------- | --------------------------- | --------- |
+| `[nzColor]`   | 模块的颜色       | `string`                    | `#1677ff` |
+| `[nzSize]`    | 色彩块的大小     | `large`｜`default`｜`small` | `default` |
+| `[nzOnClick]` | 点击色彩块的回调 | `EventEmitter<boolean>`     | -         |
 
 ### NzColor
 
-| 参数         | 说明     | 类型                                  | 默认值 |
-| ------------ | -------- | ------------------------------------- |-----|
-| `toHex`      | 转换成 `hex` 格式字符，返回格式如：`1677ff` | `() => string`                              | -   |
-| `toHexString`   | 转换成 `hex` 格式颜色字符串，返回格式如：`#1677ff` | `() => string`                              | -   |
-| `toHsb` | 转换成 `hsb` 对象 | `() => ({ h: number, s: number, b: number, a number })` | -   |
-| `toHsbString` | 转换成 `hsb` 格式颜色字符串，返回格式如：`hsb(215, 91%, 100%)` | `() => string`                              | -   |
-| `toRgb`  | 转换成 `rgb` 对象 | `() => ({ r: number, g: number, b: number, a number })` | -   |
-| `toRgbString`  | 转换成 `rgb` 格式颜色字符串，返回格式如：`rgb(22, 119, 255)` | `() => string` | -   |
+| 参数          | 说明                                                           | 类型                                                    | 默认值 |
+| ------------- | -------------------------------------------------------------- | ------------------------------------------------------- | ------ |
+| `toHex`       | 转换成 `hex` 格式字符，返回格式如：`1677ff`                    | `() => string`                                          | -      |
+| `toHexString` | 转换成 `hex` 格式颜色字符串，返回格式如：`#1677ff`             | `() => string`                                          | -      |
+| `toHsb`       | 转换成 `hsb` 对象                                              | `() => ({ h: number, s: number, b: number, a number })` | -      |
+| `toHsbString` | 转换成 `hsb` 格式颜色字符串，返回格式如：`hsb(215, 91%, 100%)` | `() => string`                                          | -      |
+| `toRgb`       | 转换成 `rgb` 对象                                              | `() => ({ r: number, g: number, b: number, a number })` | -      |
+| `toRgbString` | 转换成 `rgb` 格式颜色字符串，返回格式如：`rgb(22, 119, 255)`   | `() => string`                                          | -      |

--- a/components/color-picker/doc/index.zh-CN.md
+++ b/components/color-picker/doc/index.zh-CN.md
@@ -36,7 +36,7 @@ npm install ng-antd-color-picker
 | `[nzShowText]`       | 显示颜色文本         | `boolean`                                          | `false`   |
 | `[nzOpen]`           | 是否显示弹出窗口     | `boolean`                                          | `false`   |
 | `[nzDisabled]`       | 禁用颜色选择器       | `boolean`                                          | `false`   |
-| `[disabledAlpha]`    | 禁用透明度           | `boolean`                                          | `false`   |
+| `[nzDisabledAlpha]`  | 禁用透明度           | `boolean`                                          | `false`   |
 | `[nzTitle]`          | 设置颜色选择器的标题 | `TemplateRef<void>`｜`string`                      | -         |
 | `(nzOnChange)`       | 颜色变化的回调       | `EventEmitter<{ color: NzColor; format: string }>` | -         |
 | `(nzOnClear)`        | 清除的回调           | `EventEmitter<boolean>`                            | -         |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [✔] Tests for the changes have been added (for bug fixes / features)
- [✔] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[✔] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Unlike the color picker component in <a href="https://ant.design/components/color-picker#api">antd</a>, we do not allow disabling alpha.

## What is the new behavior?
Implementing an option to disable the alpha channel in the color component.


## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
