### PR TITLE
feat(module:pipes): make the css-unit pipe support more units

### DIFF
--- a/components/pipes/demo/css-unit.md
+++ b/components/pipes/demo/css-unit.md
@@ -9,7 +9,7 @@ title:
 
 Css 单位
 
-警告：在 `v17.0.0` 中被弃用，请使用 Angular 内置语法替代，例如：
+提示：如果条件允许，我们更推荐使用 Angular 内置语法，例如：
 
 ```html
 <div [style.border-radius.px]="1">px</div>
@@ -21,7 +21,7 @@ Css 单位
 
 Css unit
 
-WARNING: Deprecated in `v17.0.0`, please use angular's built-in syntax instead, eg:
+Tip: If possible, we prefer to use Angular's built-in syntax, for example:
 
 ```html
 <div [style.border-radius.px]="1">px</div>

--- a/components/pipes/nz-css-unit.pipe.ts
+++ b/components/pipes/nz-css-unit.pipe.ts
@@ -5,23 +5,12 @@
 
 import { Pipe, PipeTransform } from '@angular/core';
 
-/**
- * @deprecated v17.0.0 - Use angular's built-in syntax instead
- */
 @Pipe({
   name: 'nzToCssUnit',
   standalone: true
 })
 export class NzToCssUnitPipe implements PipeTransform {
   transform(value: number | string, defaultUnit: string = 'px'): string {
-    const absoluteLengthUnit = ['cm', 'mm', 'Q', 'in', 'pc', 'pt', 'px'];
-    const relativeLengthUnit = ['em', 'ex', 'ch', 'rem', '1h', 'vw', 'vh', 'vmin', 'vmax'];
-    const percentagesUnit = ['%'];
-    const listOfUnit = [...absoluteLengthUnit, ...relativeLengthUnit, ...percentagesUnit];
-    let unit = 'px';
-    if (listOfUnit.some(u => u === defaultUnit)) {
-      unit = defaultUnit;
-    }
-    return typeof value === 'number' ? `${value}${unit}` : `${value}`;
+    return typeof value === 'number' ? `${value}${defaultUnit}` : value;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

CSS 规范一直在更新，支持的单位也越来越多，我们不应该枚举这些单位。


## What is the new behavior?

不再限制 CSS 单位。同时取消弃用这个 Pipe，因为我发现了它有处理数字为带单位的字符串的能力，它仍然有使用价值。


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
