### PR TITLE
feat(module:rate): emit hover change when leave

### DIFF
--- a/components/rate/doc/index.en-US.md
+++ b/components/rate/doc/index.en-US.md
@@ -21,9 +21,9 @@ import { NzRateModule } from 'ng-zorro-antd/rate';
 ### nz-rate:standalone
 
 | Property            | Description                             | type                          | Default                               | Global Config |
-| ------------------- | --------------------------------------- | ----------------------------- | ------------------------------------- | ------------- |
-| `[nzAllowClear]`    | whether to allow clear when click again | `boolean`                     | `true`                                | ✅            |
-| `[nzAllowHalf]`     | whether to allow semi selection         | `boolean`                     | `false`                               | ✅            |
+|---------------------|-----------------------------------------|-------------------------------|---------------------------------------|---------------|
+| `[nzAllowClear]`    | whether to allow clear when click again | `boolean`                     | `true`                                | ✅             |
+| `[nzAllowHalf]`     | whether to allow semi selection         | `boolean`                     | `false`                               | ✅             |
 | `[nzAutoFocus]`     | get focus when component mounted        | `boolean`                     | `false`                               |
 | `[nzCharacter]`     | custom character of rate                | `TemplateRef<void>`           | `<span nz-icon nzType="star"></span>` |
 | `[nzCount]`         | star count                              | `number`                      | `5`                                   |
@@ -33,12 +33,12 @@ import { NzRateModule } from 'ng-zorro-antd/rate';
 | `(ngModelChange)`   | callback when select value              | `EventEmitter<number>`        | -                                     |
 | `(nzOnBlur)`        | callback when component lose focus      | `EventEmitter<FocusEvent>`    | -                                     |
 | `(nzOnFocus)`       | callback when component get focus       | `EventEmitter<FocusEvent>`    | -                                     |
-| `(nzOnHoverChange)` | callback when hover item                | `EventEmitter<number>`        | -                                     |
+| `(nzOnHoverChange)` | callback when hover / leave item        | `EventEmitter<number>`        | -                                     |
 | `(nzOnKeyDown)`     | callback when keydown on component      | `EventEmitter<KeyboardEvent>` | -                                     |
 
 #### Methods
 
 | Name    | Description  |
-| ------- | ------------ |
+|---------|--------------|
 | blur()  | remove focus |
 | focus() | get focus    |

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -223,16 +223,12 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
     if (this.nzDisabled) {
       return;
     }
-
-    if (this.hoverValue === index + 1 && isHalf === this.hasHalf) {
-      return this.nzOnHoverChange.emit(this.hoverValue);
+    if (this.hoverValue !== index + 1 || isHalf !== this.hasHalf) {
+      this.hoverValue = index + 1;
+      this.hasHalf = isHalf;
+      this.updateStarStyle();
     }
-
-    this.hoverValue = index + 1;
-    this.hasHalf = isHalf;
     this.nzOnHoverChange.emit(this.hoverValue);
-
-    this.updateStarStyle();
   }
 
   onRateLeave(): void {

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -221,6 +221,7 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
 
   onItemHover(index: number, isHalf: boolean): void {
     if (this.nzDisabled || (this.hoverValue === index + 1 && isHalf === this.hasHalf)) {
+      this.nzOnHoverChange.emit(this.hoverValue);
       return;
     }
 

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -234,7 +234,7 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
   onRateLeave(): void {
     this.hasHalf = !Number.isInteger(this.nzValue);
     this.hoverValue = Math.ceil(this.nzValue);
-
+    this.nzOnHoverChange.emit(this.hoverValue);
     this.updateStarStyle();
   }
 

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -220,9 +220,12 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
   }
 
   onItemHover(index: number, isHalf: boolean): void {
-    if (this.nzDisabled || (this.hoverValue === index + 1 && isHalf === this.hasHalf)) {
-      this.nzOnHoverChange.emit(this.hoverValue);
+    if (this.nzDisabled) {
       return;
+    }
+
+    if (this.hoverValue === index + 1 && isHalf === this.hasHalf) {
+      return this.nzOnHoverChange.emit(this.hoverValue);
     }
 
     this.hoverValue = index + 1;

--- a/components/rate/rate.spec.ts
+++ b/components/rate/rate.spec.ts
@@ -1,7 +1,7 @@
 import { BidiModule, Dir } from '@angular/cdk/bidi';
 import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import { Component, DebugElement, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -159,11 +159,12 @@ describe('rate', () => {
       expect(testComponent.onHoverChange).toHaveBeenCalledTimes(1);
       dispatchFakeEvent(rate.nativeElement.firstElementChild, 'mouseleave');
       fixture.detectChanges();
+      expect(testComponent.onHoverChange).toHaveBeenCalledTimes(2);
       expect(rate.nativeElement.firstElementChild.children[3].classList).toContain('ant-rate-star-zero');
       testComponent.disabled = true;
       fixture.detectChanges();
       dispatchFakeEvent(rate.nativeElement.firstElementChild.children[2].firstElementChild, 'mouseover');
-      expect(testComponent.onHoverChange).toHaveBeenCalledTimes(1);
+      expect(testComponent.onHoverChange).toHaveBeenCalledTimes(2);
     });
     it('should keydown work', () => {
       fixture.detectChanges();
@@ -301,6 +302,7 @@ describe('rate', () => {
     });
   });
 });
+
 @Component({
   // eslint-disable-next-line
   selector: 'nz-test-rate',
@@ -355,6 +357,7 @@ export class NzTestRateFormComponent {
     this.formControl.enable();
   }
 }
+
 @Component({
   template: `
     <div [dir]="direction">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently when the rate is left no event emitter is sent. This prevent customisation like changing icon

Issue Number: #8415


## What is the new behavior?

hoverChange event is now sent when the user left the rate

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
