### PR TITLE
fix(module:cdk): zIndex is not used properly when creating overlay

### DIFF
--- a/components/core/overlay/overlay-z-index.ts
+++ b/components/core/overlay/overlay-z-index.ts
@@ -1,0 +1,12 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { OverlayRef } from '@angular/cdk/overlay';
+
+export function overlayZIndexSetter(overlayRef: OverlayRef, zIndex?: number): void {
+  if (!zIndex) return;
+
+  (overlayRef['_host'] as HTMLElement).style.zIndex = `${zIndex}`;
+}

--- a/components/core/overlay/public-api.ts
+++ b/components/core/overlay/public-api.ts
@@ -6,3 +6,4 @@
 export * from './nz-connected-overlay';
 export * from './nz-overlay.module';
 export * from './overlay-position';
+export * from './overlay-z-index';

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -37,6 +37,7 @@ import { takeUntil } from 'rxjs/operators';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
+import { overlayZIndexSetter } from 'ng-zorro-antd/core/overlay';
 import { BooleanInput, NgStyleInterface, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { InputBoolean, isTemplateRef, toCssPixel } from 'ng-zorro-antd/core/util';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -448,6 +449,8 @@ export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extend
     if (!this.overlayRef) {
       this.portal = new TemplatePortal(this.drawerTemplate, this.viewContainerRef);
       this.overlayRef = this.overlay.create(this.getOverlayConfig());
+
+      overlayZIndexSetter(this.overlayRef, this.nzZIndex);
     }
 
     if (this.overlayRef && !this.overlayRef.hasAttached()) {

--- a/components/modal/modal.service.ts
+++ b/components/modal/modal.service.ts
@@ -12,6 +12,7 @@ import { startWith } from 'rxjs/operators';
 
 import { NzConfigService } from 'ng-zorro-antd/core/config';
 import { warn } from 'ng-zorro-antd/core/logger';
+import { overlayZIndexSetter } from 'ng-zorro-antd/core/overlay';
 import { IndexableObject, NzSafeAny } from 'ng-zorro-antd/core/types';
 import { isNotNil } from 'ng-zorro-antd/core/util';
 
@@ -97,6 +98,8 @@ export class NzModalService implements OnDestroy {
     const modalContainer = this.attachModalContainer(overlayRef, configMerged);
     const modalRef = this.attachModalContent<T, D, R>(componentOrTemplateRef, modalContainer, overlayRef, configMerged);
     modalContainer.modalRef = modalRef;
+
+    overlayZIndexSetter(overlayRef, config?.nzZIndex);
 
     this.openModals.push(modalRef);
     modalRef.afterClose.subscribe(() => this.removeOpenModal(modalRef));

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -137,6 +137,18 @@ describe('NzModal', () => {
     modalRef.close();
   });
 
+  it('should give correct z-index value to overlay', fakeAsync(() => {
+    const Z_INDEX = 9999;
+    modalService.create({
+      nzContent: TestWithModalContentComponent,
+      nzData: 'Modal',
+      nzZIndex: Z_INDEX
+    });
+
+    const overlay = document.querySelector('.cdk-global-overlay-wrapper');
+    expect((overlay as HTMLElement).style.zIndex).toEqual(`${Z_INDEX}`);
+  }));
+
   it('should open a modal with data', () => {
     const modalRef = modalService.create({
       nzContent: TestWithModalContentComponent,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The modal, drawer, or any other components that are made with the Angular CDK have the `zIndex` applied to the inner element of the created overlay. This is not desirable for two reasons:

1.  The created overlay is a direct child of the body element
2.  Each overlay has its own wrapper with the class name 'cdk-global-overlay-wrapper'
Therefore, changing the zIndex of the inner element has no effect, as it is already isolated from other overlays. The expected behavior is that the `zIndex` should be applied to the overlay wrapper instead.

The image below illustrates this issue:
-  The red sections are the overlay wrappers

-  The green section is the inner element of the overlay wrapper, which has its `zIndex` changed

The scenario is as follows:
We have a modal component, which contains a button that opens a drawer component (the first red outline is the drawer wrapper, the second is the modal wrapper).
As stated in the issue below, the drawer component should appear above the modal component; but currently, the modal component is on top. The reason why the zIndex property does not work is that it is applied to the inner element of the overlay, rather than the overlay wrapper.

This issue occurs whenever the CDK overlay is used; currently, only modal and drawer components have been fixed. If this pull request is approved, I will update other components that use the overlay as well.

Issue Number: #8353 , #8336

## What is the new behavior?
Mentioned above.

## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Currently it is not possible to set overlays' zIndex value when creating it ([issue](https://github.com/angular/components/issues/1432)).

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/62149413/de2b5139-77e8-44fd-ab26-9ef8a7e131a9)

