### PR TITLE
docs: allow footer components to participate in hydration

### DIFF
--- a/scripts/site/_site/doc/app/footer/footer.component.ts
+++ b/scripts/site/_site/doc/app/footer/footer.component.ts
@@ -90,9 +90,6 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./footer.component.less'],
-  host: {
-    ngSkipHydration: ''
-  }
 })
 export class FooterComponent implements OnInit {
   @Input() language: string = 'zh';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Previously, since the footer component used the popover directive internally, this would cause the footer to fail to hydrate, so we made the footer skip the hydration.

Now that the popover hydration issue is fixed by #8512, we can re-engage the footer component for hydration


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
