### PR TITLE
fix(module:tabs): slide indicator missing in small screens

### DIFF
--- a/components/tabs/style/patch.less
+++ b/components/tabs/style/patch.less
@@ -25,15 +25,6 @@
   }
 }
 
-nz-tabset,
-nz-tab-nav-operation,
-nz-tabs-nav {
-  display: block;
-  // https://github.com/ant-design/ant-design/pull/35195
-  // ant-design remove this since the other two bugs but not in ng-zorro-antd, so we keep it until antd solved it
-  overflow: hidden;
-}
-
 .nz-tabs-dropdown.ant-dropdown {
   .ant-dropdown-menu {
     max-height: 200px;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Slide indicator shrinks when the inline size of tab component is decreased.

Issue Number: #8351, #8384 


## What is the new behavior?
The mentioned problem is fixed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This line of code was originally added in this [commit](https://github.com/NG-ZORRO/ng-zorro-antd/commit/3a67d24dcbc666007b33322d70e18a240f74634d#diff-73cf03ccc1ce3c686f6ac080d53eea1980e3fa8acf3ddab5bb00944c7eb0271aR27-R29); currently Ant design no longer has these lines in it's code base, and by removing them the mentioned issue is fixed and no visual difference is made to other sections of Tabs component. 