### PR TITLE
feat(module:datepicker): send event emitter when panel mode change

### DIFF
--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -28,6 +28,7 @@ import { NzFormModule } from '../form';
 import en_US from '../i18n/languages/en_US';
 import { NzDatePickerComponent } from './date-picker.component';
 import { NzDatePickerModule } from './date-picker.module';
+import { NzPanelChangeType } from './standard-types';
 import { ENTER_EVENT, getPickerAbstract, getPickerInput } from './testing/util';
 import { PREFIX_CLASS } from './util';
 
@@ -1129,6 +1130,7 @@ describe('NzDatePickerComponent', () => {
     }));
 
     it('should support nzOnPanelChange', fakeAsync(() => {
+      fixtureInstance.nzValue = new Date('2020-12-01');
       spyOn(fixtureInstance, 'nzOnPanelChange');
       fixture.detectChanges();
       openPickerByClickTrigger();
@@ -1138,7 +1140,58 @@ describe('NzDatePickerComponent', () => {
       fixture.detectChanges();
       tick(500);
       fixture.detectChanges();
-      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith('month');
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({ mode: 'month', date: new Date('2020-12-01') });
+    }));
+
+    it('should support nzOnPanelChange when next button is clicked', fakeAsync(() => {
+      fixtureInstance.nzValue = new Date('2020-11-01');
+      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(getNextBtn(), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({ mode: 'date', date: new Date('2020-12-01') });
+    }));
+    it('should support nzOnPanelChange when super next button is clicked', fakeAsync(() => {
+      fixtureInstance.nzValue = new Date('2020-11-01');
+      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(getSuperNextBtn(), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({ mode: 'date', date: new Date('2021-11-01') });
+    }));
+    it('should support nzOnPanelChange when previous button is clicked', fakeAsync(() => {
+      fixtureInstance.nzValue = new Date('2020-11-01 11:22:33');
+      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(getPreBtn(), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({
+        mode: 'date',
+        date: new Date('2020-10-01 11:22:33')
+      });
+    }));
+    it('should support nzOnPanelChange when super previous button is clicked', fakeAsync(() => {
+      fixtureInstance.nzValue = new Date('2020-11-01 11:22:33');
+      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(getSuperPreBtn(), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({
+        mode: 'date',
+        date: new Date('2019-11-01 11:22:33')
+      });
     }));
 
     it('should support nzOnOk', fakeAsync(() => {
@@ -1487,7 +1540,9 @@ class NzTestDatePickerComponent {
   nzSize!: string;
 
   nzOnChange(_: Date | null): void {}
+
   nzOnCalendarChange(): void {}
+
   nzOnOpenChange(_: boolean): void {}
 
   nzValue: Date | null = null;
@@ -1507,7 +1562,7 @@ class NzTestDatePickerComponent {
   nzShowWeekNumber = false;
 
   // nzRanges;
-  nzOnPanelChange(_: string): void {}
+  nzOnPanelChange(_: NzPanelChangeType): void {}
 
   nzOnOk(_: Date): void {}
 
@@ -1547,5 +1602,6 @@ class NzTestDatePickerInFormComponent {
   validateForm = this.fb.group({
     demo: this.fb.control<Date | null>(null, Validators.required)
   });
+
   constructor(private fb: FormBuilder) {}
 }

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -17,11 +17,14 @@ import { Platform } from '@angular/cdk/platform';
 import { DOCUMENT, NgStyle, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
+  forwardRef,
+  inject,
   Input,
   NgZone,
   OnChanges,
@@ -33,10 +36,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewChildren,
-  ViewEncapsulation,
-  booleanAttribute,
-  forwardRef,
-  inject
+  ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { fromEvent, of as observableOf } from 'rxjs';
@@ -50,7 +50,7 @@ import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { DATE_PICKER_POSITION_MAP, DEFAULT_DATE_PICKER_POSITIONS, NzOverlayModule } from 'ng-zorro-antd/core/overlay';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
-import { CandyDate, CompatibleValue, cloneDate, wrongSortOrder } from 'ng-zorro-antd/core/time';
+import { CandyDate, cloneDate, CompatibleValue, wrongSortOrder } from 'ng-zorro-antd/core/time';
 import {
   BooleanInput,
   FunctionProp,
@@ -76,6 +76,7 @@ import {
   CompatibleDate,
   DisabledTimeFn,
   NzDateMode,
+  NzPanelChangeType,
   PresetRanges,
   RangePartType,
   SupportTimeOptions
@@ -323,8 +324,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, AfterViewInit, 
   @Input() nzPlacement: NzPlacement = 'bottomLeft';
   @Input({ transform: booleanAttribute }) nzShowWeekNumber: boolean = false;
 
-  // TODO(@wenqi73) The PanelMode need named for each pickers and export
-  @Output() readonly nzOnPanelChange = new EventEmitter<NzDateMode | NzDateMode[] | string | string[]>();
+  @Output() readonly nzOnPanelChange = new EventEmitter<NzPanelChangeType>();
   @Output() readonly nzOnCalendarChange = new EventEmitter<Array<Date | null>>();
   @Output() readonly nzOnOk = new EventEmitter<CompatibleDate | null>();
   @Output() readonly nzOnOpenChange = new EventEmitter<boolean>();
@@ -868,8 +868,8 @@ export class NzDatePickerComponent implements OnInit, OnChanges, AfterViewInit, 
     }
   }
 
-  onPanelModeChange(panelMode: NzDateMode | NzDateMode[]): void {
-    this.nzOnPanelChange.emit(panelMode);
+  onPanelModeChange(panelChange: NzPanelChangeType): void {
+    this.nzOnPanelChange.emit(panelChange);
   }
 
   // Emit nzOnCalendarChange when select date by nz-range-picker

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -45,6 +45,7 @@ import {
   DisabledTimeFn,
   DisabledTimePartial,
   NzDateMode,
+  NzPanelChangeType,
   PresetRanges,
   RangePartType,
   SupportTimeOptions
@@ -98,7 +99,7 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
           [showTimePicker]="hasTimePicker"
           [timeOptions]="getTimeOptions(partType)"
           [panelMode]="getPanelMode(panelMode, partType)"
-          (panelModeChange)="onPanelModeChange($event, partType)"
+          (panelChange)="onPanelModeChange($event, partType)"
           [activeDate]="getActiveDate(partType)"
           [value]="getValue(partType)"
           [disabledDate]="disabledDate"
@@ -164,7 +165,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
   @Input() defaultPickerValue!: CompatibleDate | undefined | null;
   @Input() dir: Direction = 'ltr';
 
-  @Output() readonly panelModeChange = new EventEmitter<NzDateMode | NzDateMode[]>();
+  @Output() readonly panelModeChange = new EventEmitter<NzPanelChangeType>();
   @Output() readonly calendarChange = new EventEmitter<CompatibleValue>();
   @Output() readonly resultOk = new EventEmitter<void>(); // Emitted when done with date selecting
 
@@ -270,18 +271,22 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
-  onPanelModeChange(mode: NzDateMode, partType?: RangePartType): void {
+  onPanelModeChange(panelChangeEvent: NzPanelChangeType, partType?: RangePartType): void {
     if (this.isRange) {
       const index = this.datePickerService.getActiveIndex(partType);
       if (index === 0) {
-        this.panelMode = [mode, this.panelMode[1]] as NzDateMode[];
+        this.panelMode = [panelChangeEvent.mode, this.panelMode[1]] as [NzDateMode, NzDateMode];
       } else {
-        this.panelMode = [this.panelMode[0], mode] as NzDateMode[];
+        this.panelMode = [this.panelMode[0], panelChangeEvent.mode] as [NzDateMode, NzDateMode];
       }
+      this.panelModeChange.emit({
+        mode: this.panelMode as [NzDateMode, NzDateMode],
+        date: (this.datePickerService.activeDate as SingleValue[]).map(d => d!.nativeDate) as [Date, Date]
+      });
     } else {
-      this.panelMode = mode;
+      this.panelMode = panelChangeEvent.mode as NzDateMode;
+      this.panelModeChange.emit({ mode: this.panelMode as NzDateMode, date: panelChangeEvent.date as Date });
     }
-    this.panelModeChange.emit(this.panelMode);
   }
 
   onActiveDateChange(value: CandyDate, partType: RangePartType): void {

--- a/components/date-picker/doc/index.en-US.md
+++ b/components/date-picker/doc/index.en-US.md
@@ -23,8 +23,9 @@ provided in the file of `app.module.ts`.
 For example:
 
 ```typescript
-import {registerLocaleData} from '@angular/common';
+import { registerLocaleData } from '@angular/common';
 import en from '@angular/common/locales/en';
+
 registerLocaleData(en);
 ```
 
@@ -60,6 +61,7 @@ The following APIs are shared by nz-date-picker, nz-range-picker.
 | `[nzBorderless]`         | remove the border                                                                                                                  | `boolean`                                                  | `false`                                                                                                    | -             |
 | `[nzInline]`             | inline mode                                                                                                                        | `boolean`                                                  | `false`                                                                                                    | -             |
 | `(nzOnOpenChange)`       | a callback emitter, can be executed whether the popup calendar is popped up or closed                                              | `EventEmitter<boolean>`                                    | -                                                                                                          | -             |
+| `(nzOnPanelChange)`      | a callback emitter, can be executed when the panel changes                                                                         | `EventEmitter<NzPanelChangeType>`                          | -                                                                                                          | -             |
 
 ### Common Methods
 
@@ -104,8 +106,9 @@ The following APIs are shared by nz-date-picker, nz-range-picker.
 | `[nzShowWeekNumber]` | whether to show the week number on each row (Only supported by date picker. Week picker always shows week numbers) | `boolean`                                                                                                 | `false`                                              |
 | `(nzOnOk)`           | click ok callback                                                                                                  | `EventEmitter<Date[]>`                                                                                    | -                                                    |
 
-> Currently, supported `nz-time-picker` parameters in `nzShowTime`
-> are: `nzFormat`, `nzHourStep`, `nzMinuteStep`, `nzSecondStep`, `nzDisabledHours`, `nzDisabledMinutes`, `nzDisabledSeconds`, `nzHideDisabledOptions`, `nzDefaultOpenValue`, `nzAddOn`
+> Currently, supported `nz-time-picker` parameters in `nzShowTime` are: `nzFormat`, `nzHourStep`, `nzMinuteStep`,
+`nzSecondStep`, `nzDisabledHours`, `nzDisabledMinutes`, `nzDisabledSeconds`, `nzHideDisabledOptions`,
+`nzDefaultOpenValue`, `nzAddOn`
 
 ## FAQ
 

--- a/components/date-picker/inner-popup.component.ts
+++ b/components/date-picker/inner-popup.component.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
@@ -12,8 +13,7 @@ import {
   Output,
   SimpleChanges,
   TemplateRef,
-  ViewEncapsulation,
-  booleanAttribute
+  ViewEncapsulation
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
@@ -23,7 +23,7 @@ import { NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
 import { NzTimePickerModule } from 'ng-zorro-antd/time-picker';
 
 import { LibPackerModule } from './lib';
-import { DisabledDateFn, NzDateMode, RangePartType, SupportTimeOptions } from './standard-types';
+import { DisabledDateFn, NzDateMode, NzPanelChangeType, RangePartType, SupportTimeOptions } from './standard-types';
 import { PREFIX_CLASS } from './util';
 
 @Component({
@@ -44,7 +44,7 @@ import { PREFIX_CLASS } from './util';
               [showSuperNextBtn]="enablePrevNext('next', 'decade')"
               [showNextBtn]="false"
               [showPreBtn]="false"
-              (panelModeChange)="panelModeChange.emit($event)"
+              (panelChange)="panelChange.emit($event)"
               (valueChange)="headerChange.emit($event)"
             />
             <div class="{{ prefixCls }}-body">
@@ -65,7 +65,7 @@ import { PREFIX_CLASS } from './util';
               [showSuperNextBtn]="enablePrevNext('next', 'year')"
               [showNextBtn]="false"
               [showPreBtn]="false"
-              (panelModeChange)="panelModeChange.emit($event)"
+              (panelChange)="panelChange.emit($event)"
               (valueChange)="headerChange.emit($event)"
             />
             <div class="{{ prefixCls }}-body">
@@ -89,7 +89,7 @@ import { PREFIX_CLASS } from './util';
               [showSuperNextBtn]="enablePrevNext('next', 'month')"
               [showNextBtn]="false"
               [showPreBtn]="false"
-              (panelModeChange)="panelModeChange.emit($event)"
+              (panelChange)="panelChange.emit($event)"
               (valueChange)="headerChange.emit($event)"
             />
             <div class="{{ prefixCls }}-body">
@@ -113,7 +113,7 @@ import { PREFIX_CLASS } from './util';
               [showSuperNextBtn]="enablePrevNext('next', 'month')"
               [showNextBtn]="false"
               [showPreBtn]="false"
-              (panelModeChange)="panelModeChange.emit($event)"
+              (panelChange)="panelChange.emit($event)"
               (valueChange)="headerChange.emit($event)"
             />
             <div class="{{ prefixCls }}-body">
@@ -140,7 +140,7 @@ import { PREFIX_CLASS } from './util';
               "
               [showPreBtn]="panelMode === 'week' ? enablePrevNext('prev', 'week') : enablePrevNext('prev', 'date')"
               [showNextBtn]="panelMode === 'week' ? enablePrevNext('next', 'week') : enablePrevNext('next', 'date')"
-              (panelModeChange)="panelModeChange.emit($event)"
+              (panelChange)="panelChange.emit($event)"
               (valueChange)="headerChange.emit($event)"
             />
             <div class="{{ prefixCls }}-body">
@@ -199,7 +199,7 @@ export class InnerPopupComponent implements OnChanges {
   @Input() value!: CandyDate;
   @Input() partType!: RangePartType;
 
-  @Output() readonly panelModeChange = new EventEmitter<NzDateMode>();
+  @Output() readonly panelChange = new EventEmitter<NzPanelChangeType>();
   // TODO: name is not proper
   @Output() readonly headerChange = new EventEmitter<CandyDate>(); // Emitted when user changed the header's value
   @Output() readonly selectDate = new EventEmitter<CandyDate>(); // Emitted when the date is selected by click the date panel
@@ -247,7 +247,7 @@ export class InnerPopupComponent implements OnChanges {
       this.selectDate.emit(value);
     } else {
       this.headerChange.emit(value);
-      this.panelModeChange.emit(this.endPanelMode);
+      this.panelChange.emit({ mode: this.endPanelMode, date: value.nativeDate });
     }
   }
 
@@ -264,7 +264,7 @@ export class InnerPopupComponent implements OnChanges {
       this.selectDate.emit(value);
     } else {
       this.headerChange.emit(value);
-      this.panelModeChange.emit(this.endPanelMode);
+      this.panelChange.emit({ mode: this.endPanelMode, date: value.nativeDate });
     }
   }
 
@@ -275,7 +275,7 @@ export class InnerPopupComponent implements OnChanges {
       this.selectDate.emit(value);
     } else {
       this.headerChange.emit(value);
-      this.panelModeChange.emit('year');
+      this.panelChange.emit({ mode: 'year', date: value.nativeDate });
     }
   }
 

--- a/components/date-picker/lib/abstract-panel-header.ts
+++ b/components/date-picker/lib/abstract-panel-header.ts
@@ -17,7 +17,7 @@ import {
 import { CandyDate } from 'ng-zorro-antd/core/time';
 import { NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
 
-import { NzDateMode } from '../standard-types';
+import { NzDateMode, NzPanelChangeType } from '../standard-types';
 import { PanelSelector } from './interface';
 
 @Directive()
@@ -25,6 +25,7 @@ import { PanelSelector } from './interface';
 export abstract class AbstractPanelHeader implements OnInit, OnChanges {
   prefixCls: string = `ant-picker-header`;
   selectors: PanelSelector[] = [];
+  mode!: NzDateMode;
 
   @Input() value!: CandyDate;
   @Input() locale!: NzCalendarI18nInterface;
@@ -33,7 +34,7 @@ export abstract class AbstractPanelHeader implements OnInit, OnChanges {
   @Input({transform: booleanAttribute}) showPreBtn: boolean = true;
   @Input({transform: booleanAttribute}) showNextBtn: boolean = true;
 
-  @Output() readonly panelModeChange = new EventEmitter<NzDateMode>();
+  @Output() readonly panelChange = new EventEmitter<NzPanelChangeType>();
   @Output() readonly valueChange = new EventEmitter<CandyDate>();
 
   abstract getSelectors(): PanelSelector[];
@@ -74,12 +75,13 @@ export abstract class AbstractPanelHeader implements OnInit, OnChanges {
     if (this.value !== value) {
       this.value = value;
       this.valueChange.emit(this.value);
+      this.changeMode(this.mode);
       this.render();
     }
   }
 
   changeMode(mode: NzDateMode): void {
-    this.panelModeChange.emit(mode);
+    this.panelChange.emit({mode, date: this.value.nativeDate});
   }
 
   private render(): void {

--- a/components/date-picker/lib/date-header.component.ts
+++ b/components/date-picker/lib/date-header.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgForOf, NgIf, NgClass } from '@angular/common';
+import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { DateHelperService } from 'ng-zorro-antd/i18n';
@@ -11,6 +11,7 @@ import { DateHelperService } from 'ng-zorro-antd/i18n';
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
 import { transCompatFormat } from './util';
+import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -22,6 +23,8 @@ import { transCompatFormat } from './util';
   imports: [NgForOf, NgIf, NgClass]
 })
 export class DateHeaderComponent extends AbstractPanelHeader {
+  override mode: NzDateMode = 'date';
+
   constructor(private dateHelper: DateHelperService) {
     super();
   }
@@ -31,13 +34,19 @@ export class DateHeaderComponent extends AbstractPanelHeader {
       {
         className: `${this.prefixCls}-year-btn`,
         title: this.locale.yearSelect,
-        onClick: () => this.changeMode('year'),
+        onClick: () => {
+          this.mode = 'year';
+          this.changeMode('year');
+        },
         label: this.dateHelper.format(this.value.nativeDate, transCompatFormat(this.locale.yearFormat))
       },
       {
         className: `${this.prefixCls}-month-btn`,
         title: this.locale.monthSelect,
-        onClick: () => this.changeMode('month'),
+        onClick: () => {
+          this.mode = 'month';
+          this.changeMode('month');
+        },
         label: this.dateHelper.format(this.value.nativeDate, this.locale.monthFormat || 'MMM')
       }
     ];

--- a/components/date-picker/lib/decade-header.component.ts
+++ b/components/date-picker/lib/decade-header.component.ts
@@ -8,6 +8,7 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
+import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -19,8 +20,13 @@ import { PanelSelector } from './interface';
   standalone: true
 })
 export class DecadeHeaderComponent extends AbstractPanelHeader {
-  override previous(): void {}
-  override next(): void {}
+  override previous(): void {
+  }
+
+  override next(): void {
+  }
+
+  override mode: NzDateMode = 'decade';
 
   get startYear(): number {
     return parseInt(`${this.value.getYear() / 100}`, 10) * 100;

--- a/components/date-picker/lib/month-header.component.ts
+++ b/components/date-picker/lib/month-header.component.ts
@@ -11,6 +11,7 @@ import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
 import { transCompatFormat } from './util';
 import { NgClass, NgForOf, NgIf } from '@angular/common';
+import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -22,6 +23,8 @@ import { NgClass, NgForOf, NgIf } from '@angular/common';
   imports: [NgForOf, NgIf, NgClass]
 })
 export class MonthHeaderComponent extends AbstractPanelHeader {
+  override mode: NzDateMode = 'month';
+
   constructor(private dateHelper: DateHelperService) {
     super();
   }
@@ -31,7 +34,10 @@ export class MonthHeaderComponent extends AbstractPanelHeader {
       {
         className: `${this.prefixCls}-month-btn`,
         title: this.locale.yearSelect,
-        onClick: () => this.changeMode('year'),
+        onClick: () => {
+          this.mode = 'year';
+          this.changeMode('year');
+        },
         label: this.dateHelper.format(this.value.nativeDate, transCompatFormat(this.locale.yearFormat))
       }
     ];

--- a/components/date-picker/lib/quarter-header.component.ts
+++ b/components/date-picker/lib/quarter-header.component.ts
@@ -11,6 +11,7 @@ import { DateHelperService } from 'ng-zorro-antd/i18n';
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
 import { transCompatFormat } from './util';
+import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -22,6 +23,8 @@ import { transCompatFormat } from './util';
   imports: [NgForOf, NgIf, NgClass]
 })
 export class QuarterHeaderComponent extends AbstractPanelHeader {
+  override mode: NzDateMode = 'quarter';
+
   constructor(private dateHelper: DateHelperService) {
     super();
   }
@@ -31,7 +34,10 @@ export class QuarterHeaderComponent extends AbstractPanelHeader {
       {
         className: `${this.prefixCls}-quarter-btn`,
         title: this.locale.yearSelect,
-        onClick: () => this.changeMode('year'),
+        onClick: () => {
+          this.mode = 'year';
+          this.changeMode('year');
+        },
         label: this.dateHelper.format(this.value.nativeDate, transCompatFormat(this.locale.yearFormat))
       }
     ];

--- a/components/date-picker/lib/year-header.component.ts
+++ b/components/date-picker/lib/year-header.component.ts
@@ -8,6 +8,7 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
+import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -19,6 +20,8 @@ import { PanelSelector } from './interface';
   imports: [NgForOf, NgIf, NgClass]
 })
 export class YearHeaderComponent extends AbstractPanelHeader {
+  override mode: NzDateMode = 'year';
+
   get startYear(): number {
     return parseInt(`${this.value.getYear() / 10}`, 10) * 10;
   }
@@ -40,7 +43,10 @@ export class YearHeaderComponent extends AbstractPanelHeader {
       {
         className: `${this.prefixCls}-year-btn`,
         title: '',
-        onClick: () => this.changeMode('decade'),
+        onClick: () => {
+          this.mode = 'decade';
+          this.changeMode('decade');
+        },
         label: `${this.startYear}-${this.endYear}`
       }
     ];

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -20,7 +20,7 @@ import {
 import { CandyDate } from 'ng-zorro-antd/core/time';
 import { NgStyleInterface, NzStatus } from 'ng-zorro-antd/core/types';
 import { NzRangePickerComponent } from 'ng-zorro-antd/date-picker/range-picker.component';
-import { RangePartType } from 'ng-zorro-antd/date-picker/standard-types';
+import { NzPanelChangeType, RangePartType } from 'ng-zorro-antd/date-picker/standard-types';
 import {
   ENTER_EVENT,
   getPickerAbstract,
@@ -795,7 +795,8 @@ describe('NzRangePickerComponent', () => {
     }));
 
     it('should support nzOnPanelChange', fakeAsync(() => {
-      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixtureInstance.modelValue = [new Date('2018-10-11 11:22:34'), new Date('2018-11-12 11:22:33')];
+      const spy = spyOn(fixtureInstance, 'nzOnPanelChange');
       fixture.detectChanges();
       openPickerByClickTrigger();
 
@@ -806,13 +807,73 @@ describe('NzRangePickerComponent', () => {
         'click'
       );
       fixture.detectChanges();
+
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({
+        mode: ['month', 'date'],
+        date: [new Date('2018-10-11 11:22:34'), new Date('2018-11-11 11:22:34')]
+      });
+
+      spy.calls.reset();
+
       // Right
       dispatchMouseEvent(
         overlayContainerElement.querySelector('.ant-picker-panel:last-child .ant-picker-header-year-btn')!,
         'click'
       );
       fixture.detectChanges();
-      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith(['month', 'year']);
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({
+        mode: ['month', 'year'],
+        date: [new Date('2018-10-11 11:22:34'), new Date('2018-11-11 11:22:34')]
+      });
+    }));
+
+    it('should support nzOnPanelChange when click on prev button', fakeAsync(() => {
+      fixtureInstance.modelValue = [new Date('2018-10-11 11:22:34'), new Date('2018-11-12 11:22:33')];
+      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(getPreBtn('left'), 'click');
+      fixture.detectChanges();
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({
+        mode: ['date', 'date'],
+        date: [new Date('2018-09-11 11:22:34'), new Date('2018-10-11 11:22:34')]
+      });
+    }));
+    it('should support nzOnPanelChange when click on next button', fakeAsync(() => {
+      fixtureInstance.modelValue = [new Date('2018-10-11 11:22:34'), new Date('2018-11-12 11:22:33')];
+      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(getNextBtn('right'), 'click');
+      fixture.detectChanges();
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({
+        mode: ['date', 'date'],
+        date: [new Date('2018-11-11 11:22:34'), new Date('2018-12-11 11:22:34')]
+      });
+    }));
+    it('should support nzOnPanelChange when click on super prev button', fakeAsync(() => {
+      fixtureInstance.modelValue = [new Date('2018-10-11 11:22:34'), new Date('2018-11-12 11:22:33')];
+      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(getSuperPreBtn('left'), 'click');
+      fixture.detectChanges();
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({
+        mode: ['date', 'date'],
+        date: [new Date('2017-10-11 11:22:34'), new Date('2017-11-11 11:22:34')]
+      });
+    }));
+    it('should support nzOnPanelChange when click on super next button', fakeAsync(() => {
+      fixtureInstance.modelValue = [new Date('2018-10-11 11:22:34'), new Date('2018-11-12 11:22:33')];
+      spyOn(fixtureInstance, 'nzOnPanelChange');
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+      dispatchMouseEvent(getSuperNextBtn('left'), 'click');
+      fixture.detectChanges();
+      expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({
+        mode: ['date', 'date'],
+        date: [new Date('2019-10-11 11:22:34'), new Date('2019-11-11 11:22:34')]
+      });
     }));
 
     it('should support nzOnOk', fakeAsync(() => {
@@ -1268,9 +1329,13 @@ class NzTestRangePickerComponent {
   nzPopupStyle!: NgStyleInterface;
   nzDropdownClassName!: string;
   nzSize!: string;
+
   nzOnOpenChange(_: boolean): void {}
+
   modelValue: Array<Date | null> = [];
+
   modelValueChange(_: Date[]): void {}
+
   nzDefaultPickerValue!: Array<Date | null>;
   nzSeparator!: string;
   nzInline: boolean = false;
@@ -1284,8 +1349,10 @@ class NzTestRangePickerComponent {
   nzMode = 'date';
 
   nzRanges: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  nzOnPanelChange(_: string[]): void {}
+  nzOnPanelChange(_: NzPanelChangeType): void {}
+
   nzOnCalendarChange(): void {}
+
   nzOnOk(_: Array<null | Date>): void {}
 
   // --- Suite 2

--- a/components/date-picker/standard-types.ts
+++ b/components/date-picker/standard-types.ts
@@ -17,9 +17,18 @@ export type CompatibleDate = Date | Date[];
 
 export type DisabledTimeFn = (current: Date | Date[], partial?: DisabledTimePartial) => DisabledTimeConfig | undefined;
 
+export type NzPanelChangeType =
+  | { mode: NzDateMode; date: Date }
+  | {
+      mode: [startMode: NzDateMode, endMode: NzDateMode];
+      date: [startDate: Date, endDate: Date];
+    };
+
 export interface DisabledTimeConfig {
   nzDisabledHours(): number[];
+
   nzDisabledMinutes(hour: number): number[];
+
   nzDisabledSeconds(hour: number, minute: number): number[];
 }
 
@@ -28,9 +37,13 @@ export interface SupportTimeOptions {
   nzHourStep?: number;
   nzMinuteStep?: number;
   nzSecondStep?: number;
+
   nzDisabledHours?(): number[];
+
   nzDisabledMinutes?(hour: number): number[];
+
   nzDisabledSeconds?(hour: number, minute: number): number[];
+
   nzHideDisabledOptions?: boolean;
   nzDefaultOpenValue?: Date;
   nzAddOn?: TemplateRef<void>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently panel mode change event is not sent when user click on the arrow on the header panel of the datepicker.

This is not the same behavior of the ant design. When user click on the arrow we must send the new mode and the date

Issue Number: #8648

## What is the new behavior?

An event is sent each time user click on an arrow, and the event send the information as an object 

{ date, mode }


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
