### PR TITLE
fix(module:schematics): import RouterLink

### DIFF
--- a/schematics/ng-generate/side-menu/standalone/src/app/app.component.ts.template
+++ b/schematics/ng-generate/side-menu/standalone/src/app/app.component.ts.template
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterOutlet } from '@angular/router';
+import { RouterLink, RouterOutlet } from '@angular/router';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzLayoutModule } from 'ng-zorro-antd/layout';
 import { NzMenuModule } from 'ng-zorro-antd/menu';
@@ -8,7 +8,7 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
 @Component({
   selector: '<%= prefix %>-root',
   standalone: true,
-  imports: [CommonModule, RouterOutlet, NzIconModule, NzLayoutModule, NzMenuModule],
+  imports: [CommonModule, RouterLink, RouterOutlet, NzIconModule, NzLayoutModule, NzMenuModule],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.<%= style %>']
 })


### PR DESCRIPTION
Every time 'side-menu' is chosen when adding ng-zorro-antd into Angular project, app.component.html uses RouterLink in Dashboard/welcome router, but the Routerlink is not imported in app.component.ts, I have to import RouterLink in app.component.html whenever I create a new project.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

1. Choose sidemenu when import ng-zorro-antd
<img width="624" alt="截屏2024-07-02 10 09 52" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/3973419/55b9cad6-61f8-473d-8c9e-a192dafc20fd">

2. the generated app.component.html used 'RouterLink' without 'RouterLink' in import code block
<img width="935" alt="截屏2024-07-02 10 13 10" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/3973419/dc59bb34-f0cd-42b0-8bc8-b51bd9153510">

3. The 'RouterLink' is missed
<img width="669" alt="截屏2024-07-02 10 17 00" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/3973419/cfef38a1-4ee9-47ba-a5f8-647b405d9fdb">

## What is the new behavior?
import RouterLink

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
