### PR TITLE
fix(module: select): multiple select cause switch size flash when init

### DIFF
--- a/components/select/select-search.component.ts
+++ b/components/select/select-search.component.ts
@@ -20,6 +20,8 @@ import {
 } from '@angular/core';
 import { COMPOSITION_BUFFER_MODE, FormsModule } from '@angular/forms';
 
+import { reqAnimFrame } from 'ng-zorro-antd/core/polyfill';
+
 @Component({
   selector: 'nz-select-search',
   encapsulation: ViewEncapsulation.None,
@@ -68,7 +70,9 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
     this.value = value;
     this.valueChange.next(value);
     if (this.mirrorSync) {
-      this.syncMirrorWidth();
+      reqAnimFrame(() => {
+        this.syncMirrorWidth();
+      });
     }
   }
 
@@ -121,7 +125,9 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
 
   ngAfterViewInit(): void {
     if (this.mirrorSync) {
-      this.syncMirrorWidth();
+      reqAnimFrame(() => {
+        this.syncMirrorWidth();
+      });
     }
     if (this.autofocus) {
       this.focus();

--- a/components/select/select-search.component.ts
+++ b/components/select/select-search.component.ts
@@ -70,9 +70,7 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
     this.value = value;
     this.valueChange.next(value);
     if (this.mirrorSync) {
-      reqAnimFrame(() => {
-        this.syncMirrorWidth();
-      });
+      this.syncMirrorWidth();
     }
   }
 
@@ -83,12 +81,14 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
   }
 
   syncMirrorWidth(): void {
-    const mirrorDOM = this.mirrorElement!.nativeElement;
-    const hostDOM = this.elementRef.nativeElement;
-    const inputDOM = this.inputElement.nativeElement;
-    this.renderer.removeStyle(hostDOM, 'width');
-    this.renderer.setProperty(mirrorDOM, 'textContent', `${inputDOM.value}\u00a0`);
-    this.renderer.setStyle(hostDOM, 'width', `${mirrorDOM.scrollWidth}px`);
+    reqAnimFrame(() => {
+      const mirrorDOM = this.mirrorElement!.nativeElement;
+      const hostDOM = this.elementRef.nativeElement;
+      const inputDOM = this.inputElement.nativeElement;
+      this.renderer.removeStyle(hostDOM, 'width');
+      this.renderer.setProperty(mirrorDOM, 'textContent', `${inputDOM.value}\u00a0`);
+      this.renderer.setStyle(hostDOM, 'width', `${mirrorDOM.scrollWidth}px`);
+    });
   }
 
   focus(): void {
@@ -125,9 +125,7 @@ export class NzSelectSearchComponent implements AfterViewInit, OnChanges {
 
   ngAfterViewInit(): void {
     if (this.mirrorSync) {
-      reqAnimFrame(() => {
-        this.syncMirrorWidth();
-      });
+      this.syncMirrorWidth();
     }
     if (this.autofocus) {
       this.focus();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Close #8847 



## What is the new behavior?

当 select 的 nzMode 设为 multiple 或 tags 且 switch 的 nzSize 设为 small 时，switch 组件初始化时不再出现大小闪烁现象（由 default 变为 small）

When nzMode of select is multiple or tags, and nzSize of switch is small, the size flashing (change from default to small) of switch no longer occurs at initialization.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
