### PR TITLE
fix(module:color-picker): avoid emitted twice nzOnChange event

### DIFF
--- a/components/color-picker/color-format.component.ts
+++ b/components/color-picker/color-format.component.ts
@@ -24,7 +24,7 @@ import {
   ValidatorFn
 } from '@angular/forms';
 import { Subject } from 'rxjs';
-import { debounceTime, filter, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, takeUntil } from 'rxjs/operators';
 
 import { InputBoolean } from 'ng-zorro-antd/core/util';
 import { NzInputDirective, NzInputGroupComponent } from 'ng-zorro-antd/input';
@@ -32,7 +32,7 @@ import { NzInputNumberComponent } from 'ng-zorro-antd/input-number';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 
 import { generateColor } from './src/util/util';
-import { NzColorPickerFormatType } from './typings';
+import { NzColorPickerFormatType, ValidFormKey } from './typings';
 
 @Component({
   selector: 'nz-color-format',
@@ -183,6 +183,9 @@ export class NzColorFormatComponent implements OnChanges, OnInit, OnDestroy {
       .pipe(
         filter(() => this.validateForm.valid),
         debounceTime(200),
+        distinctUntilChanged((prev, current) =>
+          Object.keys(prev).every(key => prev[key as ValidFormKey] === current[key as ValidFormKey])
+        ),
         takeUntil(this.destroy$)
       )
       .subscribe(value => {

--- a/components/color-picker/typings.ts
+++ b/components/color-picker/typings.ts
@@ -9,4 +9,18 @@ export type NzColorPickerFormatType = 'rgb' | 'hex' | 'hsb';
 
 export type NzColorPickerTriggerType = 'click' | 'hover';
 
+export interface ValidForm {
+  isFormat: NzColorPickerFormatType | null;
+  hex: string | null;
+  hsbH: number;
+  hsbS: number;
+  hsbB: number;
+  rgbR: number;
+  rgbG: number;
+  rgbB: number;
+  roundA: number;
+}
+
+export type ValidFormKey = keyof ValidForm;
+
 export interface NzColor extends Color {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

When we change the color of color-picket nzOnChange event is emitted twice

Issue Number: #8502


## What is the new behavior?

When we change the color of color picker nzOnChange event is emitted only one time


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
