### PR TITLE
feat(module:segmented): redesign the segmented component

### DIFF
--- a/components/flex/demo/align.ts
+++ b/components/flex/demo/align.ts
@@ -20,12 +20,7 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
       <nz-segmented [nzOptions]="alignSegment" [(ngModel)]="selectedLAlignment"></nz-segmented>
     </div>
 
-    <div
-      class="btn-wrappers"
-      nz-flex
-      [nzJustify]="justifySegment[selectedJustification]"
-      [nzAlign]="alignSegment[selectedLAlignment]"
-    >
+    <div class="btn-wrappers" nz-flex [nzJustify]="selectedJustification" [nzAlign]="selectedLAlignment">
       <button nz-button nzType="primary">Primary</button>
       <button nz-button nzType="primary">Primary</button>
       <button nz-button nzType="primary">Primary</button>
@@ -59,6 +54,6 @@ export class NzDemoFlexAlignComponent {
     'space-evenly'
   ];
   public alignSegment: NzAlign[] = ['flex-start', 'center', 'flex-end'];
-  public selectedJustification = 0;
-  public selectedLAlignment = 0;
+  public selectedJustification: NzJustify = 'flex-start';
+  public selectedLAlignment: NzAlign = 'flex-start';
 }

--- a/components/flex/demo/gap.ts
+++ b/components/flex/demo/gap.ts
@@ -15,15 +15,10 @@ import { NzSliderModule } from 'ng-zorro-antd/slider';
       <span>Select gap:</span>
       <nz-segmented [nzOptions]="gapSegment" [(ngModel)]="selectedGap"></nz-segmented>
     </div>
-    @if (gapSegment[selectedGap] === 'custom') {
+    @if (selectedGap === 'custom') {
       <nz-slider [nzMin]="0" [nzMax]="100" [(ngModel)]="customGapValue" />
     }
-    <div
-      nz-flex
-      [nzGap]="
-        selectedGap === 0 ? 'small' : selectedGap === 1 ? 'middle' : selectedGap === 2 ? 'large' : customGapValue
-      "
-    >
+    <div nz-flex [nzGap]="selectedGap === 'custom' ? customGapValue : selectedGap">
       <button nz-button nzType="primary">Primary</button>
       <button nz-button nzType="dashed">Dashed</button>
       <button nz-button nzType="default">Default</button>
@@ -44,6 +39,6 @@ import { NzSliderModule } from 'ng-zorro-antd/slider';
 })
 export class NzDemoFlexGapComponent {
   public gapSegment: string[] = ['small', 'middle', 'large', 'custom'];
-  public selectedGap = 0;
+  public selectedGap = 'small';
   public customGapValue = 0;
 }

--- a/components/flex/demo/wrap.ts
+++ b/components/flex/demo/wrap.ts
@@ -14,7 +14,7 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
       <span>Select wrap:</span>
       <nz-segmented [nzOptions]="wrapSegment" [(ngModel)]="selectedWrap"></nz-segmented>
     </div>
-    <div class="btn-wrapper" nz-flex [nzGap]="'middle'" [nzWrap]="wrapSegment[selectedWrap]">
+    <div class="btn-wrapper" nz-flex [nzGap]="'middle'" [nzWrap]="selectedWrap">
       @for (_ of array; track _) {
         <button style="width: 100px" nz-button nzType="primary">Button {{ _ }}</button>
       }
@@ -39,6 +39,6 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
 })
 export class NzDemoFlexWrapComponent {
   wrapSegment: NzWrap[] = ['wrap', 'wrap-reverse', 'nowrap'];
-  selectedWrap = 0;
+  selectedWrap: NzWrap = 'wrap';
   array = Array.from({ length: 20 }, (_, index) => index + 1);
 }

--- a/components/qr-code/demo/error-level.ts
+++ b/components/qr-code/demo/error-level.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 import { NzQRCodeModule } from 'ng-zorro-antd/qr-code';
 import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
@@ -6,10 +7,10 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
 @Component({
   selector: 'nz-demo-qr-code-error-level',
   standalone: true,
-  imports: [NzQRCodeModule, NzSegmentedModule],
+  imports: [NzQRCodeModule, NzSegmentedModule, FormsModule],
   template: `
     <nz-qrcode nzValue="https://github.com/NG-ZORRO/ng-zorro-antd/issues" [nzLevel]="errorLevel"></nz-qrcode>
-    <nz-segmented [nzOptions]="options" (nzValueChange)="handleIndexChange($event)"></nz-segmented>
+    <nz-segmented [nzOptions]="options" [(ngModel)]="errorLevel"></nz-segmented>
   `,
   styles: [
     `
@@ -28,8 +29,4 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
 export class NzDemoQrCodeErrorLevelComponent {
   options: Array<'L' | 'M' | 'Q' | 'H'> = ['L', 'M', 'Q', 'H'];
   errorLevel: 'L' | 'M' | 'Q' | 'H' = 'L';
-
-  handleIndexChange(e: number): void {
-    this.errorLevel = this.options[e];
-  }
 }

--- a/components/segmented/demo/basic.ts
+++ b/components/segmented/demo/basic.ts
@@ -6,12 +6,12 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
   selector: 'nz-demo-segmented-basic',
   standalone: true,
   imports: [NzSegmentedModule],
-  template: `<nz-segmented [nzOptions]="options" (nzValueChange)="handleIndexChange($event)"></nz-segmented>`
+  template: `<nz-segmented [nzOptions]="options" (nzValueChange)="handleValueChange($event)"></nz-segmented>`
 })
 export class NzDemoSegmentedBasicComponent {
   options = ['Daily', 'Weekly', 'Monthly', 'Quarterly', 'Yearly'];
 
-  handleIndexChange(e: number): void {
+  handleValueChange(e: string | number): void {
     console.log(e);
   }
 }

--- a/components/segmented/demo/custom.md
+++ b/components/segmented/demo/custom.md
@@ -7,8 +7,8 @@ title:
 
 ## zh-CN
 
-使用 nzLabelTemplate 自定义渲染每一个 Segmented Item。
+自定义渲染每一个 Segmented Item。
 
 ## en-US
 
-Custom each Segmented Item by nzLabelTemplate.
+Custom render each Segmented Item.

--- a/components/segmented/demo/custom.ts
+++ b/components/segmented/demo/custom.ts
@@ -1,41 +1,63 @@
-import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
-import { NzSegmentedModule, NzSegmentedOption } from 'ng-zorro-antd/segmented';
+import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
 
 @Component({
   selector: 'nz-demo-segmented-custom',
   standalone: true,
   imports: [NzAvatarModule, NzSegmentedModule],
   template: `
-    <nz-segmented [nzLabelTemplate]="templateRef" [nzOptions]="options"></nz-segmented>
-    <ng-template #temp let-index="index">
-      @switch (index) {
-        @case (0) {
-          <nz-avatar nzSrc="https://joeschmoe.io/api/v1/random"></nz-avatar>
+    <nz-segmented>
+      <label nz-segmented-item nzValue="user1">
+        <div [style.padding.px]="4">
+          <nz-avatar nzSrc="https://joeschmoe.io/api/v1/random" />
           <div>User 1</div>
-        }
-        @case (1) {
-          <nz-avatar nzText="K"></nz-avatar>
+        </div>
+      </label>
+      <label nz-segmented-item nzValue="user2">
+        <div [style.padding.px]="4">
+          <nz-avatar nzText="K" [style.background]="'#f56a00'" />
           <div>User 2</div>
-        }
-        @case (2) {
-          <nz-avatar nzIcon="user"></nz-avatar>
+        </div>
+      </label>
+      <label nz-segmented-item nzValue="user3">
+        <div [style.padding.px]="4">
+          <nz-avatar nzIcon="user" [style.background]="'#87d068'" />
           <div>User 3</div>
-        }
-      }
-    </ng-template>
+        </div>
+      </label>
+    </nz-segmented>
+
+    <br />
+    <br />
+
+    <nz-segmented>
+      <label nz-segmented-item nzValue="spring">
+        <div [style.padding.px]="4">
+          <div>Spring</div>
+          <div>Jan-Mar</div>
+        </div>
+      </label>
+      <label nz-segmented-item nzValue="summer">
+        <div [style.padding.px]="4">
+          <div>Summer</div>
+          <div>Apr-Jun</div>
+        </div>
+      </label>
+      <label nz-segmented-item nzValue="autumn">
+        <div [style.padding.px]="4">
+          <div>Autumn</div>
+          <div>Jul-Sept</div>
+        </div>
+      </label>
+      <label nz-segmented-item nzValue="winter">
+        <div [style.padding.px]="4">
+          <div>Winter</div>
+          <div>Oct-Dec</div>
+        </div>
+      </label>
+    </nz-segmented>
   `
 })
-export class NzDemoSegmentedCustomComponent {
-  @ViewChild('temp', { static: true, read: TemplateRef }) templateRef!: TemplateRef<{
-    $implicit: NzSegmentedOption;
-    index: number;
-  }>;
-
-  options = [
-    { label: 'user1', value: 'user1', useTemplate: true },
-    { label: 'user2', value: 'user2', useTemplate: true },
-    { label: 'user3', value: 'user3', useTemplate: true }
-  ];
-}
+export class NzDemoSegmentedCustomComponent {}

--- a/components/segmented/demo/disabled.ts
+++ b/components/segmented/demo/disabled.ts
@@ -10,7 +10,14 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
     <nz-segmented [nzOptions]="['Map', 'Transit', 'Satellite']" nzDisabled></nz-segmented>
     <br />
     <nz-segmented [nzOptions]="options"></nz-segmented>
-  `
+  `,
+  styles: [
+    `
+      .ant-segmented {
+        margin-bottom: 10px;
+      }
+    `
+  ]
 })
 export class NzDemoSegmentedDisabledComponent {
   options = [

--- a/components/segmented/demo/dynamic.ts
+++ b/components/segmented/demo/dynamic.ts
@@ -13,7 +13,14 @@ const defaultOptions = ['Daily', 'Weekly', 'Monthly'];
     <nz-segmented [nzOptions]="options"></nz-segmented>
     <br />
     <button nz-button nzType="primary" [disabled]="moreLoaded" (click)="handleLoadMore()"> Load more options </button>
-  `
+  `,
+  styles: [
+    `
+      .ant-segmented {
+        margin-bottom: 10px;
+      }
+    `
+  ]
 })
 export class NzDemoSegmentedDynamicComponent {
   options = [...defaultOptions];

--- a/components/segmented/demo/size.ts
+++ b/components/segmented/demo/size.ts
@@ -9,12 +9,17 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
   template: `
     <nz-segmented [nzOptions]="options" nzSize="small"></nz-segmented>
     <br />
-    <br />
     <nz-segmented [nzOptions]="options"></nz-segmented>
     <br />
-    <br />
     <nz-segmented [nzOptions]="options" nzSize="large"></nz-segmented>
-  `
+  `,
+  styles: [
+    `
+      .ant-segmented {
+        margin-bottom: 10px;
+      }
+    `
+  ]
 })
 export class NzDemoSegmentedSizeComponent {
   options = ['Daily', 'Weekly', 'Monthly', 'Quarterly', 'Yearly'];

--- a/components/segmented/demo/value.md
+++ b/components/segmented/demo/value.md
@@ -7,7 +7,7 @@ title:
 
 ## zh-CN
 
-通过 ngModel 指定选中的 index
+通过 ngModel 指定选中的 value
 
 ## en-US
 

--- a/components/segmented/demo/value.ts
+++ b/components/segmented/demo/value.ts
@@ -8,28 +8,23 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
   standalone: true,
   imports: [FormsModule, NzSegmentedModule],
   template: `
-    <nz-segmented
-      [nzOptions]="options"
-      [(ngModel)]="selectedIndex"
-      (ngModelChange)="handleModelChange($event)"
-    ></nz-segmented>
+    <nz-segmented [nzOptions]="options" [(ngModel)]="selectedValue" (ngModelChange)="handleModelChange($event)" />
     <br />
-    <br />
-    <nz-segmented
-      [nzOptions]="options"
-      [(ngModel)]="selectedIndex"
-      (ngModelChange)="handleModelChange($event)"
-    ></nz-segmented>
-    <br />
-    <br />
-    Selected index: {{ selectedIndex }}
-  `
+    Selected value: {{ selectedValue }}
+  `,
+  styles: [
+    `
+      .ant-segmented {
+        margin-bottom: 10px;
+      }
+    `
+  ]
 })
 export class NzDemoSegmentedValueComponent {
-  selectedIndex = 1;
+  selectedValue = 'Weekly';
   options = ['Daily', 'Weekly', 'Monthly', 'Quarterly', 'Yearly'];
 
-  handleModelChange(index: number): void {
-    console.log(index);
+  handleModelChange(value: string): void {
+    console.log(value);
   }
 }

--- a/components/segmented/doc/index.en-US.md
+++ b/components/segmented/doc/index.en-US.md
@@ -16,14 +16,22 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
 
 ## API
 
-### Segmented:standalone
+### nz-segmented:standalone
 
-| Property          | Description                                               | Type                                                                                                                                 | Default | Global Config |
-| ----------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------------- |
-| `[nzBlock]`       | Option to fit width to its parent\'s width                | `boolean`                                                                                                                            | false   |               |
-| `[nzDisabled]`    | Disable all segments                                      | `boolean`                                                                                                                            | false   |               |
-| `[nzOptions]`     | Set children optional                                     | `string[] \| number[] \| Array<{ label: string; value: string \| number; icon: string; disabled?: boolean; useTemplate?: boolean }>` | -       |               |
-| `[nzSize]`        | The size of the Segmented                                 | `large \| default \| small`                                                                                                          | -       | ✅            |
-| `[ngModel]`       | Index of the currently selected option                    | `number`                                                                                                                             | -       |               |
-| `(nzValueChange)` | Emits when index of the currently selected option changes | `EventEmitter<number>`                                                                                                               | -       |               |
-| `(ngModelChange)` | Emits when index of the currently selected option changes | `EventEmitter<number>`                                                                                                               | -       |               |
+| Property          | Description                                               | Type                                                                                                          | Default | Global Config |
+| ----------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- | ------------- |
+| `[nzBlock]`       | Option to fit width to its parent\'s width                | `boolean`                                                                                                     | false   |               |
+| `[nzDisabled]`    | Disable all segments                                      | `boolean`                                                                                                     | false   |               |
+| `[nzOptions]`     | Set children optional                                     | `string[] \| number[] \| Array<{ label: string; value: string \| number; icon: string; disabled?: boolean }>` | -       |               |
+| `[nzSize]`        | The size of the Segmented                                 | `large \| default \| small`                                                                                   | -       | ✅             |
+| `[ngModel]`       | Value of the currently selected option                    | `string \| number`                                                                                            | -       |               |
+| `(nzValueChange)` | Emits when value of the currently selected option changes | `EventEmitter<string \| number>`                                                                              | -       |               |
+| `(ngModelChange)` | Emits when value of the currently selected option changes | `EventEmitter<string \| number>`                                                                              | -       |               |
+
+### label[nz-segmented-item]:standalone
+
+| Property       | Description                | Type               | Default | Global Config |
+| -------------- | -------------------------- | ------------------ | ------- | ------------- |
+| `[nzIcon]`     | Icon in segmented item     | `string`           | -       |               |
+| `[nzValue]`    | Value of segmented item    | `string \| number` | -       |               |
+| `[nzDisabled]` | Disable the segmented item | `boolean`          | false   |               |

--- a/components/segmented/doc/index.zh-CN.md
+++ b/components/segmented/doc/index.zh-CN.md
@@ -17,14 +17,22 @@ import { NzSegmentedModule } from 'ng-zorro-antd/segmented';
 
 ## API
 
-### Segmented:standalone
+### nz-segmented:standalone
 
-| 参数              | 说明                         | 类型                                                                                                                                 | 默认值 | 全局配置 |
-| ----------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------ | -------- |
-| `[nzBlock]`       | 将宽度调整为父元素宽度的选项 | `boolean`                                                                                                                            | false  |          |
-| `[nzDisabled]`    | 是否禁用                     | `boolean`                                                                                                                            | false  |          |
-| `[nzOptions]`     | 数据化配置选项内容           | `string[] \| number[] \| Array<{ label: string; value: string \| number; icon: string; disabled?: boolean; useTemplate?: boolean }>` | -      |          |
-| `[nzSize]`        | 控件尺寸                     | `large \| default \| small`                                                                                                          | -      | ✅       |
-| `[ngModel]`       | 当前选中项目的 index         | `number`                                                                                                                             | -      |          |
-| `(nzValueChange)` | 当前选中项目变化时触发回调   | `EventEmitter<number>`                                                                                                               | -      |          |
-| `(ngModelChange)` | 当前选中项目变化时触发回调   | `EventEmitter<number>`                                                                                                               | -      |          |
+| 参数              | 说明                         | 类型                                                                                                           | 默认值 | 全局配置 |
+| ----------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------- | ------ | -------- |
+| `[nzBlock]`       | 将宽度调整为父元素宽度的选项 | `boolean`                                                                                                      | false  |          |
+| `[nzDisabled]`    | 是否禁用                     | `boolean`                                                                                                      | false  |          |
+| `[nzOptions]`     | 数据化配置选项内容           | `string[] \| number[] \| Array<{ label: string; value: string \| number; icon: string; disabled?: boolean; }>` | -      |          |
+| `[nzSize]`        | 控件尺寸                     | `large \| default \| small`                                                                                    | -      | ✅        |
+| `[ngModel]`       | 当前选中项目的 value         | `string \| number`                                                                                             | -      |          |
+| `(nzValueChange)` | 当前选中项目变化时触发回调   | `EventEmitter<string \| number>`                                                                               | -      |          |
+| `(ngModelChange)` | 当前选中项目变化时触发回调   | `EventEmitter<string \| number>`                                                                               | -      |          |
+
+### label[nz-segmented-item]:standalone
+
+| 参数           | 说明     | 类型               | 默认值 | 全局配置 |
+| -------------- | -------- | ------------------ | ------ | -------- |
+| `[nzIcon]`     | 图标     | `string`           | -      |          |
+| `[nzValue]`    | 值       | `string \| number` | -      |          |
+| `[nzDisabled]` | 是否禁用 | `boolean`          | false  |          |

--- a/components/segmented/public-api.ts
+++ b/components/segmented/public-api.ts
@@ -3,6 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-export { NzSegmentedModule } from './segmented.module';
+export { NzSegmentedItemComponent } from './segmented-item.component';
 export { NzSegmentedComponent } from './segmented.component';
+export { NzSegmentedModule } from './segmented.module';
 export * from './types';

--- a/components/segmented/segmented-item.component.ts
+++ b/components/segmented/segmented-item.component.ts
@@ -1,0 +1,102 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  inject,
+  Input,
+  ViewEncapsulation
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+
+import { NzIconModule } from 'ng-zorro-antd/icon';
+
+import { NzSegmentedService } from './segmented.service';
+
+@Component({
+  selector: 'label[nz-segmented-item],label[nzSegmentedItem]',
+  exportAs: 'nzSegmentedItem',
+  imports: [NzIconModule, NgTemplateOutlet],
+  standalone: true,
+  template: `
+    <input class="ant-segmented-item-input" type="radio" [checked]="isChecked" (click)="$event.stopPropagation()" />
+    <div class="ant-segmented-item-label">
+      @if (nzIcon) {
+        <span class="ant-segmented-item-icon"><span nz-icon [nzType]="nzIcon"></span></span>
+        <span>
+          <ng-template [ngTemplateOutlet]="content" />
+        </span>
+      } @else {
+        <ng-template [ngTemplateOutlet]="content" />
+      }
+    </div>
+
+    <ng-template #content>
+      <ng-content></ng-content>
+    </ng-template>
+  `,
+  host: {
+    class: 'ant-segmented-item',
+    '[class.ant-segmented-item-selected]': 'isChecked',
+    '[class.ant-segmented-item-disabled]': 'nzDisabled',
+    '(click)': 'handleClick()'
+  },
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None
+})
+export class NzSegmentedItemComponent {
+  @Input() nzIcon?: string;
+  @Input() nzValue!: string | number;
+  @Input() nzDisabled?: boolean;
+
+  protected isChecked = false;
+
+  private readonly service = inject(NzSegmentedService);
+
+  constructor() {
+    const cdr = inject(ChangeDetectorRef);
+    const elementRef = inject(ElementRef);
+
+    this.service.selected$
+      .pipe(
+        tap(value => {
+          this.isChecked = false;
+          cdr.markForCheck();
+          if (value === this.nzValue) {
+            this.service.activated$.next(elementRef.nativeElement);
+          }
+        }),
+        switchMap(value =>
+          this.service.animationDone$.pipe(
+            filter(event => event.toState === 'to'),
+            take(1),
+            map(() => value)
+          )
+        ),
+        filter(value => value === this.nzValue),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => {
+        this.isChecked = true;
+        cdr.markForCheck();
+      });
+
+    this.service.disabled$.pipe(takeUntilDestroyed()).subscribe(disabled => {
+      this.nzDisabled = disabled;
+      cdr.markForCheck();
+    });
+  }
+
+  handleClick(): void {
+    if (!this.nzDisabled) {
+      this.service.selected$.next(this.nzValue);
+    }
+  }
+}

--- a/components/segmented/segmented.component.ts
+++ b/components/segmented/segmented.component.ts
@@ -3,36 +3,38 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { AnimationEvent } from '@angular/animations';
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgClass } from '@angular/common';
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  ElementRef,
+  contentChildren,
+  effect,
   EventEmitter,
   forwardRef,
+  inject,
   Input,
   OnChanges,
   Output,
-  QueryList,
   SimpleChanges,
-  TemplateRef,
-  ViewChildren,
+  viewChildren,
   ViewEncapsulation
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { bufferCount } from 'rxjs/operators';
 
 import { ThumbAnimationProps, thumbMotion } from 'ng-zorro-antd/core/animation';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
-import { NzSafeAny, NzSizeLDSType, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
+import { NzSizeLDSType, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
-import { normalizeOptions, NzNormalizedOptions, NzSegmentedOption, NzSegmentedOptions } from './types';
+import { NzSegmentedItemComponent } from './segmented-item.component';
+import { NzSegmentedService } from './segmented.service';
+import { normalizeOptions, NzSegmentedOption, NzSegmentedOptions } from './types';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'segmented';
 
@@ -46,133 +48,125 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'segmented';
     <div class="ant-segmented-group">
       @if (animationState) {
         <div
-          [ngClass]="{ 'ant-segmented-thumb': true, 'ant-segmented-thumb-motion': true }"
+          class="ant-segmented-thumb ant-segmented-thumb-motion"
           [@thumbMotion]="animationState"
           (@thumbMotion.done)="handleThumbAnimationDone($event)"
         ></div>
       }
 
-      @for (item of normalizedOptions; track item; let i = $index) {
-        <label
-          #itemLabels
-          [ngClass]="{
-            'ant-segmented-item': true,
-            'ant-segmented-item-selected': i === selectedIndex,
-            'ant-segmented-item-disabled': !!nzDisabled || item.disabled
-          }"
-        >
-          <input class="ant-segmented-item-input" type="radio" [checked]="i === selectedIndex" />
-          <div class="ant-segmented-item-label" (click)="!item.disabled && handleOptionClick(i)">
-            @if (item.icon) {
-              <span class="ant-segmented-item-icon"><span nz-icon [nzType]="item.icon"></span></span>
-              <span>
-                <ng-container
-                  *nzStringTemplateOutlet="item.useTemplate && nzLabelTemplate; context: { $implicit: item, index: i }"
-                >
-                  {{ item.label }}
-                </ng-container>
-              </span>
-            } @else {
-              <ng-container
-                *nzStringTemplateOutlet="item.useTemplate && nzLabelTemplate; context: { $implicit: item, index: i }"
-              >
-                {{ item.label }}
-              </ng-container>
-            }
-          </div>
-        </label>
-      }
+      <ng-content>
+        @for (item of normalizedOptions; track item.value) {
+          <label nz-segmented-item [nzIcon]="item.icon" [nzValue]="item.value" [nzDisabled]="item.disabled">{{
+            item.label
+          }}</label>
+        }
+      </ng-content>
     </div>
   `,
   host: {
     class: 'ant-segmented',
-    '[class.ant-segmented-disabled]': '!!nzDisabled',
+    '[class.ant-segmented-disabled]': 'nzDisabled',
     '[class.ant-segmented-rtl]': `dir === 'rtl'`,
     '[class.ant-segmented-lg]': `nzSize === 'large'`,
     '[class.ant-segmented-sm]': `nzSize === 'small'`,
-    '[class.ant-segmented-block]': `!!nzBlock`
+    '[class.ant-segmented-block]': `nzBlock`
   },
-  providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NzSegmentedComponent), multi: true }],
+  providers: [
+    NzSegmentedService,
+    { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NzSegmentedComponent), multi: true }
+  ],
   animations: [thumbMotion],
-  imports: [NgClass, NzIconModule, NzOutletModule],
+  imports: [NzIconModule, NzOutletModule, NzSegmentedItemComponent],
   standalone: true
 })
 export class NzSegmentedComponent implements OnChanges, ControlValueAccessor {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 
-  @ViewChildren('itemLabels', { read: ElementRef }) listOfOptions!: QueryList<ElementRef>;
-
-  @Input({ transform: booleanAttribute })
-  nzBlock: boolean = false;
-
-  @Input({ transform: booleanAttribute })
-  nzDisabled: boolean = false;
-
+  @Input({ transform: booleanAttribute }) nzBlock: boolean = false;
+  @Input({ transform: booleanAttribute }) nzDisabled = false;
   @Input() nzOptions: NzSegmentedOptions = [];
-
   @Input() @WithConfig() nzSize: NzSizeLDSType = 'default';
 
-  @Input() nzLabelTemplate: TemplateRef<{ $implicit: NzSegmentedOption; index: number }> | null = null;
+  @Output() readonly nzValueChange = new EventEmitter<number | string>();
 
-  @Output() readonly nzValueChange = new EventEmitter<number>();
+  private viewItemCmps = viewChildren(NzSegmentedItemComponent);
+  private contentItemCmps = contentChildren(NzSegmentedItemComponent);
 
-  public dir: Direction = 'ltr';
+  protected dir: Direction = 'ltr';
+  protected value?: number | string;
+  protected animationState: null | { value: string; params: ThumbAnimationProps } = {
+    value: 'to',
+    params: thumbAnimationParamsOf()
+  };
+  protected normalizedOptions: NzSegmentedOption[] = [];
+  protected onChange: OnChangeType = () => {};
+  protected onTouched: OnTouchedType = () => {};
 
-  public selectedIndex = 0;
-  public transitionedToIndex = -1;
-  public animationState: null | { value: string; params: ThumbAnimationProps } = null;
-
-  public normalizedOptions: NzNormalizedOptions = [];
-
-  private destroy$ = new Subject<void>();
-
-  onChange: OnChangeType = () => {};
-
-  onTouched: OnTouchedType = () => {};
+  private readonly service = inject(NzSegmentedService);
 
   constructor(
     public readonly nzConfigService: NzConfigService,
     private readonly cdr: ChangeDetectorRef,
     private readonly directionality: Directionality
   ) {
-    this.directionality.change?.pipe(takeUntil(this.destroy$)).subscribe(direction => {
+    this.directionality.change.pipe(takeUntilDestroyed()).subscribe(direction => {
       this.dir = direction;
+      this.cdr.markForCheck();
+    });
+
+    this.service.selected$.pipe(takeUntilDestroyed()).subscribe(value => {
+      this.value = value;
+      this.nzValueChange.emit(value);
+      this.onChange(value);
+    });
+
+    this.service.activated$.pipe(bufferCount(2, 1), takeUntilDestroyed()).subscribe(elements => {
+      this.animationState = {
+        value: 'from',
+        params: thumbAnimationParamsOf(elements[0])
+      };
       this.cdr.detectChanges();
+
+      this.animationState = {
+        value: 'to',
+        params: thumbAnimationParamsOf(elements[1])
+      };
+      this.cdr.detectChanges();
+    });
+
+    effect(() => {
+      const itemCmps = this.viewItemCmps().concat(this.contentItemCmps());
+
+      if (
+        this.value === null ||
+        this.value === undefined ||
+        !itemCmps.some(item => item.nzValue === this.value) // handle value not in options
+      ) {
+        this.service.selected$.next(itemCmps[0].nzValue);
+      }
     });
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    const { nzOptions } = changes;
+    const { nzOptions, nzDisabled } = changes;
     if (nzOptions) {
       this.normalizedOptions = normalizeOptions(nzOptions.currentValue);
     }
-  }
-
-  handleOptionClick(index: number): void {
-    if (this.nzDisabled) {
-      return;
+    if (nzDisabled) {
+      this.service.disabled$.next(nzDisabled.currentValue);
     }
-
-    this.changeSelectedIndex(index);
-
-    this.onChange(index);
-    this.nzValueChange.emit(index);
   }
 
-  handleThumbAnimationDone(e: NzSafeAny): void {
-    if (e.fromState === 'from') {
-      this.selectedIndex = this.transitionedToIndex;
-      this.transitionedToIndex = -1;
+  handleThumbAnimationDone(event: AnimationEvent): void {
+    if (event.toState === 'to') {
       this.animationState = null;
-      this.cdr.detectChanges();
     }
+    this.service.animationDone$.next(event);
   }
 
-  writeValue(value: number | null): void {
-    if (typeof value === 'number' && value > -1) {
-      this.changeSelectedIndex(value);
-      this.cdr.markForCheck();
-    }
+  writeValue(value: number | string): void {
+    if (value === null || value === undefined) return;
+    this.service.selected$.next(value);
   }
 
   registerOnChange(fn: OnChangeType): void {
@@ -182,31 +176,11 @@ export class NzSegmentedComponent implements OnChanges, ControlValueAccessor {
   registerOnTouched(fn: OnTouchedType): void {
     this.onTouched = fn;
   }
-
-  private changeSelectedIndex(index: number): void {
-    if (!this.listOfOptions || this.selectedIndex === -1 || this.selectedIndex === index) {
-      return;
-    }
-
-    this.animationState = {
-      value: 'from',
-      params: getThumbAnimationProps(this.listOfOptions.get(this.selectedIndex)!.nativeElement!)
-    };
-    this.selectedIndex = -1;
-    this.cdr.detectChanges();
-
-    this.animationState = {
-      value: 'to',
-      params: getThumbAnimationProps(this.listOfOptions.get(index)!.nativeElement!)
-    };
-    this.transitionedToIndex = index;
-    this.cdr.detectChanges();
-  }
 }
 
-function getThumbAnimationProps(element: HTMLElement): ThumbAnimationProps {
+function thumbAnimationParamsOf(element?: HTMLElement): ThumbAnimationProps {
   return {
-    transform: element.offsetLeft,
-    width: element.clientWidth
+    transform: element?.offsetLeft ?? 0,
+    width: element?.clientWidth ?? 0
   };
 }

--- a/components/segmented/segmented.module.ts
+++ b/components/segmented/segmented.module.ts
@@ -5,10 +5,11 @@
 
 import { NgModule } from '@angular/core';
 
+import { NzSegmentedItemComponent } from './segmented-item.component';
 import { NzSegmentedComponent } from './segmented.component';
 
 @NgModule({
-  imports: [NzSegmentedComponent],
-  exports: [NzSegmentedComponent]
+  imports: [NzSegmentedComponent, NzSegmentedItemComponent],
+  exports: [NzSegmentedComponent, NzSegmentedItemComponent]
 })
 export class NzSegmentedModule {}

--- a/components/segmented/segmented.service.ts
+++ b/components/segmented/segmented.service.ts
@@ -1,0 +1,23 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { AnimationEvent } from '@angular/animations';
+import { Injectable, OnDestroy } from '@angular/core';
+import { ReplaySubject, Subject } from 'rxjs';
+
+@Injectable()
+export class NzSegmentedService implements OnDestroy {
+  readonly selected$ = new ReplaySubject<string | number>(1);
+  readonly activated$ = new ReplaySubject<HTMLElement>(1);
+  readonly disabled$ = new ReplaySubject<boolean>(1);
+  readonly animationDone$ = new Subject<AnimationEvent>();
+
+  ngOnDestroy(): void {
+    this.selected$.complete();
+    this.activated$.complete();
+    this.disabled$.complete();
+    this.animationDone$.complete();
+  }
+}

--- a/components/segmented/segmented.spec.ts
+++ b/components/segmented/segmented.spec.ts
@@ -38,30 +38,36 @@ describe('nz-segmented', () => {
       expect((segmentedComponent.nativeElement as HTMLElement).classList.contains('ant-segmented-block')).toBeTrue();
     });
 
-    it('should emit when index changes', fakeAsync(() => {
-      spyOn(component, 'handleIndexChange');
+    it('should be auto selected the first option', async () => {
+      const theFirstElement = getSegmentedOptionByIndex(0);
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(component.value).toBe(1);
+      expect(theFirstElement.classList.contains('ant-segmented-item-selected')).toBeTrue();
+    });
+
+    it('should emit when value changes', fakeAsync(() => {
+      spyOn(component, 'handleValueChange');
 
       const theFirstElement = getSegmentedOptionByIndex(0);
-      expect(theFirstElement.classList.contains('ant-segmented-item-selected')).toBeTrue();
-
       const theThirdElement = getSegmentedOptionByIndex(2);
       dispatchMouseEvent(theThirdElement.querySelector('.ant-segmented-item-label')!, 'click');
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();
-      expect(component.index).toBe(2);
+      expect(component.value).toBe(3);
       expect(theFirstElement.classList.contains('ant-segmented-item-selected')).toBeFalse();
       expect(theThirdElement.classList.contains('ant-segmented-item-selected')).toBeTrue();
-      expect(component.handleIndexChange).toHaveBeenCalledWith(2);
-      expect(component.handleIndexChange).toHaveBeenCalledTimes(2);
+      expect(component.handleValueChange).toHaveBeenCalledWith(3);
+      expect(component.handleValueChange).toHaveBeenCalledTimes(1);
 
-      component.index = 1;
+      component.value = 2;
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();
       const theSecondElement = getSegmentedOptionByIndex(1);
-      expect(segmentedComponent.componentInstance.selectedIndex).toBe(1);
-      expect(component.handleIndexChange).toHaveBeenCalledTimes(2);
+      expect(segmentedComponent.componentInstance.value).toBe(2);
+      expect(component.handleValueChange).toHaveBeenCalledTimes(2);
       expect(theSecondElement.classList.contains('ant-segmented-item-selected')).toBeTrue();
     }));
 
@@ -74,7 +80,7 @@ describe('nz-segmented', () => {
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();
-      expect(component.index).toBe(0);
+      expect(component.value).toBe(1);
 
       component.disabled = false;
       fixture.detectChanges();
@@ -82,7 +88,7 @@ describe('nz-segmented', () => {
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();
-      expect(component.index).toBe(2);
+      expect(component.value).toBe(3);
 
       component.options = [
         'Daily',
@@ -98,7 +104,7 @@ describe('nz-segmented', () => {
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();
-      expect(component.index).toBe(2);
+      expect(component.value).toBe('Daily');
     }));
   });
 });
@@ -110,22 +116,21 @@ describe('nz-segmented', () => {
     <nz-segmented
       [nzSize]="size"
       [nzOptions]="options"
-      [(ngModel)]="index"
+      [(ngModel)]="value"
       [nzDisabled]="disabled"
       [nzBlock]="block"
-      (ngModelChange)="handleIndexChange($event)"
-      (nzValueChange)="handleIndexChange($event)"
+      (nzValueChange)="handleValueChange($event)"
     ></nz-segmented>
   `
 })
 export class NzSegmentedTestComponent {
   size: NzSizeLDSType = 'default';
   options: NzSegmentedOptions = [1, 2, 3];
-  index = 0;
+  value?: number | string;
   block = false;
   disabled = false;
 
-  handleIndexChange(_e: number): void {
+  handleValueChange(_e: string | number): void {
     // empty
   }
 }

--- a/components/segmented/types.ts
+++ b/components/segmented/types.ts
@@ -5,9 +5,7 @@
 
 export type NzSegmentedOption = {
   value: string | number;
-  useTemplate?: boolean;
   disabled?: boolean;
-  className?: string;
 } & (NzSegmentedWithLabel | NzSegmentedWithIcon);
 
 export interface NzSegmentedWithLabel {
@@ -22,17 +20,15 @@ export interface NzSegmentedWithIcon {
 
 export type NzSegmentedOptions = Array<NzSegmentedOption | string | number>;
 
-export type NzNormalizedOptions = NzSegmentedOption[];
-
-export function normalizeOptions(unnormalized: NzSegmentedOptions): NzNormalizedOptions {
+export function normalizeOptions(unnormalized: NzSegmentedOptions): NzSegmentedOption[] {
   return unnormalized.map(item => {
     if (typeof item === 'string' || typeof item === 'number') {
       return {
         label: `${item}`,
         value: item
-      } as NzSegmentedOption;
+      };
     }
 
-    return item as NzSegmentedOption;
+    return item;
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

1. ngModel 的值是 index
2. 自定义渲染用法不符合人体工学

```html
<nz-segmented [nzLabelTemplate]="templateRef" [nzOptions]="options"></nz-segmented>
<ng-template #temp let-index="index">
  @switch (index) {
    @case (0) {
      <nz-avatar nzSrc="https://joeschmoe.io/api/v1/random"></nz-avatar>
      <div>User 1</div>
    }
    @case (1) {
      <nz-avatar nzText="K"></nz-avatar>
      <div>User 2</div>
    }
    @case (2) {
      <nz-avatar nzIcon="user"></nz-avatar>
      <div>User 3</div>
    }
  }
</ng-template>
```


## What is the new behavior?

1. 将 ngModel 的值改为 `option.value`
2. 新增 `[nz-segmented-item]` 组件，提供直接的自定义渲染功能

![QQ_1726415516692](https://github.com/user-attachments/assets/dc7e39d5-b208-4377-832a-ce64c11f809f)

```html
<nz-segmented>
  <label nz-segmented-item nzValue="user1">
    <div [style.padding.px]="4">
      <nz-avatar nzSrc="https://joeschmoe.io/api/v1/random" />
      <div>User 1</div>
    </div>
  </label>
  <label nz-segmented-item nzValue="user2">
    <div [style.padding.px]="4">
      <nz-avatar nzText="K" [style.background]="'#f56a00'" />
      <div>User 2</div>
    </div>
  </label>
  <label nz-segmented-item nzValue="user3">
    <div [style.padding.px]="4">
      <nz-avatar nzIcon="user" [style.background]="'#87d068'" />
      <div>User 3</div>
    </div>
  </label>
</nz-segmented>
```


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

1. ngModel 的值从 index 修正为 `option.value`
2. 不再需要 `nzLabelTemplate` input，将其移除
3. nzValueChange 的类型从 `EventEmitter<number>` 修改为 `EventEmitter<number | string>`

## Other information
