### PR TITLE
fix(module:tabs): wrong cursor

### DIFF
--- a/components/tabs/style/patch.less
+++ b/components/tabs/style/patch.less
@@ -7,6 +7,7 @@
 .ant-tabs-tab-btn {
   border: none;
   background-color: unset;
+  cursor: pointer;
 }
 
 .ant-tabs-tab a[nz-tab-link] {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✔️] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔️] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when you hover tabs, the mouse cursor is the default one.

Issue Number: #8385 


## What is the new behavior?
Now is pointer cursor

## Does this PR introduce a breaking change?
```
[ ] Yes
[✔️] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
