### PR TITLE
fix(module:pagination): add accessible name for nz-pagination-item

### DIFF
--- a/components/pagination/pagination-item.component.ts
+++ b/components/pagination/pagination-item.component.ts
@@ -33,7 +33,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
           <a>{{ page }}</a>
         }
         @case ('prev') {
-          <button type="button" [disabled]="disabled" class="ant-pagination-item-link">
+          <button type="button" [disabled]="disabled" [attr.title]="locale.prev_page" class="ant-pagination-item-link">
             @if (direction === 'rtl') {
               <span nz-icon nzType="right"></span>
             } @else {
@@ -42,7 +42,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
           </button>
         }
         @case ('next') {
-          <button type="button" [disabled]="disabled" class="ant-pagination-item-link">
+          <button type="button" [disabled]="disabled" [attr.title]="locale.next_page" class="ant-pagination-item-link">
             @if (direction === 'rtl') {
               <span nz-icon nzType="left"></span>
             } @else {

--- a/components/pagination/pagination-simple.component.ts
+++ b/components/pagination/pagination-simple.component.ts
@@ -42,6 +42,7 @@ import { PaginationItemRenderContext } from './pagination.types';
       <ul>
         <li
           nz-pagination-item
+          [locale]="locale"
           [attr.title]="locale.prev_page"
           [disabled]="isFirstIndex"
           [direction]="dir"
@@ -56,6 +57,7 @@ import { PaginationItemRenderContext } from './pagination.types';
         </li>
         <li
           nz-pagination-item
+          [locale]="locale"
           [attr.title]="locale?.next_page"
           [disabled]="isLastIndex"
           [direction]="dir"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8405 


## What is the new behavior?
add accessible name for nz-pagination-item component (the lighthouse point is improved from 82 to 88 in https://ng.ant.design/components/pagination/zh page)

PS: to solve the second issue `Form elements do not have associated labels`, we should refactor the nz-select component to accept more aria-* props.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I've noticed that ant-design has done a lot of support work for a11y already, it's worth following up on this feature for zorro.

