### PR TITLE
fix(module:transfer): disabling selection does not affect selecting all

### DIFF
--- a/components/transfer/demo/basic.ts
+++ b/components/transfer/demo/basic.ts
@@ -10,7 +10,7 @@ import { TransferItem } from 'ng-zorro-antd/transfer';
       [nzDisabled]="disabled"
       [nzTitles]="['Source', 'Target']"
       (nzSelectChange)="select($event)"
-      [nzSelectedKeys]="['0', '2']"
+      [nzSelectedKeys]="['0', '2', '3']"
       (nzChange)="change($event)"
     ></nz-transfer>
     <div style="margin-top: 8px;">

--- a/components/transfer/transfer.component.ts
+++ b/components/transfer/transfer.component.ts
@@ -234,6 +234,9 @@ export class NzTransferComponent implements OnInit, OnChanges, OnDestroy {
 
   handleSelect(direction: TransferDirection, checked: boolean, item?: TransferItem): void {
     const list = this.getCheckedData(direction);
+    if (list.every(i => i.disabled)) {
+      return;
+    }
     this.updateOperationStatus(direction, list.length);
     this.nzSelectChange.emit({ direction, checked, list, item });
   }
@@ -329,6 +332,7 @@ export class NzTransferComponent implements OnInit, OnChanges, OnDestroy {
         e.checked = true;
       }
     });
+
     const term = (ld: TransferItem): boolean => ld.disabled === false && ld.checked === true;
     this.rightActive = this.leftDataSource.some(term);
     this.leftActive = this.rightDataSource.some(term);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

[REPRODUTION STEPS]

- take the [basic usage demo](https://ng.ant.design/components/transfer/zh#components-transfer-demo-basic) for example
- select all items in left and transfer to right
- then all the items in left are disabled, but the SELECT-ALL button in left still works

![transfer](https://github.com/user-attachments/assets/79ead6bd-91da-4e02-8cf7-858247a86b76)


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
