### PR TITLE
fix(module:transfer): use fill theme for icon instead of outline

### DIFF
--- a/components/transfer/transfer-search.component.ts
+++ b/components/transfer/transfer-search.component.ts
@@ -35,7 +35,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       [ngClass]="{ 'ant-input-disabled': disabled }"
     />
     <span *ngIf="value && value.length > 0" class="ant-input-suffix" (click)="_clear()">
-      <span nz-icon nzType="close-circle" class="ant-input-clear-icon"></span>
+      <span nz-icon nzType="close-circle" nzTheme="fill" class="ant-input-clear-icon"></span>
     </span>
   `,
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[] Other... Please describe: 
```

## What is the current behavior?
In Ant v4, the clear icon in Transfer component's search box is filled but here we are using the outline theme.

## What is the new behavior?
Change icon theme from outline to fill.

## Does this PR introduce a breaking change?
```
[] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/62149413/db90eff6-1740-4883-b57b-d01bda4c6582)
