### PR TITLE
fix(module:avatar): avatar not re-scaling properly

### DIFF
--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -3,15 +3,15 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Platform, PlatformModule } from '@angular/cdk/platform';
+import { PlatformModule } from '@angular/cdk/platform';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
-  NgZone,
   OnChanges,
   Output,
   ViewChild,
@@ -59,7 +59,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
-export class NzAvatarComponent implements OnChanges {
+export class NzAvatarComponent implements OnChanges, AfterViewInit {
   static ngAcceptInputType_nzGap: NumberInput;
 
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
@@ -86,9 +86,7 @@ export class NzAvatarComponent implements OnChanges {
   constructor(
     public nzConfigService: NzConfigService,
     private elementRef: ElementRef,
-    private cdr: ChangeDetectorRef,
-    private platform: Platform,
-    private ngZone: NgZone
+    private cdr: ChangeDetectorRef
   ) {}
 
   imgError($event: Event): void {
@@ -104,7 +102,7 @@ export class NzAvatarComponent implements OnChanges {
       }
       this.cdr.detectChanges();
       this.setSizeStyle();
-      this.notifyCalc();
+      this.calcStringSize();
     }
   }
 
@@ -114,15 +112,19 @@ export class NzAvatarComponent implements OnChanges {
     this.hasSrc = !!this.nzSrc;
 
     this.setSizeStyle();
-    this.notifyCalc();
+    this.calcStringSize();
+  }
+
+  ngAfterViewInit(): void {
+    this.calcStringSize();
   }
 
   private calcStringSize(): void {
-    if (!this.hasText) {
+    if (!this.hasText || !this.textEl) {
       return;
     }
 
-    const textEl = this.textEl!.nativeElement;
+    const textEl = this.textEl.nativeElement;
     const childrenWidth = textEl.offsetWidth;
     const avatarWidth = this.el.getBoundingClientRect().width;
     const offset = this.nzGap * 2 < avatarWidth ? this.nzGap * 2 : 8;
@@ -130,17 +132,6 @@ export class NzAvatarComponent implements OnChanges {
 
     textEl.style.transform = `scale(${scale}) translateX(-50%)`;
     textEl.style.lineHeight = this.customSize || '';
-  }
-
-  private notifyCalc(): void {
-    // If use ngAfterViewChecked, always demands more computations, so......
-    if (this.platform.isBrowser) {
-      this.ngZone.runOutsideAngular(() => {
-        setTimeout(() => {
-          this.calcStringSize();
-        });
-      });
-    }
   }
 
   private setSizeStyle(): void {

--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -140,6 +140,7 @@ export class NzAvatarComponent implements OnChanges, AfterViewInit {
     } else {
       this.customSize = null;
     }
+
     this.cdr.markForCheck();
   }
 }

--- a/components/avatar/avatar.spec.ts
+++ b/components/avatar/avatar.spec.ts
@@ -136,6 +136,7 @@ describe('avatar', () => {
       context.nzText = 'LongUsername';
       fixture.detectChanges();
       tick();
+      context.comp.ngAfterViewInit();
       const scale = getScaleFromCSSTransform(dl.nativeElement.querySelector('.ant-avatar-string')!.style.transform!);
       expect(scale).toBeLessThan(1);
     }));
@@ -149,6 +150,7 @@ describe('avatar', () => {
         fixture.detectChanges();
         tick();
         avatarText = dl.nativeElement.querySelector('.ant-avatar-string')!;
+        context.comp.ngAfterViewInit();
         firstScale = getScaleFromCSSTransform(avatarText.style.transform);
       }));
 
@@ -234,6 +236,7 @@ describe('avatar', () => {
       fixture.detectChanges();
       flush();
       const textEl = document.querySelector<HTMLElement>('.ant-avatar-string')!;
+      context.comp.ngAfterViewInit();
       const scale = getScaleFromCSSTransform(textEl.style.transform);
       expect(scale).toBeLessThan(1);
       expect(textEl.style.lineHeight).toEqual(`${size}px`);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [✔] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The scaling of the avatar component was previously performed by a method named `notifyCalc`. This method used a setTimeout function to delay the scaling function for 4 milliseconds, ensuring that the avatar component was fully rendered and ready to be scaled.

However, this caused a problem when the avatar component was used within components that had opening animation effects, as the avatar component would have an incorrect width. The avatar component required more than 4 milliseconds in these cases to reach its sinalsize, and calling the scaling function, `calcStringSize`, too early would result in incorrect scale values for the avatar component.

Issue Number: #8363 


## What is the new behavior?
Calling `calcStringSize` after avatar component is fully rendered.

## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
