### PR TITLE
chore: set default server configuration to development

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -93,6 +93,9 @@
           "configurations": {
             "production": {
               "buildTarget": "ng-zorro-antd-doc:build:production"
+            },
+            "development": {
+              "buildTarget": "ng-zorro-antd-doc:build:development"
             }
           }
         }

--- a/angular.json
+++ b/angular.json
@@ -97,7 +97,8 @@
             "development": {
               "buildTarget": "ng-zorro-antd-doc:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "NODE_ENV=development gulp start:dev",
+    "start:dev": "ng serve --project=ng-zorro-antd-doc --configuration=development",
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI --code-coverage",
     "test:watch": "gulp test:watch --tags",
     "test:schematics": "gulp build:schematics && gulp test:schematics",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "start": "NODE_ENV=development gulp start:dev",
-    "start:dev": "ng serve --project=ng-zorro-antd-doc --configuration=development",
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI --code-coverage",
     "test:watch": "gulp test:watch --tags",
     "test:schematics": "gulp build:schematics && gulp test:schematics",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, when running the application with `npm run start`, it starts in development mode without sourceMap enabled. This means that the source maps, which are useful for debugging, are not generated.

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/41280500/89077efc-8e29-4236-a590-7718e2268698)


## What is the new behavior?
Now, when running the application with the new `npm run start:dev` command, it starts in development mode with sourceMap enabled. 

![image](https://github.com/NG-ZORRO/ng-zorro-antd/assets/41280500/4ba02d18-2d04-4221-ae2c-5d1ef74625cc)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
