### PR TITLE
fix(module:autocomplete): remove NgZone dependency

### DIFF
--- a/components/auto-complete/autocomplete.spec.ts
+++ b/components/auto-complete/autocomplete.spec.ts
@@ -630,9 +630,9 @@ describe('auto-complete', () => {
 
       let options = overlayContainerElement.querySelectorAll('nz-auto-option') as NodeListOf<HTMLElement>;
       options[0].click();
-      fixture.detectChanges();
-      zone.simulateZoneExit();
-      fixture.detectChanges();
+
+      // `tick()` will handle over after next render hooks.
+      TestBed.inject(ApplicationRef).tick();
 
       const componentOptions = fixture.componentInstance.optionComponents.toArray();
       expect(componentOptions[0].selected).toBe(true);
@@ -655,9 +655,9 @@ describe('auto-complete', () => {
 
       let options = overlayContainerElement.querySelectorAll('nz-auto-option') as NodeListOf<HTMLElement>;
       options[0].click();
-      fixture.detectChanges();
-      zone.simulateZoneExit();
-      fixture.detectChanges();
+
+      // `tick()` will handle over after next render hooks.
+      TestBed.inject(ApplicationRef).tick();
 
       const componentOptions = fixture.componentInstance.optionComponents.toArray();
       expect(componentOptions[0].selected).toBe(true);

--- a/components/core/render/after-next-render.ts
+++ b/components/core/render/after-next-render.ts
@@ -1,0 +1,32 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { InjectionToken, Injector, afterNextRender, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+/**
+ * An injection token representing `afterNextRender` as an observable rather
+ * than a callback-based API has been added. This might be necessary in code
+ * where streams of data are already being used and we need to wait until
+ * the change detection ends before performing any tasks.
+ */
+export const NZ_AFTER_NEXT_RENDER$ = new InjectionToken<Observable<void>>('nz-after-next-render', {
+  providedIn: 'root',
+  factory: () => {
+    const injector = inject(Injector);
+
+    return new Observable<void>(subscriber => {
+      const ref = afterNextRender(
+        () => {
+          subscriber.next();
+          subscriber.complete();
+        },
+        { injector }
+      );
+
+      return () => ref.destroy();
+    });
+  }
+});

--- a/components/core/render/index.ts
+++ b/components/core/render/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+export * from './public-api';

--- a/components/core/render/ng-package.json
+++ b/components/core/render/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/components/core/render/public-api.ts
+++ b/components/core/render/public-api.ts
@@ -1,0 +1,6 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+export * from './after-next-render';


### PR DESCRIPTION
This commit eliminates the `NgZone` dependency from the autocomplete component. Since zone.js is becoming optional, `onStable` won't emit any value when `provideZonelessChangeDetection` is used in the application config. Instead, we now use the alternative approach provided by `afterNextRender`. Most of the code that was using `onStable` should be replaced with `afterNextRender`.