### PR TITLE
fix(module:input-number): remove suffix and suffix icon

### DIFF
--- a/components/input-number/doc/index.en-US.md
+++ b/components/input-number/doc/index.en-US.md
@@ -48,9 +48,7 @@ import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 | `[nzAddOnAfter]`  | The label text displayed after (on the right side of) the input number field, can work with `nzAddOnBefore` | `string \| TemplateRef<void>`     | -           |
 | `[nzAddOnBefore]` | The label text displayed before (on the left side of) the input number field, can work with `nzAddOnAfter`  | `string \| TemplateRef<void>`     | -           |
 | `[nzPrefix]`      | The prefix icon for the Input Number, can work with `nzSuffix`                                              | `string \| TemplateRef<void>`     | -           |
-| `[nzSuffix]`      | The suffix icon for the Input Number, can work with `nzPrefix`                                              | `string \| TemplateRef<void>`     | -           |
 | `[nzPrefixIcon]`  | The prefix icon for the Input Number                                                                        | `string`                          | -           |
-| `[nzSuffixIcon]`  | The suffix icon for the Input Number                                                                        | `string`                          | -           |
 | `[nzCompact]`     | Whether use compact style                                                                                   | `boolean`                         | `false`     |
 | `[nzSize]`        | The size of `nz-input-number-group` specifies the size of the included `nz-input-number` fields             | `'large' \| 'small' \| 'default'` | `'default'` |
 | `[nzStatus]`      | Set validation status                                                                                       | `'error' \| 'warning'`            | -           |

--- a/components/input-number/doc/index.zh-CN.md
+++ b/components/input-number/doc/index.zh-CN.md
@@ -49,9 +49,7 @@ import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 | `[nzAddOnAfter]`  | 带标签的 input-number，设置后置标签，可以与 `nzAddOnBefore` 配合使用 | `string \| TemplateRef<void>`     | -           |
 | `[nzAddOnBefore]` | 带标签的 input-number，设置前置标签，可以与 `nzAddOnAfter` 配合使用  | `string \| TemplateRef<void>`     | -           |
 | `[nzPrefix]`      | 带有前缀图标的 input-number，可以与 `nzSuffix` 配合使用              | `string \| TemplateRef<void>`     | -           |
-| `[nzSuffix]`      | 带有后缀图标的 input-number，可以与 `nzPrefix` 配合使用              | `string \| TemplateRef<void>`     | -           |
 | `[nzPrefixIcon]`  | 带有前缀图标的 input-number                                          | `string`                          | -           |
-| `[nzSuffixIcon]`  | 带有后缀图标的 input-number                                          | `string`                          | -           |
 | `[nzCompact]`     | 是否用紧凑模式                                                       | `boolean`                         | `false`     |
 | `[nzSize]`        | `nz-input-number-group` 中所有的 `nz-input-number` 的大小            | `'large' \| 'small' \| 'default'` | `'default'` |
 | `[nzStatus]`      | 设置校验状态                                                         | `'error' \| 'warning'`            | -           |

--- a/components/input-number/input-number-group.component.ts
+++ b/components/input-number/input-number-group.component.ts
@@ -12,7 +12,6 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChildren,
-  Directive,
   ElementRef,
   Input,
   OnChanges,
@@ -35,14 +34,6 @@ import { getStatusClassNames } from 'ng-zorro-antd/core/util';
 
 import { NzInputNumberGroupSlotComponent } from './input-number-group-slot.component';
 import { NzInputNumberComponent } from './input-number.component';
-
-@Directive({
-  selector: `nz-input-number-group[nzSuffix], nz-input-number-group[nzPrefix]`,
-  standalone: true
-})
-export class NzInputNumberGroupWhitSuffixOrPrefixDirective {
-  constructor(public elementRef: ElementRef) {}
-}
 
 @Component({
   selector: 'nz-input-number-group',
@@ -77,12 +68,10 @@ export class NzInputNumberGroupWhitSuffixOrPrefixDirective {
           <span nz-input-number-group-slot type="addon" [icon]="nzAddOnAfterIcon" [template]="nzAddOnAfter"></span>
         }
       </span>
+    } @else if (isAffix) {
+      <ng-template [ngTemplateOutlet]="affixTemplate" />
     } @else {
-      @if (isAffix) {
-        <ng-template [ngTemplateOutlet]="affixTemplate" />
-      } @else {
-        <ng-template [ngTemplateOutlet]="contentTemplate" />
-      }
+      <ng-template [ngTemplateOutlet]="contentTemplate" />
     }
 
     <!-- Affix Template -->
@@ -91,11 +80,9 @@ export class NzInputNumberGroupWhitSuffixOrPrefixDirective {
         <span nz-input-number-group-slot type="prefix" [icon]="nzPrefixIcon" [template]="nzPrefix"></span>
       }
       <ng-template [ngTemplateOutlet]="contentTemplate" />
-      @if (nzSuffix || nzSuffixIcon || isFeedback) {
-        <span nz-input-number-group-slot type="suffix" [icon]="nzSuffixIcon" [template]="nzSuffix">
-          @if (isFeedback) {
-            <nz-form-item-feedback-icon [status]="status" />
-          }
+      @if (isFeedback) {
+        <span nz-input-number-group-slot type="suffix">
+          <nz-form-item-feedback-icon [status]="status" />
         </span>
       }
     </ng-template>
@@ -105,9 +92,7 @@ export class NzInputNumberGroupWhitSuffixOrPrefixDirective {
       <ng-content />
       @if (!isAddOn && !isAffix && isFeedback) {
         <span nz-input-number-group-slot type="suffix">
-          @if (isFeedback) {
-            <nz-form-item-feedback-icon [status]="status" />
-          }
+          <nz-form-item-feedback-icon [status]="status" />
         </span>
       }
     </ng-template>
@@ -135,12 +120,10 @@ export class NzInputNumberGroupComponent implements AfterContentInit, OnChanges,
   @Input() nzAddOnBeforeIcon?: string | null = null;
   @Input() nzAddOnAfterIcon?: string | null = null;
   @Input() nzPrefixIcon?: string | null = null;
-  @Input() nzSuffixIcon?: string | null = null;
   @Input() nzAddOnBefore?: string | TemplateRef<void>;
   @Input() nzAddOnAfter?: string | TemplateRef<void>;
   @Input() nzPrefix?: string | TemplateRef<void>;
   @Input() nzStatus: NzStatus = '';
-  @Input() nzSuffix?: string | TemplateRef<void>;
   @Input() nzSize: NzSizeLDSType = 'default';
   @Input({ transform: booleanAttribute }) nzCompact = false;
   isLarge = false;
@@ -224,10 +207,8 @@ export class NzInputNumberGroupComponent implements AfterContentInit, OnChanges,
   ngOnChanges(changes: SimpleChanges): void {
     const {
       nzSize,
-      nzSuffix,
       nzPrefix,
       nzPrefixIcon,
-      nzSuffixIcon,
       nzAddOnAfter,
       nzAddOnBefore,
       nzAddOnAfterIcon,
@@ -239,8 +220,8 @@ export class NzInputNumberGroupComponent implements AfterContentInit, OnChanges,
       this.isLarge = this.nzSize === 'large';
       this.isSmall = this.nzSize === 'small';
     }
-    if (nzSuffix || nzPrefix || nzPrefixIcon || nzSuffixIcon) {
-      this.isAffix = !!(this.nzSuffix || this.nzPrefix || this.nzPrefixIcon || this.nzSuffixIcon);
+    if (nzPrefix || nzPrefixIcon) {
+      this.isAffix = !!(this.nzPrefix || this.nzPrefixIcon);
     }
     if (nzAddOnAfter || nzAddOnBefore || nzAddOnAfterIcon || nzAddOnBeforeIcon) {
       this.isAddOn = !!(this.nzAddOnAfter || this.nzAddOnBefore || this.nzAddOnAfterIcon || this.nzAddOnBeforeIcon);
@@ -261,7 +242,7 @@ export class NzInputNumberGroupComponent implements AfterContentInit, OnChanges,
     this.status = status;
     this.hasFeedback = hasFeedback;
     this.isFeedback = !!status && hasFeedback;
-    const baseAffix = !!(this.nzSuffix || this.nzPrefix || this.nzPrefixIcon || this.nzSuffixIcon);
+    const baseAffix = !!(this.nzPrefix || this.nzPrefixIcon);
     this.isAffix = baseAffix || (!this.isAddOn && hasFeedback);
     this.affixInGroupStatusCls =
       this.isAffix || this.isFeedback

--- a/components/input-number/input-number-group.spec.ts
+++ b/components/input-number/input-number-group.spec.ts
@@ -127,24 +127,6 @@ describe('input-number-group', () => {
         expect((inputNumberGroupElement.firstElementChild as HTMLElement).innerText).toBe('beforeTemplate');
       });
 
-      it('should after content string work', () => {
-        testComponent.afterContent = 'after';
-        fixture.detectChanges();
-        expect(inputNumberGroupElement.lastElementChild!.classList).toContain('ant-input-number-suffix');
-        expect(inputNumberGroupElement.children.length).toBe(2);
-        expect(inputNumberGroupElement.firstElementChild!.classList).toContain('ant-input-number');
-        expect((inputNumberGroupElement.lastElementChild as HTMLElement).innerText).toBe('after');
-      });
-
-      it('should after content template work', () => {
-        testComponent.afterContent = testComponent.afterTemplate;
-        fixture.detectChanges();
-        expect(inputNumberGroupElement.lastElementChild!.classList).toContain('ant-input-number-suffix');
-        expect(inputNumberGroupElement.children.length).toBe(2);
-        expect(inputNumberGroupElement.firstElementChild!.classList).toContain('ant-input-number');
-        expect((inputNumberGroupElement.lastElementChild as HTMLElement).innerText).toBe('afterTemplate');
-      });
-
       it('should size work', () => {
         testComponent.beforeContent = 'before';
         fixture.detectChanges();
@@ -363,18 +345,15 @@ export class NzTestInputNumberGroupAddonComponent {
 
 @Component({
   template: `
-    <nz-input-number-group [nzPrefix]="beforeContent" [nzSuffix]="afterContent" [nzSize]="size">
+    <nz-input-number-group [nzPrefix]="beforeContent" [nzSize]="size">
       <nz-input-number [nzDisabled]="disabled"></nz-input-number>
     </nz-input-number-group>
     <ng-template #beforeTemplate>beforeTemplate</ng-template>
-    <ng-template #afterTemplate>afterTemplate</ng-template>
   `
 })
 export class NzTestInputNumberGroupAffixComponent {
   @ViewChild('beforeTemplate', { static: false }) beforeTemplate!: TemplateRef<void>;
-  @ViewChild('afterTemplate', { static: false }) afterTemplate!: TemplateRef<void>;
   beforeContent?: string | TemplateRef<void>;
-  afterContent?: string | TemplateRef<void>;
   size: NzSizeLDSType = 'default';
   disabled = false;
 }

--- a/components/input-number/input-number.module.ts
+++ b/components/input-number/input-number.module.ts
@@ -6,19 +6,11 @@
 import { NgModule } from '@angular/core';
 
 import { NzInputNumberGroupSlotComponent } from './input-number-group-slot.component';
-import {
-  NzInputNumberGroupComponent,
-  NzInputNumberGroupWhitSuffixOrPrefixDirective
-} from './input-number-group.component';
+import { NzInputNumberGroupComponent } from './input-number-group.component';
 import { NzInputNumberComponent } from './input-number.component';
 
 @NgModule({
-  imports: [
-    NzInputNumberComponent,
-    NzInputNumberGroupComponent,
-    NzInputNumberGroupWhitSuffixOrPrefixDirective,
-    NzInputNumberGroupSlotComponent
-  ],
-  exports: [NzInputNumberComponent, NzInputNumberGroupComponent, NzInputNumberGroupWhitSuffixOrPrefixDirective]
+  imports: [NzInputNumberComponent, NzInputNumberGroupComponent, NzInputNumberGroupSlotComponent],
+  exports: [NzInputNumberComponent, NzInputNumberGroupComponent]
 })
 export class NzInputNumberModule {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

According to antd's API definition, input-number does not support the suffix attribute, but in past implementations of zorro suffix support has been added, however there are styling errors.


https://4x.ant.design/components/input-number-cn/#API


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
