### PR TITLE
fix(module:modal): remove dark backdrop when nzMask is false

### DIFF
--- a/components/modal/modal.service.ts
+++ b/components/modal/modal.service.ts
@@ -134,13 +134,11 @@ export class NzModalService implements OnDestroy {
     const overlayConfig = new OverlayConfig({
       hasBackdrop: true,
       scrollStrategy: this.overlay.scrollStrategies.block(),
+      backdropClass: getValueWithConfig(config.nzMask, globalConfig.nzMask, true) ? MODAL_MASK_CLASS_NAME : '',
       positionStrategy: this.overlay.position().global(),
       disposeOnNavigation: getValueWithConfig(config.nzCloseOnNavigation, globalConfig.nzCloseOnNavigation, true),
       direction: getValueWithConfig(config.nzDirection, globalConfig.nzDirection, this.directionality.value)
     });
-    if (getValueWithConfig(config.nzMask, globalConfig.nzMask, true)) {
-      overlayConfig.backdropClass = MODAL_MASK_CLASS_NAME;
-    }
 
     return this.overlay.create(overlayConfig);
   }

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -504,6 +504,32 @@ describe('NzModal', () => {
     flush();
   }));
 
+  it('nzMask work', fakeAsync(() => {
+    configService.set('modal', { nzMask: false });
+
+    const modalRef = modalService.create({
+      nzContent: TestWithModalContentComponent
+    });
+
+    fixture.detectChanges();
+
+    expect(modalRef.getBackdropElement()?.classList)
+      .not.withContext('not has default cdk dark backdrop')
+      .toContain('cdk-overlay-dark-backdrop');
+
+    configService.set('modal', { nzMask: true });
+    fixture.detectChanges();
+
+    expect(modalRef.getBackdropElement()?.classList).toContain(
+      'ant-modal-mask',
+      'should add class when global config changed'
+    );
+
+    modalRef.close();
+    fixture.detectChanges();
+    flush();
+  }));
+
   it(
     'should not close when clicking on the modal wrap and ' + 'nzMaskClosable or nzMask is false',
     fakeAsync(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
In Angular CDK Overlay, if backdropClass is not set, the default is 'cdk-overlay-dark-backdrop', which causes a black background even when nzMask is set to false. Therefore, set the default value based on the value of nzMask.