### PR TITLE
fix(module:dropdown): unable to set bool attr to false

### DIFF
--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -205,10 +205,10 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges 
     if (nzTrigger) {
       this.nzTrigger$.next(this.nzTrigger);
     }
-    if (nzVisible) {
+    if (nzVisible !== undefined) {
       this.inputVisible$.next(this.nzVisible);
     }
-    if (nzDisabled) {
+    if (nzDisabled !== undefined) {
       const nativeElement = this.elementRef.nativeElement;
       if (this.nzDisabled) {
         this.renderer.setAttribute(nativeElement, 'disabled', '');


### PR DESCRIPTION
fix(module:dropdown): unable to set bool attr to false

The issue of not being able to update the value of a `boolean` attribute to **false** externally needs to be corrected.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
