### PR TITLE
feat(module:table): add nzSortDirections to table global config (#6613)

### DIFF
--- a/components/core/config/config.ts
+++ b/components/core/config/config.ts
@@ -18,6 +18,7 @@ import {
   NzSizeMDSType,
   NzTSType
 } from 'ng-zorro-antd/core/types';
+import { NzTableSortOrder } from 'ng-zorro-antd/table';
 
 interface MonacoEnvironment {
   globalAPI?: boolean;
@@ -296,6 +297,7 @@ export interface TableConfig {
   nzShowSizeChanger?: boolean;
   nzSimple?: boolean;
   nzHideOnSinglePage?: boolean;
+  nzSortDirections?: NzTableSortOrder[];
 }
 
 export interface TabsConfig {

--- a/components/core/config/config.ts
+++ b/components/core/config/config.ts
@@ -18,7 +18,6 @@ import {
   NzSizeMDSType,
   NzTSType
 } from 'ng-zorro-antd/core/types';
-import { NzTableSortOrder } from 'ng-zorro-antd/table';
 
 interface MonacoEnvironment {
   globalAPI?: boolean;
@@ -297,7 +296,7 @@ export interface TableConfig {
   nzShowSizeChanger?: boolean;
   nzSimple?: boolean;
   nzHideOnSinglePage?: boolean;
-  nzSortDirections?: NzTableSortOrder[];
+  nzSortDirections?: Array<string | null>;
 }
 
 export interface TabsConfig {

--- a/components/core/config/config.ts
+++ b/components/core/config/config.ts
@@ -299,7 +299,7 @@ export interface TableConfig {
   /**
    * @see {@link NzTableSortOrder}
    */
-  nzSortDirections?: Array<string | null>;
+  nzSortDirections?: Array<string | 'ascend' | 'descend' | null>;
 }
 
 export interface TabsConfig {

--- a/components/core/config/config.ts
+++ b/components/core/config/config.ts
@@ -296,6 +296,9 @@ export interface TableConfig {
   nzShowSizeChanger?: boolean;
   nzSimple?: boolean;
   nzHideOnSinglePage?: boolean;
+  /**
+   * @see {@link NzTableSortOrder}
+   */
   nzSortDirections?: Array<string | null>;
 }
 

--- a/components/table/doc/index.en-US.md
+++ b/components/table/doc/index.en-US.md
@@ -125,12 +125,12 @@ Selection property
 
 Sort property
 
-| Property              | Description                                                                                                                                    | Type                                          | Default                       |
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|-------------------------------|
+| Property              | Description                                                                                                                                    | Type                                          | Default                       | Global Config |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|-------------------------------|---------------|
 | `[nzShowSort]`        | Whether to display sorting                                                                                                                     | `boolean`                                     | -                             |
 | `[nzSortFn]`          | Sort function used to sort the data on client side (ref to Array.sort compareFunction). Should be set to `true` when using server side sorting | `NzTableSortFn<T> \| boolean`                 | -                             |
 | `[nzSortOrder]`       | Sort direction                                                                                                                                 | `'ascend' \| 'descend' \| null`               | -                             |
-| `[nzSortDirections]`  | Supported sort order, could be `'ascend'`, `'descend'`, `null`                                                                                 | `Array<'ascend' \| 'descend' \| null>`        | `['ascend', 'descend', null]` |
+| `[nzSortDirections]`  | Supported sort order, could be `'ascend'`, `'descend'`, `null`                                                                                 | `Array<'ascend' \| 'descend' \| null>`        | `['ascend', 'descend', null]` | ✅            |
 | `(nzSortOrderChange)` | Callback when sort direction changes                                                                                                           | `EventEmitter<'ascend' \| 'descend' \| null>` | -                             |
 
 Filter property

--- a/components/table/doc/index.zh-CN.md
+++ b/components/table/doc/index.zh-CN.md
@@ -125,11 +125,11 @@ Table 组件同时具备了易用性和高度可定制性
 
 排序属性
 
-| 参数                    | 说明                                                             | 类型                                            | 默认值                           |
-|-----------------------|----------------------------------------------------------------|-----------------------------------------------|-------------------------------|
+| 参数                    | 说明                                                             | 类型                                            | 默认值                           | 全局配置 |
+|-----------------------|----------------------------------------------------------------|-----------------------------------------------|-------------------------------|------|
 | `[nzShowSort]`        | 是否显示排序                                                         | `boolean`                                     | -                             |
 | `[nzSortFn]`          | 排序函数，前端排序使用一个函数(参考 Array.sort 的 compareFunction)，服务端排序时传入 true | `NzTableSortFn<T> \| boolean`                 | -                             |
-| `[nzSortDirections]`  | 支持的排序方式，取值为 `'ascend'`, `'descend'`, `null`                    | `Array<'ascend' \| 'descend' \| null>`        | `['ascend', 'descend', null]` |
+| `[nzSortDirections]`  | 支持的排序方式，取值为 `'ascend'`, `'descend'`, `null`                    | `Array<'ascend' \| 'descend' \| null>`        | `['ascend', 'descend', null]` | ✅    |
 | `[nzSortOrder]`       | 当前排序状态，可双向绑定                                                   | 'descend' \| 'ascend' \| null                 | null                          |
 | `(nzSortOrderChange)` | 排序状态改变回调                                                       | `EventEmitter<'descend' \| 'ascend' \| null>` | -                             |
 

--- a/components/table/src/cell/th-addon.component.ts
+++ b/components/table/src/cell/th-addon.component.ts
@@ -24,6 +24,7 @@ import {
 import { Subject, fromEvent } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
+import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
 
 import { NzTableFilterComponent } from '../addon/filter.component';
@@ -35,6 +36,8 @@ import {
   NzTableSortFn,
   NzTableSortOrder
 } from '../table.types';
+
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
 
 @Component({
   selector:
@@ -82,6 +85,8 @@ import {
   standalone: true
 })
 export class NzThAddOnComponent<T> implements OnChanges, OnInit {
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
   manualClickOrder$ = new Subject<NzThAddOnComponent<T>>();
   calcOperatorChange$ = new Subject<void>();
   nzFilterValue: NzTableFilterValue = null;
@@ -94,7 +99,7 @@ export class NzThAddOnComponent<T> implements OnChanges, OnInit {
   @Input() nzFilterMultiple = true;
   @Input() nzSortOrder: NzTableSortOrder = null;
   @Input() nzSortPriority: number | boolean = false;
-  @Input() nzSortDirections: NzTableSortOrder[] = ['ascend', 'descend', null];
+  @Input() @WithConfig() nzSortDirections: NzTableSortOrder[] = ['ascend', 'descend', null];
   @Input() nzFilters: NzTableFilterList = [];
   @Input() nzSortFn: NzTableSortFn<T> | boolean | null = null;
   @Input() nzFilterFn: NzTableFilterFn<T> | boolean | null = null;
@@ -135,6 +140,7 @@ export class NzThAddOnComponent<T> implements OnChanges, OnInit {
   }
 
   constructor(
+    public nzConfigService: NzConfigService,
     private host: ElementRef<HTMLElement>,
     private cdr: ChangeDetectorRef,
     private ngZone: NgZone,


### PR DESCRIPTION
add nzSortDirections to table global config

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
We can't change nzSortDirections for table component globally

Issue Number: #6613


## What is the new behavior?
We can now change nzSortDirections for table component globally in the TableConfig object

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No




## Other information
