### PR TITLE
feat(module:modal): expose componentRef nzContent

### DIFF
--- a/components/modal/doc/index.en-US.md
+++ b/components/modal/doc/index.en-US.md
@@ -9,9 +9,14 @@ Modal dialogs.
 
 ## When To Use
 
-When requiring users to interact with the application without jumping to a new page to interrupt the user's workflow, you can use `Modal` to create a new floating layer over the current page for user-getting feedback or information purposes. Additionally, if you need to show a simple confirmation dialog, you can use `NzModalService.confirm()` and so on.
+When requiring users to interact with the application without jumping to a new page to interrupt the user's workflow,
+you can use `Modal` to create a new floating layer over the current page for user-getting feedback or information
+purposes. Additionally, if you need to show a simple confirmation dialog, you can use `NzModalService.confirm()` and so
+on.
 
-It is recommended to use the `Component` way to pop up the Modal so that the component logic of the popup layer can be completely isolated from the outer component and reused at any time. In the popup layer component, you can obtain Modal's component instance by injecting `NzModalRef` to control the behavior of the modal box.
+It is recommended to use the `Component` way to pop up the Modal so that the component logic of the popup layer can be
+completely isolated from the outer component and reused at any time. In the popup layer component, you can obtain
+Modal's component instance by injecting `NzModalRef` to control the behavior of the modal box.
 
 ```ts
 import { NzModalModule } from 'ng-zorro-antd/modal';
@@ -21,10 +26,12 @@ import { NzModalModule } from 'ng-zorro-antd/modal';
 
 ### NzModalService
 
-The dialog is currently divided into 2 modes, `normal mode` and `confirm box mode` (for instance, the `Confirm` dialog, which is called by `confirm/info/success/error/warning`). The degree of API support for the two modes is slightly different.
+The dialog is currently divided into 2 modes, `normal mode` and `confirm box mode` (for instance, the `Confirm` dialog,
+which is called by `confirm/info/success/error/warning`). The degree of API support for the two modes is slightly
+different.
 
 | Property              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Type                                                                                             | Default               | Global Config |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | --------------------- | ------------- |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|-----------------------|---------------|
 | `nzAfterOpen`         | Specify a EventEmitter that will be emitted when modal opened                                                                                                                                                                                                                                                                                                                                                                                                                              | EventEmitter                                                                                     | -                     |
 | `nzAfterClose`        | Specify a EventEmitter that will be emitted when modal is closed completely (Can listen for parameters passed in the close/destroy method)                                                                                                                                                                                                                                                                                                                                                 | EventEmitter                                                                                     | -                     |
 | `nzBodyStyle`         | Body style for modal body element. Such as height, padding etc.                                                                                                                                                                                                                                                                                                                                                                                                                            | `object`                                                                                         | -                     |
@@ -37,10 +44,10 @@ The dialog is currently divided into 2 modes, `normal mode` and `confirm box mod
 | `nzCancelDisabled`    | Whether to disable Cancel button or not                                                                                                                                                                                                                                                                                                                                                                                                                                                    | `boolean`                                                                                        | `false`               |
 | `nzFooter`            | Footer content, set as footer=null when you don't need default buttons. <i>1. Only valid in normal mode.<br>2. You can customize the buttons to the maximum extent by passing a `ModalButtonOptions` configuration (see the case or the instructions below).</i>                                                                                                                                                                                                                           | string<br>TemplateRef<br>ModalButtonOptions                                                      | OK and Cancel buttons |
 | `nzKeyboard`          | Whether support press esc to close                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `boolean`                                                                                        | `true`                |
-| `nzMask`              | Whether show mask or not.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `boolean`                                                                                        | `true`                | ✅            |
-| `nzMaskClosable`      | Whether to close the modal dialog when the mask (area outside the modal) is clicked                                                                                                                                                                                                                                                                                                                                                                                                        | `boolean`                                                                                        | `true`                | ✅            |
-| `nzCloseOnNavigation` | Whether to close the modal when the user goes backwards/forwards in history. Note that this usually doesn't include clicking on links (unless the user is using the HashLocationStrategy).                                                                                                                                                                                                                                                                                                 | `boolean`                                                                                        | `true`                | ✅            |
-| `nzDirection`         | Direction of the text in the modal                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `'ltr' \| 'rtl'`                                                                                 | -                     | ✅            |
+| `nzMask`              | Whether show mask or not.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `boolean`                                                                                        | `true`                | ✅             |
+| `nzMaskClosable`      | Whether to close the modal dialog when the mask (area outside the modal) is clicked                                                                                                                                                                                                                                                                                                                                                                                                        | `boolean`                                                                                        | `true`                | ✅             |
+| `nzCloseOnNavigation` | Whether to close the modal when the user goes backwards/forwards in history. Note that this usually doesn't include clicking on links (unless the user is using the HashLocationStrategy).                                                                                                                                                                                                                                                                                                 | `boolean`                                                                                        | `true`                | ✅             |
+| `nzDirection`         | Direction of the text in the modal                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `'ltr' \| 'rtl'`                                                                                 | -                     | ✅             |
 | `nzMaskStyle`         | Style for modal's mask element.                                                                                                                                                                                                                                                                                                                                                                                                                                                            | `object`                                                                                         | -                     |
 | `nzOkText`            | Text of the OK button. <i>Set to null to show no ok button (this value is invalid if the nzFooter parameter is used in normal mode)</i>                                                                                                                                                                                                                                                                                                                                                    | `string`                                                                                         | OK                    |
 | `nzOkType`            | Button type of the OK button. <i>Consistent with the `nzType` of the `nz-button`.</i>                                                                                                                                                                                                                                                                                                                                                                                                      | `string`                                                                                         | `primary`             |
@@ -58,16 +65,18 @@ The dialog is currently divided into 2 modes, `normal mode` and `confirm box mod
 | `nzContent`           | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | string / TemplateRef / Component / ng-content                                                    | -                     |
 | `nzData`              | Will be a template variable when `nzContent` is `TemplateRef`                                                                                                                                                                                                                                                                                                                                                                                                                              | `object`, will be the value of the injection token NZ_MODAL_DATA when `nzContent` is a component | -                     |
 | `nzIconType`          | Icon type of the Icon component. <i>Only valid in confirm box mode</i>                                                                                                                                                                                                                                                                                                                                                                                                                     | `string`                                                                                         | question-circle       |
-| `nzAutofocus`         | autofocus and the position，disabled when is `null`                                                                                                                                                                                                                                                                                                                                                                                                                                        | `'ok' \| 'cancel' \| 'auto' \| null`                                                             | `'auto'`              |
+| `nzAutofocus`         | autofocus and the position，disabled when is `null`                                                                                                                                                                                                                                                                                                                                                                                                                                         | `'ok' \| 'cancel' \| 'auto' \| null`                                                             | `'auto'`              |
 
 #### NZ_MODAL_DATA
 
 > NZ_MODAL_DATA injection token is used to retrieve `nzData` in the custom component.
-> The dialog created by the service method `NzModalService.create()` inject a `NZ_MODAL_DATA` token (if `nzContent` is used as Component) to retrieve the parameters that have used to the '`nzContent` component'
+> The dialog created by the service method `NzModalService.create()` inject a `NZ_MODAL_DATA` token (if `nzContent` is
+> used as Component) to retrieve the parameters that have used to the '`nzContent` component'
 
 #### Using service to create Normal Mode modal
 
-> You can call `NzModalService.create(options)` to dynamically create **normal mode** modals, where `options` is an object that supports the support given in the API above **normal mode** parameters
+> You can call `NzModalService.create(options)` to dynamically create **normal mode** modals, where `options` is an
+> object that supports the support given in the API above **normal mode** parameters
 
 ### Confirm box mode - NzModalService.method()
 
@@ -83,7 +92,7 @@ The above items are all functions, expecting a settings object as a parameter.
 Consistent with the above API, some property types or initial values are different as follows:
 
 | Property       | Description                                                                                                                                                                                                                                                                                                                                                 | Type            | Default |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------- |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|---------|
 | nzOnOk         | Specify a EventEmitter that will be emitted when a user clicks the OK button (If nzContent is Component, the Component instance will be put in as an argument.). <i>This function returns a promise, which is automatically closed when the execution is complete or the promise ends (return `false` to prevent closing)</i>                               | function        | -       |
 | nzOnCancel     | Specify a function that will be called when a user clicks mask, close button on top right or Cancel button (If nzContent is Component, the Component instance will be put in as an argument.). <i>This function returns a promise, which is automatically closed when the execution is complete or the promise ends (return `false` to prevent closing)</i> | function        | -       |
 | nzWidth        | Width of the modal dialog                                                                                                                                                                                                                                                                                                                                   | string / number | 416     |
@@ -92,7 +101,11 @@ Consistent with the above API, some property types or initial values are differe
 All the `NzModalService.method`s will return a reference, and then we can close the popup by the reference.
 
 ```ts
-constructor(modal: NzModalService) {
+constructor(modal
+:
+NzModalService
+)
+{
   const ref: NzModalRef = modal.info();
   ref.close(); // Or ref.destroy(); This dialog will be destroyed directly
 }
@@ -103,7 +116,7 @@ constructor(modal: NzModalService) {
 #### Other Methods/Attributes for NzModalService
 
 | Methods/Attributes | Description                                        | Type                   |
-| ------------------ | -------------------------------------------------- | ---------------------- |
+|--------------------|----------------------------------------------------|------------------------|
 | `openModals`       | All currently open Modal list                      | NzModalRef[]           |
 | `afterAllClose`    | Callback called after all Modals closed completely | Observable&lt;void&gt; |
 | `closeAll()`       | Close all modals                                   | function               |
@@ -112,15 +125,18 @@ constructor(modal: NzModalService) {
 
 > `NzModalRef` object is used to control dialogs and communicate with their content
 
-The dialog created by the service method `NzModalService.xxx()` will return a `NzModalRef` object that is used to manipulate the dialog (this object can also be obtained by dependency injection `NzModalRef` if `nzContent` is used as Component) , This object has the following methods:
+The dialog created by the service method `NzModalService.xxx()` will return a `NzModalRef` object that is used to
+manipulate the dialog (this object can also be obtained by dependency injection `NzModalRef` if `nzContent` is used as
+Component), This object has the following methods:
 
 | Method                                   | Description                                                                                                                                                                                     |
-| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | afterOpen                                | Same as nzAfterOpen but of type Observable&lt;void&gt;                                                                                                                                          |
 | afterClose                               | Same as nzAfterClose, but of type Observable&lt;result:any&gt;                                                                                                                                  |
 | close()                                  | Close (hide) the dialog. <i>Note: When used for a dialog created as a service, this method will destroy the dialog directly (as with the destroy method)</i>                                    |
 | destroy()                                | Destroy the dialog. <i>Note: Used only for dialogs created by the service (non-service created dialogs, this method only hides the dialog)</i>                                                  |
 | getContentComponent()                    | Gets the Component instance in the contents of the dialog for `nzContent`. <i> Note: When the dialog is not initialized (`ngOnInit` is not executed), this function will return `undefined`</i> |
+| getContentComponentRef()                 | Gets the Component ref in the contents of the dialog for `nzContent`. <i> Note: When the dialog is not initialized (`ngOnInit` is not executed), this function will return `null`</i>           |
 | triggerOk()                              | Manually trigger nzOnOk                                                                                                                                                                         |
 | triggerCancel()                          | Manually trigger nzOnCancel                                                                                                                                                                     |
 | updateConfig(config: ModalOptions): void | Update the config                                                                                                                                                                               |
@@ -134,22 +150,22 @@ The button configuration items are as follows (along with the button component):
 ```ts
 nzFooter: [{
   label: string; // Button text
-  type?: string; // Types
-  danger?: boolean; // Whether danger
-  shape?: string; // Shape
-  ghost?: boolean; // Whether ghost
-  size?: string; // Size
-  autoLoading?: boolean; // The default is true. If true, this button will automatically be set to the loading state when onClick returns a promise.
+  type? : string; // Types
+  danger? : boolean; // Whether danger
+  shape? : string; // Shape
+  ghost? : boolean; // Whether ghost
+  size? : string; // Size
+  autoLoading? : boolean; // The default is true. If true, this button will automatically be set to the loading state when onClick returns a promise.
 
   // Tip: The `this` of below methods points to the configuration object itself. When nzContent is a component class, the contentComponentInstance parameter passed in by the method below is an instance of the component class
   // Whether to show this button
-  show?: boolean | ((this: ModalButtonOptions, contentComponentInstance?: object) => boolean);
+  show? : boolean | ((this: ModalButtonOptions, contentComponentInstance?: object) => boolean);
   // Whether to display loading
-  loading?: boolean | ((this: ModalButtonOptions, contentComponentInstance?: object) => boolean);
+  loading? : boolean | ((this: ModalButtonOptions, contentComponentInstance?: object) => boolean);
   // Is it disabled
-  disabled?: boolean | ((this: ModalButtonOptions, contentComponentInstance?: object) => boolean);
+  disabled? : boolean | ((this: ModalButtonOptions, contentComponentInstance?: object) => boolean);
   // Callback of clicking
-  onClick?(this: ModalButtonOptions, contentComponentInstance?: object): void | Promise<void> | any;
+  onClick? (this: ModalButtonOptions, contentComponentInstance?: object): void | Promise<void> | any;
 }]
 ```
 
@@ -160,11 +176,12 @@ The above configuration items can also be changed in real-time to trigger the bu
 Customize the title.
 
 ```html
-<div *nzModalTitle> Custom Modal Title </div>
+
+<div *nzModalTitle> Custom Modal Title</div>
 
 <!-- or -->
 
-<ng-template [nzModalTitle]> Custom Modal Title </ng-template>
+<ng-template [nzModalTitle]> Custom Modal Title</ng-template>
 ```
 
 ### [nzModalContent]:standalone
@@ -172,11 +189,12 @@ Customize the title.
 Customize the content.
 
 ```html
-<div *nzModalContent> Custom Modal Content </div>
+
+<div *nzModalContent> Custom Modal Content</div>
 
 <!-- or -->
 
-<ng-template [nzModalContent]> Custom Modal Content </ng-template>
+<ng-template [nzModalContent]> Custom Modal Content</ng-template>
 ```
 
 ### [nzModalFooter]
@@ -184,6 +202,7 @@ Customize the content.
 Customize the footer.
 
 ```html
+
 <div *nzModalFooter>
   <button nz-button nzType="default" (click)="handleCancel()">Custom Callback</button>
   <button nz-button nzType="primary" (click)="handleOk()" [nzLoading]="isConfirmLoading">Custom Submit</button>

--- a/components/modal/modal-ref.ts
+++ b/components/modal/modal-ref.ts
@@ -5,7 +5,7 @@
 
 import { ESCAPE, hasModifierKey } from '@angular/cdk/keycodes';
 import { OverlayRef } from '@angular/cdk/overlay';
-import { EventEmitter } from '@angular/core';
+import { ComponentRef, EventEmitter } from '@angular/core';
 import { Subject } from 'rxjs';
 import { filter, take, takeUntil } from 'rxjs/operators';
 
@@ -29,6 +29,7 @@ export const enum NzTriggerAction {
 
 export class NzModalRef<T = NzSafeAny, R = NzSafeAny> implements NzModalLegacyAPI<T, R> {
   componentInstance: T | null = null;
+  componentRef: ComponentRef<T> | null = null;
   result?: R;
   state: NzModalState = NzModalState.OPEN;
   afterClose: Subject<R | undefined> = new Subject();
@@ -103,12 +104,17 @@ export class NzModalRef<T = NzSafeAny, R = NzSafeAny> implements NzModalLegacyAP
         config.nzAfterClose.emit(this.result);
       }
       this.componentInstance = null;
+      this.componentRef = null;
       this.overlayRef.dispose();
     });
   }
 
   getContentComponent(): T {
     return this.componentInstance as T;
+  }
+
+  getContentComponentRef(): Readonly<ComponentRef<T> | null> {
+    return this.componentRef as Readonly<ComponentRef<T> | null>;
   }
 
   getElement(): HTMLElement {

--- a/components/modal/modal.service.ts
+++ b/components/modal/modal.service.ts
@@ -188,6 +188,7 @@ export class NzModalService implements OnDestroy {
       const contentRef = modalContainer.attachComponentPortal<T>(
         new ComponentPortal(componentOrTemplateRef, config.nzViewContainerRef, injector)
       );
+      modalRef.componentRef = contentRef;
       modalRef.componentInstance = contentRef.instance;
     } else {
       modalContainer.attachStringContent();

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -134,6 +134,7 @@ describe('NzModal', () => {
     expect(modalContentElement!.textContent).toBe('Hello Modal');
     expect(modalRef.getContentComponent() instanceof TestWithModalContentComponent).toBe(true);
     expect(modalRef.getContentComponent().modalRef).toBe(modalRef);
+    expect(modalRef.getContentComponentRef()).not.toBeNull();
     modalRef.close();
   });
 
@@ -148,6 +149,7 @@ describe('NzModal', () => {
     expect(modalContentElement!.textContent?.toString().includes('NG-ZORRO')).toBeTruthy();
     expect(modalRef.getContentComponent() instanceof TestWithModalContentComponent).toBe(true);
     expect(modalRef.getContentComponent().modalRef).toBe(modalRef);
+    expect(modalRef.getContentComponentRef()).not.toBeNull();
     modalRef.close();
   });
 
@@ -162,6 +164,8 @@ describe('NzModal', () => {
     expect(modalContentElement).toBeTruthy();
     expect(modalContentElement!.textContent).toBe('Hello Modal');
     expect(fixture.componentInstance.modalRef).toBe(modalRef);
+    expect(modalRef.getContentComponentRef()).toBeNull();
+    expect(modalRef.getContentComponent()).toBeNull();
     modalRef.close();
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently modalRef don't expose the componentRef of nzContent which is too restricted. With the new API of Angular, user must have he possibilities to retrieve the ref of the component of nzContent to use for exemple APIs like setInput

Issue Number: N/A


## What is the new behavior?

Now ModalRef expose the component Ref of the nzContent when nzContent is a component. This exposition is done by the mehtod getComponentRef which return the ref in a readonly mode


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
