### PR TITLE
chore(docs): update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,17 +10,15 @@ Please check if your PR fulfills the following requirements:
 What kind of change does this PR introduce?
 
 <!-- Please check the one that applies to this PR using "x". -->
-```
-[ ] Bugfix
-[ ] Feature
-[ ] Code style update (formatting, local variables)
-[ ] Refactoring (no functional changes, no api changes)
-[ ] Build related changes
-[ ] CI related changes
-[ ] Documentation content changes
-[ ] Application (the showcase website) / infrastructure changes
-[ ] Other... Please describe:
-```
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Documentation content changes
+- [ ] Application (the showcase website) / infrastructure changes
+- [ ] Other... Please describe:
 
 ## What is the current behavior?
 <!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
@@ -32,10 +30,8 @@ Issue Number: N/A
 
 
 ## Does this PR introduce a breaking change?
-```
-[ ] Yes
-[ ] No
-```
+- [ ] Yes
+- [ ] No
 
 <!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
 


### PR DESCRIPTION
1. Fix a problem: add x follow the comments when I choose a PR type
(this commets doesn't work)
```
<!-- Please check the one that applies to this PR using "x". -->
```
2. Declared as a selection box
(1) Delete the code block(```) declaration
(2) add list(-) declaration

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

selection box doesn't rendered 
<img width="522" alt="截屏2024-07-02 11 16 10" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/3973419/31fd4063-8f0a-4226-bfba-a5baada5287a">


<img width="522" alt="截屏2024-07-02 11 16 21" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/3973419/f073bc1f-9a00-430d-a01f-3fa493bbd89a">


## What is the new behavior?
selection box do rendered 
<img width="448" alt="截屏2024-07-02 11 17 51" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/3973419/0dbd86b9-d6db-4897-8057-23968589e30a">

<img width="423" alt="截屏2024-07-02 11 18 07" src="https://github.com/NG-ZORRO/ng-zorro-antd/assets/3973419/9e706bbc-9395-47a1-b892-16dee618ced0">


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
