### PR TITLE
fix(module:date-picker): cell title should reflect nzFormat

### DIFF
--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -210,6 +210,7 @@ export type NzPlacement = 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight';
           [extraFooter]="extraFooter"
           [ranges]="nzRanges"
           [dir]="dir"
+          [format]="nzFormat"
           (resultOk)="onResultOk()"
         />
       </div>

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -106,6 +106,7 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
           [dateRender]="dateRender"
           [selectedValue]="$any(datePickerService?.value)"
           [hoverValue]="$any(hoverValue)"
+          [format]="format"
           (cellHover)="onCellHover($event)"
           (selectDate)="changeValueFromSelect($event, !showTime)"
           (selectTime)="onSelectTime($event, partType)"
@@ -164,6 +165,7 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
   @Input() panelMode!: NzDateMode | NzDateMode[];
   @Input() defaultPickerValue!: CompatibleDate | undefined | null;
   @Input() dir: Direction = 'ltr';
+  @Input() format?: string;
 
   @Output() readonly panelModeChange = new EventEmitter<NzPanelChangeType>();
   @Output() readonly calendarChange = new EventEmitter<CompatibleValue>();

--- a/components/date-picker/inner-popup.component.ts
+++ b/components/date-picker/inner-popup.component.ts
@@ -154,6 +154,7 @@ import { PREFIX_CLASS } from './util';
                 [selectedValue]="selectedValue"
                 [hoverValue]="hoverValue"
                 [canSelectWeek]="panelMode === 'week'"
+                [format]="format"
                 (valueChange)="onSelectDate($event)"
                 (cellHover)="cellHover.emit($event)"
               />
@@ -198,6 +199,7 @@ export class InnerPopupComponent implements OnChanges {
   @Input() hoverValue!: CandyDate[]; // Range ONLY
   @Input() value!: CandyDate;
   @Input() partType!: RangePartType;
+  @Input() format?: string;
 
   @Output() readonly panelChange = new EventEmitter<NzPanelChangeType>();
   // TODO: name is not proper

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -26,6 +26,7 @@ import { transCompatFormat } from './util';
 })
 export class DateTableComponent extends AbstractTable implements OnChanges, OnInit {
   @Input() override locale!: NzCalendarI18nInterface;
+  @Input() format?: string;
 
   constructor(private i18n: NzI18nService, private dateHelper: DateHelperService) {
     super();
@@ -78,7 +79,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
 
       for (let day = 0; day < 7; day++) {
         const date = weekStart.addDays(day);
-        const dateFormat = transCompatFormat(this.i18n.getLocaleData('DatePicker.lang.dateFormat', 'YYYY-MM-DD'));
+        const dateFormat = transCompatFormat(this.format ?? 'YYYY-MM-DD');
         const title = this.dateHelper.format(date.nativeDate, dateFormat);
         const label = this.dateHelper.format(date.nativeDate, 'dd');
         const cell: DateCell = {

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -79,7 +79,7 @@ export class DateTableComponent extends AbstractTable implements OnChanges, OnIn
 
       for (let day = 0; day < 7; day++) {
         const date = weekStart.addDays(day);
-        const dateFormat = transCompatFormat(this.format ?? 'YYYY-MM-DD');
+        const dateFormat = transCompatFormat(this.format ?? this.i18n.getLocaleData('DatePicker.lang.dateFormat', 'YYYY-MM-DD'));
         const title = this.dateHelper.format(date.nativeDate, dateFormat);
         const label = this.dateHelper.format(date.nativeDate, 'dd');
         const cell: DateCell = {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8743 


## What is the new behavior?
The cell title of the date picker reflects `nzFormat` instead of relying on the locale setting.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
