### PR TITLE
fix: progress组件nzSuccessPercent没有设置默认值0

### DIFF
--- a/components/progress/doc/index.zh-CN.md
+++ b/components/progress/doc/index.zh-CN.md
@@ -25,16 +25,16 @@ import { NzProgressModule } from 'ng-zorro-antd/progress';
 
 各类型通用的属性。
 
-| 属性                 | 说明                         | 类型                                                                                   | 默认值                     |全局配置|
-| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | -------------------------- | --- |
-| `[nzType]`           | 类型                         | `'line' \| 'circle' \| 'dashboard'`                                                    | `'line'`                   ||
+| 属性                 | 说明                         | 类型                                                                                   | 默认值                       |全局配置|
+| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |---------------------------| --- |
+| `[nzType]`           | 类型                         | `'line' \| 'circle' \| 'dashboard'`                                                    | `'line'`                  ||
 | `[nzFormat]`         | 内容的模板函数               | `(percent: number) => string \| TemplateRef<{ $implicit: number }>`                    | `percent => percent + '%'` |
-| `[nzPercent]`        | 百分比                       | `number`                                                                               | `0`                        ||
-| `[nzShowInfo]`       | 是否显示进度数值或状态图标   | `boolean`                                                                              | `true`                     | ✅  |
-| `[nzStatus]`         | 状态                         | `'success' \| 'exception' \| 'active' \| 'normal'`                                     | -                          ||
-| `[nzStrokeLinecap]`  | 进度条端点形状               | `'round' \| 'square'`                                                                  | `'round'`                  | ✅  |
-| `[nzStrokeColor]`    | 进度条颜色，传入对象时为渐变 | `string \| { from: string; to: string: direction: string; [percent: string]: string }` | -                          | ✅  |
-| `[nzSuccessPercent]` | 已完成的分段百分比           | `number`                                                                               | 0                          ||
+| `[nzPercent]`        | 百分比                       | `number`                                                                               | `0`                       ||
+| `[nzShowInfo]`       | 是否显示进度数值或状态图标   | `boolean`                                                                              | `true`                    | ✅  |
+| `[nzStatus]`         | 状态                         | `'success' \| 'exception' \| 'active' \| 'normal'`                                     | -                         ||
+| `[nzStrokeLinecap]`  | 进度条端点形状               | `'round' \| 'square'`                                                                  | `'round'`                 | ✅  |
+| `[nzStrokeColor]`    | 进度条颜色，传入对象时为渐变 | `string \| { from: string; to: string: direction: string; [percent: string]: string }` | -                         | ✅  |
+| `[nzSuccessPercent]` | 已完成的分段百分比           | `number`                                                                               | `0`                         ||
 
 ### `nzType="line"`
 

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -171,7 +171,7 @@ export class NzProgressComponent implements OnChanges, OnInit, OnDestroy {
   @Input() @WithConfig() nzStrokeColor?: NzProgressStrokeColorType = undefined;
   @Input() @WithConfig() nzSize: 'default' | 'small' = 'default';
   @Input() nzFormat?: NzProgressFormatter;
-  @Input() @InputNumber() nzSuccessPercent?: number;
+  @Input() @InputNumber() nzSuccessPercent?: number = 0;
   @Input() @InputNumber() nzPercent: number = 0;
   @Input() @WithConfig() @InputNumber() nzStrokeWidth?: number = undefined;
   @Input() @WithConfig() @InputNumber() nzGapDegree?: number = undefined;

--- a/components/progress/progress.spec.ts
+++ b/components/progress/progress.spec.ts
@@ -243,6 +243,7 @@ describe('progress', () => {
       fixture.detectChanges();
       expect(progress.nativeElement.querySelector('.ant-progress-text').innerText.trim()).toBe('50%');
       testComponent.percent = 100;
+      testComponent.successPercent = 100;
       fixture.detectChanges();
       expect(progress.nativeElement.querySelector('.ant-progress-text').innerText.trim()).toBe('');
       expect(progress.nativeElement.querySelector('.anticon-check-circle')).toBeDefined();
@@ -479,6 +480,7 @@ export class NzTestProgressDashBoardComponent {
   format?: NzProgressFormatter;
   strokeWidth?: number;
   percent = 0;
+  successPercent = 0;
   showInfo = true;
   width = 132;
   strokeLinecap = 'round';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
文档如下
`
[nzSuccessPercent] | 已完成的分段百分比 | number | 0
`
但是代码里并没有给默认值
代码如下，文件components/progress/progress.component.ts里
`@Input() @InputNumber() nzSuccessPercent?: number;`


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
