### PR TITLE
docs: replace the new tag with the supported version of the component

### DIFF
--- a/components/color-picker/doc/index.en-US.md
+++ b/components/color-picker/doc/index.en-US.md
@@ -2,7 +2,7 @@
 category: Components
 type: Data Entry
 title: ColorPicker
-tag: New
+tag: 16.2.0
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*PpY4RYNM8UcAAAAAAAAAAAAADrJ8AQ/original
 ---
 
@@ -10,8 +10,18 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*PpY4RYNM8UcAAAAAAA
 
 Used when the user needs to customize the color selection.
 
+### Import Module
+
+module:
+
 ```ts
 import { NzColorPickerModule } from 'ng-zorro-antd/color-picker';
+```
+
+standalone:
+
+```ts
+import { NzColorPickerComponent } from 'ng-zorro-antd/color-picker';
 ```
 
 ## API

--- a/components/color-picker/doc/index.zh-CN.md
+++ b/components/color-picker/doc/index.zh-CN.md
@@ -3,7 +3,7 @@ category: Components
 subtitle: 颜色选择器
 type: 数据录入
 title: ColorPicker
-tag: New
+tag: 16.2.0
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*PpY4RYNM8UcAAAAAAAAAAAAADrJ8AQ/original
 ---
 
@@ -11,8 +11,18 @@ cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*PpY4RYNM8UcAAAAAAA
 
 当用户需要自定义颜色选择的时候使用。
 
+### 引入模块
+
+module:
+
 ```ts
 import { NzColorPickerModule } from 'ng-zorro-antd/color-picker';
+```
+
+standalone:
+
+```ts
+import { NzColorPickerComponent } from 'ng-zorro-antd/color-picker'
 ```
 
 ## API

--- a/components/flex/doc/index.en-US.md
+++ b/components/flex/doc/index.en-US.md
@@ -4,10 +4,10 @@ type: Layout
 cols: 1
 title: Flex
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*SMzgSJZE_AwAAAAAAAAAAAAADrJ8AQ/original
-tag: New
+tag: 17.1.0
 ---
 
-Wrapper for `Display: flex`.
+Wrapper for `display: flex`.
 
 ## When To Use
 
@@ -16,8 +16,10 @@ Wrapper for `Display: flex`.
 
 ### Difference with Space component
 
-- Space is used to set the spacing between inline elements. It will add a wrapper element for each child element for inline alignment. Suitable for equidistant arrangement of multiple child elements in rows and columns.
-- Flex is used to set the layout of block-level elements. It does not add a wrapper element. Suitable for layout of child elements in vertical or horizontal direction, and provides more flexibility and control.
+- Space is used to set the spacing between inline elements. It will add a wrapper element for each child element for
+  inline alignment. Suitable for equidistant arrangement of multiple child elements in rows and columns.
+- Flex is used to set the layout of block-level elements. It does not add a wrapper element. Suitable for layout of
+  child elements in vertical or horizontal direction, and provides more flexibility and control.
 
 ### Import Module
 
@@ -30,7 +32,7 @@ import { NzFlexModule } from 'ng-zorro-antd/flex';
 ### [nz-flex]:standalone
 
 | Property       | Description                                                                | Type                                                                                          | Default    |
-| -------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------- |
+|----------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|------------|
 | `[nzVertical]` | Is direction of the flex vertical, use `flex-direction: column`            | `boolean`                                                                                     | `false`    |
 | `[nzJustify]`  | Sets the alignment of elements in the direction of the main axis           | reference [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) | `'normal'` |
 | `[nzAlign]`    | Sets the alignment of elements in the direction of the cross axis          | reference [align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items)         | `'normal'` |

--- a/components/flex/doc/index.zh-CN.md
+++ b/components/flex/doc/index.zh-CN.md
@@ -5,7 +5,7 @@ type: 布局
 cols: 1
 title: Flex
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*SMzgSJZE_AwAAAAAAAAAAAAADrJ8AQ/original
-tag: New
+tag: 17.1.0
 ---
 
 弹性布局
@@ -30,11 +30,11 @@ import { NzFlexModule } from 'ng-zorro-antd/flex';
 
 ### [nz-flex]:standalone
 
-| 参数  | 说明   | 类型   | 默认值  |
-| -------- | ---------------- | --------------- | ---------- |
-| `[nzVertical]` | 使用 `flex-direction: column`描述flex的垂直方向  | `boolean`  | `false`  |
-| `[nzJustify]` | 设置元素在主轴方向上的对齐方式，参照 [justify-content](https://developer.mozilla.org/zh-CN/docs/Web/CSS/justify-content) | `NzJustify` | `'normal'` |
-| `[nzAlign]` | 设置元素在交叉轴方向上的对齐方式，参照 [align-items](https://developer.mozilla.org/zh-CN/docs/Web/CSS/align-items) | `NzAlign` | `'normal'` |
-| `[nzGap]`  | 设置项目的间隙   | `'small' \| 'middle' \| 'large' \| number \| string`    | `0`    |
-| `[nzWrap]` | 指定 flex 元素单行显示还是多行显示，参照 [flex-wrap](https://developer.mozilla.org/zh-CN/docs/Web/CSS/flex-wrap) | `NzWrap` | `'nowrap'` |
-| `[nzFlex]` | flex css简写属性，参照 [flex](https://developer.mozilla.org/zh-CN/docs/Web/CSS/flex)   |   `NzFlex`   | `'unset'` |
+| 参数             | 说明                                                                                                     | 类型                                                   | 默认值        |
+|----------------|--------------------------------------------------------------------------------------------------------|------------------------------------------------------|------------|
+| `[nzVertical]` | 使用 `flex-direction: column`描述flex的垂直方向                                                                 | `boolean`                                            | `false`    |
+| `[nzJustify]`  | 设置元素在主轴方向上的对齐方式，参照 [justify-content](https://developer.mozilla.org/zh-CN/docs/Web/CSS/justify-content) | `NzJustify`                                          | `'normal'` |
+| `[nzAlign]`    | 设置元素在交叉轴方向上的对齐方式，参照 [align-items](https://developer.mozilla.org/zh-CN/docs/Web/CSS/align-items)        | `NzAlign`                                            | `'normal'` |
+| `[nzGap]`      | 设置项目的间隙                                                                                                | `'small' \| 'middle' \| 'large' \| number \| string` | `0`        |
+| `[nzWrap]`     | 指定 flex 元素单行显示还是多行显示，参照 [flex-wrap](https://developer.mozilla.org/zh-CN/docs/Web/CSS/flex-wrap)        | `NzWrap`                                             | `'nowrap'` |
+| `[nzFlex]`     | flex css简写属性，参照 [flex](https://developer.mozilla.org/zh-CN/docs/Web/CSS/flex)                          | `NzFlex`                                             | `'unset'`  |

--- a/components/hash-code/doc/index.en-US.md
+++ b/components/hash-code/doc/index.en-US.md
@@ -2,21 +2,25 @@
 category: Components
 type: Featured Components
 title: HashCode
-tag: New
+tag: 17.0.0
 cover: https://img.alicdn.com/imgextra/i3/O1CN01ePPF8q1cxXFz041Q9_!!6000000003667-0-tps-172-57.jpg
 ---
 
 ## Import Module
 
-- The hash code component is styled for 64-bit design, and if the data given is less than or more than 64-bit, it may bring some differences in presentation.
+The hash code component is styled for 64-bit design, and if the data given is less than or more than 64-bit, it may
+bring some differences in presentation.
 
 ### Import Module
 
 module:
+
 ```ts
 import { NzHashCodeModule } from 'ng-zorro-antd/hash-code';
 ```
+
 standalone:
+
 ```ts
 import { NzHashCodeComponent } from 'ng-zorro-antd/hash-code';
 ```
@@ -25,11 +29,11 @@ import { NzHashCodeComponent } from 'ng-zorro-antd/hash-code';
 
 ### nz-hashCode:standalone
 
-| Property              | Description                                         | Type                            | Default   |
-| -------------- |-----------------------------------------------------|-------------------------------------|------------|
-| `[nzValue]`    | The value of the hash code                          | `string`                            | -          |
-| `[nzTitle]`    | Description of the content in the upper left corner | `string`                            | `HashCode` |
-| `[nzLogo]` | Display in the upper right corner                   | `TemplateRef<void> \| string`       | -          |
-| `[nzMode]`     | Demonstration Mode               | `single \| double \| strip \| rect` | `double`   |
-| `[nzType]`  | style             | `defalut \| primary`                | `primary`  |
-| `(nzOnCopy)`  | Clicking the Copy callback            | `EventEmitter<string>`              | -          |
+| Property     | Description                                         | Type                                | Default    |
+|--------------|-----------------------------------------------------|-------------------------------------|------------|
+| `[nzValue]`  | The value of the hash code                          | `string`                            | -          |
+| `[nzTitle]`  | Description of the content in the upper left corner | `string`                            | `HashCode` |
+| `[nzLogo]`   | Display in the upper right corner                   | `TemplateRef<void> \| string`       | -          |
+| `[nzMode]`   | Demonstration Mode                                  | `single \| double \| strip \| rect` | `double`   |
+| `[nzType]`   | style                                               | `defalut \| primary`                | `primary`  |
+| `(nzOnCopy)` | Clicking the Copy callback                          | `EventEmitter<string>`              | -          |

--- a/components/hash-code/doc/index.zh-CN.md
+++ b/components/hash-code/doc/index.zh-CN.md
@@ -3,21 +3,24 @@ category: Components
 subtitle: 哈希码
 type: 特色组件
 title: HashCode
-tag: New
+tag: 17.0.0
 cover: https://img.alicdn.com/imgextra/i3/O1CN01ePPF8q1cxXFz041Q9_!!6000000003667-0-tps-172-57.jpg
 ---
 
 ## 何时使用
 
-- 哈希码组件是以 64 位设计的样式，如果给出的数据不足或者高于 64 位，可能会带来一些展示上的差异。
+哈希码组件是以 64 位设计的样式，如果给出的数据不足或者高于 64 位，可能会带来一些展示上的差异。
 
 ### 引入模块
 
 module:
+
 ```ts
 import { NzHashCodeModule } from 'ng-zorro-antd/hash-code';
 ```
+
 standalone:
+
 ```ts
 import { NzHashCodeComponent } from 'ng-zorro-antd/hash-code';
 ```
@@ -27,10 +30,10 @@ import { NzHashCodeComponent } from 'ng-zorro-antd/hash-code';
 ### nz-hashCode:standalone
 
 | 参数           | 说明        | 类型                                  | 默认值        |
-| -------------- |-----------|-------------------------------------|------------|
-| `[nzValue]`    | 哈希码的值     | `string`                            | -          |
-| `[nzTitle]`    | 左上角的描述内容  | `string`                            | `HashCode` |
-| `[nzLogo]` | 右上角的展示    | `TemplateRef<void> \| string`       | -          |
-| `[nzMode]`     | 展示模式      | `single \| double \| strip \| rect` | `double`   |
-| `[nzType]`  | 样式        | `defalut \| primary`                | `primary`  |
-| `(nzOnCopy)`  | 点击"复制"的回调 | `EventEmitter<string>`              | -          |
+|--------------|-----------|-------------------------------------|------------|
+| `[nzValue]`  | 哈希码的值     | `string`                            | -          |
+| `[nzTitle]`  | 左上角的描述内容  | `string`                            | `HashCode` |
+| `[nzLogo]`   | 右上角的展示    | `TemplateRef<void> \| string`       | -          |
+| `[nzMode]`   | 展示模式      | `single \| double \| strip \| rect` | `double`   |
+| `[nzType]`   | 样式        | `defalut \| primary`                | `primary`  |
+| `(nzOnCopy)` | 点击"复制"的回调 | `EventEmitter<string>`              | -          |

--- a/components/qr-code/doc/index.en-US.md
+++ b/components/qr-code/doc/index.en-US.md
@@ -2,7 +2,7 @@
 category: Components
 type: Data Display
 title: QRCode
-tag: New
+tag: 15.1.0
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*cJopQrf0ncwAAAAAAAAAAAAADrJ8AQ/original
 ---
 
@@ -20,30 +20,36 @@ import { NzQRCodeModule } from 'ng-zorro-antd/qr-code';
 
 ### nz-qrcode:standalone
 
-| Property       | Description                         | Type                              | Default   |
-| -------------- | ----------------------------------- | --------------------------------- | --------- |
-| `[nzValue]`    | scanned link                        | `string`                          | -         |
-| `[nzColor]`    | QR code Color                       | `string`                          | `#000`    |
-| `[nzBgColor]`  | QR code background color            | `string`                          | `#FFFFFF` |
-| `[nzSize]`     | QR code Size                        | `number`                          | `160`     |
-| `[nzPadding]`  | QR code Padding                     | `number \| number[]`              | `0`       |
-| `[nzIcon]`     | Icon address in QR code             | `string`                          | -         |
-| `[nzIconSize]` | The size of the icon in the QR code | `number`                          | `40`      |
-| `[nzBordered]` | Whether has border style            | `boolean`                         | `true`    |
+| Property       | Description                         | Type                            | Default   |
+|----------------|-------------------------------------|---------------------------------|-----------|
+| `[nzValue]`    | scanned link                        | `string`                        | -         |
+| `[nzColor]`    | QR code Color                       | `string`                        | `#000`    |
+| `[nzBgColor]`  | QR code background color            | `string`                        | `#FFFFFF` |
+| `[nzSize]`     | QR code Size                        | `number`                        | `160`     |
+| `[nzPadding]`  | QR code Padding                     | `number \| number[]`            | `0`       |
+| `[nzIcon]`     | Icon address in QR code             | `string`                        | -         |
+| `[nzIconSize]` | The size of the icon in the QR code | `number`                        | `40`      |
+| `[nzBordered]` | Whether has border style            | `boolean`                       | `true`    |
 | `[nzStatus]`   | QR code status                      | `'active'｜'expired' ｜'loading'` | `active`  |
-| `[nzLevel]`    | Error Code Level                    | `'L'｜'M'｜'Q'｜'H'`              | `M`       |
-| `(nzRefresh)`  | callback                            | `EventEmitter<string>`            | -         |
+| `[nzLevel]`    | Error Code Level                    | `'L'｜'M'｜'Q'｜'H'`               | `M`       |
+| `(nzRefresh)`  | callback                            | `EventEmitter<string>`          | -         |
 
 ## Note
 
 ### Invalid QR Code
 
-`nzValue` has a conservative upper limit of 738 or fewer strings. If error correction levels are used, the `nzValue` upper limit will be lowered.
+`nzValue` has a conservative upper limit of 738 or fewer strings. If error correction levels are used, the `nzValue`
+upper limit will be lowered.
 
 ### QR Code error correction level
 
-The ErrorLevel means that the QR code can be scanned normally after being blocked, and the maximum area that can be blocked is the error correction rate.
+The ErrorLevel means that the QR code can be scanned normally after being blocked, and the maximum area that can be
+blocked is the error correction rate.
 
-Generally, the QR code is divided into 4 error correction levels: Level `L` can correct about `7%` errors, Level `M` can correct about `15%` errors, Level `Q` can correct about `25%` errors, and Level `H` can correct about `30%` errors. When the content encoding of the QR code carries less information, in other words, when the value link is short, set different error correction levels, and the generated image will not change.
+Generally, the QR code is divided into 4 error correction levels: Level `L` can correct about `7%` errors, Level `M` can
+correct about `15%` errors, Level `Q` can correct about `25%` errors, and Level `H` can correct about `30%` errors. When
+the content encoding of the QR code carries less information, in other words, when the value link is short, set
+different error correction levels, and the generated image will not change.
 
-> For more information, see the: [https://www.qrcode.com/en/about/error_correction](https://www.qrcode.com/en/about/error_correction.html)
+> For more information, see
+> the: [https://www.qrcode.com/en/about/error_correction](https://www.qrcode.com/en/about/error_correction.html)

--- a/components/qr-code/doc/index.zh-CN.md
+++ b/components/qr-code/doc/index.zh-CN.md
@@ -3,7 +3,7 @@ category: Components
 subtitle: 二维码
 type: 数据展示
 title: QRCode
-tag: New
+tag: 15.1.0
 cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*cJopQrf0ncwAAAAAAAAAAAAADrJ8AQ/original
 ---
 
@@ -21,19 +21,19 @@ import { NzQRCodeModule } from 'ng-zorro-antd/qr-code';
 
 ### nz-qrcode:standalone
 
-| 参数           | 说明                 | 类型                              | 默认值    |
-| -------------- | -------------------- | --------------------------------- | --------- |
-| `[nzValue]`    | 扫描后的地址         | `string`                          | -         |
-| `[nzColor]`    | 二维码颜色           | `string`                          | `#000`    |
-| `[nzBgColor]`  | 二维码背景颜色       | `string`                          | `#FFFFFF` |
-| `[nzSize]`     | 二维码大小           | `number`                          | `160`     |
-| `[nzPadding]`  | 二维码填充           | `number \| number[]`              | `0`       |
-| `[nzIcon]`     | 二维码中 icon 地址   | `string`                          | -         |
-| `[nzIconSize]` | 二维码中 icon 大小   | `number`                          | `40`      |
-| `[nzBordered]` | 是否有边框           | `boolean`                         | `true`    |
-| `[nzStatus]`   | 二维码状态           | `'active'｜'expired' ｜'loading'` | `active`  |
-| `[nzLevel]`    | 二维码容错等级       | `'L'｜'M'｜'Q'｜'H'`              | `M`       |
-| `(nzRefresh)`  | 点击"点击刷新"的回调 | `EventEmitter<string>`            | -         |
+| 参数             | 说明           | 类型                              | 默认值       |
+|----------------|--------------|---------------------------------|-----------|
+| `[nzValue]`    | 扫描后的地址       | `string`                        | -         |
+| `[nzColor]`    | 二维码颜色        | `string`                        | `#000`    |
+| `[nzBgColor]`  | 二维码背景颜色      | `string`                        | `#FFFFFF` |
+| `[nzSize]`     | 二维码大小        | `number`                        | `160`     |
+| `[nzPadding]`  | 二维码填充        | `number \| number[]`            | `0`       |
+| `[nzIcon]`     | 二维码中 icon 地址 | `string`                        | -         |
+| `[nzIconSize]` | 二维码中 icon 大小 | `number`                        | `40`      |
+| `[nzBordered]` | 是否有边框        | `boolean`                       | `true`    |
+| `[nzStatus]`   | 二维码状态        | `'active'｜'expired' ｜'loading'` | `active`  |
+| `[nzLevel]`    | 二维码容错等级      | `'L'｜'M'｜'Q'｜'H'`               | `M`       |
+| `(nzRefresh)`  | 点击"点击刷新"的回调  | `EventEmitter<string>`          | -         |
 
 ## 注意
 
@@ -45,6 +45,8 @@ import { NzQRCodeModule } from 'ng-zorro-antd/qr-code';
 
 容错等级也叫容错率，就是指二维码可以被遮挡后还能正常扫描，而这个能被遮挡的最大面积就是容错率。
 
-通常情况下二维码分为 4 个容错等级：`L级` 可纠正约 `7%` 错误、`M级` 可纠正约 `15%` 错误、`Q级` 可纠正约 `25%` 错误、`H级` 可纠正约 `30%` 错误。并不是所有位置都可以缺损，像最明显的三个角上的方框，直接影响初始定位。中间零散的部分是内容编码，可以容忍缺损。当二维码的内容编码携带信息比较少的时候，也就是链接比较短的时候，设置不同的容错等级，生成的图片不会发生变化。
+通常情况下二维码分为 4 个容错等级：`L级` 可纠正约 `7%` 错误、`M级` 可纠正约 `15%` 错误、`Q级` 可纠正约 `25%` 错误、`H级`
+可纠正约 `30%`
+错误。并不是所有位置都可以缺损，像最明显的三个角上的方框，直接影响初始定位。中间零散的部分是内容编码，可以容忍缺损。当二维码的内容编码携带信息比较少的时候，也就是链接比较短的时候，设置不同的容错等级，生成的图片不会发生变化。
 
 > 有关更多信息，可参阅相关资料：[https://www.qrcode.com/zh/about/error_correction](https://www.qrcode.com/zh/about/error_correction.html)

--- a/components/water-mark/doc/index.en-US.md
+++ b/components/water-mark/doc/index.en-US.md
@@ -3,7 +3,7 @@ category: Components
 type: Other
 cols: 1
 title: WaterMark
-tag: New
+tag: 15.1.0
 cover: https://img.alicdn.com/imgextra/i3/O1CN0194FGAd1FlrwQShfR8_!!6000000000528-0-tps-952-502.jpg
 ---
 
@@ -14,11 +14,16 @@ Add specific text or patterns to the page.
 - Use when the page needs to be watermarked to identify the copyright.
 - Suitable for preventing information theft.
 
+### Import Module
+
 module:
+
 ```ts
 import { NzWaterMarkModule } from 'ng-zorro-antd/water-mark';
 ```
+
 standalone:
+
 ```ts
 import { NzWaterMarkComponent } from 'ng-zorro-antd/water-mark';
 ```
@@ -27,35 +32,36 @@ import { NzWaterMarkComponent } from 'ng-zorro-antd/water-mark';
 
 ### nz-water-mark:standalone
 
-| Property    | Description                                                                                       | Type                 | Default                  |
-| ----------- | ------------------------------------------------------------------------------------------------- | -------------------- | ------------------------ |
+| Property    | Description                                                                                       | Type                | Default                  |
+|-------------|---------------------------------------------------------------------------------------------------|---------------------|--------------------------|
 | `nzContent` | Watermark text content                                                                            | `string ｜ string[]` | -                        |
-| `nzWidth`   | The width of the watermark, the default value of `nzContent` is its own width                     | `number`             | 120                      |
-| `nzHeight`  | The height of the watermark, the default value of `nzContent` is its own height                   | `number`             | 64                       |
-| `nzRotate`  | When the watermark is drawn, the rotation Angle, unit `°`                                         | `number`             | -22                      |
-| `nzZIndex`  | The z-index of the appended watermark element                                                     | `number`             | 9                        |
-| `nzImage`   | Image source, it is recommended to export 2x or 3x image, high priority (support base64 format)   | `string`             | -                        |
-| `nzFont`    | Text style                                                                                        | `FontType`           | FontType                 |
-| `nzGap`     | The spacing between watermarks                                                                    | `[number, number]`   | [100, 100]               |
-| `nzOffset`  | The offset of the watermark from the upper left corner of the container. The default is `nzGap/2` | `[number, number]`   | [nzGap[0]/2, nzGap[1]/2] |
+| `nzWidth`   | The width of the watermark, the default value of `nzContent` is its own width                     | `number`            | 120                      |
+| `nzHeight`  | The height of the watermark, the default value of `nzContent` is its own height                   | `number`            | 64                       |
+| `nzRotate`  | When the watermark is drawn, the rotation Angle, unit `°`                                         | `number`            | -22                      |
+| `nzZIndex`  | The z-index of the appended watermark element                                                     | `number`            | 9                        |
+| `nzImage`   | Image source, it is recommended to export 2x or 3x image, high priority (support base64 format)   | `string`            | -                        |
+| `nzFont`    | Text style                                                                                        | `FontType`          | FontType                 |
+| `nzGap`     | The spacing between watermarks                                                                    | `[number, number]`  | [100, 100]               |
+| `nzOffset`  | The offset of the watermark from the upper left corner of the container. The default is `nzGap/2` | `[number, number]`  | [nzGap[0]/2, nzGap[1]/2] |
 
 ### FontType
 
-| Property     | Description | Type                                  | Default         |
-| ------------ | ----------- | ------------------------------------- | --------------- |
-| `color`      | font color  | `string`                              | rgba(0,0,0,.15) |
-| `fontSize`   | font size   | `number`                              | 16              |
+| Property     | Description | Type                               | Default         |
+|--------------|-------------|------------------------------------|-----------------|
+| `color`      | font color  | `string`                           | rgba(0,0,0,.15) |
+| `fontSize`   | font size   | `number`                           | 16              |
 | `fontWeight` | font weight | `normal ｜ light ｜ weight ｜ number` | normal          |
-| `fontFamily` | font family | `string`                              | sans-serif      |
+| `fontFamily` | font family | `string`                           | sans-serif      |
 | `fontStyle`  | font style  | `none ｜ normal ｜ italic ｜ oblique` | normal          |
 
 ## FAQ
 
 ### Handle abnormal image watermarks
 
-When using an image watermark and the image loads abnormally, you can add `nzContent` at the same time to prevent the watermark from becoming invalid.
+When using an image watermark and the image loads abnormally, you can add `nzContent` at the same time to prevent the
+watermark from becoming invalid.
 
-```ts
+```html
 <nz-water-mark
   [nzWidth]="212"
   [nzHeight]="32"

--- a/components/water-mark/doc/index.en-US.md
+++ b/components/water-mark/doc/index.en-US.md
@@ -58,8 +58,7 @@ import { NzWaterMarkComponent } from 'ng-zorro-antd/water-mark';
 
 ### Handle abnormal image watermarks
 
-When using an image watermark and the image loads abnormally, you can add `nzContent` at the same time to prevent the
-watermark from becoming invalid.
+When using an image watermark and the image loads abnormally, you can add `nzContent` at the same time to prevent the watermark from becoming invalid.
 
 ```html
 <nz-water-mark

--- a/components/water-mark/doc/index.zh-CN.md
+++ b/components/water-mark/doc/index.zh-CN.md
@@ -4,7 +4,7 @@ type: 其他
 subtitle: 水印
 title: WaterMark
 cols: 1
-tag: New
+tag: 15.1.0
 cover: https://img.alicdn.com/imgextra/i3/O1CN0194FGAd1FlrwQShfR8_!!6000000000528-0-tps-952-502.jpg
 ---
 
@@ -15,11 +15,16 @@ cover: https://img.alicdn.com/imgextra/i3/O1CN0194FGAd1FlrwQShfR8_!!600000000052
 - 页面需要添加水印标识版权时使用。
 - 适用于防止信息盗用。
 
+### 引入模块
+
 module:
+
 ```ts
 import { NzWaterMarkModule } from 'ng-zorro-antd/water-mark';
 ```
+
 standalone:
+
 ```ts
 import { NzWaterMarkComponent } from 'ng-zorro-antd/water-mark';
 ```
@@ -28,26 +33,26 @@ import { NzWaterMarkComponent } from 'ng-zorro-antd/water-mark';
 
 ### nz-water-mark:standalone
 
-| 参数        | 说明                                                        | 类型                 | 默认值                   |
-| ----------- | ----------------------------------------------------------- | -------------------- | ------------------------ |
-| `nzContent` | 水印文字内容                                                | `string ｜ string[]` | -                        |
-| `nzWidth`   | 水印的宽度，`nzContent` 的默认值为自身的宽度                | `number`             | 120                      |
-| `nzHeight`  | 水印的高度，`nzContent` 的默认值为自身的高度                | `number`             | 64                       |
-| `nzRotate`  | 水印绘制时，旋转的角度，单位 `°`                            | `number`             | -22                      |
-| `nzZIndex`  | 追加的水印元素的 z-index                                    | `number`             | 9                        |
-| `nzImage`   | 图片源，建议导出 2 倍或 3 倍图，优先级高 (支持 base64 格式) | `string`             | -                        |
-| `nzFont`    | 文字样式                                                    | `FontType`           | FontType                 |
-| `nzGap`     | 水印之间的间距                                              | `[number, number]`   | [100, 100]               |
-| `nzOffset`  | 水印距离容器左上角的偏移量，默认为 `nzGap/2`                | `[number, number]`   | [nzGap[0]/2, nzGap[1]/2] |
+| 参数          | 说明                                     | 类型                  | 默认值                      |
+|-------------|----------------------------------------|---------------------|--------------------------|
+| `nzContent` | 水印文字内容                                 | `string ｜ string[]` | -                        |
+| `nzWidth`   | 水印的宽度，`nzContent` 的默认值为自身的宽度           | `number`            | 120                      |
+| `nzHeight`  | 水印的高度，`nzContent` 的默认值为自身的高度           | `number`            | 64                       |
+| `nzRotate`  | 水印绘制时，旋转的角度，单位 `°`                     | `number`            | -22                      |
+| `nzZIndex`  | 追加的水印元素的 z-index                       | `number`            | 9                        |
+| `nzImage`   | 图片源，建议导出 2 倍或 3 倍图，优先级高 (支持 base64 格式) | `string`            | -                        |
+| `nzFont`    | 文字样式                                   | `FontType`          | FontType                 |
+| `nzGap`     | 水印之间的间距                                | `[number, number]`  | [100, 100]               |
+| `nzOffset`  | 水印距离容器左上角的偏移量，默认为 `nzGap/2`            | `[number, number]`  | [nzGap[0]/2, nzGap[1]/2] |
 
 ### FontType
 
-| 参数         | 说明     | 类型                                  | 默认值          |
-| ------------ | -------- | ------------------------------------- | --------------- |
-| `color`      | 字体颜色 | `string`                              | rgba(0,0,0,.15) |
-| `fontSize`   | 字体大小 | `number`                              | 16              |
+| 参数           | 说明   | 类型                                 | 默认值             |
+|--------------|------|------------------------------------|-----------------|
+| `color`      | 字体颜色 | `string`                           | rgba(0,0,0,.15) |
+| `fontSize`   | 字体大小 | `number`                           | 16              |
 | `fontWeight` | 字体粗细 | `normal ｜ light ｜ weight ｜ number` | normal          |
-| `fontFamily` | 字体类型 | `string`                              | sans-serif      |
+| `fontFamily` | 字体类型 | `string`                           | sans-serif      |
 | `fontStyle`  | 字体样式 | `none ｜ normal ｜ italic ｜ oblique` | normal          |
 
 ## FAQ
@@ -56,7 +61,7 @@ import { NzWaterMarkComponent } from 'ng-zorro-antd/water-mark';
 
 当使用图片水印且图片加载异常时，可以同时添加 `nzContent` 防止水印失效。
 
-```ts
+```html
 <nz-water-mark
   [nzWidth]="212"
   [nzHeight]="32"

--- a/scripts/site/_site/doc/app/side/side.component.less
+++ b/scripts/site/_site/doc/app/side/side.component.less
@@ -1,0 +1,5 @@
+.menu-title-content-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/scripts/site/_site/doc/app/side/side.component.less
+++ b/scripts/site/_site/doc/app/side/side.component.less
@@ -2,4 +2,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  > .ant-tag {
+    margin-inline-end: 0;
+  }
 }

--- a/scripts/site/_site/doc/app/side/side.component.less
+++ b/scripts/site/_site/doc/app/side/side.component.less
@@ -1,7 +1,7 @@
 .menu-title-content-link {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
 
   > .ant-tag {
     margin-inline-end: 0;

--- a/scripts/site/_site/doc/app/side/side.component.ts
+++ b/scripts/site/_site/doc/app/side/side.component.ts
@@ -27,7 +27,7 @@ import { RouterList } from '../router';
                 <a routerLink="{{ component.path }}">
                   <span>{{ component.label }}</span>
                   <span class="chinese">{{ component.zh }}</span>
-                  <span class="ant-tag ant-tag-warning" style="margin: 0 8px;" *ngIf="!!component.tag">{{ component.tag }}</span>
+                  <span class="ant-tag ant-tag-success" style="margin: 0 8px;" *ngIf="!!component.tag">{{ component.tag }}</span>
                 </a>
               </li>
             </ng-container>

--- a/scripts/site/_site/doc/app/side/side.component.ts
+++ b/scripts/site/_site/doc/app/side/side.component.ts
@@ -3,7 +3,6 @@ import { RouterList } from '../router';
 
 @Component({
   selector: 'app-side',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ul nz-menu [nzMode]="'inline'" class="aside-container menu-site" [nzInlineIndent]="40" [class.ant-menu-rtl]="direction === 'rtl'">
       <ng-container *ngIf="page === 'docs'">
@@ -24,10 +23,12 @@ import { RouterList } from '../router';
           <ul>
             <ng-container>
               <li nz-menu-item nzMatchRouter *ngFor="let component of group.children">
-                <a routerLink="{{ component.path }}">
-                  <span>{{ component.label }}</span>
-                  <span class="chinese">{{ component.zh }}</span>
-                  <span class="ant-tag ant-tag-success ant-tag-borderless" style="margin: 0 8px;" *ngIf="!!component.tag">{{ component.tag }}</span>
+                <a class="menu-title-content-link" [routerLink]="component.path">
+                  <span>
+                    {{ component.label }}
+                    <span class="chinese">{{ component.zh }}</span>
+                  </span>
+                  <span class="ant-tag ant-tag-success ant-tag-borderless" *ngIf="!!component.tag">{{ component.tag }}</span>
                 </a>
               </li>
             </ng-container>
@@ -45,10 +46,12 @@ import { RouterList } from '../router';
           <ul>
             <ng-container>
               <li nz-menu-item nzMatchRouter *ngFor="let component of group.experimentalChildren">
-                <a routerLink="{{ component.path }}">
-                  <span>{{ component.label }}</span>
-                  <span class="chinese">{{ component.zh }}</span>
-                  <span class="ant-tag ant-tag-warning" style="margin: 0 8px;" *ngIf="!!component.tag">{{ component.tag }}</span>
+                <a class="menu-title-content-link" [routerLink]="component.path">
+                  <span>
+                    {{ component.label }}
+                    <span class="chinese">{{ component.zh }}</span>
+                  </span>
+                  <span class="ant-tag ant-tag-warning ant-tag-borderless" *ngIf="!!component.tag">{{ component.tag }}</span>
                 </a>
               </li>
             </ng-container>
@@ -56,7 +59,9 @@ import { RouterList } from '../router';
         </li>
       </ng-container>
     </ul>
-  `
+  `,
+  styleUrl: './side.component.less',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SideComponent {
   @Input() direction: 'ltr' | 'rtl' = 'ltr';

--- a/scripts/site/_site/doc/app/side/side.component.ts
+++ b/scripts/site/_site/doc/app/side/side.component.ts
@@ -27,7 +27,7 @@ import { RouterList } from '../router';
                 <a routerLink="{{ component.path }}">
                   <span>{{ component.label }}</span>
                   <span class="chinese">{{ component.zh }}</span>
-                  <span class="ant-tag ant-tag-success" style="margin: 0 8px;" *ngIf="!!component.tag">{{ component.tag }}</span>
+                  <span class="ant-tag ant-tag-success ant-tag-borderless" style="margin: 0 8px;" *ngIf="!!component.tag">{{ component.tag }}</span>
                 </a>
               </li>
             </ng-container>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

We had supported to display `New` tag in the components list of side bar in v17.0.0, which followed antd

<img width="297" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/e5a000ce-2a83-4305-a4eb-00d22da60dc0">

Currently I found that AntDesign had updated their `New` tag to the supported version of the component`x.x.x`, it's much more clearer for users who use the old version and wanna use new features that the lowest version since the component has been supported.

<img width="324" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/554c1350-d0fc-4e6e-b7bf-af49dd89a928">

## What is the new behavior?

Display the supported version of the component. (Style has been changed as well)

<img width="300" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/dd491355-11b1-4f7d-b4b5-60088fa68f43">

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
