### PR TITLE
fix(module:typography): remove NgZone dependency

### DIFF
--- a/components/typography/typography.spec.ts
+++ b/components/typography/typography.spec.ts
@@ -2,7 +2,7 @@ import { CAPS_LOCK, ENTER, ESCAPE, TAB } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { ApplicationRef, Component, NgZone, ViewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, flushMicrotasks, inject, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -279,22 +279,18 @@ describe('typography', () => {
       expect(testComponent.str).toBe('test');
     }));
 
-    it('should edit focus', fakeAsync(() => {
+    it('should edit focus', () => {
       const editButton = componentElement.querySelector<HTMLButtonElement>('.ant-typography-edit');
       editButton!.click();
       fixture.detectChanges();
-      // The zone may be already stable (see `isStable` condition), thus there're no tasks
-      // in the queue that have been scheduled previously.
-      // This will schedule a microtask (except of waiting for `onStable`).
-      flushMicrotasks();
+
+      // `tick()` will handle over after next render hooks.
+      TestBed.inject(ApplicationRef).tick();
 
       const textarea = componentElement.querySelector<HTMLTextAreaElement>('textarea')! as HTMLTextAreaElement;
 
       expect(document.activeElement === textarea).toBe(true);
-      dispatchFakeEvent(textarea, 'blur');
-      flush();
-      fixture.detectChanges();
-    }));
+    });
 
     it('should apply changes when Enter keydown', fakeAsync(() => {
       const editButton = componentElement.querySelector<HTMLButtonElement>('.ant-typography-edit');


### PR DESCRIPTION
This commit eliminates the `NgZone` dependency from the text edit component. Since zone.js is becoming optional, `onStable` won't emit any value when `provideZonelessChangeDetection` is used in the application config. Instead, we now use the alternative approach provided by `afterNextRender`. Most of the code that was using `onStable` should be replaced with `afterNextRender`.