### PR TITLE
test(module:*): deprecate internal APIs and remove references

### DIFF
--- a/components/button/button-group.spec.ts
+++ b/components/button/button-group.spec.ts
@@ -1,45 +1,53 @@
 import { BidiModule, Dir, Direction } from '@angular/cdk/bidi';
 import { Component, Input, ViewChild } from '@angular/core';
-import { fakeAsync } from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-
-import { ɵcreateComponentBed as createComponentBed } from 'ng-zorro-antd/core/testing';
 
 import { NzButtonGroupComponent, NzButtonGroupSize } from './button-group.component';
 
 describe('button-group', () => {
   it('should button group size work', () => {
-    const testBed = createComponentBed(TestButtonGroupComponent, { imports: [NzButtonGroupComponent] });
-    const buttonGroupElement = testBed.debugElement.query(By.directive(NzButtonGroupComponent)).nativeElement;
+    const fixture = TestBed.createComponent(TestButtonGroupComponent);
+    const component = fixture.componentInstance;
+
+    const buttonGroupElement = fixture.debugElement.query(By.directive(NzButtonGroupComponent)).nativeElement;
     expect(buttonGroupElement.className).toBe('ant-btn-group');
-    testBed.component.nzSize = 'large';
-    testBed.fixture.detectChanges();
+
+    component.nzSize = 'large';
+    fixture.detectChanges();
     expect(buttonGroupElement.classList).toContain('ant-btn-group-lg');
-    testBed.component.nzSize = 'small';
-    testBed.fixture.detectChanges();
+
+    component.nzSize = 'small';
+    fixture.detectChanges();
     expect(buttonGroupElement.classList).toContain('ant-btn-group-sm');
   });
 
   it('should RTL classname work', fakeAsync(() => {
-    const testBed = createComponentBed(NzTestButtonGroupRtlComponent, {
-      imports: [BidiModule, NzButtonGroupComponent]
-    });
-    const buttonGroupElement = testBed.debugElement.query(By.directive(NzButtonGroupComponent)).nativeElement;
+    const fixture = TestBed.createComponent(NzTestButtonGroupRtlComponent);
+    const component = fixture.componentInstance;
+
+    fixture.detectChanges();
+    const buttonGroupElement = fixture.debugElement.query(By.directive(NzButtonGroupComponent)).nativeElement;
     expect(buttonGroupElement.className).toBe('ant-btn-group ant-btn-group-rtl');
-    testBed.component.direction = 'ltr';
-    testBed.fixture.detectChanges();
+
+    component.direction = 'ltr';
+    fixture.detectChanges();
     expect(buttonGroupElement.className).toBe('ant-btn-group');
   }));
 });
 
 @Component({
-  template: ` <nz-button-group [nzSize]="nzSize"></nz-button-group> `
+  standalone: true,
+  imports: [NzButtonGroupComponent],
+  template: `<nz-button-group [nzSize]="nzSize"></nz-button-group>`
 })
 export class TestButtonGroupComponent {
   @Input() nzSize: NzButtonGroupSize = 'default';
 }
 
 @Component({
+  standalone: true,
+  imports: [BidiModule, NzButtonGroupComponent],
   template: `
     <div [dir]="direction">
       <nz-button-group></nz-button-group>

--- a/components/color-picker/color-block.component.spec.ts
+++ b/components/color-picker/color-block.component.spec.ts
@@ -1,64 +1,63 @@
 import { Component, DebugElement } from '@angular/core';
-import { ComponentFixture } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { NzColorBlockComponent, NzColorPickerModule } from 'ng-zorro-antd/color-picker';
-import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
 
 describe('nz-color-block', () => {
-  describe('basic', () => {
-    let testBed: ComponentBed<NzTestColorBlockComponent>;
-    let fixture: ComponentFixture<NzTestColorBlockComponent>;
-    let testComponent: NzTestColorBlockComponent;
-    let resultEl: DebugElement;
+  let fixture: ComponentFixture<NzTestColorBlockComponent>;
+  let component: NzTestColorBlockComponent;
+  let resultEl: DebugElement;
 
-    beforeEach(() => {
-      testBed = createComponentBed(NzTestColorBlockComponent, {
-        imports: [NzColorPickerModule]
-      });
-      fixture = testBed.fixture;
-      fixture.detectChanges();
-      testComponent = testBed.component;
-      resultEl = fixture.debugElement.query(By.directive(NzColorBlockComponent));
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideNoopAnimations()]
     });
+    fixture = TestBed.createComponent(NzTestColorBlockComponent);
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+    resultEl = fixture.debugElement.query(By.directive(NzColorBlockComponent));
+  });
 
-    it('color-block basic', () => {
-      fixture.detectChanges();
-      const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
-      expect(colorDom.style.backgroundColor).toBe('rgb(22, 119, 255)');
-    });
+  it('color-block basic', () => {
+    fixture.detectChanges();
+    const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
+    expect(colorDom.style.backgroundColor).toBe('rgb(22, 119, 255)');
+  });
 
-    it('color-block color', () => {
-      testComponent.nzColor = '#ff6600';
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner').style.backgroundColor).toBe(
-        'rgb(255, 102, 0)'
-      );
-    });
+  it('color-block color', () => {
+    component.nzColor = '#ff6600';
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner').style.backgroundColor).toBe(
+      'rgb(255, 102, 0)'
+    );
+  });
 
-    it('color-block size', () => {
-      testComponent.nzSize = 'small';
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.querySelector('ng-antd-color-block').parentNode.classList).toContain(
-        'ant-color-picker-inline-sm'
-      );
-      testComponent.nzSize = 'large';
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.querySelector('ng-antd-color-block').parentNode.classList).toContain(
-        'ant-color-picker-inline-lg'
-      );
-    });
+  it('color-block size', () => {
+    component.nzSize = 'small';
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.querySelector('ng-antd-color-block').parentNode.classList).toContain(
+      'ant-color-picker-inline-sm'
+    );
+    component.nzSize = 'large';
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.querySelector('ng-antd-color-block').parentNode.classList).toContain(
+      'ant-color-picker-inline-lg'
+    );
+  });
 
-    it('color-block click', () => {
-      fixture.detectChanges();
-      resultEl.nativeElement.querySelector('.ant-color-picker-color-block').click();
-      expect(testComponent.isClick).toBeTrue();
-    });
+  it('color-block click', () => {
+    fixture.detectChanges();
+    resultEl.nativeElement.querySelector('.ant-color-picker-color-block').click();
+    expect(component.isClick).toBeTrue();
   });
 });
 
 @Component({
+  standalone: true,
+  imports: [NzColorPickerModule],
   template: `
     <nz-color-block [nzColor]="nzColor" [nzSize]="nzSize" (nzOnClick)="clickHandle($event)"></nz-color-block>
   `

--- a/components/color-picker/color-picker.component.spec.ts
+++ b/components/color-picker/color-picker.component.spec.ts
@@ -1,233 +1,233 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component, DebugElement } from '@angular/core';
-import { ComponentFixture, fakeAsync, inject, tick, discardPeriodicTasks } from '@angular/core/testing';
-import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ComponentFixture, fakeAsync, inject, tick, discardPeriodicTasks, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
+import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzColorPickerComponent, NzColorPickerModule } from 'ng-zorro-antd/color-picker';
 import { NzColor, NzColorPickerFormatType, NzColorPickerTriggerType } from 'ng-zorro-antd/color-picker/typings';
 import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
-import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
 import { NzFormModule } from 'ng-zorro-antd/form';
 
 describe('nz-color-picker', () => {
-  describe('basic', () => {
-    let testBed: ComponentBed<NzTestColorPickerComponent>;
-    let fixture: ComponentFixture<NzTestColorPickerComponent>;
-    let testComponent: NzTestColorPickerComponent;
-    let resultEl: DebugElement;
-    let overlayContainer: OverlayContainer;
-    let overlayContainerElement: HTMLElement;
+  let fixture: ComponentFixture<NzTestColorPickerComponent>;
+  let testComponent: NzTestColorPickerComponent;
+  let resultEl: DebugElement;
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
 
-    function waitingForTooltipToggling(): void {
+  function waitingForTooltipToggling(): void {
+    fixture.detectChanges();
+    tick(500);
+    fixture.detectChanges();
+  }
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [provideNoopAnimations()]
+    });
+    fixture = TestBed.createComponent(NzTestColorPickerComponent);
+    fixture.detectChanges();
+    testComponent = fixture.componentInstance;
+    resultEl = fixture.debugElement.query(By.directive(NzColorPickerComponent));
+  }));
+
+  beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
+    overlayContainer = oc;
+    overlayContainerElement = oc.getContainerElement();
+  }));
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('color-picker basic', () => {
+    fixture.detectChanges();
+    const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
+    expect(colorDom.style.backgroundColor).toBe('rgb(22, 119, 255)');
+  });
+
+  it('color-picker nzValue', () => {
+    testComponent.nzValue = '#ff6600';
+    fixture.detectChanges();
+    const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
+    expect(colorDom.style.backgroundColor).toBe('rgb(255, 102, 0)');
+  });
+
+  it('color-picker nzDefaultValue', () => {
+    testComponent.nzDefaultValue = '#ff6600';
+    fixture.detectChanges();
+    const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
+    expect(colorDom.style.backgroundColor).toBe('rgb(255, 102, 0)');
+  });
+
+  it('color-picker nzSize', () => {
+    testComponent.nzSize = 'small';
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.querySelector('.ant-color-picker-trigger').classList).toContain(
+      'ant-color-picker-sm'
+    );
+    testComponent.nzSize = 'large';
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.querySelector('.ant-color-picker-trigger').classList).toContain(
+      'ant-color-picker-lg'
+    );
+  });
+
+  it('color-picker nzDisabled', () => {
+    testComponent.nzDisabled = true;
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.classList).toContain('ant-color-picker-disabled');
+  });
+
+  it('color-picker nzShowText', () => {
+    testComponent.nzShowText = true;
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.querySelector('.ant-color-picker-trigger-text').innerText).toBe('#1677ff');
+  });
+
+  it('color-picker nzTrigger click', fakeAsync(() => {
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    expect(!!overlayContainerElement.querySelector('.ant-popover-inner-content')).toBeTrue();
+  }));
+
+  it('color-picker nzTrigger hover', fakeAsync(() => {
+    testComponent.nzTrigger = 'hover';
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'mouseenter');
+    waitingForTooltipToggling();
+    expect(!!overlayContainerElement.querySelector('.ant-popover-inner-content')).toBeTrue();
+  }));
+
+  it('color-picker nzOpen', () => {
+    testComponent.nzOpen = true;
+    fixture.detectChanges();
+    expect(!!overlayContainerElement.querySelector('.ant-popover-inner-content')).toBeTrue();
+  });
+
+  it('color-picker nzAllowClear', fakeAsync(() => {
+    testComponent.nzAllowClear = true;
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    expect(!!overlayContainerElement.querySelector('.ant-color-picker-clear')).toBeTrue();
+  }));
+
+  it('color-picker nzTitle', fakeAsync(() => {
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    expect(
+      overlayContainerElement.querySelector('.ant-color-picker-title-content')?.querySelector('span')?.innerText
+    ).toBe('Color Picker');
+  }));
+
+  it('color-picker nzFlipFlop', () => {
+    testComponent.isFlipFlop = true;
+    fixture.detectChanges();
+    expect(!!resultEl.nativeElement.querySelector('button')).toBeTrue();
+  });
+
+  it('color-picker nzFormat', fakeAsync(() => {
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    expect(!!overlayContainerElement.querySelector('.ant-color-picker-hex-input')).toBeTrue();
+    testComponent.nzFormat = 'hsb';
+    fixture.detectChanges();
+    waitingForTooltipToggling();
+    expect(!!overlayContainerElement.querySelector('.ant-color-picker-hsb-input')).toBeTrue();
+    testComponent.nzFormat = 'rgb';
+    fixture.detectChanges();
+    waitingForTooltipToggling();
+    expect(!!overlayContainerElement.querySelector('.ant-color-picker-rgb-input')).toBeTrue();
+  }));
+
+  it('color-picker nzOnOpenChange', fakeAsync(() => {
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    expect(testComponent.openChange).toBeTrue();
+  }));
+
+  it('color-picker nzOnClear', fakeAsync(() => {
+    testComponent.nzAllowClear = true;
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    const clear = overlayContainerElement.querySelector('.ant-color-picker-clear');
+    if (!!clear) {
+      dispatchMouseEvent(clear, 'click');
       fixture.detectChanges();
-      tick(500);
-      fixture.detectChanges();
+      waitingForTooltipToggling();
+      const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
+      expect(colorDom.style.backgroundColor).toBe('rgba(22, 119, 255, 0)');
+      discardPeriodicTasks();
     }
+  }));
 
-    beforeEach(fakeAsync(() => {
-      testBed = createComponentBed(NzTestColorPickerComponent, {
-        imports: [NzColorPickerModule]
-      });
-      fixture = testBed.fixture;
-      fixture.detectChanges();
-      testComponent = testBed.component;
-      resultEl = fixture.debugElement.query(By.directive(NzColorPickerComponent));
-    }));
+  it('color-picker nzOnChange', fakeAsync(() => {
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    const select = overlayContainerElement.querySelector('nz-select') as Element;
+    dispatchMouseEvent(select, 'click');
+    waitingForTooltipToggling();
+    const item = overlayContainerElement.querySelectorAll('nz-option-item')[1];
+    dispatchMouseEvent(item, 'click');
+    waitingForTooltipToggling();
+    expect(testComponent.colorChange?.format).toBe('hsb');
+    expect(testComponent.colorChange?.color.toHsbString()).toBe('hsb(215, 91%, 100%)');
+    discardPeriodicTasks();
+  }));
 
-    beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
-      overlayContainer = oc;
-      overlayContainerElement = oc.getContainerElement();
-    }));
+  it('color-picker disableAlpha', fakeAsync(() => {
+    testComponent.nzAlphaDisabled = true;
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    const alphaSlider = overlayContainerElement.querySelector('.ant-color-picker-slider-alpha') as Element;
+    expect(alphaSlider).toBeFalsy();
+    discardPeriodicTasks();
+  }));
 
-    afterEach(() => {
-      overlayContainer.ngOnDestroy();
-    });
-
-    it('color-picker basic', () => {
-      fixture.detectChanges();
-      const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
-      expect(colorDom.style.backgroundColor).toBe('rgb(22, 119, 255)');
-    });
-
-    it('color-picker nzValue', () => {
-      testComponent.nzValue = '#ff6600';
-      fixture.detectChanges();
-      const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
-      expect(colorDom.style.backgroundColor).toBe('rgb(255, 102, 0)');
-    });
-
-    it('color-picker nzDefaultValue', () => {
-      testComponent.nzDefaultValue = '#ff6600';
-      fixture.detectChanges();
-      const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
-      expect(colorDom.style.backgroundColor).toBe('rgb(255, 102, 0)');
-    });
-
-    it('color-picker nzSize', () => {
-      testComponent.nzSize = 'small';
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.querySelector('.ant-color-picker-trigger').classList).toContain(
-        'ant-color-picker-sm'
-      );
-      testComponent.nzSize = 'large';
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.querySelector('.ant-color-picker-trigger').classList).toContain(
-        'ant-color-picker-lg'
-      );
-    });
-
-    it('color-picker nzDisabled', () => {
-      testComponent.nzDisabled = true;
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.classList).toContain('ant-color-picker-disabled');
-    });
-
-    it('color-picker nzShowText', () => {
-      testComponent.nzShowText = true;
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.querySelector('.ant-color-picker-trigger-text').innerText).toBe('#1677ff');
-    });
-
-    it('color-picker nzTrigger click', fakeAsync(() => {
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      expect(!!overlayContainerElement.querySelector('.ant-popover-inner-content')).toBeTrue();
-    }));
-
-    it('color-picker nzTrigger hover', fakeAsync(() => {
-      testComponent.nzTrigger = 'hover';
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'mouseenter');
-      waitingForTooltipToggling();
-      expect(!!overlayContainerElement.querySelector('.ant-popover-inner-content')).toBeTrue();
-    }));
-
-    it('color-picker nzOpen', () => {
-      testComponent.nzOpen = true;
-      fixture.detectChanges();
-      expect(!!overlayContainerElement.querySelector('.ant-popover-inner-content')).toBeTrue();
-    });
-
-    it('color-picker nzAllowClear', fakeAsync(() => {
-      testComponent.nzAllowClear = true;
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      expect(!!overlayContainerElement.querySelector('.ant-color-picker-clear')).toBeTrue();
-    }));
-
-    it('color-picker nzTitle', fakeAsync(() => {
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      expect(
-        overlayContainerElement.querySelector('.ant-color-picker-title-content')?.querySelector('span')?.innerText
-      ).toBe('Color Picker');
-    }));
-
-    it('color-picker nzFlipFlop', () => {
-      testComponent.isFlipFlop = true;
-      fixture.detectChanges();
-      expect(!!resultEl.nativeElement.querySelector('button')).toBeTrue();
-    });
-
-    it('color-picker nzFormat', fakeAsync(() => {
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      expect(!!overlayContainerElement.querySelector('.ant-color-picker-hex-input')).toBeTrue();
-      testComponent.nzFormat = 'hsb';
-      fixture.detectChanges();
-      waitingForTooltipToggling();
-      expect(!!overlayContainerElement.querySelector('.ant-color-picker-hsb-input')).toBeTrue();
-      testComponent.nzFormat = 'rgb';
-      fixture.detectChanges();
-      waitingForTooltipToggling();
-      expect(!!overlayContainerElement.querySelector('.ant-color-picker-rgb-input')).toBeTrue();
-    }));
-
-    it('color-picker nzOnOpenChange', fakeAsync(() => {
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      expect(testComponent.openChange).toBeTrue();
-    }));
-
-    it('color-picker nzOnClear', fakeAsync(() => {
-      testComponent.nzAllowClear = true;
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      const clear = overlayContainerElement.querySelector('.ant-color-picker-clear');
-      if (!!clear) {
-        dispatchMouseEvent(clear, 'click');
-        fixture.detectChanges();
-        waitingForTooltipToggling();
-        const colorDom = resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner');
-        expect(colorDom.style.backgroundColor).toBe('rgba(22, 119, 255, 0)');
-        discardPeriodicTasks();
-      }
-    }));
-
-    it('color-picker nzOnChange', fakeAsync(() => {
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      const select = overlayContainerElement.querySelector('nz-select') as Element;
-      dispatchMouseEvent(select, 'click');
-      waitingForTooltipToggling();
-      const item = overlayContainerElement.querySelectorAll('nz-option-item')[1];
+  it('nz-color-format disableAlpha', fakeAsync(() => {
+    testComponent.nzAlphaDisabled = true;
+    fixture.detectChanges();
+    const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
+    dispatchMouseEvent(dom, 'click');
+    waitingForTooltipToggling();
+    const select = overlayContainerElement.querySelector('nz-select') as Element;
+    dispatchMouseEvent(select, 'click');
+    waitingForTooltipToggling();
+    const items = overlayContainerElement.querySelectorAll('nz-option-item');
+    items.forEach(item => {
       dispatchMouseEvent(item, 'click');
       waitingForTooltipToggling();
-      expect(testComponent.colorChange?.format).toBe('hsb');
-      expect(testComponent.colorChange?.color.toHsbString()).toBe('hsb(215, 91%, 100%)');
-      discardPeriodicTasks();
-    }));
-
-    it('color-picker disableAlpha', fakeAsync(() => {
-      testComponent.nzAlphaDisabled = true;
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      const alphaSlider = overlayContainerElement.querySelector('.ant-color-picker-slider-alpha') as Element;
-      expect(alphaSlider).toBeFalsy();
-      discardPeriodicTasks();
-    }));
-
-    it('nz-color-format disableAlpha', fakeAsync(() => {
-      testComponent.nzAlphaDisabled = true;
-      fixture.detectChanges();
-      const dom = resultEl.nativeElement.querySelector('.ant-color-picker-trigger');
-      dispatchMouseEvent(dom, 'click');
-      waitingForTooltipToggling();
-      const select = overlayContainerElement.querySelector('nz-select') as Element;
-      dispatchMouseEvent(select, 'click');
-      waitingForTooltipToggling();
-      const items = overlayContainerElement.querySelectorAll('nz-option-item');
-      items.forEach(item => {
-        dispatchMouseEvent(item, 'click');
-        waitingForTooltipToggling();
-        let alphaInputElement = overlayContainerElement.querySelector('.ant-color-picker-alpha-input') as Element;
-        expect(alphaInputElement).toBeFalsy();
-      });
-      discardPeriodicTasks();
-    }));
-  });
+      let alphaInputElement = overlayContainerElement.querySelector('.ant-color-picker-alpha-input') as Element;
+      expect(alphaInputElement).toBeFalsy();
+    });
+    discardPeriodicTasks();
+  }));
 });
 
 @Component({
+  standalone: true,
+  imports: [NzButtonModule, NzColorPickerModule],
   template: `
     <nz-color-picker
       [nzValue]="nzValue"
@@ -285,41 +285,40 @@ export class NzTestColorPickerComponent {
 }
 
 describe('nz-color-picker form', () => {
-  describe('basic', () => {
-    let testBed: ComponentBed<NzTestColorPickerFormComponent>;
-    let fixture: ComponentFixture<NzTestColorPickerFormComponent>;
-    let testComponent: NzTestColorPickerFormComponent;
-    let resultEl: DebugElement;
+  let fixture: ComponentFixture<NzTestColorPickerFormComponent>;
+  let component: NzTestColorPickerFormComponent;
+  let resultEl: DebugElement;
 
-    beforeEach(fakeAsync(() => {
-      testBed = createComponentBed(NzTestColorPickerFormComponent, {
-        imports: [NzColorPickerModule, NzFormModule, ReactiveFormsModule, FormsModule]
-      });
-      fixture = testBed.fixture;
-      fixture.detectChanges();
-      testComponent = testBed.component;
-      resultEl = fixture.debugElement.query(By.directive(NzColorPickerComponent));
-    }));
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [provideNoopAnimations()]
+    });
+    fixture = TestBed.createComponent(NzTestColorPickerFormComponent);
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+    resultEl = fixture.debugElement.query(By.directive(NzColorPickerComponent));
+  }));
 
-    it('color-picker form base', fakeAsync(() => {
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner').style.backgroundColor).toBe(
-        'rgb(255, 102, 0)'
-      );
-    }));
+  it('color-picker form base', fakeAsync(() => {
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.querySelector('.ant-color-picker-color-block-inner').style.backgroundColor).toBe(
+      'rgb(255, 102, 0)'
+    );
+  }));
 
-    it('color-picker form disable', fakeAsync(() => {
-      testComponent.disable();
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.classList).toContain('ant-color-picker-disabled');
-      testComponent.enable();
-      fixture.detectChanges();
-      expect(resultEl.nativeElement.classList).not.toContain('ant-color-picker-disabled');
-    }));
-  });
+  it('color-picker form disable', fakeAsync(() => {
+    component.disable();
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.classList).toContain('ant-color-picker-disabled');
+    component.enable();
+    fixture.detectChanges();
+    expect(resultEl.nativeElement.classList).not.toContain('ant-color-picker-disabled');
+  }));
 });
 
 @Component({
+  standalone: true,
+  imports: [NzColorPickerModule, NzFormModule, ReactiveFormsModule],
   template: `
     <form nz-form [formGroup]="validateForm">
       <nz-form-item>

--- a/components/core/element-patch/element-patch.spec.ts
+++ b/components/core/element-patch/element-patch.spec.ts
@@ -1,30 +1,26 @@
 import { Component, ViewChild } from '@angular/core';
-import { fakeAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { NzButtonModule } from 'ng-zorro-antd/button';
-
-import { ComponentBed, createComponentBed } from '../testing/component-bed';
 import { NzElementPatchDirective } from './element-patch.directive';
-import { NzElementPatchModule } from './element-patch.module';
 
 describe('nz-element', () => {
-  let testBed: ComponentBed<NzTestElementPatchComponent>;
-  let component: NzTestElementPatchComponent;
+  let fixture: ComponentFixture<NzTestElementPatchComponent>;
 
-  beforeEach(fakeAsync(() => {
-    testBed = createComponentBed(NzTestElementPatchComponent, {
-      imports: [NzElementPatchModule, NzButtonModule]
-    });
-    component = testBed.component;
-  }));
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NzTestElementPatchComponent);
+    fixture.detectChanges();
+  });
 
   it('should getters work', () => {
-    expect((component.element.nativeElement as HTMLButtonElement).tagName).toBe('BUTTON');
+    const element = fixture.componentInstance.element.nativeElement as HTMLButtonElement;
+    expect(element.tagName).toBe('BUTTON');
   });
 });
 
 @Component({
-  template: ` <button nz-button nz-element>Action</button> `
+  standalone: true,
+  imports: [NzElementPatchDirective],
+  template: `<button nz-element>Action</button> `
 })
 export class NzTestElementPatchComponent {
   @ViewChild(NzElementPatchDirective) element!: NzElementPatchDirective;

--- a/components/core/form/nz-form-item-feedback-icon.spec.ts
+++ b/components/core/form/nz-form-item-feedback-icon.spec.ts
@@ -1,54 +1,54 @@
-import { Component, DebugElement } from '@angular/core';
-import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { DebugElement, SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
-import { NzFormPatchModule } from 'ng-zorro-antd/core/form/nz-form-patch.module';
-import { ɵComponentBed as ComponentBed, ɵcreateComponentBed as createComponentBed } from 'ng-zorro-antd/core/testing';
 import { NzValidateStatus } from 'ng-zorro-antd/core/types';
+import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 
 import { NzFormItemFeedbackIconComponent } from './nz-form-item-feedback-icon.component';
 
-const testBedOptions = { imports: [NzFormPatchModule, NoopAnimationsModule] };
-
 describe('nz-form-item-feedback-icon', () => {
-  describe('default', () => {
-    let testBed: ComponentBed<NzTestFormItemFeedbackIconComponent>;
-    let fixtureInstance: NzTestFormItemFeedbackIconComponent;
-    let feedback: DebugElement;
-    beforeEach(() => {
-      testBed = createComponentBed(NzTestFormItemFeedbackIconComponent, testBedOptions);
-      fixtureInstance = testBed.fixture.componentInstance;
-      feedback = testBed.fixture.debugElement.query(By.directive(NzFormItemFeedbackIconComponent));
-      testBed.fixture.detectChanges();
+  let fixture: ComponentFixture<NzFormItemFeedbackIconComponent>;
+  let component: NzFormItemFeedbackIconComponent;
+  let feedback: DebugElement;
+  let firstChange = true;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideNoopAnimations(), provideNzIconsTesting()]
     });
-    it('should className correct', () => {
-      expect(feedback.nativeElement.classList).toContain('ant-form-item-feedback-icon');
-      fixtureInstance.status = 'success';
-      testBed.fixture.detectChanges();
-      expect(feedback.nativeElement.classList).toContain('ant-form-item-feedback-icon-success');
-      expect(feedback.nativeElement.querySelector('.anticon-check-circle-fill')).toBeTruthy();
+    fixture = TestBed.createComponent(NzFormItemFeedbackIconComponent);
+    component = fixture.componentInstance;
+    feedback = fixture.debugElement;
+    fixture.detectChanges();
+  });
 
-      fixtureInstance.status = 'error';
-      testBed.fixture.detectChanges();
-      expect(feedback.nativeElement.classList).toContain('ant-form-item-feedback-icon-error');
-      expect(feedback.nativeElement.querySelector('.anticon-close-circle-fill')).toBeTruthy();
+  function changeStatus(status: NzValidateStatus): void {
+    const previousStatus: NzValidateStatus = component.status;
+    component.status = status;
+    component.ngOnChanges({ status: new SimpleChange(previousStatus, status, firstChange) });
+    firstChange = false;
+    fixture.detectChanges();
+  }
 
-      fixtureInstance.status = 'warning';
-      testBed.fixture.detectChanges();
-      expect(feedback.nativeElement.classList).toContain('ant-form-item-feedback-icon-warning');
-      expect(feedback.nativeElement.querySelector('.anticon-exclamation-circle-fill')).toBeTruthy();
+  it('should className correct', () => {
+    changeStatus('');
+    expect(fixture.nativeElement.classList).toContain('ant-form-item-feedback-icon');
 
-      fixtureInstance.status = 'validating';
-      testBed.fixture.detectChanges();
-      expect(feedback.nativeElement.classList).toContain('ant-form-item-feedback-icon-validating');
-      expect(feedback.nativeElement.querySelector('.anticon-loading')).toBeTruthy();
-    });
+    changeStatus('success');
+    expect(fixture.nativeElement.classList).toContain('ant-form-item-feedback-icon-success');
+    expect(fixture.nativeElement.querySelector('.anticon-check-circle-fill')).toBeTruthy();
+
+    changeStatus('error');
+    expect(feedback.nativeElement.classList).toContain('ant-form-item-feedback-icon-error');
+    expect(feedback.nativeElement.querySelector('.anticon-close-circle-fill')).toBeTruthy();
+
+    changeStatus('warning');
+    expect(feedback.nativeElement.classList).toContain('ant-form-item-feedback-icon-warning');
+    expect(feedback.nativeElement.querySelector('.anticon-exclamation-circle-fill')).toBeTruthy();
+
+    changeStatus('validating');
+    expect(feedback.nativeElement.classList).toContain('ant-form-item-feedback-icon-validating');
+    expect(feedback.nativeElement.querySelector('.anticon-loading')).toBeTruthy();
   });
 });
-
-@Component({
-  template: ` <nz-form-item-feedback-icon [status]="status"></nz-form-item-feedback-icon> `
-})
-export class NzTestFormItemFeedbackIconComponent {
-  status: NzValidateStatus = '';
-}

--- a/components/core/outlet/string_template_outlet.spec.ts
+++ b/components/core/outlet/string_template_outlet.spec.ts
@@ -1,113 +1,123 @@
 import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ɵcreateComponentBed as createComponentBed } from 'ng-zorro-antd/core/testing';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 import { NzOutletModule } from './outlet.module';
 import { NzStringTemplateOutletDirective } from './string_template_outlet.directive';
 
 describe('string template outlet', () => {
+  let fixture: ComponentFixture<StringTemplateOutletTestComponent>;
+  let component: StringTemplateOutletTestComponent;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StringTemplateOutletTestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
   describe('null', () => {
     it('should no error when null', () => {
-      const testBed = createComponentBed(StringTemplateOutletTestComponent, { imports: [NzOutletModule] });
-      expect(testBed.nativeElement.innerText).toBe('TargetText');
+      expect(fixture.nativeElement.innerText).toBe('TargetText');
     });
   });
+
   describe('outlet change', () => {
     it('should work when switch between null and string', () => {
-      const testBed = createComponentBed(StringTemplateOutletTestComponent, { imports: [NzOutletModule] });
-      testBed.component.stringTemplateOutlet = 'String Testing';
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText String Testing');
-      testBed.component.stringTemplateOutlet = null;
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText');
+      component.stringTemplateOutlet = 'String Testing';
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText String Testing');
+      component.stringTemplateOutlet = null;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText');
     });
+
     it('should work when switch between null and template', () => {
-      const testBed = createComponentBed(StringTemplateOutletTestComponent, { imports: [NzOutletModule] });
-      testBed.component.stringTemplateOutlet = testBed.component.stringTpl;
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText The data is');
-      testBed.component.stringTemplateOutlet = null;
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText');
+      component.stringTemplateOutlet = component.stringTpl;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText The data is');
+      component.stringTemplateOutlet = null;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText');
     });
+
     it('should work when switch between string', () => {
-      const testBed = createComponentBed(StringTemplateOutletTestComponent, { imports: [NzOutletModule] });
-      testBed.component.stringTemplateOutlet = 'String Testing';
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText String Testing');
-      testBed.component.stringTemplateOutlet = 'String String';
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText String String');
+      component.stringTemplateOutlet = 'String Testing';
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText String Testing');
+      component.stringTemplateOutlet = 'String String';
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText String String');
     });
+
     it('should work when switch between string and template', () => {
-      const testBed = createComponentBed(StringTemplateOutletTestComponent, { imports: [NzOutletModule] });
-      testBed.component.stringTemplateOutlet = 'String Testing';
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText String Testing');
-      testBed.component.stringTemplateOutlet = testBed.component.stringTpl;
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText The data is');
-      testBed.component.stringTemplateOutlet = 'String Testing';
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText String Testing');
+      component.stringTemplateOutlet = 'String Testing';
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText String Testing');
+      component.stringTemplateOutlet = component.stringTpl;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText The data is');
+      component.stringTemplateOutlet = 'String Testing';
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText String Testing');
     });
+
     it('should work when switch between template', () => {
-      const testBed = createComponentBed(StringTemplateOutletTestComponent, { imports: [NzOutletModule] });
-      testBed.component.stringTemplateOutlet = testBed.component.stringTpl;
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText The data is');
-      testBed.component.stringTemplateOutlet = testBed.component.emptyTpl;
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText Empty Template');
+      component.stringTemplateOutlet = component.stringTpl;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText The data is');
+      component.stringTemplateOutlet = component.emptyTpl;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText Empty Template');
     });
   });
+
   describe('context shape change', () => {
     it('should work when context shape change', () => {
-      const testBed = createComponentBed(StringTemplateOutletTestComponent, { imports: [NzOutletModule] });
-      testBed.component.stringTemplateOutlet = testBed.component.dataTimeTpl;
+      component.stringTemplateOutlet = component.dataTimeTpl;
       const spyOnUpdateContext = spyOn(
-        testBed.component.nzStringTemplateOutletDirective as NzSafeAny,
+        component.nzStringTemplateOutletDirective as NzSafeAny,
         'updateContext'
       ).and.callThrough();
       const spyOnRecreateView = spyOn(
-        testBed.component.nzStringTemplateOutletDirective as NzSafeAny,
+        component.nzStringTemplateOutletDirective as NzSafeAny,
         'recreateView'
       ).and.callThrough();
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText The data is , The time is');
-      testBed.component.context = { $implicit: 'data', time: 'time' };
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText The data is , The time is');
+      component.context = { $implicit: 'data', time: 'time' };
+      fixture.detectChanges();
       expect(spyOnUpdateContext).toHaveBeenCalledTimes(0);
       expect(spyOnRecreateView).toHaveBeenCalledTimes(2);
-      expect(testBed.nativeElement.innerText).toBe('TargetText The data is data, The time is time');
+      expect(fixture.nativeElement.innerText).toBe('TargetText The data is data, The time is time');
     });
   });
+
   describe('context data change', () => {
     it('should work when context implicit change', () => {
-      const testBed = createComponentBed(StringTemplateOutletTestComponent, { imports: [NzOutletModule] });
-      testBed.component.stringTemplateOutlet = testBed.component.stringTpl;
+      component.stringTemplateOutlet = component.stringTpl;
       const spyOnUpdateContext = spyOn(
-        testBed.component.nzStringTemplateOutletDirective as NzSafeAny,
+        component.nzStringTemplateOutletDirective as NzSafeAny,
         'updateContext'
       ).and.callThrough();
       const spyOnRecreateView = spyOn(
-        testBed.component.nzStringTemplateOutletDirective as NzSafeAny,
+        component.nzStringTemplateOutletDirective as NzSafeAny,
         'recreateView'
       ).and.callThrough();
-      testBed.fixture.detectChanges();
-      expect(testBed.nativeElement.innerText).toBe('TargetText The data is');
-      testBed.component.context = { $implicit: 'data' };
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerText).toBe('TargetText The data is');
+      component.context = { $implicit: 'data' };
+      fixture.detectChanges();
       expect(spyOnUpdateContext).toHaveBeenCalledTimes(1);
       expect(spyOnRecreateView).toHaveBeenCalledTimes(1);
-      expect(testBed.nativeElement.innerText).toBe('TargetText The data is data');
+      expect(fixture.nativeElement.innerText).toBe('TargetText The data is data');
     });
   });
 });
 
 @Component({
+  standalone: true,
+  imports: [NzOutletModule],
   template: `
     TargetText
     <ng-container *nzStringTemplateOutlet="stringTemplateOutlet; context: context; let stringTemplateOutlet">

--- a/components/core/testing/component-bed.ts
+++ b/components/core/testing/component-bed.ts
@@ -9,6 +9,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 type ComponentBedOptions = Pick<NgModule, 'providers' | 'declarations' | 'imports'>;
+
+/**
+ * @internal
+ * @deprecated Internal use only, do not use directly. Will be removed in v20
+ */
 export interface ComponentBed<T> {
   bed: TestBed;
   fixture: ComponentFixture<T>;
@@ -16,6 +21,11 @@ export interface ComponentBed<T> {
   debugElement: DebugElement;
   component: T;
 }
+
+/**
+ * @internal
+ * @deprecated Internal use only, do not use directly. Will be removed in v20
+ */
 export function createComponentBed<T>(
   component: Type<T>,
   options: ComponentBedOptions = {

--- a/components/core/testing/fake-viewport-ruler.ts
+++ b/components/core/testing/fake-viewport-ruler.ts
@@ -22,7 +22,10 @@ interface FakeViewportScrollPosition {
   left: number;
 }
 
-/** @docs-private */
+/**
+ * @internal
+ * @deprecated Internal use only, do not use directly. Will be removed in v20
+ */
 export class FakeViewportRuler {
   getViewportRect(): FakeViewportRect {
     return {

--- a/components/core/testing/wrapped-error-message.ts
+++ b/components/core/testing/wrapped-error-message.ts
@@ -6,6 +6,9 @@
 /**
  * Gets a RegExp used to detect an angular wrapped error message.
  * See https://github.com/angular/angular/issues/8348
+ *
+ * @internal
+ * @deprecated Internal use only, do not use directly. Will be removed in v20
  */
 export function wrappedErrorMessage(e: Error): RegExp {
   const escapedMessage = e.message.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');

--- a/components/core/transition-patch/transition-patch.spec.ts
+++ b/components/core/transition-patch/transition-patch.spec.ts
@@ -4,70 +4,81 @@
  */
 
 import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ɵcreateComponentBed as createComponentBed } from 'ng-zorro-antd/core/testing';
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { NzButtonModule } from 'ng-zorro-antd/button';
 
 import { NzTransitionPatchDirective } from './transition-patch.directive';
 import { NzTransitionPatchModule } from './transition-patch.module';
 
 describe('transition-patch', () => {
   it('should visible after afterViewInit', () => {
-    const testBed = createComponentBed(TestTransitionPatchComponent, { imports: [NzTransitionPatchModule] });
-    const buttonElement = testBed.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
+    const fixture = TestBed.createComponent(TestTransitionPatchComponent);
+    const buttonElement = fixture.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
     expect(buttonElement.getAttribute('hidden')).toBeFalsy();
   });
+
   it('should hidden after afterViewInit', () => {
-    const testBed = createComponentBed(TestTransitionPatchHiddenComponent, { imports: [NzTransitionPatchModule] });
-    const buttonElement = testBed.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
+    const fixture = TestBed.createComponent(TestTransitionPatchHiddenComponent);
+    const buttonElement = fixture.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
     expect(buttonElement.getAttribute('hidden')).toBeFalsy();
   });
+
   it('should restore after afterViewInit', () => {
-    const testBed = createComponentBed(TestTransitionPatchRestoreComponent, { imports: [NzTransitionPatchModule] });
-    const buttonElement = testBed.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
+    const fixture = TestBed.createComponent(TestTransitionPatchRestoreComponent);
+    fixture.detectChanges();
+    const buttonElement = fixture.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
     expect(buttonElement.getAttribute('hidden')).toBe('abc');
   });
+
   it('should work if hidden binding', () => {
-    const testBed = createComponentBed(TestTransitionPatchHiddenBindingComponent, {
-      imports: [NzTransitionPatchModule]
-    });
-    const buttonElement = testBed.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
+    const fixture = TestBed.createComponent(TestTransitionPatchHiddenBindingComponent);
+    const component = fixture.componentInstance;
+    const buttonElement = fixture.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
     expect(buttonElement.getAttribute('hidden')).toBeFalsy();
-    testBed.component.hidden = true;
-    testBed.fixture.detectChanges();
+    component.hidden = true;
+    fixture.detectChanges();
     expect(buttonElement.getAttribute('hidden')).toBe('');
   });
+
   it('should work if hidden binding with undefined', () => {
-    const testBed = createComponentBed(TestTransitionPatchHiddenBindingComponent, {
-      imports: [NzTransitionPatchModule]
-    });
-    const buttonElement = testBed.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
+    const fixture = TestBed.createComponent(TestTransitionPatchHiddenBindingComponent);
+    const component = fixture.componentInstance;
+    const buttonElement = fixture.debugElement.query(By.directive(NzTransitionPatchDirective)).nativeElement;
     expect(buttonElement.getAttribute('hidden')).toBeFalsy();
-    testBed.component.hidden = undefined;
-    testBed.fixture.detectChanges();
+    component.hidden = undefined;
+    fixture.detectChanges();
     expect(buttonElement.hasAttribute('hidden')).toBeFalse();
   });
 });
 
 @Component({
-  template: ` <button nz-button></button> `
+  standalone: true,
+  imports: [NzButtonModule, NzTransitionPatchModule],
+  template: `<button nz-button></button>`
 })
 export class TestTransitionPatchComponent {}
 
 @Component({
-  template: ` <button nz-button hidden></button> `
+  standalone: true,
+  imports: [NzButtonModule, NzTransitionPatchModule],
+  template: `<button nz-button hidden></button>`
 })
 export class TestTransitionPatchHiddenComponent {}
 
 @Component({
-  template: ` <button nz-button hidden="abc"></button> `
+  standalone: true,
+  imports: [NzButtonModule, NzTransitionPatchModule],
+  template: `<button nz-button hidden="abc"></button>`
 })
 export class TestTransitionPatchRestoreComponent {}
 
 @Component({
-  template: ` <button nz-button [hidden]="hidden"></button> `
+  standalone: true,
+  imports: [NzButtonModule, NzTransitionPatchModule],
+  template: `<button nz-button [hidden]="hidden"></button>`
 })
 export class TestTransitionPatchHiddenBindingComponent {
-  hidden: NzSafeAny = false;
+  hidden?: boolean = false;
 }

--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -1,13 +1,10 @@
-import { Directionality } from '@angular/cdk/bidi';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { registerLocaleData } from '@angular/common';
-import zh from '@angular/common/locales/zh';
 import { ApplicationRef, Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
 import { FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import isEqual from 'date-fns/isEqual';
 import isSameDay from 'date-fns/isSameDay';
@@ -19,20 +16,16 @@ import {
   dispatchMouseEvent,
   typeInElement
 } from 'ng-zorro-antd/core/testing';
-import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
-import { NgStyleInterface, NzStatus } from 'ng-zorro-antd/core/types';
+import { NgStyleInterface, NzSafeAny, NzStatus } from 'ng-zorro-antd/core/types';
 import { NzFormModule } from 'ng-zorro-antd/form';
-import { NZ_DATE_LOCALE, NzI18nModule, NzI18nService } from 'ng-zorro-antd/i18n';
+import { NZ_DATE_LOCALE, NzI18nService } from 'ng-zorro-antd/i18n';
 import en_US from 'ng-zorro-antd/i18n/languages/en_US';
-import { NzIconTestModule } from 'ng-zorro-antd/icon/testing';
 
 import { NzDatePickerComponent, NzDatePickerSizeType, NzPlacement } from './date-picker.component';
 import { NzDatePickerModule } from './date-picker.module';
 import { CompatibleDate, NzPanelChangeType } from './standard-types';
 import { ENTER_EVENT, getPickerAbstract, getPickerInput } from './testing/util';
 import { PREFIX_CLASS } from './util';
-
-registerLocaleData(zh);
 
 describe('NzDatePickerComponent', () => {
   let fixture: ComponentFixture<NzTestDatePickerComponent>;
@@ -42,19 +35,11 @@ describe('NzDatePickerComponent', () => {
   let overlayContainerElement: HTMLElement;
   let i18nService: NzI18nService;
 
-  beforeEach(fakeAsync(() => {
-    const dir = 'ltr';
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule, NoopAnimationsModule, NzDatePickerModule, NzI18nModule, ReactiveFormsModule],
-      providers: [
-        { provide: Directionality, useFactory: () => ({ value: dir }) }
-        // { provide: NZ_DATE_CONFIG, useValue: { firstDayOfWeek: 1 } }
-      ],
-      declarations: [NzTestDatePickerComponent]
+      providers: [provideNoopAnimations()]
     });
-
-    TestBed.compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NzTestDatePickerComponent);
@@ -186,6 +171,7 @@ describe('NzDatePickerComponent', () => {
       expect(isSameDay(new Date('2021-04-12'), result)).toBeTruthy();
       expect(getPickerContainer()).toBeNull();
     }));
+
     it("should not send onChangeEvent if value doesn't change", fakeAsync(() => {
       const nzOnChange = spyOn(fixtureInstance, 'nzOnChange');
       fixtureInstance.useSuite = 5;
@@ -210,7 +196,6 @@ describe('NzDatePickerComponent', () => {
       fixture.detectChanges();
       expect(getPickerInput(fixture.debugElement).placeholder).toBe('请选择日期');
       i18nService.setLocale(en_US);
-      // i18nService.setDateLocale(en);
       fixture.detectChanges();
       expect(getPickerInput(fixture.debugElement).placeholder).toBe('Select date');
 
@@ -881,8 +866,7 @@ describe('NzDatePickerComponent', () => {
 
     it('should support nzShowTime', fakeAsync(() => {
       fixtureInstance.nzValue = new Date('2018-11-11 11:22:33');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fixtureInstance.nzShowTime = '' as any;
+      fixtureInstance.nzShowTime = '' as NzSafeAny;
       fixture.detectChanges();
       openPickerByClickTrigger();
       flush();
@@ -1154,6 +1138,7 @@ describe('NzDatePickerComponent', () => {
       fixture.detectChanges();
       expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({ mode: 'date', date: new Date('2020-12-01') });
     }));
+
     it('should support nzOnPanelChange when super next button is clicked', fakeAsync(() => {
       fixtureInstance.nzValue = new Date('2020-11-01');
       spyOn(fixtureInstance, 'nzOnPanelChange');
@@ -1165,6 +1150,7 @@ describe('NzDatePickerComponent', () => {
       fixture.detectChanges();
       expect(fixtureInstance.nzOnPanelChange).toHaveBeenCalledWith({ mode: 'date', date: new Date('2021-11-01') });
     }));
+
     it('should support nzOnPanelChange when previous button is clicked', fakeAsync(() => {
       fixtureInstance.nzValue = new Date('2020-11-01 11:22:33');
       spyOn(fixtureInstance, 'nzOnPanelChange');
@@ -1179,6 +1165,7 @@ describe('NzDatePickerComponent', () => {
         date: new Date('2020-10-01 11:22:33')
       });
     }));
+
     it('should support nzOnPanelChange when super previous button is clicked', fakeAsync(() => {
       fixtureInstance.nzValue = new Date('2020-11-01 11:22:33');
       spyOn(fixtureInstance, 'nzOnPanelChange');
@@ -1316,8 +1303,6 @@ describe('NzDatePickerComponent', () => {
     }));
   });
 
-  ////////////
-
   function getPickerContainer(): HTMLElement {
     return queryFromOverlay(`.${PREFIX_CLASS}-panel-container`) as HTMLElement;
   }
@@ -1359,11 +1344,8 @@ describe('date-fns testing', () => {
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule, NoopAnimationsModule, NzDatePickerModule, NzI18nModule],
-      providers: [{ provide: NZ_DATE_LOCALE, useValue: enUS }],
-      declarations: [NzTestDatePickerComponent]
+      providers: [provideNoopAnimations(), { provide: NZ_DATE_LOCALE, useValue: enUS }]
     });
-    TestBed.compileComponents();
   }));
 
   beforeEach(() => {
@@ -1381,11 +1363,13 @@ describe('date-fns testing', () => {
     tick(500);
     fixture.detectChanges();
     const input = getPickerInput(fixture.debugElement);
+    expect(input).not.toBeNull();
     typeInElement('25.10.2019', input);
     fixture.detectChanges();
     input.dispatchEvent(ENTER_EVENT);
     fixture.detectChanges();
     flush();
+    expect(nzOnChange).toHaveBeenCalled();
     const result = (nzOnChange.calls.allArgs()[0] as Date[])[0];
     expect(result.getFullYear()).toBe(2019);
     expect(result.getMonth() + 1).toBe(10);
@@ -1394,17 +1378,23 @@ describe('date-fns testing', () => {
 });
 
 describe('status', () => {
-  let testBed: ComponentBed<NzTestDatePickerStatusComponent>;
   let fixture: ComponentFixture<NzTestDatePickerStatusComponent>;
   let fixtureInstance: NzTestDatePickerStatusComponent;
   let datePickerElement!: HTMLElement;
+
   beforeEach(() => {
-    testBed = createComponentBed(NzTestDatePickerStatusComponent, { imports: [NzDatePickerModule, NzIconTestModule] });
-    fixture = testBed.fixture;
+    TestBed.configureTestingModule({
+      providers: [provideNoopAnimations()]
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NzTestDatePickerStatusComponent);
     fixtureInstance = fixture.componentInstance;
     datePickerElement = fixture.debugElement.query(By.directive(NzDatePickerComponent)).nativeElement;
     fixture.detectChanges();
   });
+
   it('should classname correct', () => {
     expect(datePickerElement.classList).toContain('ant-picker-status-error');
 
@@ -1419,21 +1409,25 @@ describe('status', () => {
 });
 
 describe('in form', () => {
-  let testBed: ComponentBed<NzTestDatePickerInFormComponent>;
   let fixture: ComponentFixture<NzTestDatePickerInFormComponent>;
   let datePickerElement!: HTMLElement;
   let formGroup: FormGroup<{
     demo: FormControl<Date | null>;
   }>;
+
   beforeEach(() => {
-    testBed = createComponentBed(NzTestDatePickerInFormComponent, {
-      imports: [NzDatePickerModule, NzIconTestModule, NzFormModule, ReactiveFormsModule, FormsModule]
+    TestBed.configureTestingModule({
+      providers: [provideNoopAnimations()]
     });
-    fixture = testBed.fixture;
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NzTestDatePickerInFormComponent);
     datePickerElement = fixture.debugElement.query(By.directive(NzDatePickerComponent)).nativeElement;
     formGroup = fixture.componentInstance.validateForm;
     fixture.detectChanges();
   });
+
   it('should classname correct', () => {
     expect(datePickerElement.classList).not.toContain('ant-picker-status-error');
     expect(datePickerElement.querySelector('nz-form-item-feedback-icon')).toBeNull();
@@ -1462,6 +1456,8 @@ describe('in form', () => {
 });
 
 @Component({
+  standalone: true,
+  imports: [ReactiveFormsModule, FormsModule, NzDatePickerModule],
   template: `
     @switch (useSuite) {
       @case (1) {
@@ -1533,7 +1529,7 @@ class NzTestDatePickerComponent {
   nzInputReadOnly: boolean = false;
   nzFormat!: string;
   nzDisabledDate!: (d: Date) => boolean;
-  nzLocale: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  nzLocale: NzSafeAny;
   nzPlaceHolder!: string;
   nzPopupStyle!: NgStyleInterface;
   nzDropdownClassName!: string;
@@ -1547,9 +1543,9 @@ class NzTestDatePickerComponent {
 
   nzValue: Date | null = null;
   nzDefaultPickerValue: Date | null = null;
-  nzDateRender: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  nzDateRender: NzSafeAny;
   nzShowTime: boolean | object = false;
-  nzDisabledTime: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  nzDisabledTime: NzSafeAny;
   nzRenderExtraFooter!: string | (() => TemplateRef<void> | string);
   nzShowToday = false;
   nzShowNow = false;
@@ -1581,13 +1577,17 @@ class NzTestDatePickerComponent {
 }
 
 @Component({
-  template: ` <nz-date-picker [nzStatus]="status"></nz-date-picker> `
+  standalone: true,
+  imports: [NzDatePickerModule],
+  template: `<nz-date-picker [nzStatus]="status"></nz-date-picker>`
 })
 class NzTestDatePickerStatusComponent {
   status: NzStatus = 'error';
 }
 
 @Component({
+  standalone: true,
+  imports: [ReactiveFormsModule, NzFormModule, NzDatePickerModule],
   template: `
     <form nz-form [formGroup]="validateForm">
       <nz-form-item>

--- a/components/flex/flex.spec.ts
+++ b/components/flex/flex.spec.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ɵComponentBed as ComponentBed, ɵcreateComponentBed as createComponentBed } from 'ng-zorro-antd/core/testing';
 import {
   NzAlign,
   NzCustomGap,
@@ -17,23 +17,30 @@ import { NzFlexModule } from 'ng-zorro-antd/flex/flex.module';
 import { NzFlexDirective } from 'ng-zorro-antd/flex/nz-flex.directive';
 
 describe('flex', () => {
+  let fixture: ComponentFixture<TestFlexComponent>;
+  let component: TestFlexComponent;
   let element: HTMLElement;
-  let testBed: ComponentBed<TestFlexComponent>;
+
   beforeEach(() => {
-    testBed = createComponentBed(TestFlexComponent, { imports: [NzFlexModule] });
-    element = testBed.debugElement.query(By.directive(NzFlexDirective)).nativeElement;
+    fixture = TestBed.createComponent(TestFlexComponent);
+    element = fixture.debugElement.query(By.directive(NzFlexDirective)).nativeElement;
+    component = fixture.componentInstance;
+    fixture.detectChanges();
   });
+
   it('should apply className', () => {
     expect(element.className).toContain('ant-flex');
   });
+
   it('should have correct direction', () => {
-    testBed.component.isVertical = false;
-    testBed.fixture.detectChanges();
+    component.isVertical = false;
+    fixture.detectChanges();
     expect(element.className).not.toContain('vertical');
-    testBed.component.isVertical = true;
-    testBed.fixture.detectChanges();
+    component.isVertical = true;
+    fixture.detectChanges();
     expect(element.className).toContain('vertical');
   });
+
   it('should have correct justification value', () => {
     const listOfJustifications: NzJustify[] = [
       'flex-start',
@@ -50,24 +57,26 @@ describe('flex', () => {
       'normal'
     ];
     listOfJustifications.forEach(justification => {
-      testBed.component.justify = justification;
-      testBed.fixture.detectChanges();
+      component.justify = justification;
+      fixture.detectChanges();
       expect(element.className).toContain(justification);
     });
   });
+
   it('should have correct alignment value', () => {
     const listOfAlignments: NzAlign[] = ['flex-start', 'center', 'flex-end', 'start', 'end', 'stretch', 'normal'];
     listOfAlignments.forEach(alignment => {
-      testBed.component.align = alignment;
-      testBed.fixture.detectChanges();
+      component.align = alignment;
+      fixture.detectChanges();
       expect(element.className).toContain(alignment);
     });
   });
+
   it('should have correct gap value', () => {
     const listOfGaps: NzGap[] = ['small', 'middle', 'large', 10, 20, 30, 40];
     listOfGaps.forEach(gap => {
-      testBed.component.gap = gap;
-      testBed.fixture.detectChanges();
+      component.gap = gap;
+      fixture.detectChanges();
       let gapValue: string;
       switch (gap) {
         case 'small':
@@ -86,51 +95,61 @@ describe('flex', () => {
       expect(getComputedStyle(element).getPropertyValue('gap')).toEqual(gapValue);
     });
 
-    testBed.component.gap = '10rem';
-    testBed.fixture.detectChanges();
+    component.gap = '10rem';
+    fixture.detectChanges();
     expect(getComputedStyle(element).getPropertyValue('gap')).toEqual(`${10 * 16}px`);
   });
+
   it('should have correct wrap value', () => {
     const listOfWraps: NzWrap[] = ['wrap', 'nowrap', 'wrap-reverse'];
     listOfWraps.forEach(wrap => {
-      testBed.component.wrap = wrap;
-      testBed.fixture.detectChanges();
+      component.wrap = wrap;
+      fixture.detectChanges();
       expect(element.className).toContain(`flex-wrap-${wrap}`);
     });
   });
+
   it('should have correct flex value', () => {
     const listOfFlexes: NzFlex[] = ['0 0 auto', '1 1 100%', '0 1 50px'];
     listOfFlexes.forEach(flex => {
-      testBed.component.flex = flex;
-      testBed.fixture.detectChanges();
+      component.flex = flex;
+      fixture.detectChanges();
       expect(getComputedStyle(element).getPropertyValue('flex')).toEqual(flex);
     });
 
-    testBed.component.flex = '1 0 50rem';
-    testBed.fixture.detectChanges();
+    component.flex = '1 0 50rem';
+    fixture.detectChanges();
     expect(getComputedStyle(element).getPropertyValue('flex')).toEqual('1 0 800px');
   });
+
   it('should have initial value for nzVertical', () => {
     expect(element.className).not.toContain('vertical');
   });
+
   it('should have initial value for justification', () => {
     expect(element.className).toContain('normal');
   });
+
   it('should have initial value for alignment', () => {
     expect(element.className).toContain('normal');
   });
+
   it('should have initial value for gap', () => {
     expect(getComputedStyle(element).getPropertyValue('gap')).toEqual('0px');
   });
+
   it('should have initial value for wrap', () => {
     expect(element.className).toContain('nowrap');
   });
+
   it('should have initial value for flex', () => {
     expect(getComputedStyle(element).getPropertyValue('--flex')).toEqual('');
   });
 });
 
 @Component({
+  standalone: true,
+  imports: [NzFlexModule],
   template: `
     <div
       nz-flex

--- a/components/grid/grid.spec.ts
+++ b/components/grid/grid.spec.ts
@@ -1,9 +1,8 @@
 import { BidiModule, Dir, Direction } from '@angular/cdk/bidi';
 import { Component, ViewChild } from '@angular/core';
-import { fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ɵComponentBed as ComponentBed, ɵcreateComponentBed as createComponentBed } from 'ng-zorro-antd/core/testing';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 import { EmbeddedProperty, NzColDirective } from './col.directive';
@@ -19,92 +18,105 @@ const setWindowWidth = (width: number): void => {
 
 describe('grid', () => {
   describe('row', () => {
+    let fixture: ComponentFixture<TestGridComponent>;
+    let component: TestGridComponent;
     let rowElement: HTMLElement;
     let colElement: HTMLElement;
-    let testBed: ComponentBed<TestGridComponent>;
+
     beforeEach(() => {
-      testBed = createComponentBed(TestGridComponent, { imports: [NzGridModule] });
-      rowElement = testBed.debugElement.query(By.directive(NzRowDirective)).nativeElement;
-      colElement = testBed.debugElement.query(By.directive(NzColDirective)).nativeElement;
+      fixture = TestBed.createComponent(TestGridComponent);
+      component = fixture.componentInstance;
+      rowElement = fixture.debugElement.query(By.directive(NzRowDirective)).nativeElement;
+      colElement = fixture.debugElement.query(By.directive(NzColDirective)).nativeElement;
     });
+
     it('should apply className', () => {
       expect(rowElement.className).toBe('ant-row');
     });
+
     it('should apply className according to align', () => {
       const listOfAlign: NzAlign[] = ['top', 'middle', 'bottom'];
       listOfAlign.forEach(align => {
-        testBed.component.align = align;
-        testBed.fixture.detectChanges();
+        component.align = align;
+        fixture.detectChanges();
         expect(rowElement.classList).toContain(`ant-row-${align}`);
       });
     });
+
     it('should apply className according to justify', () => {
       const listOfJustify: NzJustify[] = ['start', 'end', 'center', 'space-around', 'space-between'];
       listOfJustify.forEach(justify => {
-        testBed.component.justify = justify;
-        testBed.fixture.detectChanges();
+        component.justify = justify;
+        fixture.detectChanges();
         expect(rowElement.classList).toContain(`ant-row-${justify}`);
       });
     });
+
     it('should gutter number work', () => {
       expect(rowElement.style.cssText).toBe('');
       expect(colElement.style.cssText).toBe('');
-      testBed.component.gutter = 16;
-      testBed.fixture.detectChanges();
+      component.gutter = 16;
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin-left: -8px; margin-right: -8px;');
       expect(colElement.style.cssText).toBe('padding-left: 8px; padding-right: 8px;');
     });
+
     it('should gutter string work', () => {
       expect(rowElement.style.cssText).toBe('');
       expect(colElement.style.cssText).toBe('');
-      testBed.component.gutter = '16';
-      testBed.fixture.detectChanges();
+      component.gutter = '16';
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin-left: -8px; margin-right: -8px;');
       expect(colElement.style.cssText).toBe('padding-left: 8px; padding-right: 8px;');
     });
+
     it('should gutter number array work', () => {
-      testBed.component.gutter = [16, 16];
-      testBed.fixture.detectChanges();
+      component.gutter = [16, 16];
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin: -8px;');
       expect(colElement.style.cssText).toBe('padding: 8px;');
     });
+
     it('should gutter responsive work', fakeAsync(() => {
-      testBed.component.gutter = { xs: 8, sm: 16, md: 24 };
+      component.gutter = { xs: 8, sm: 16, md: 24 };
       setWindowWidth(480);
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin-left: -4px; margin-right: -4px;');
       expect(colElement.style.cssText).toBe('padding-left: 4px; padding-right: 4px;');
       setWindowWidth(600);
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin-left: -8px; margin-right: -8px;');
       expect(colElement.style.cssText).toBe('padding-left: 8px; padding-right: 8px;');
       setWindowWidth(800);
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin-left: -12px; margin-right: -12px;');
       expect(colElement.style.cssText).toBe('padding-left: 12px; padding-right: 12px;');
     }));
+
     it('should gutter responsive array work', fakeAsync(() => {
-      testBed.component.gutter = [
+      component.gutter = [
         { xs: 8, sm: 16, md: 24 },
         { xs: 4, sm: 8, md: 12 }
       ];
       setWindowWidth(480);
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin: -2px -4px;');
       expect(colElement.style.cssText).toBe('padding: 2px 4px;');
       setWindowWidth(600);
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin: -4px -8px;');
       expect(colElement.style.cssText).toBe('padding: 4px 8px;');
       setWindowWidth(800);
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(rowElement.style.cssText).toBe('margin: -6px -12px;');
       expect(colElement.style.cssText).toBe('padding: 6px 12px;');
     }));
   });
+
   describe('col', () => {
+    let fixture: ComponentFixture<TestColComponent>;
+    let component: TestColComponent;
     let colElement: HTMLElement;
-    let testBed: ComponentBed<TestColComponent>;
     const sizeMatch = (name: string, count: number, size?: string): boolean => {
       const middle = size ? `-${size}-` : '-';
       if (name === 'span') {
@@ -113,25 +125,31 @@ describe('grid', () => {
         return colElement.classList.contains(`ant-col${middle}${name}-${count}`);
       }
     };
+
     beforeEach(() => {
-      testBed = createComponentBed(TestColComponent, { imports: [NzGridModule] });
-      colElement = testBed.debugElement.query(By.directive(NzColDirective)).nativeElement;
+      fixture = TestBed.createComponent(TestColComponent);
+      colElement = fixture.debugElement.query(By.directive(NzColDirective)).nativeElement;
+      component = fixture.componentInstance;
+      fixture.detectChanges();
     });
+
     it('should apply className', () => {
       expect(colElement.className).toBe('ant-col');
     });
+
     it('should apply style according to flex', () => {
-      testBed.component.flex = 1;
-      testBed.fixture.detectChanges();
+      component.flex = 1;
+      fixture.detectChanges();
       expect(colElement.style.cssText).toBe('flex: 1 1 auto;');
-      testBed.component.flex = '100px';
-      testBed.fixture.detectChanges();
+      component.flex = '100px';
+      fixture.detectChanges();
       expect(colElement.style.cssText).toBe('flex: 0 0 100px;');
     });
+
     it('should apply className according to property', () => {
       const propertySizeMatch = (name: keyof TestColComponent, count: number): boolean => {
-        testBed.component[name] = count;
-        testBed.fixture.detectChanges();
+        component[name] = count;
+        fixture.detectChanges();
         return sizeMatch(name, count);
       };
       expect(propertySizeMatch('span', 8)).toBe(true);
@@ -146,6 +164,7 @@ describe('grid', () => {
       expect(propertySizeMatch('xl', 8)).toBe(true);
       expect(propertySizeMatch('xxl', 8)).toBe(true);
     });
+
     it('should apply className according to responsive size object', () => {
       const batchSizeMatch = (count: number, size: string): boolean =>
         sizeMatch('span', count, size) &&
@@ -153,49 +172,54 @@ describe('grid', () => {
         sizeMatch('order', count, size) &&
         sizeMatch('pull', count, size) &&
         sizeMatch('push', count, size);
-      testBed.component.xs = { span: 1, offset: 1, order: 1, pull: 1, push: 1 };
-      testBed.component.sm = { span: 2, offset: 2, order: 2, pull: 2, push: 2 };
-      testBed.component.md = { span: 3, offset: 3, order: 3, pull: 3, push: 3 };
-      testBed.component.lg = { span: 4, offset: 4, order: 4, pull: 4, push: 4 };
-      testBed.component.xl = { span: 5, offset: 5, order: 5, pull: 5, push: 5 };
-      testBed.component.xxl = { span: 6, offset: 6, order: 6, pull: 6, push: 6 };
-      testBed.fixture.detectChanges();
+      component.xs = { span: 1, offset: 1, order: 1, pull: 1, push: 1 };
+      component.sm = { span: 2, offset: 2, order: 2, pull: 2, push: 2 };
+      component.md = { span: 3, offset: 3, order: 3, pull: 3, push: 3 };
+      component.lg = { span: 4, offset: 4, order: 4, pull: 4, push: 4 };
+      component.xl = { span: 5, offset: 5, order: 5, pull: 5, push: 5 };
+      component.xxl = { span: 6, offset: 6, order: 6, pull: 6, push: 6 };
+      fixture.detectChanges();
       expect(batchSizeMatch(1, 'xs')).toBe(true);
       expect(batchSizeMatch(2, 'sm')).toBe(true);
       expect(batchSizeMatch(3, 'md')).toBe(true);
       expect(batchSizeMatch(4, 'lg')).toBe(true);
       expect(batchSizeMatch(5, 'xl')).toBe(true);
       expect(batchSizeMatch(6, 'xxl')).toBe(true);
-      testBed.component.xs = { span: 2, offset: 2, order: 2, pull: 2, push: 2 };
-      testBed.fixture.detectChanges();
+      component.xs = { span: 2, offset: 2, order: 2, pull: 2, push: 2 };
+      fixture.detectChanges();
       expect(batchSizeMatch(1, 'xs')).toBe(false);
     });
   });
+
   describe('RTL', () => {
+    let fixture: ComponentFixture<NzTestGridRtlComponent>;
     let rowElement: HTMLElement;
     let colElement: HTMLElement;
-    let testBed: ComponentBed<NzTestGridRtlComponent>;
+
     beforeEach(() => {
-      testBed = createComponentBed(NzTestGridRtlComponent, { imports: [BidiModule, NzGridModule] });
-      rowElement = testBed.debugElement.query(By.directive(NzRowDirective)).nativeElement;
-      colElement = testBed.debugElement.query(By.directive(NzColDirective)).nativeElement;
+      fixture = TestBed.createComponent(NzTestGridRtlComponent);
+      rowElement = fixture.debugElement.query(By.directive(NzRowDirective)).nativeElement;
+      colElement = fixture.debugElement.query(By.directive(NzColDirective)).nativeElement;
+      fixture.detectChanges();
     });
+
     describe('row', () => {
       it('should className correct on dir change', () => {
         expect(rowElement.className).toBe('ant-row ant-row-rtl');
 
-        testBed.fixture.componentInstance.direction = 'ltr';
-        testBed.fixture.detectChanges();
+        fixture.componentInstance.direction = 'ltr';
+        fixture.detectChanges();
 
         expect(rowElement.className).toBe('ant-row');
       });
     });
+
     describe('col', () => {
       it('should className correct on dir change', () => {
         expect(colElement.className).toBe('ant-col ant-col-rtl');
 
-        testBed.fixture.componentInstance.direction = 'ltr';
-        testBed.fixture.detectChanges();
+        fixture.componentInstance.direction = 'ltr';
+        fixture.detectChanges();
 
         expect(colElement.className).toBe('ant-col');
       });
@@ -204,6 +228,8 @@ describe('grid', () => {
 });
 
 @Component({
+  standalone: true,
+  imports: [NzGridModule],
   template: `
     <div nz-row [nzGutter]="gutter" [nzJustify]="justify" [nzAlign]="align">
       <div nz-col></div>
@@ -224,6 +250,8 @@ export class TestGridComponent {
 }
 
 @Component({
+  standalone: true,
+  imports: [NzGridModule],
   template: `
     <div nz-row>
       <div
@@ -260,6 +288,8 @@ export class TestColComponent {
 }
 
 @Component({
+  standalone: true,
+  imports: [BidiModule, NzGridModule],
   template: `
     <div [dir]="direction">
       <div nz-row>

--- a/components/icon/icon.spec.ts
+++ b/components/icon/icon.spec.ts
@@ -13,40 +13,36 @@ import {
 } from '@ant-design/icons-angular/icons';
 
 import { NzConfigService } from 'ng-zorro-antd/core/config';
-import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 
 import { NzIconDirective } from './icon.directive';
 import { NzIconModule } from './icon.module';
-import { NzIconService, NZ_ICONS } from './icon.service';
+import { NzIconService } from './icon.service';
 import { provideNzIcons, provideNzIconsPatch } from './provide-icons';
 
 describe('nz-icon', () => {
-  describe('basics', () => {
-    let testBed: ComponentBed<NzTestIconExtensionsComponent>;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideNzIcons([
+          LeftOutline,
+          RightOutline,
+          QuestionOutline,
+          QuestionCircleOutline,
+          LoadingOutline,
+          QuestionCircleFill
+        ])
+      ]
+    });
+  });
+
+  describe('basic', () => {
     let testComponent: NzTestIconExtensionsComponent;
     let fixture: ComponentFixture<NzTestIconExtensionsComponent>;
     let icons: DebugElement[];
 
     beforeEach(() => {
-      testBed = createComponentBed(NzTestIconExtensionsComponent, {
-        imports: [NzIconModule],
-        providers: [
-          {
-            provide: NZ_ICONS,
-            useValue: [
-              LeftOutline,
-              RightOutline,
-              QuestionOutline,
-              QuestionCircleOutline,
-              LoadingOutline,
-              QuestionCircleFill
-            ]
-          }
-        ]
-      });
-      fixture = testBed.fixture;
-
-      testComponent = testBed.component;
+      fixture = TestBed.createComponent(NzTestIconExtensionsComponent);
+      testComponent = fixture.componentInstance;
       icons = fixture.debugElement.queryAll(By.directive(NzIconDirective));
     });
 
@@ -107,69 +103,34 @@ describe('nz-icon', () => {
   });
 
   describe('custom', () => {
-    let testBed: ComponentBed<NzTestIconCustomComponent>;
     let fixture: ComponentFixture<NzTestIconCustomComponent>;
     let icons: DebugElement[];
 
     beforeEach(() => {
-      testBed = createComponentBed(NzTestIconCustomComponent, {
-        imports: [NzIconModule],
-        providers: [
-          {
-            provide: NZ_ICONS,
-            useValue: [
-              LeftOutline,
-              RightOutline,
-              QuestionOutline,
-              QuestionCircleOutline,
-              LoadingOutline,
-              QuestionCircleFill
-            ]
-          }
-        ]
-      });
-      fixture = testBed.fixture;
+      fixture = TestBed.createComponent(NzTestIconCustomComponent);
+      fixture.detectChanges();
     });
 
     it('should support custom svg element', () => {
-      fixture.detectChanges();
       icons = fixture.debugElement.queryAll(By.directive(NzIconDirective));
-      const icon1 = icons[0];
-      expect(icon1.nativeElement.className).toContain('anticon');
-      expect(icon1.nativeElement.innerHTML).toContain('svg');
-      expect(icon1.nativeElement.innerHTML).toContain(
+      expect(icons[0].nativeElement.className).toContain('anticon');
+      expect(icons[0].nativeElement.innerHTML).toContain('svg');
+      expect(icons[0].nativeElement.innerHTML).toContain(
         'viewBox="0 0 1024 1024" width="1em" height="1em" fill="currentColor"'
       );
     });
   });
 
   describe('iconfont', () => {
-    let testBed: ComponentBed<NzTestIconIconfontComponent>;
     let fixture: ComponentFixture<NzTestIconIconfontComponent>;
     let icons: DebugElement[];
 
     beforeEach(() => {
-      testBed = createComponentBed(NzTestIconIconfontComponent, {
-        imports: [NzIconModule],
-        providers: [
-          {
-            provide: NZ_ICONS,
-            useValue: [
-              LeftOutline,
-              RightOutline,
-              QuestionOutline,
-              QuestionCircleOutline,
-              LoadingOutline,
-              QuestionCircleFill
-            ]
-          }
-        ]
-      });
-      fixture = testBed.fixture;
+      fixture = TestBed.createComponent(NzTestIconIconfontComponent);
+      fixture.detectChanges();
     });
 
     it('should support iconfont', waitForAsync(() => {
-      fixture.detectChanges();
       fixture.whenStable().then(() => {
         fixture.detectChanges();
         icons = fixture.debugElement.queryAll(By.directive(NzIconDirective));
@@ -182,23 +143,12 @@ describe('nz-icon', () => {
   });
 
   describe('config service', () => {
-    let testBed: ComponentBed<NzTestIconExtensionsComponent>;
     let fixture: ComponentFixture<NzTestIconExtensionsComponent>;
     let nzConfigService: NzConfigService;
     let icons: DebugElement[];
 
     beforeEach(() => {
-      testBed = createComponentBed(NzTestIconExtensionsComponent, {
-        imports: [NzIconModule],
-        providers: [
-          {
-            provide: NZ_ICONS,
-            useValue: [LeftOutline, RightOutline, QuestionOutline]
-          }
-        ]
-      });
-
-      fixture = testBed.fixture;
+      fixture = TestBed.createComponent(NzTestIconExtensionsComponent);
       fixture.detectChanges();
       icons = fixture.debugElement.queryAll(By.directive(NzIconDirective));
     });
@@ -217,17 +167,22 @@ describe('nz-icon', () => {
       expect(icons[0].componentInstance.iconService.twoToneColor.primaryColor).toBe('#1890ff');
     });
   });
+});
 
+describe('nz-icon injection', () => {
   describe('injection on multi places', () => {
-    let testBed: ComponentBed<NzTestIconMultiInjectionComponent>;
     let fixture: ComponentFixture<NzTestIconMultiInjectionComponent>;
     let icons: DebugElement[];
 
     beforeEach(() => {
-      testBed = createComponentBed(NzTestIconMultiInjectionComponent, {
-        imports: [NzIconModule.forRoot([HomeOutline]), ChildModule]
+      TestBed.configureTestingModule({
+        providers: [provideNzIcons([HomeOutline])]
       });
-      fixture = testBed.fixture;
+    });
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzTestIconMultiInjectionComponent);
+      fixture.detectChanges();
     });
 
     it('should support forRoot and forChild', () => {
@@ -238,15 +193,13 @@ describe('nz-icon', () => {
     });
   });
 
-  describe('[standalone] injection on multi places with provideNzIcon', () => {
+  describe('[standalone] injection on multi places', () => {
     let fixture: ComponentFixture<NzTestIconMultiInjectionStandaloneComponent>;
-    let icons: DebugElement[];
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [NzTestIconMultiInjectionStandaloneComponent],
         providers: [provideNzIcons([HomeOutline])]
-      }).compileComponents();
+      });
     });
 
     beforeEach(() => {
@@ -255,7 +208,7 @@ describe('nz-icon', () => {
     });
 
     it('should support forRoot and forChild', () => {
-      icons = fixture.debugElement.queryAll(By.directive(NzIconDirective));
+      const icons = fixture.debugElement.queryAll(By.directive(NzIconDirective));
       expect(icons[0].nativeElement.classList.contains('anticon-home')).toBe(true);
       expect(icons[1].nativeElement.classList.contains('anticon-question')).toBe(true);
     });
@@ -263,8 +216,8 @@ describe('nz-icon', () => {
 });
 
 @Component({
-  // eslint-disable-next-line
-  selector: 'nz-test-icon-extensions',
+  standalone: true,
+  imports: [NzIconModule],
   template: `
     <span nz-icon [nzType]="type" [nzTheme]="theme" [nzSpin]="spin" [nzRotate]="rotate"></span>
     <span nz-icon [nzType]="'loading'" [nzTheme]="theme"></span>
@@ -272,7 +225,7 @@ describe('nz-icon', () => {
 })
 export class NzTestIconExtensionsComponent {
   type = 'question';
-  theme = 'outline';
+  theme: 'fill' | 'outline' | 'twotone' = 'outline';
   spin = true;
   rotate = 0;
 
@@ -280,6 +233,8 @@ export class NzTestIconExtensionsComponent {
 }
 
 @Component({
+  standalone: true,
+  imports: [NzIconModule],
   template: `
     <span nz-icon style="color: hotpink;">
       <svg>
@@ -293,10 +248,12 @@ export class NzTestIconExtensionsComponent {
 export class NzTestIconCustomComponent {}
 
 @Component({
+  standalone: true,
+  imports: [NzIconModule],
   template: `
-    <span nz-icon [nzIconfont]="'icon-tuichu'"></span>
-    <span nz-icon [nzIconfont]="'icon-facebook'"></span>
-    <span nz-icon [nzIconfont]="'icon-twitter'"></span>
+    <span nz-icon nzIconfont="icon-tuichu"></span>
+    <span nz-icon nzIconfont="icon-facebook"></span>
+    <span nz-icon nzIconfont="icon-twitter"></span>
   `
 })
 export class NzTestIconIconfontComponent {
@@ -308,13 +265,13 @@ export class NzTestIconIconfontComponent {
 }
 
 @NgModule({
-  imports: [NzIconModule.forChild([QuestionOutline])],
-  declarations: [NzTestIconExtensionsComponent],
-  exports: [NzTestIconExtensionsComponent]
+  imports: [NzIconModule.forChild([QuestionOutline])]
 })
 class ChildModule {}
 
 @Component({
+  standalone: true,
+  imports: [NzIconModule, ChildModule],
   template: `
     <span nz-icon nzType="home"></span>
     <span nz-icon nzType="question"></span>

--- a/components/layout/layout.spec.ts
+++ b/components/layout/layout.spec.ts
@@ -1,11 +1,11 @@
 import { BidiModule, Dir, Direction } from '@angular/cdk/bidi';
 import { Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
-import { discardPeriodicTasks, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ɵComponentBed as ComponentBed, ɵcreateComponentBed as createComponentBed } from 'ng-zorro-antd/core/testing';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
-import { NzIconTestModule } from 'ng-zorro-antd/icon/testing';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 
 import { NzContentComponent } from './content.component';
 import { NzFooterComponent } from './footer.component';
@@ -16,25 +16,26 @@ import { NzSiderComponent } from './sider.component';
 
 declare const viewport: NzSafeAny;
 
-describe('layout', () => {
+describe('nz-layout', () => {
   describe('basic', () => {
-    let testBed: ComponentBed<NzLayoutBasicComponent>;
+    let fixture: ComponentFixture<NzLayoutBasicComponent>;
     let headers: DebugElement[];
     let contents: DebugElement[];
     let footers: DebugElement[];
     let siders: DebugElement[];
     let layouts: DebugElement[];
 
-    beforeEach(waitForAsync(() => {
-      testBed = createComponentBed(NzLayoutBasicComponent, { imports: [NzLayoutModule] });
-      headers = testBed.fixture.debugElement.queryAll(By.directive(NzHeaderComponent));
-      contents = testBed.fixture.debugElement.queryAll(By.directive(NzContentComponent));
-      footers = testBed.fixture.debugElement.queryAll(By.directive(NzFooterComponent));
-      siders = testBed.fixture.debugElement.queryAll(By.directive(NzSiderComponent));
-      layouts = testBed.fixture.debugElement.queryAll(By.directive(NzLayoutComponent));
-    }));
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzLayoutBasicComponent);
+      headers = fixture.debugElement.queryAll(By.directive(NzHeaderComponent));
+      contents = fixture.debugElement.queryAll(By.directive(NzContentComponent));
+      footers = fixture.debugElement.queryAll(By.directive(NzFooterComponent));
+      siders = fixture.debugElement.queryAll(By.directive(NzSiderComponent));
+      layouts = fixture.debugElement.queryAll(By.directive(NzLayoutComponent));
+    });
 
     it('should have correct class', () => {
+      fixture.detectChanges();
       expect(headers.every(header => header.nativeElement.classList.contains('ant-layout-header'))).toBe(true);
       expect(layouts.every(layout => layout.nativeElement.classList.contains('ant-layout'))).toBe(true);
       expect(contents.every(content => content.nativeElement.classList.contains('ant-layout-content'))).toBe(true);
@@ -51,84 +52,86 @@ describe('layout', () => {
       expect(layouts[5].nativeElement.classList.contains('ant-layout-has-sider')).toBe(true);
     });
   });
+
   describe('side', () => {
-    let testBed: ComponentBed<NzLayoutSideComponent>;
+    let fixture: ComponentFixture<NzLayoutSideComponent>;
     let testComponent: NzLayoutSideComponent;
     let sider: DebugElement;
     let trigger: DebugElement;
 
     beforeEach(() => {
-      testBed = createComponentBed(NzLayoutSideComponent, { imports: [NzLayoutModule] });
-      testComponent = testBed.component;
-      sider = testBed.fixture.debugElement.query(By.directive(NzSiderComponent));
+      fixture = TestBed.createComponent(NzLayoutSideComponent);
+      testComponent = fixture.componentInstance;
+      sider = fixture.debugElement.query(By.directive(NzSiderComponent));
     });
 
     it('should nzCollapsed work', () => {
       testComponent.isCollapsed = false;
-      testBed.fixture.detectChanges();
-      trigger = testBed.fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
+      fixture.detectChanges();
+      trigger = fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 200px;').toBe(true);
       trigger.nativeElement.click();
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(testComponent.isCollapsed).toBe(true);
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 80px; max-width: 80px; min-width: 80px; width: 80px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 80px;').toBe(true);
       trigger.nativeElement.click();
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(testComponent.isCollapsed).toBe(false);
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 200px;').toBe(true);
       testComponent.isCollapsed = true;
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 80px; max-width: 80px; min-width: 80px; width: 80px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 80px;').toBe(true);
       testComponent.isCollapsed = false;
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 200px;').toBe(true);
     });
+
     it('should nzWidth work', () => {
       testComponent.isCollapsed = false;
       testComponent.width = 300;
-      testBed.fixture.detectChanges();
-      trigger = testBed.fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
+      fixture.detectChanges();
+      trigger = fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 300px; max-width: 300px; min-width: 300px; width: 300px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 300px;').toBe(true);
       trigger.nativeElement.click();
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(testComponent.isCollapsed).toBe(true);
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 80px; max-width: 80px; min-width: 80px; width: 80px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 80px;').toBe(true);
       trigger.nativeElement.click();
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(testComponent.isCollapsed).toBe(false);
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 300px; max-width: 300px; min-width: 300px; width: 300px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 300px;').toBe(true);
       testComponent.isCollapsed = true;
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 80px; max-width: 80px; min-width: 80px; width: 80px;'
       ).toBe(true);
       expect(trigger.nativeElement.style.cssText === 'width: 80px;').toBe(true);
       testComponent.isCollapsed = false;
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(
         sider.nativeElement.style.cssText === 'flex: 0 0 300px; max-width: 300px; min-width: 300px; width: 300px;'
       ).toBe(true);
@@ -137,59 +140,69 @@ describe('layout', () => {
 
     it('should nzReverseArrow work', () => {
       testComponent.isCollapsed = false;
-      testBed.fixture.detectChanges();
-      trigger = testBed.fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
+      fixture.detectChanges();
+      trigger = fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
       expect(trigger.nativeElement.firstElementChild!.classList.contains('anticon-left')).toBe(true);
       testComponent.isCollapsed = true;
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(trigger.nativeElement.firstElementChild!.classList.contains('anticon-right')).toBe(true);
       testComponent.isReverseArrow = true;
       testComponent.isCollapsed = false;
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(trigger.nativeElement.firstElementChild!.classList.contains('anticon-right')).toBe(true);
       testComponent.isCollapsed = true;
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(trigger.nativeElement.firstElementChild!.classList.contains('anticon-left')).toBe(true);
     });
   });
+
   describe('custom-trigger', () => {
-    let testBed: ComponentBed<NzLayoutCustomTriggerComponent>;
+    let fixture: ComponentFixture<NzLayoutCustomTriggerComponent>;
     let testComponent: NzLayoutCustomTriggerComponent;
 
     beforeEach(() => {
-      testBed = createComponentBed(NzLayoutCustomTriggerComponent, { imports: [NzLayoutModule, NzIconTestModule] });
-      testComponent = testBed.component;
+      TestBed.configureTestingModule({
+        providers: [provideNzIconsTesting()]
+      });
+      fixture = TestBed.createComponent(NzLayoutCustomTriggerComponent);
+      testComponent = fixture.componentInstance;
     });
+
     it('should not display trigger', () => {
-      testBed.fixture.detectChanges();
-      const trigger = testBed.fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
+      fixture.detectChanges();
+      const trigger = fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
       expect(trigger).toBeNull();
     });
+
     it('should display trigger', () => {
       testComponent.changeTrigger();
-      testBed.fixture.detectChanges();
-      const trigger = testBed.fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
+      fixture.detectChanges();
+      const trigger = fixture.debugElement.query(By.css('.ant-layout-sider-trigger'));
       expect(trigger.nativeElement.firstElementChild!.classList.contains('anticon-up')).toBe(true);
       expect(trigger).not.toBeNull();
     });
   });
+
   describe('responsive', () => {
-    let testBed: ComponentBed<NzLayoutResponsiveComponent>;
+    let fixture: ComponentFixture<NzLayoutResponsiveComponent>;
     let sider: DebugElement;
 
     beforeEach(() => {
-      testBed = createComponentBed(NzLayoutResponsiveComponent, { imports: [NzLayoutModule] });
-      sider = testBed.fixture.debugElement.query(By.directive(NzSiderComponent));
+      TestBed.configureTestingModule({
+        providers: [provideNzIconsTesting()]
+      });
+      fixture = TestBed.createComponent(NzLayoutResponsiveComponent);
+      sider = fixture.debugElement.query(By.directive(NzSiderComponent));
     });
 
     it('should responsive work', fakeAsync(() => {
       viewport.set(500);
       window.dispatchEvent(new Event('resize'));
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       tick(1000);
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       discardPeriodicTasks();
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(sider.nativeElement.style.cssText).toBe('flex: 0 0 0px; max-width: 0px; min-width: 0px; width: 0px;');
       expect(
         sider.nativeElement
@@ -199,24 +212,22 @@ describe('layout', () => {
       viewport.reset();
     }));
   });
+
   describe('RTL', () => {
-    let testBed: ComponentBed<NzTestLayoutRtlComponent>;
+    let fixture: ComponentFixture<NzTestLayoutRtlComponent>;
     let layouts: DebugElement[];
 
     beforeEach(() => {
-      testBed = createComponentBed(NzTestLayoutRtlComponent, {
-        imports: [BidiModule, NzLayoutModule],
-        declarations: [NzLayoutBasicComponent]
-      });
-      layouts = testBed.fixture.debugElement.queryAll(By.directive(NzLayoutComponent));
+      fixture = TestBed.createComponent(NzTestLayoutRtlComponent);
+      layouts = fixture.debugElement.queryAll(By.directive(NzLayoutComponent));
     });
 
     it('should className correct on dir change', fakeAsync(() => {
-      testBed.fixture.detectChanges();
+      fixture.detectChanges();
       expect(layouts.every(layout => layout.nativeElement.classList.contains('ant-layout-rtl'))).toBe(true);
 
-      testBed.fixture.componentInstance.direction = 'ltr';
-      testBed.fixture.detectChanges();
+      fixture.componentInstance.direction = 'ltr';
+      fixture.detectChanges();
 
       expect(layouts.every(layout => layout.nativeElement.classList.contains('ant-layout-rtl'))).toBe(false);
     }));
@@ -224,6 +235,8 @@ describe('layout', () => {
 });
 
 @Component({
+  standalone: true,
+  imports: [NzIconModule, NzLayoutModule],
   template: `
     <nz-layout>
       <nz-sider nzCollapsible [(nzCollapsed)]="isCollapsed" [nzTrigger]="triggerTemplate"></nz-sider>
@@ -259,6 +272,8 @@ export class NzLayoutCustomTriggerComponent {
 }
 
 @Component({
+  standalone: true,
+  imports: [NzLayoutModule],
   template: `
     <nz-layout>
       <nz-sider
@@ -284,6 +299,8 @@ export class NzLayoutSideComponent {
 }
 
 @Component({
+  standalone: true,
+  imports: [NzIconModule, NzLayoutModule],
   template: `
     <nz-layout>
       <nz-sider
@@ -311,7 +328,8 @@ export class NzLayoutResponsiveComponent {
 }
 
 @Component({
-  // eslint-disable-next-line
+  standalone: true,
+  imports: [NzLayoutModule],
   selector: 'nz-test-layout-basic',
   template: `
     <nz-layout>
@@ -351,6 +369,8 @@ export class NzLayoutResponsiveComponent {
 export class NzLayoutBasicComponent {}
 
 @Component({
+  standalone: true,
+  imports: [BidiModule, NzLayoutBasicComponent],
   template: `
     <div [dir]="direction">
       <nz-test-layout-basic></nz-test-layout-basic>

--- a/components/qr-code/qrcode.component.spec.ts
+++ b/components/qr-code/qrcode.component.spec.ts
@@ -5,39 +5,28 @@
 
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Component, DebugElement } from '@angular/core';
-import { ComponentFixture } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-
-import { ComponentBed, createComponentBed } from 'ng-zorro-antd/core/testing/component-bed';
 
 import { NzQRCodeComponent } from './qrcode.component';
 import { NzQRCodeModule } from './qrcode.module';
 
-@Component({
-  template: ` <nz-qrcode [nzValue]="value" [nzSize]="size" [nzBordered]="bordered" [nzStatus]="status"> </nz-qrcode> `
-})
-export class NzTestQrCodeBasicComponent {
-  value: string = 'https://ng.ant.design/';
-  size: number = 160;
-  bordered: boolean = true;
-  status: 'active' | 'expired' | 'loading' | 'scanned' = 'active';
-}
-
 describe('nz-qrcode', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClientTesting()]
+    });
+  });
+
   describe('basic', () => {
-    let testBed: ComponentBed<NzTestQrCodeBasicComponent>;
     let fixture: ComponentFixture<NzTestQrCodeBasicComponent>;
     let testComponent: NzTestQrCodeBasicComponent;
     let resultEl: DebugElement;
 
     beforeEach(() => {
-      testBed = createComponentBed(NzTestQrCodeBasicComponent, {
-        imports: [NzQRCodeModule],
-        providers: [provideHttpClientTesting()]
-      });
-      fixture = testBed.fixture;
+      fixture = TestBed.createComponent(NzTestQrCodeBasicComponent);
       fixture.detectChanges();
-      testComponent = testBed.component;
+      testComponent = fixture.componentInstance;
       resultEl = fixture.debugElement.query(By.directive(NzQRCodeComponent));
     });
 
@@ -70,3 +59,15 @@ describe('nz-qrcode', () => {
     });
   });
 });
+
+@Component({
+  standalone: true,
+  imports: [NzQRCodeModule],
+  template: `<nz-qrcode [nzValue]="value" [nzSize]="size" [nzBordered]="bordered" [nzStatus]="status"></nz-qrcode>`
+})
+export class NzTestQrCodeBasicComponent {
+  value: string = 'https://ng.ant.design/';
+  size: number = 160;
+  bordered: boolean = true;
+  status: 'active' | 'expired' | 'loading' | 'scanned' = 'active';
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The following methods or classes are internally used and we are not willing users to use them directly:

- component/core/testing/wrapped-error-message.ts: `wrappedErrorMessage`
- component/core/testing/component-bed.ts: `createComponentBed`
- component/core/testing/fake-viewport-ruler.ts: `FakeViewportRuler`

They are marked as DEPRECATED, and will be REMOVED in v20


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
