### PR TITLE
fix(module:table): updated the condition for displaying nz-pagination when nzTotal > 0

### DIFF
--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -116,7 +116,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
       }
     </nz-spin>
     <ng-template #paginationTemplate>
-      @if (nzShowPagination && data.length) {
+      @if (nzShowPagination && data.length || nzShowPagination && nzTotal) {
         <nz-pagination
           [hidden]="!showPagination"
           class="ant-table-pagination ant-table-pagination-right"


### PR DESCRIPTION
updated the condition for displaying nz-pagination when data.length === 0 && total > 0

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
In order to hide the nz-pagination, one more condition is not taken into account: when nzTotal > 0
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
