### PR TITLE
refactor: migrate to standard decorators

### DIFF
--- a/components/affix/affix.component.ts
+++ b/components/affix/affix.component.ts
@@ -62,11 +62,11 @@ export class NzAffixComponent implements AfterViewInit, OnChanges, OnDestroy, On
   @Input() nzTarget?: string | Element | Window;
 
   @Input({ transform: numberAttributeWithZeroFallback })
-  @WithConfig<number | null>()
+  @WithConfig()
   nzOffsetTop?: null | number;
 
   @Input({ transform: numberAttributeWithZeroFallback })
-  @WithConfig<number | null>()
+  @WithConfig()
   nzOffsetBottom?: null | number;
 
   @Output() readonly nzChange = new EventEmitter<boolean>();

--- a/components/anchor/anchor.component.ts
+++ b/components/anchor/anchor.component.ts
@@ -97,11 +97,11 @@ export class NzAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
   nzBounds: number = 5;
 
   @Input({ transform: numberAttributeWithZeroFallback })
-  @WithConfig<number>()
+  @WithConfig()
   nzOffsetTop?: number = undefined;
 
   @Input({ transform: numberAttributeWithZeroFallback })
-  @WithConfig<number>()
+  @WithConfig()
   nzTargetOffset?: number = undefined;
 
   @Input() nzContainer?: string | HTMLElement;

--- a/components/breadcrumb/breadcrumb.component.ts
+++ b/components/breadcrumb/breadcrumb.component.ts
@@ -16,7 +16,8 @@ import {
   Renderer2,
   TemplateRef,
   ViewEncapsulation,
-  booleanAttribute
+  booleanAttribute,
+  forwardRef
 } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, PRIMARY_OUTLET, Params, Router } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -39,7 +40,7 @@ export interface BreadcrumbOption {
   selector: 'nz-breadcrumb',
   exportAs: 'nzBreadcrumb',
   preserveWhitespaces: false,
-  providers: [{ provide: NzBreadcrumb, useExisting: NzBreadCrumbComponent }],
+  providers: [{ provide: NzBreadcrumb, useExisting: forwardRef(() => NzBreadCrumbComponent) }],
   standalone: true,
   imports: [NzBreadCrumbItemComponent],
   template: `

--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -64,7 +64,7 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges 
   @Input() nzDropdownMenu: NzDropdownMenuComponent | null = null;
   @Input() nzTrigger: 'click' | 'hover' = 'hover';
   @Input() nzMatchWidthElement: ElementRef | null = null;
-  @Input({ transform: booleanAttribute }) @WithConfig<boolean>() nzBackdrop = false;
+  @Input({ transform: booleanAttribute }) @WithConfig() nzBackdrop = false;
   @Input({ transform: booleanAttribute }) nzClickHide = true;
   @Input({ transform: booleanAttribute }) nzDisabled = false;
   @Input({ transform: booleanAttribute }) nzVisible = false;

--- a/components/float-button/float-button-top.component.ts
+++ b/components/float-button/float-button-top.component.ts
@@ -12,13 +12,13 @@ import {
   Component,
   ElementRef,
   EventEmitter,
-  Inject,
+  inject,
   Input,
   NgZone,
+  numberAttribute,
   OnChanges,
   OnDestroy,
   OnInit,
-  Optional,
   Output,
   SimpleChanges,
   TemplateRef,
@@ -31,8 +31,6 @@ import { debounceTime, takeUntil } from 'rxjs/operators';
 import { fadeMotion } from 'ng-zorro-antd/core/animation';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzDestroyService, NzScrollService } from 'ng-zorro-antd/core/services';
-import { NumberInput, NzSafeAny } from 'ng-zorro-antd/core/types';
-import { InputNumber } from 'ng-zorro-antd/core/util';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import { NzFloatButtonComponent } from './float-button.component';
@@ -75,11 +73,9 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
 })
 export class NzFloatButtonTopComponent implements OnInit, OnDestroy, OnChanges {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
-  static ngAcceptInputType_nzVisibilityHeight: NumberInput;
-  static ngAcceptInputType_nzDuration: NumberInput;
 
   private scrollListenerDestroy$ = new Subject<void>();
-  private target: HTMLElement | null = null;
+  private target?: HTMLElement | null = null;
 
   visible: boolean = false;
   dir: Direction = 'ltr';
@@ -91,9 +87,9 @@ export class NzFloatButtonTopComponent implements OnInit, OnDestroy, OnChanges {
   @Input() nzDescription: TemplateRef<void> | null = null;
 
   @Input() nzTemplate?: TemplateRef<void>;
-  @Input() @WithConfig() @InputNumber() nzVisibilityHeight: number = 400;
+  @Input({ transform: numberAttribute }) @WithConfig() nzVisibilityHeight: number = 400;
   @Input() nzTarget?: string | HTMLElement;
-  @Input() @InputNumber() nzDuration: number = 450;
+  @Input({ transform: numberAttribute }) nzDuration: number = 450;
   @Output() readonly nzOnClick: EventEmitter<boolean> = new EventEmitter();
 
   @ViewChild('backTop', { static: false })
@@ -114,10 +110,10 @@ export class NzFloatButtonTopComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
+  private doc = inject(DOCUMENT);
   private backTopClickSubscription = Subscription.EMPTY;
 
   constructor(
-    @Inject(DOCUMENT) private doc: NzSafeAny,
     public nzConfigService: NzConfigService,
     private scrollSrv: NzScrollService,
     private platform: Platform,
@@ -125,7 +121,7 @@ export class NzFloatButtonTopComponent implements OnInit, OnDestroy, OnChanges {
     private zone: NgZone,
     private cdr: ChangeDetectorRef,
     private destroy$: NzDestroyService,
-    @Optional() private directionality: Directionality
+    private directionality: Directionality
   ) {
     this.dir = this.directionality.value;
   }

--- a/components/graph/graph.component.ts
+++ b/components/graph/graph.component.ts
@@ -23,6 +23,7 @@ import {
   ViewChildren,
   ViewEncapsulation,
   booleanAttribute,
+  forwardRef,
   inject
 } from '@angular/core';
 import { Observable, ReplaySubject, Subject, Subscription, forkJoin } from 'rxjs';
@@ -72,7 +73,7 @@ export function isDataSource(value: NzSafeAny): value is NzGraphData {
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-graph',
   exportAs: 'nzGraph',
-  providers: [{ provide: NzGraph, useExisting: NzGraphComponent }],
+  providers: [{ provide: NzGraph, useExisting: forwardRef(() => NzGraphComponent) }],
   template: `
     <ng-content></ng-content>
     <svg width="100%" height="100%">

--- a/components/image/image-preview.component.ts
+++ b/components/image/image-preview.component.ts
@@ -13,7 +13,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
-  Inject,
+  inject,
   NgZone,
   OnInit,
   ViewChild,
@@ -230,6 +230,7 @@ export class NzImagePreviewComponent implements OnInit {
   @ViewChild('imgRef') imageRef!: ElementRef<HTMLImageElement>;
   @ViewChild('imagePreviewWrapper', { static: true }) imagePreviewWrapper!: ElementRef<HTMLElement>;
 
+  private document = inject(DOCUMENT);
   private zoom: number;
   private rotate: number;
   private scaleStep: number;
@@ -251,8 +252,7 @@ export class NzImagePreviewComponent implements OnInit {
     public nzConfigService: NzConfigService,
     public config: NzImagePreviewOptions,
     private destroy$: NzDestroyService,
-    private sanitizer: DomSanitizer,
-    @Inject(DOCUMENT) private document: Document
+    private sanitizer: DomSanitizer
   ) {
     this.zoom = this.config.nzZoom ?? this._defaultNzZoom;
     this.scaleStep = this.config.nzScaleStep ?? this._defaultNzScaleStep;

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -224,7 +224,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   @Input() nzId: string | null = null;
   @Input() nzSize: NzSelectSizeType = 'default';
   @Input() nzStatus: NzStatus = '';
-  @Input() @WithConfig<number>() nzOptionHeightPx = 32;
+  @Input() @WithConfig() nzOptionHeightPx = 32;
   @Input() nzOptionOverflowSize = 8;
   @Input() nzDropdownClassName: string[] | string | null = null;
   @Input() nzDropdownMatchSelectWidth = true;
@@ -236,7 +236,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   @Input() nzDropdownRender: TemplateRef<NzSafeAny> | null = null;
   @Input() nzCustomTemplate: TemplateRef<{ $implicit: NzSelectItemInterface }> | null = null;
   @Input()
-  @WithConfig<TemplateRef<NzSafeAny> | string | null>()
+  @WithConfig()
   nzSuffixIcon: TemplateRef<NzSafeAny> | string | null = null;
   @Input() nzClearIcon: TemplateRef<NzSafeAny> | null = null;
   @Input() nzRemoveIcon: TemplateRef<NzSafeAny> | null = null;
@@ -248,7 +248,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   @Input() nzFilterOption: NzFilterOptionType = defaultFilterOption;
   @Input() compareWith: (o1: NzSafeAny, o2: NzSafeAny) => boolean = (o1: NzSafeAny, o2: NzSafeAny) => o1 === o2;
   @Input({ transform: booleanAttribute }) nzAllowClear = false;
-  @Input({ transform: booleanAttribute }) @WithConfig<boolean>() nzBorderless = false;
+  @Input({ transform: booleanAttribute }) @WithConfig() nzBorderless = false;
   @Input({ transform: booleanAttribute }) nzShowSearch = false;
   @Input({ transform: booleanAttribute }) nzLoading = false;
   @Input({ transform: booleanAttribute }) nzAutoFocus = false;
@@ -257,7 +257,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   @Input({ transform: booleanAttribute }) nzDisabled = false;
   @Input({ transform: booleanAttribute }) nzOpen = false;
   @Input({ transform: booleanAttribute }) nzSelectOnTab = false;
-  @Input({ transform: booleanAttribute }) @WithConfig<boolean>() nzBackdrop = false;
+  @Input({ transform: booleanAttribute }) @WithConfig() nzBackdrop = false;
   @Input() nzOptions: NzSelectOptionInterface[] = [];
 
   @Input({ transform: booleanAttribute })

--- a/components/table/src/addon/filter-trigger.component.ts
+++ b/components/table/src/addon/filter-trigger.component.ts
@@ -60,7 +60,7 @@ export class NzFilterTriggerComponent implements OnInit {
   @Input() nzDropdownMenu!: NzDropdownMenuComponent;
   @Input() nzVisible = false;
 
-  @Input({ transform: booleanAttribute }) @WithConfig<boolean>() nzBackdrop = false;
+  @Input({ transform: booleanAttribute }) @WithConfig() nzBackdrop = false;
 
   @Output() readonly nzVisibleChange = new EventEmitter<boolean>();
 

--- a/components/tabs/tabset.component.ts
+++ b/components/tabs/tabset.component.ts
@@ -18,6 +18,7 @@ import {
   Component,
   ContentChildren,
   EventEmitter,
+  forwardRef,
   inject,
   Input,
   NgZone,
@@ -67,7 +68,7 @@ let nextId = 0;
   providers: [
     {
       provide: NZ_TAB_SET,
-      useExisting: NzTabSetComponent
+      useExisting: forwardRef(() => NzTabSetComponent)
     }
   ],
   template: `

--- a/components/time-picker/time-picker-panel.component.ts
+++ b/components/time-picker/time-picker-panel.component.ts
@@ -22,6 +22,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   booleanAttribute,
+  forwardRef,
   numberAttribute
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -146,7 +147,7 @@ export type NzTimePickerUnit = 'hour' | 'minute' | 'second' | '12-hour';
     '[class.ant-picker-time-panel-narrow]': `enabledColumns < 3`,
     '[class.ant-picker-time-panel-placement-bottomLeft]': `!nzInDatePicker`
   },
-  providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: NzTimePickerPanelComponent, multi: true }],
+  providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NzTimePickerPanelComponent), multi: true }],
   imports: [DecimalPipe, NgTemplateOutlet, NzI18nModule, NzButtonModule],
   standalone: true
 })

--- a/components/time-picker/time-picker.component.ts
+++ b/components/time-picker/time-picker.component.ts
@@ -25,6 +25,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   booleanAttribute,
+  forwardRef,
   inject
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -144,7 +145,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'timePicker';
     '(click)': 'open()'
   },
   animations: [slideMotion],
-  providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: NzTimePickerComponent, multi: true }],
+  providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NzTimePickerComponent), multi: true }],
   imports: [
     AsyncPipe,
     FormsModule,

--- a/components/tree-view/node.ts
+++ b/components/tree-view/node.ts
@@ -11,6 +11,7 @@ import {
   Directive,
   ElementRef,
   EmbeddedViewRef,
+  forwardRef,
   Input,
   OnChanges,
   OnDestroy,
@@ -39,8 +40,8 @@ export interface NzTreeVirtualNodeData<T> {
   exportAs: 'nzTreeNode',
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
-    { provide: CdkTreeNode, useExisting: NzTreeNodeComponent },
-    { provide: NzNodeBase, useExisting: NzTreeNodeComponent }
+    { provide: CdkTreeNode, useExisting: forwardRef(() => NzTreeNodeComponent) },
+    { provide: NzNodeBase, useExisting: forwardRef(() => NzTreeNodeComponent) }
   ],
   template: `
     @if (indents.length) {
@@ -127,7 +128,7 @@ export class NzTreeNodeComponent<T> extends NzNodeBase<T> implements OnDestroy, 
 
 @Directive({
   selector: '[nzTreeNodeDef]',
-  providers: [{ provide: CdkTreeNodeDef, useExisting: NzTreeNodeDefDirective }],
+  providers: [{ provide: CdkTreeNodeDef, useExisting: forwardRef(() => NzTreeNodeDefDirective) }],
   standalone: true
 })
 export class NzTreeNodeDefDirective<T> extends CdkTreeNodeDef<T> {

--- a/components/tree-view/outlet.ts
+++ b/components/tree-view/outlet.ts
@@ -4,14 +4,14 @@
  */
 
 import { CDK_TREE_NODE_OUTLET_NODE, CdkTreeNodeOutlet } from '@angular/cdk/tree';
-import { Directive, ViewContainerRef, inject } from '@angular/core';
+import { Directive, ViewContainerRef, forwardRef, inject } from '@angular/core';
 
 @Directive({
   selector: '[nzTreeNodeOutlet]',
   providers: [
     {
       provide: CdkTreeNodeOutlet,
-      useExisting: NzTreeNodeOutletDirective
+      useExisting: forwardRef(() => NzTreeNodeOutletDirective)
     }
   ],
   standalone: true

--- a/components/tree-view/padding.ts
+++ b/components/tree-view/padding.ts
@@ -4,11 +4,11 @@
  */
 
 import { CdkTreeNodePadding } from '@angular/cdk/tree';
-import { Directive, Input, numberAttribute } from '@angular/core';
+import { Directive, forwardRef, Input, numberAttribute } from '@angular/core';
 
 @Directive({
   selector: '[nzTreeNodePadding]',
-  providers: [{ provide: CdkTreeNodePadding, useExisting: NzTreeNodePaddingDirective }],
+  providers: [{ provide: CdkTreeNodePadding, useExisting: forwardRef(() => NzTreeNodePaddingDirective) }],
   standalone: true
 })
 export class NzTreeNodePaddingDirective<T> extends CdkTreeNodePadding<T> {

--- a/components/tree-view/toggle.ts
+++ b/components/tree-view/toggle.ts
@@ -4,7 +4,7 @@
  */
 
 import { CdkTreeNodeToggle } from '@angular/cdk/tree';
-import { booleanAttribute, Directive, Input } from '@angular/core';
+import { booleanAttribute, Directive, forwardRef, Input } from '@angular/core';
 
 @Directive({
   selector: 'nz-tree-node-toggle[nzTreeNodeNoopToggle], [nzTreeNodeNoopToggle]',
@@ -17,7 +17,7 @@ export class NzTreeNodeNoopToggleDirective {}
 
 @Directive({
   selector: 'nz-tree-node-toggle:not([nzTreeNodeNoopToggle]), [nzTreeNodeToggle]',
-  providers: [{ provide: CdkTreeNodeToggle, useExisting: NzTreeNodeToggleDirective }],
+  providers: [{ provide: CdkTreeNodeToggle, useExisting: forwardRef(() => NzTreeNodeToggleDirective) }],
   host: {
     class: 'ant-tree-switcher',
     '[class.ant-tree-switcher_open]': 'isExpanded',

--- a/components/tree-view/tree-view.ts
+++ b/components/tree-view/tree-view.ts
@@ -4,7 +4,14 @@
  */
 
 import { CdkTree } from '@angular/cdk/tree';
-import { AfterViewInit, ChangeDetectionStrategy, Component, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
 
 import { treeCollapseMotion } from 'ng-zorro-antd/core/animation';
 
@@ -28,8 +35,8 @@ import { NzTreeView } from './tree';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
-    { provide: CdkTree, useExisting: NzTreeViewComponent },
-    { provide: NzTreeView, useExisting: NzTreeViewComponent }
+    { provide: CdkTree, useExisting: forwardRef(() => NzTreeViewComponent) },
+    { provide: NzTreeView, useExisting: forwardRef(() => NzTreeViewComponent) }
   ],
   host: {
     class: 'ant-tree',

--- a/components/tree-view/tree-virtual-scroll-view.ts
+++ b/components/tree-view/tree-virtual-scroll-view.ts
@@ -8,6 +8,7 @@ import { BaseTreeControl, CdkTree, CdkTreeNodeOutletContext } from '@angular/cdk
 import {
   ChangeDetectionStrategy,
   Component,
+  forwardRef,
   Input,
   OnChanges,
   SimpleChanges,
@@ -45,8 +46,8 @@ const DEFAULT_SIZE = 28;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
-    { provide: NzTreeView, useExisting: NzTreeVirtualScrollViewComponent },
-    { provide: CdkTree, useExisting: NzTreeVirtualScrollViewComponent }
+    { provide: NzTreeView, useExisting: forwardRef(() => NzTreeVirtualScrollViewComponent) },
+    { provide: CdkTree, useExisting: forwardRef(() => NzTreeVirtualScrollViewComponent) }
   ],
   host: {
     class: 'ant-tree',

--- a/schematics/ng-update/test-cases/config.ts
+++ b/schematics/ng-update/test-cases/config.ts
@@ -5,12 +5,22 @@
 
 export const SchematicsTestTsConfig = {
   compilerOptions: {
-    experimentalDecorators: true,
     lib: ['es2015']
   }
 }
 
 export const SchematicsTestNGConfig = {
   version: 1,
-  projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+  projects: {
+    t: {
+      root: '',
+      architect: {
+        build: {
+          options: {
+            tsConfig: './tsconfig.json'
+          }
+        }
+      }
+    }
+  }
 }

--- a/scripts/gulp/tsconfig.json
+++ b/scripts/gulp/tsconfig.json
@@ -1,10 +1,11 @@
-
 {
   "compilerOptions": {
-    "experimentalDecorators": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
-    "lib": ["es2015", "dom"],
+    "lib": [
+      "es2015",
+      "dom"
+    ],
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "../../dist",

--- a/scripts/prerender/tsconfig.json
+++ b/scripts/prerender/tsconfig.json
@@ -5,10 +5,16 @@
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",
-    "experimentalDecorators": true,
     "target": "es5",
-    "typeRoots": ["../../node_modules/@types"],
-    "lib": ["es2017", "dom"]
+    "typeRoots": [
+      "../../node_modules/@types"
+    ],
+    "lib": [
+      "es2017",
+      "dom"
+    ]
   },
-  "include": ["sitemap.ts"]
+  "include": [
+    "sitemap.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "declaration": false,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true,
     "target": "ES2022",
     "lib": [
       "es2020",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

`@WithConfig()` 装饰器现在是标准装饰器，关闭 `experimentalDecorators` 选项。

该 API 从未在文档中公开，应该属于 ZORRO 私有 API，因此不会对用户造成 "breaking change"，
但如果用户也使用了该 API，则需要关闭 `experimentalDecorators` 选项。

不太确定是否需要添加 "breaking change" label。


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
