### PR TITLE
docs: fix issues in components overview page

### DIFF
--- a/components/hash-code/doc/index.en-US.md
+++ b/components/hash-code/doc/index.en-US.md
@@ -3,7 +3,7 @@ category: Components
 type: Featured Components
 title: HashCode
 tag: 17.0.0
-cover: https://img.alicdn.com/imgextra/i3/O1CN01ePPF8q1cxXFz041Q9_!!6000000003667-0-tps-172-57.jpg
+cover: https://img.alicdn.com/imgextra/i3/O1CN01jn3OGS1qq7Xkq6O6b_!!6000000005546-2-tps-1074-374.png
 ---
 
 ## Import Module

--- a/components/hash-code/doc/index.zh-CN.md
+++ b/components/hash-code/doc/index.zh-CN.md
@@ -4,7 +4,7 @@ subtitle: 哈希码
 type: 特色组件
 title: HashCode
 tag: 17.0.0
-cover: https://img.alicdn.com/imgextra/i3/O1CN01ePPF8q1cxXFz041Q9_!!6000000003667-0-tps-172-57.jpg
+cover: https://img.alicdn.com/imgextra/i3/O1CN01jn3OGS1qq7Xkq6O6b_!!6000000005546-2-tps-1074-374.png
 ---
 
 ## 何时使用

--- a/components/water-mark/doc/index.en-US.md
+++ b/components/water-mark/doc/index.en-US.md
@@ -4,7 +4,7 @@ type: Other
 cols: 1
 title: WaterMark
 tag: 15.1.0
-cover: https://img.alicdn.com/imgextra/i3/O1CN0194FGAd1FlrwQShfR8_!!6000000000528-0-tps-952-502.jpg
+cover: https://img.alicdn.com/imgextra/i2/O1CN01ozPPZp1wj9CwsVvDL_!!6000000006343-0-tps-1232-820.jpg
 ---
 
 Add specific text or patterns to the page.

--- a/components/water-mark/doc/index.zh-CN.md
+++ b/components/water-mark/doc/index.zh-CN.md
@@ -5,7 +5,7 @@ subtitle: 水印
 title: WaterMark
 cols: 1
 tag: 15.1.0
-cover: https://img.alicdn.com/imgextra/i3/O1CN0194FGAd1FlrwQShfR8_!!6000000000528-0-tps-952-502.jpg
+cover: https://img.alicdn.com/imgextra/i2/O1CN01ozPPZp1wj9CwsVvDL_!!6000000006343-0-tps-1232-820.jpg
 ---
 
 给页面的某个区域加上水印。

--- a/scripts/site/_site/doc/app/components-overview/components-overview.component.html
+++ b/scripts/site/_site/doc/app/components-overview/components-overview.component.html
@@ -1,4 +1,4 @@
-<section>
+<section class="markdown">
   <h1>{{ language === 'en' ? 'Components Overview' : '组件总览' }}</h1>
 
   <section>

--- a/scripts/site/_site/doc/app/components-overview/components-overview.component.less
+++ b/scripts/site/_site/doc/app/components-overview/components-overview.component.less
@@ -2,6 +2,9 @@
   padding: 0;
 
   &-group-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     margin-top: 24px !important;
   }
 

--- a/scripts/site/_site/doc/app/components-overview/components-overview.component.less
+++ b/scripts/site/_site/doc/app/components-overview/components-overview.component.less
@@ -3,8 +3,8 @@
 
   &-group-title {
     display: flex;
-    align-items: center;
     gap: 8px;
+    align-items: center;
     margin-top: 24px !important;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

1. `ng-zorro-antd` not rendered in markdown
<img width="601" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/f659e5b7-c5a8-4c97-a4ca-d1679e19ca7a">

2. should align center
<img width="287" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/e460e52b-7a11-48b3-9fb6-115c7ce00a29">

3. image size overflow
<img width="1282" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/7a0b04b0-d14e-42d8-a7a1-63b551ddf3f4">

4. covers of component are vague 😵‍💫
<img width="1000" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/809e948e-b2af-4414-a22f-41b74ef3ac9c">

## What is the new behavior?

<img width="583" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/19fe9626-7003-4245-9154-ce525f62d7f2">

<img width="195" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/e0d5f2f9-2fb8-4a63-b884-14ec9335b79e">

<img width="1106" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/49607541/dd91458f-b58d-48fa-bb09-041f6893f755">


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
