### PR TITLE
feat(module:segmented): now supports segmented with icon only

### DIFF
--- a/components/segmented/demo/with-icon-only.md
+++ b/components/segmented/demo/with-icon-only.md
@@ -1,0 +1,14 @@
+---
+order: 11
+title:
+  zh-CN: 只设置图标
+  en-US: With Icon only
+---
+
+## zh-CN
+
+在 Segmented Item 选项中只设置 Icon。
+
+## en-US
+
+Set `icon` without `label` for Segmented Item.

--- a/components/segmented/demo/with-icon-only.ts
+++ b/components/segmented/demo/with-icon-only.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+
+import { NzSegmentedOptions } from 'ng-zorro-antd/segmented';
+
+@Component({
+  selector: 'nz-demo-segmented-with-icon-only',
+  template: `<nz-segmented [nzOptions]="options"></nz-segmented>`
+})
+export class NzDemoSegmentedWithIconOnlyComponent {
+  options: NzSegmentedOptions = [
+    { value: 'List', icon: 'bars' },
+    { value: 'Kanban', icon: 'appstore' }
+  ];
+}

--- a/components/segmented/types.ts
+++ b/components/segmented/types.ts
@@ -3,13 +3,21 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-export interface NzSegmentedOption {
-  label: string;
+export type NzSegmentedOption = {
   value: string | number;
   useTemplate?: boolean;
-  icon?: string;
   disabled?: boolean;
   className?: string;
+} & (NzSegmentedWithLabel | NzSegmentedWithIcon);
+
+export interface NzSegmentedWithLabel {
+  label: string;
+  icon?: string;
+}
+
+export interface NzSegmentedWithIcon {
+  icon: string;
+  label?: string;
 }
 
 export type NzSegmentedOptions = Array<NzSegmentedOption | string | number>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[✔] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The segmented component in Ant Design([With Icon only](https://ant.design/components/segmented)) supports icons without labels.


## What is the new behavior?
This feature has been implemented.

## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
