### PR TITLE
fix(module:experimental-image): link to image component is not correct

### DIFF
--- a/components/experimental-image/doc/index.en-US.md
+++ b/components/experimental-image/doc/index.en-US.md
@@ -16,7 +16,7 @@ experimental: true
 - When you need the browser to prioritize image loading (needs to be handled in SSR).
 - When you need to optimize for HD displays (e.g. retina screens).
 - When using image CDN.
-- More in [Image documentation](/components/image)
+- More in [Image documentation](/components/image/en)
 - Next steps
   * Add [sizes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) attribute and responsive support.
 

--- a/components/experimental-image/doc/index.zh-CN.md
+++ b/components/experimental-image/doc/index.zh-CN.md
@@ -17,7 +17,7 @@ experimental: true
 - 需要浏览器优先加载图片时（需要在 SSR 下处理）。
 - 需要对高清显示器（如视网膜屏）优化时。
 - 使用图片 CDN 服务时。
-- 以及 [Image documentation](/components/image) 中的功能
+- 以及 [Image documentation](/components/image/zh) 中的功能
 - 下一步计划
   * 添加 [sizes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) 属性及响应式的支持
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The link to the image component is incorrect in the experimental image component.

## What is the new behavior?
Successfully redirects to the appropriate page.

## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/62149413/8cb1a485-232c-4250-9023-0a780ab004a9)
![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/62149413/c4cb4c21-16d5-4ed9-956b-119e91ccefda)
