### PR TITLE
fix(module:avatar): calculate size at the right time

### DIFF
--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -5,7 +5,6 @@
 
 import { PlatformModule } from '@angular/cdk/platform';
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -16,6 +15,7 @@ import {
   Output,
   ViewChild,
   ViewEncapsulation,
+  afterRender,
   numberAttribute
 } from '@angular/core';
 
@@ -33,11 +33,9 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
   template: `
     @if (nzIcon && hasIcon) {
       <span nz-icon [nzType]="nzIcon"></span>
-    }
-    @if (nzSrc && hasSrc) {
+    } @else if (nzSrc && hasSrc) {
       <img [src]="nzSrc" [attr.srcset]="nzSrcSet" [attr.alt]="nzAlt" (error)="imgError($event)" />
-    }
-    @if (nzText && hasText) {
+    } @else if (nzText && hasText) {
       <span class="ant-avatar-string" #textEl>{{ nzText }}</span>
     }
   `,
@@ -59,7 +57,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
-export class NzAvatarComponent implements OnChanges, AfterViewInit {
+export class NzAvatarComponent implements OnChanges {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
   @Input() @WithConfig() nzShape: NzShapeSCType = 'circle';
   @Input() @WithConfig() nzSize: NzSizeLDSType | number = 'default';
@@ -85,7 +83,9 @@ export class NzAvatarComponent implements OnChanges, AfterViewInit {
     public nzConfigService: NzConfigService,
     private elementRef: ElementRef,
     private cdr: ChangeDetectorRef
-  ) {}
+  ) {
+    afterRender(() => this.calcStringSize());
+  }
 
   imgError($event: Event): void {
     this.nzError.emit($event);
@@ -110,10 +110,6 @@ export class NzAvatarComponent implements OnChanges, AfterViewInit {
     this.hasSrc = !!this.nzSrc;
 
     this.setSizeStyle();
-    this.calcStringSize();
-  }
-
-  ngAfterViewInit(): void {
     this.calcStringSize();
   }
 

--- a/components/avatar/avatar.spec.ts
+++ b/components/avatar/avatar.spec.ts
@@ -136,7 +136,7 @@ describe('avatar', () => {
       context.nzText = 'LongUsername';
       fixture.detectChanges();
       tick();
-      context.comp.ngAfterViewInit();
+      context.comp['calcStringSize']();
       const scale = getScaleFromCSSTransform(dl.nativeElement.querySelector('.ant-avatar-string')!.style.transform!);
       expect(scale).toBeLessThan(1);
     }));
@@ -150,7 +150,7 @@ describe('avatar', () => {
         fixture.detectChanges();
         tick();
         avatarText = dl.nativeElement.querySelector('.ant-avatar-string')!;
-        context.comp.ngAfterViewInit();
+        context.comp['calcStringSize']();
         firstScale = getScaleFromCSSTransform(avatarText.style.transform);
       }));
 
@@ -236,7 +236,7 @@ describe('avatar', () => {
       fixture.detectChanges();
       flush();
       const textEl = document.querySelector<HTMLElement>('.ant-avatar-string')!;
-      context.comp.ngAfterViewInit();
+      context.comp['calcStringSize']();
       const scale = getScaleFromCSSTransform(textEl.style.transform);
       expect(scale).toBeLessThan(1);
       expect(textEl.style.lineHeight).toEqual(`${size}px`);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

当 文字类型的头像 在像 dropdown 这种 overlay 组件中渲染时，无法正确计算文本尺寸：
![image](https://github.com/user-attachments/assets/e080535d-48e4-44c4-a847-50a96d3f7848)



## What is the new behavior?

通过使用 `afterRender` 来确保可以正确 读/写 DOM 来解决该问题：
![image](https://github.com/user-attachments/assets/4d5639d6-f586-47a6-994e-05b4d4bef809)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
