### PR TITLE
fix(module:carousel): not adapting to new size when resizing

### DIFF
--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -32,8 +32,9 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { fromEvent, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
+import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzDragService, NzResizeService } from 'ng-zorro-antd/core/services';
 import { BooleanInput, NumberInput, NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -182,6 +183,7 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
     private readonly platform: Platform,
     private readonly resizeService: NzResizeService,
     private readonly nzDragService: NzDragService,
+    private nzResizeObserver: NzResizeObserver,
     @Optional() private directionality: Directionality,
     @Optional() @Inject(NZ_CAROUSEL_CUSTOM_STRATEGIES) private customStrategies: NzCarouselStrategyRegistryItem[]
   ) {
@@ -222,6 +224,13 @@ export class NzCarouselComponent implements AfterContentInit, AfterViewInit, OnD
           });
         });
     });
+
+    this.nzResizeObserver
+      .observe(this.el)
+      .pipe(debounceTime(100), distinctUntilChanged(), takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.layout();
+      });
   }
 
   ngAfterContentInit(): void {

--- a/components/carousel/carousel.spec.ts
+++ b/components/carousel/carousel.spec.ts
@@ -4,6 +4,7 @@ import { Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
 import { dispatchKeyboardEvent, dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
 
 import { NzCarouselContentDirective } from './carousel-content.directive';
@@ -75,6 +76,19 @@ describe('carousel', () => {
         carouselWrapper.nativeElement.querySelector('.slick-dots').firstElementChild.firstElementChild.tagName
       ).toBe('A');
     });
+
+    it('should call layout on component resize', fakeAsync(() => {
+      testComponent.nzCarouselComponent.ngOnInit();
+      const spy = spyOn(testComponent.nzCarouselComponent, 'layout');
+      window.dispatchEvent(new Event('resize'));
+      tick(500);
+
+      (testComponent.nzCarouselComponent['nzResizeObserver'] as NzResizeObserver)
+        .observe(testComponent.nzCarouselComponent.el)
+        .subscribe(() => {
+          expect(spy).toHaveBeenCalled();
+        });
+    }));
 
     it('should call layout on component resize', fakeAsync(() => {
       const spyOnResize = spyOn(testComponent.nzCarouselComponent, 'layout');

--- a/components/carousel/carousel.spec.ts
+++ b/components/carousel/carousel.spec.ts
@@ -1,7 +1,7 @@
 import { BidiModule, Dir } from '@angular/cdk/bidi';
 import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import { Component, DebugElement, ViewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { dispatchKeyboardEvent, dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
@@ -75,6 +75,15 @@ describe('carousel', () => {
         carouselWrapper.nativeElement.querySelector('.slick-dots').firstElementChild.firstElementChild.tagName
       ).toBe('A');
     });
+
+    it('should call layout on component resize', fakeAsync(() => {
+      const spyOnResize = spyOn(testComponent.nzCarouselComponent, 'layout');
+      window.dispatchEvent(new Event('resize'));
+      tick(500);
+
+      expect(spyOnResize).toHaveBeenCalled();
+      discardPeriodicTasks();
+    }));
 
     it('should click content change', () => {
       expect(carouselContents[0].nativeElement.classList).toContain('slick-active');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Carousel component currently does not adapt to the new size when it is resized.

Issue Number: #8359 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[✔] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I have set a 100ms delay for the the debounceTime, so the `this.layout()` method does not fire so often; but I am not sure as to what is the best value for dueTime of debounceTime.