### PR TITLE
refactor(module:core): expose `fromEventOutsideAngular` utility

### DIFF
--- a/components/anchor/anchor.component.ts
+++ b/components/anchor/anchor.component.ts
@@ -15,7 +15,6 @@ import {
   EventEmitter,
   inject,
   Input,
-  NgZone,
   numberAttribute,
   OnChanges,
   OnDestroy,
@@ -25,14 +24,14 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { fromEvent, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { takeUntil, throttleTime } from 'rxjs/operators';
 
 import { NzAffixModule } from 'ng-zorro-antd/affix';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzScrollService } from 'ng-zorro-antd/core/services';
 import { NgStyleInterface, NzDirectionVHType } from 'ng-zorro-antd/core/types';
-import { numberAttributeWithZeroFallback } from 'ng-zorro-antd/core/util';
+import { fromEventOutsideAngular, numberAttributeWithZeroFallback } from 'ng-zorro-antd/core/util';
 
 import { NzAnchorLinkComponent } from './anchor-link.component';
 import { getOffsetTop } from './util';
@@ -129,7 +128,6 @@ export class NzAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
     private scrollSrv: NzScrollService,
     private cdr: ChangeDetectorRef,
     private platform: Platform,
-    private zone: NgZone,
     private renderer: Renderer2
   ) {}
 
@@ -160,11 +158,10 @@ export class NzAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
       return;
     }
     this.destroy$.next(true);
-    this.zone.runOutsideAngular(() => {
-      fromEvent(this.getContainer(), 'scroll', <AddEventListenerOptions>passiveEventListenerOptions)
-        .pipe(throttleTime(50), takeUntil(this.destroy$))
-        .subscribe(() => this.handleScroll());
-    });
+
+    fromEventOutsideAngular(this.getContainer(), 'scroll', passiveEventListenerOptions)
+      .pipe(throttleTime(50), takeUntil(this.destroy$))
+      .subscribe(() => this.handleScroll());
     // Browser would maintain the scrolling position when refreshing.
     // So we have to delay calculation in avoid of getting a incorrect result.
     this.handleScrollTimeoutID = setTimeout(() => this.handleScroll());

--- a/components/auto-complete/autocomplete-option.component.ts
+++ b/components/auto-complete/autocomplete-option.component.ts
@@ -18,11 +18,11 @@ import {
   booleanAttribute,
   inject
 } from '@angular/core';
-import { Subject, fromEvent } from 'rxjs';
+import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
-import { scrollIntoView } from 'ng-zorro-antd/core/util';
+import { fromEventOutsideAngular, scrollIntoView } from 'ng-zorro-antd/core/util';
 
 import { NzAutocompleteOptgroupComponent } from './autocomplete-optgroup.component';
 
@@ -77,20 +77,18 @@ export class NzAutocompleteOptionComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.element.nativeElement, 'mouseenter')
-        .pipe(
-          filter(() => this.mouseEntered.observers.length > 0),
-          takeUntil(this.destroy$)
-        )
-        .subscribe(() => {
-          this.ngZone.run(() => this.mouseEntered.emit(this));
-        });
+    fromEventOutsideAngular(this.element.nativeElement, 'mouseenter')
+      .pipe(
+        filter(() => this.mouseEntered.observers.length > 0),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        this.ngZone.run(() => this.mouseEntered.emit(this));
+      });
 
-      fromEvent(this.element.nativeElement, 'mousedown')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => event.preventDefault());
-    });
+    fromEventOutsideAngular(this.element.nativeElement, 'mousedown')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => event.preventDefault());
   }
 
   ngOnDestroy(): void {

--- a/components/back-top/back-top.component.ts
+++ b/components/back-top/back-top.component.ts
@@ -25,12 +25,13 @@ import {
   inject,
   numberAttribute
 } from '@angular/core';
-import { Subject, Subscription, fromEvent } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 
 import { fadeMotion } from 'ng-zorro-antd/core/animation';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzDestroyService, NzScrollService } from 'ng-zorro-antd/core/services';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'backTop';
@@ -82,16 +83,14 @@ export class NzBackTopComponent implements OnInit, OnDestroy, OnChanges {
     if (backTop) {
       this.backTopClickSubscription.unsubscribe();
 
-      this.backTopClickSubscription = this.zone.runOutsideAngular(() =>
-        fromEvent(backTop.nativeElement, 'click')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe(() => {
-            this.scrollSrv.scrollTo(this.getTarget(), 0, { duration: this.nzDuration });
-            if (this.nzClick.observers.length) {
-              this.zone.run(() => this.nzClick.emit(true));
-            }
-          })
-      );
+      this.backTopClickSubscription = fromEventOutsideAngular(backTop.nativeElement, 'click')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.scrollSrv.scrollTo(this.getTarget(), 0, { duration: this.nzDuration });
+          if (this.nzClick.observers.length) {
+            this.zone.run(() => this.nzClick.emit(true));
+          }
+        });
     }
   }
 
@@ -139,11 +138,9 @@ export class NzBackTopComponent implements OnInit, OnDestroy, OnChanges {
     }
     this.scrollListenerDestroy$.next(true);
     this.handleScroll();
-    this.zone.runOutsideAngular(() => {
-      fromEvent(this.getTarget(), 'scroll', <AddEventListenerOptions>passiveEventListenerOptions)
-        .pipe(debounceTime(50), takeUntil(this.scrollListenerDestroy$))
-        .subscribe(() => this.handleScroll());
-    });
+    fromEventOutsideAngular(this.getTarget(), 'scroll', <AddEventListenerOptions>passiveEventListenerOptions)
+      .pipe(debounceTime(50), takeUntil(this.scrollListenerDestroy$))
+      .subscribe(() => this.handleScroll());
   }
 
   ngOnDestroy(): void {

--- a/components/back-top/back-top.component.ts
+++ b/components/back-top/back-top.component.ts
@@ -5,7 +5,7 @@
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { Platform, normalizePassiveListenerOptions } from '@angular/cdk/platform';
-import { DOCUMENT, NgIf, NgTemplateOutlet } from '@angular/common';
+import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -43,7 +43,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
   exportAs: 'nzBackTop',
   animations: [fadeMotion],
   standalone: true,
-  imports: [NgIf, NgTemplateOutlet, NzIconModule],
+  imports: [NgTemplateOutlet, NzIconModule],
   template: `
     @if (visible) {
       <div #backTop class="ant-back-top" [class.ant-back-top-rtl]="dir === 'rtl'" @fadeMotion>

--- a/components/back-top/back-top.spec.ts
+++ b/components/back-top/back-top.spec.ts
@@ -3,7 +3,7 @@ import { Platform } from '@angular/cdk/platform';
 import { ApplicationRef, Component, DebugElement, SimpleChanges, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Subject } from 'rxjs';
 
 import { NzScrollService } from 'ng-zorro-antd/core/services';
@@ -12,7 +12,7 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { NzBackTopComponent } from './back-top.component';
 import { NzBackTopModule } from './back-top.module';
 
-describe('Component:nz-back-top', () => {
+describe('nz-back-top', () => {
   let scrollService: MockNzScrollService;
   let fixture: ComponentFixture<TestBackTopComponent>;
   let debugElement: DebugElement;
@@ -37,15 +37,14 @@ describe('Component:nz-back-top', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NzBackTopModule, NoopAnimationsModule],
-      declarations: [TestBackTopComponent, TestBackTopTemplateComponent],
       providers: [
+        provideNoopAnimations(),
         {
           provide: NzScrollService,
           useClass: MockNzScrollService
         }
       ]
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TestBackTopComponent);
     component = fixture.componentInstance.nzBackTopComponent;
@@ -167,11 +166,11 @@ describe('Component:nz-back-top', () => {
 
   describe('[nzTarget]', () => {
     let fakeTarget: HTMLElement;
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fakeTarget = debugElement.query(By.css('#fakeTarget')).nativeElement;
       fixture.componentInstance.setTarget(fakeTarget);
       fixture.detectChanges();
-    }));
+    });
 
     it('window scroll does not show the button', fakeAsync(() => {
       componentObject.scrollTo(window, defaultVisibilityHeight + 1);
@@ -181,27 +180,27 @@ describe('Component:nz-back-top', () => {
       expect(componentObject.backTopButton() === null).toBe(true);
     }));
 
-    it('element scroll shows the button', fakeAsync(() => {
-      const time = 50;
-
+    it('element scroll shows the button', (done: () => void) => {
       componentObject.scrollTo(fakeTarget, defaultVisibilityHeight + 1);
-      tick(time + 1);
       fixture.detectChanges();
 
-      expect(componentObject.backTopButton() === null).toBe(false);
-    }));
+      setTimeout(() => {
+        expect(componentObject.backTopButton() === null).toBe(false);
+        done();
+      }, 50);
+    });
 
-    it('element (use string id) scroll shows the button', fakeAsync(() => {
+    it('element (use string id) scroll shows the button', (done: () => void) => {
       component.nzTarget = '#fakeTarget';
 
-      const time = 50;
-
       componentObject.scrollTo(fakeTarget, defaultVisibilityHeight + 1);
-      tick(time + 1);
       fixture.detectChanges();
 
-      expect(componentObject.backTopButton() === null).toBe(false);
-    }));
+      setTimeout(() => {
+        expect(componentObject.backTopButton() === null).toBe(false);
+        done();
+      }, 50);
+    });
   });
 
   describe('#nzTemplate', () => {
@@ -218,6 +217,8 @@ describe('Component:nz-back-top', () => {
 });
 
 @Component({
+  standalone: true,
+  imports: [NzBackTopModule],
   template: `
     <nz-back-top [nzTarget]="target"></nz-back-top>
     <div id="fakeTarget"></div>
@@ -227,7 +228,7 @@ class TestBackTopComponent {
   @ViewChild(NzBackTopComponent, { static: true })
   nzBackTopComponent!: NzBackTopComponent;
 
-  target: HTMLElement | null = null;
+  target: HTMLElement | undefined = undefined;
 
   setTarget(target: HTMLElement): void {
     this.target = target;
@@ -235,6 +236,8 @@ class TestBackTopComponent {
 }
 
 @Component({
+  standalone: true,
+  imports: [NzBackTopModule],
   template: `
     my comp
     <nz-back-top [nzTemplate]="tpl">
@@ -273,7 +276,6 @@ describe('back-to-top', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NzBackTopModule],
       providers: [
         {
           provide: Directionality,
@@ -282,7 +284,7 @@ describe('back-to-top', () => {
         { provide: Platform, useValue: { isBrowser: false } },
         { provide: Document, useValue: document }
       ]
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(NzBackTopComponent);
     component = fixture.componentInstance;

--- a/components/checkbox/checkbox.component.ts
+++ b/components/checkbox/checkbox.component.ts
@@ -24,11 +24,12 @@ import {
   inject
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Subject, fromEvent } from 'rxjs';
+import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzFormStatusService } from 'ng-zorro-antd/core/form';
 import { NzSafeAny, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzCheckboxWrapperComponent } from './checkbox-wrapper.component';
 
@@ -161,25 +162,23 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, OnDest
 
     this.dir = this.directionality.value;
 
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.elementRef.nativeElement, 'click')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => {
-          event.preventDefault();
-          this.focus();
-          if (this.nzDisabled) {
-            return;
-          }
-          this.ngZone.run(() => {
-            this.innerCheckedChange(!this.nzChecked);
-            this.cdr.markForCheck();
-          });
+    fromEventOutsideAngular(this.elementRef.nativeElement, 'click')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        event.preventDefault();
+        this.focus();
+        if (this.nzDisabled) {
+          return;
+        }
+        this.ngZone.run(() => {
+          this.innerCheckedChange(!this.nzChecked);
+          this.cdr.markForCheck();
         });
+      });
 
-      fromEvent(this.inputElement.nativeElement, 'click')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => event.stopPropagation());
-    });
+    fromEventOutsideAngular(this.inputElement.nativeElement, 'click')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => event.stopPropagation());
   }
 
   ngAfterViewInit(): void {

--- a/components/code-editor/code-editor.component.ts
+++ b/components/code-editor/code-editor.component.ts
@@ -21,14 +21,14 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
-import { BehaviorSubject, combineLatest, fromEvent, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
 
 import type { editor, IDisposable } from 'monaco-editor';
 
 import { warn } from 'ng-zorro-antd/core/logger';
 import { NzSafeAny, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
-import { inNextTick } from 'ng-zorro-antd/core/util';
+import { fromEventOutsideAngular, inNextTick } from 'ng-zorro-antd/core/util';
 import { NzSpinComponent } from 'ng-zorro-antd/spin';
 
 import { NzCodeEditorService } from './code-editor.service';
@@ -204,28 +204,26 @@ export class NzCodeEditorComponent implements OnDestroy, AfterViewInit {
   }
 
   private registerResizeChange(): void {
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(window, 'resize')
-        .pipe(debounceTime(300), takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.layout();
-        });
+    fromEventOutsideAngular(window, 'resize')
+      .pipe(debounceTime(300), takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.layout();
+      });
 
-      this.resize$
-        .pipe(
-          takeUntil(this.destroy$),
-          filter(() => !!this.editorInstance),
-          map(() => ({
-            width: this.el.clientWidth,
-            height: this.el.clientHeight
-          })),
-          distinctUntilChanged((a, b) => a.width === b.width && a.height === b.height),
-          debounceTime(50)
-        )
-        .subscribe(() => {
-          this.editorInstance!.layout();
-        });
-    });
+    this.resize$
+      .pipe(
+        takeUntil(this.destroy$),
+        filter(() => !!this.editorInstance),
+        map(() => ({
+          width: this.el.clientWidth,
+          height: this.el.clientHeight
+        })),
+        distinctUntilChanged((a, b) => a.width === b.width && a.height === b.height),
+        debounceTime(50)
+      )
+      .subscribe(() => {
+        this.editorInstance!.layout();
+      });
   }
 
   private setValue(): void {

--- a/components/collapse/collapse-panel.component.ts
+++ b/components/collapse/collapse-panel.component.ts
@@ -20,7 +20,6 @@ import {
   booleanAttribute,
   inject
 } from '@angular/core';
-import { fromEvent } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { collapseMotion } from 'ng-zorro-antd/core/animation';
@@ -28,6 +27,7 @@ import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/con
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import { NzCollapseComponent } from './collapse.component';
@@ -122,19 +122,17 @@ export class NzCollapsePanelComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.nzCollapseComponent.addPanel(this);
 
-    this.ngZone.runOutsideAngular(() =>
-      fromEvent(this.collapseHeader.nativeElement, 'click')
-        .pipe(
-          filter(() => !this.nzDisabled),
-          takeUntil(this.destroy$)
-        )
-        .subscribe(() => {
-          this.ngZone.run(() => {
-            this.nzCollapseComponent.click(this);
-            this.cdr.markForCheck();
-          });
-        })
-    );
+    fromEventOutsideAngular(this.collapseHeader.nativeElement, 'click')
+      .pipe(
+        filter(() => !this.nzDisabled),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        this.ngZone.run(() => {
+          this.nzCollapseComponent.click(this);
+          this.cdr.markForCheck();
+        });
+      });
   }
 
   ngOnDestroy(): void {

--- a/components/core/util/from-event-outside-angular.spec.ts
+++ b/components/core/util/from-event-outside-angular.spec.ts
@@ -1,0 +1,45 @@
+import { Component, inject, NgZone } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TestBed } from '@angular/core/testing';
+import { fromEvent } from 'rxjs';
+
+import { NzSafeAny } from 'ng-zorro-antd/core/types';
+
+import { fromEventOutsideAngular } from './from-event-outside-angular';
+
+@Component({
+  template: ``,
+  standalone: true
+})
+class TestComponent {
+  readonly recorder: NzSafeAny[] = [];
+
+  constructor() {
+    const ngZone = inject(NgZone);
+
+    ngZone.run(() => {
+      fromEvent(document, 'click')
+        .pipe(takeUntilDestroyed())
+        .subscribe(() => {
+          this.recorder.push(['fromEvent in zone: ', NgZone.isInAngularZone()]);
+        });
+
+      fromEventOutsideAngular(document, 'click')
+        .pipe(takeUntilDestroyed())
+        .subscribe(() => {
+          this.recorder.push(['fromEventOutsideAngular in zone: ', NgZone.isInAngularZone()]);
+        });
+    });
+  }
+}
+
+describe('fromEventOutsideAngular', () => {
+  it('should add event listener outside of the Angular zone', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    document.body.click();
+    expect(fixture.componentInstance.recorder).toEqual([
+      ['fromEvent in zone: ', true],
+      ['fromEventOutsideAngular in zone: ', false]
+    ]);
+  });
+});

--- a/components/core/util/from-event-outside-angular.ts
+++ b/components/core/util/from-event-outside-angular.ts
@@ -1,0 +1,49 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { EMPTY, fromEvent, Observable } from 'rxjs';
+
+// This would be exposed in the global environment whenever `zone.js` is
+// included in the `polyfills` configuration property. Starting from Angular 17,
+// users can opt-in to use zoneless change detection.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const Zone: any;
+
+function runOutsideAngular<T>(fn: () => T): T {
+  // The function that does the same job as `NgZone.runOutsideAngular`.
+  // The difference is that we don't need to rely on the `NgZone` service,
+  // allowing `fromEventOutsideAngular` to function without requiring an explicit
+  // injection context (where we might otherwise call `inject(NgZone)`).
+  return typeof Zone !== 'undefined' ? Zone.root.run(fn) : fn();
+}
+
+/**
+ * This function replaces `runOutsideAngular` with `fromEvent`, introducing a
+ * lot of boilerplate where we need to inject the `NgZone` service and then subscribe
+ * to `fromEvent` within the `runOutsideAngular` callback.
+ */
+export function fromEventOutsideAngular<TEvent extends Event>(
+  target: EventTarget | null | undefined,
+  name: string,
+  options?: boolean | AddEventListenerOptions
+): Observable<TEvent> {
+  // Allow the event target to be nullable to avoid requiring callers to check
+  // if the target exists. We simply complete the observable immediately,
+  // as this might potentially be used within a `switchMap`.
+  if (!target) {
+    return EMPTY;
+  }
+
+  return new Observable<TEvent>(subscriber => {
+    // Note that we're wrapping fromEvent with an observable because `fromEvent`
+    // is eager and only calls `addEventListener` when a new subscriber comes in.
+    // Therefore, we're wrapping the subscription with `runOutsideAngular` to ensure
+    // that `addEventListener` is also called outside of Angular when there's a subscriber.
+    return runOutsideAngular(() =>
+      // Casting because the inferred overload is incorrect :(
+      fromEvent<TEvent>(target, name, <AddEventListenerOptions>options).subscribe(subscriber)
+    );
+  });
+}

--- a/components/core/util/public-api.ts
+++ b/components/core/util/public-api.ts
@@ -22,3 +22,4 @@ export * from './observable';
 export * from './can-use-dom';
 export * from './dynamic-css';
 export * from './status-util';
+export * from './from-event-outside-angular';

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -27,7 +27,6 @@ import {
   forwardRef,
   inject,
   Input,
-  NgZone,
   OnChanges,
   OnInit,
   Output,
@@ -41,7 +40,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { fromEvent, of as observableOf } from 'rxjs';
+import { of as observableOf } from 'rxjs';
 import { distinctUntilChanged, map, takeUntil, withLatestFrom } from 'rxjs/operators';
 
 import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
@@ -64,7 +63,7 @@ import {
   OnChangeType,
   OnTouchedType
 } from 'ng-zorro-antd/core/types';
-import { getStatusClassNames, toBoolean, valueFunctionProp } from 'ng-zorro-antd/core/util';
+import { fromEventOutsideAngular, getStatusClassNames, toBoolean, valueFunctionProp } from 'ng-zorro-antd/core/util';
 import {
   DateHelperService,
   NzDatePickerI18nInterface,
@@ -402,17 +401,15 @@ export class NzDatePickerComponent implements OnInit, OnChanges, AfterViewInit, 
     });
 
     if (this.platform.isBrowser) {
-      this.ngZone.runOutsideAngular(() =>
-        // prevent mousedown event to trigger focusout event when click in date picker
-        // see: https://github.com/NG-ZORRO/ng-zorro-antd/issues/7450
-        fromEvent(this.elementRef.nativeElement, 'mousedown')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe(event => {
-            if ((event.target as HTMLInputElement).tagName.toLowerCase() !== 'input') {
-              event.preventDefault();
-            }
-          })
-      );
+      // prevent mousedown event to trigger focusout event when click in date picker
+      // see: https://github.com/NG-ZORRO/ng-zorro-antd/issues/7450
+      fromEventOutsideAngular(this.elementRef.nativeElement, 'mousedown')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(event => {
+          if ((event.target as HTMLInputElement).tagName.toLowerCase() !== 'input') {
+            event.preventDefault();
+          }
+        });
     }
   }
 
@@ -634,7 +631,6 @@ export class NzDatePickerComponent implements OnInit, OnChanges, AfterViewInit, 
     protected i18n: NzI18nService,
     protected cdr: ChangeDetectorRef,
     private renderer: Renderer2,
-    private ngZone: NgZone,
     private elementRef: ElementRef<HTMLElement>,
     private dateHelper: DateHelperService,
     private nzResizeObserver: NzResizeObserver,

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -13,7 +13,6 @@ import {
   ElementRef,
   EventEmitter,
   Input,
-  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -22,7 +21,7 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { fromEvent, merge, Subject } from 'rxjs';
+import { merge, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {
@@ -34,6 +33,7 @@ import {
   wrongSortOrder
 } from 'ng-zorro-antd/core/time';
 import { FunctionProp } from 'ng-zorro-antd/core/types';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzCalendarI18nInterface } from 'ng-zorro-antd/i18n';
 
 import { CalendarFooterComponent } from './calendar-footer.component';
@@ -193,7 +193,6 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
   constructor(
     public datePickerService: DatePickerService,
     public cdr: ChangeDetectorRef,
-    private ngZone: NgZone,
     private host: ElementRef<HTMLElement>
   ) {}
 
@@ -205,11 +204,9 @@ export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {
         this.cdr.markForCheck();
       });
 
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.host.nativeElement, 'mousedown')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => event.preventDefault());
-    });
+    fromEventOutsideAngular(this.host.nativeElement, 'mousedown')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => event.preventDefault());
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -22,7 +22,7 @@ import {
   booleanAttribute
 } from '@angular/core';
 import { BehaviorSubject, EMPTY, Subject, combineLatest, fromEvent, merge } from 'rxjs';
-import { auditTime, distinctUntilChanged, filter, map, mapTo, switchMap, takeUntil } from 'rxjs/operators';
+import { auditTime, distinctUntilChanged, filter, map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { POSITION_MAP } from 'ng-zorro-antd/core/overlay';
@@ -93,8 +93,8 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges 
       const nativeElement: HTMLElement = this.elementRef.nativeElement;
       /** host mouse state **/
       const hostMouseState$ = merge(
-        fromEvent(nativeElement, 'mouseenter').pipe(mapTo(true)),
-        fromEvent(nativeElement, 'mouseleave').pipe(mapTo(false))
+        fromEvent(nativeElement, 'mouseenter').pipe(map(() => true)),
+        fromEvent(nativeElement, 'mouseleave').pipe(map(() => false))
       );
       /** menu mouse state **/
       const menuMouseState$ = this.nzDropdownMenu.mouseState$;
@@ -116,7 +116,7 @@ export class NzDropDownDirective implements AfterViewInit, OnDestroy, OnChanges 
       );
       const descendantMenuItemClick$ = this.nzDropdownMenu.descendantMenuItemClick$.pipe(
         filter(() => this.nzClickHide),
-        mapTo(false)
+        map(() => false)
       );
       const domTriggerVisible$ = merge(visibleStateByTrigger$, descendantMenuItemClick$, this.overlayClose$).pipe(
         filter(() => !this.nzDisabled)

--- a/components/float-button/float-button-top.component.spec.ts
+++ b/components/float-button/float-button-top.component.spec.ts
@@ -1,14 +1,14 @@
 import { ApplicationRef, Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { NzScrollService } from 'ng-zorro-antd/core/services';
 
 import { NzFloatButtonTopComponent } from './float-button-top.component';
 import { NzFloatButtonModule } from './float-button.module';
 
-describe('Component:nz-float-button-top', () => {
+describe('nz-float-button-top', () => {
   let scrollService: MockNzScrollService;
   let fixture: ComponentFixture<TestBackTopComponent>;
   let debugElement: DebugElement;
@@ -33,15 +33,14 @@ describe('Component:nz-float-button-top', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NzFloatButtonModule, NoopAnimationsModule],
-      declarations: [TestBackTopComponent, TestBackTopTemplateComponent],
       providers: [
+        provideNoopAnimations(),
         {
           provide: NzScrollService,
           useClass: MockNzScrollService
         }
       ]
-    }).compileComponents();
+    });
 
     fixture = TestBed.createComponent(TestBackTopComponent);
     component = fixture.componentInstance.nzBackTopComponent;
@@ -177,27 +176,28 @@ describe('Component:nz-float-button-top', () => {
       expect(componentObject.backTopButton().nativeElement.classList).toContain('ant-float-btn-hidden');
     }));
 
-    it('element scroll shows the button', fakeAsync(() => {
-      const time = 50;
-
+    it('element scroll shows the button', (done: () => void) => {
       componentObject.scrollTo(fakeTarget, defaultVisibilityHeight + 1);
-      tick(time + 1);
       fixture.detectChanges();
 
-      expect(componentObject.backTopButton().nativeElement.classList).not.toContain('ant-float-btn-hidden');
-    }));
+      setTimeout(() => {
+        fixture.detectChanges();
+        expect(componentObject.backTopButton().nativeElement.classList).not.toContain('ant-float-btn-hidden');
+        done();
+      }, 50);
+    });
 
-    it('element (use string id) scroll shows the button', fakeAsync(() => {
+    it('element (use string id) scroll shows the button', (done: () => void) => {
       component.nzTarget = '#fakeTarget';
-
-      const time = 50;
-
       componentObject.scrollTo(fakeTarget, defaultVisibilityHeight + 1);
-      tick(time + 1);
       fixture.detectChanges();
 
-      expect(componentObject.backTopButton().nativeElement.classList).not.toContain('ant-float-btn-hidden');
-    }));
+      setTimeout(() => {
+        fixture.detectChanges();
+        expect(componentObject.backTopButton().nativeElement.classList).not.toContain('ant-float-btn-hidden');
+        done();
+      }, 50);
+    });
   });
 
   describe('#nzTemplate', () => {
@@ -214,6 +214,8 @@ describe('Component:nz-float-button-top', () => {
 });
 
 @Component({
+  standalone: true,
+  imports: [NzFloatButtonModule],
   template: `
     <nz-float-button-top [nzTarget]="target"></nz-float-button-top>
     <div id="fakeTarget"></div>
@@ -231,6 +233,8 @@ class TestBackTopComponent {
 }
 
 @Component({
+  standalone: true,
+  imports: [NzFloatButtonModule],
   template: `
     my comp
     <nz-float-button-top [nzIcon]="tpl">

--- a/components/graph/graph-node.component.ts
+++ b/components/graph/graph-node.component.ts
@@ -17,8 +17,10 @@ import {
   Renderer2,
   TemplateRef
 } from '@angular/core';
-import { fromEvent, Observable, Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
+
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzGraph } from './graph';
 import { NzGraphGroupNode, NzGraphNode } from './interface';
@@ -73,21 +75,19 @@ export class NzGraphNodeComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent<MouseEvent>(this.el.nativeElement, 'click')
-        .pipe(
-          filter(event => {
-            event.preventDefault();
-            return this.graphComponent.nzNodeClick.observers.length > 0;
-          }),
-          takeUntil(this.destroy$)
-        )
-        .subscribe(() => {
-          // Re-enter the Angular zone and run the change detection only if there're any `nzNodeClick` listeners,
-          // e.g.: `<nz-graph (nzNodeClick)="..."></nz-graph>`.
-          this.ngZone.run(() => this.graphComponent.nzNodeClick.emit(this.node));
-        });
-    });
+    fromEventOutsideAngular<MouseEvent>(this.el.nativeElement, 'click')
+      .pipe(
+        filter(event => {
+          event.preventDefault();
+          return this.graphComponent.nzNodeClick.observers.length > 0;
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        // Re-enter the Angular zone and run the change detection only if there're any `nzNodeClick` listeners,
+        // e.g.: `<nz-graph (nzNodeClick)="..."></nz-graph>`.
+        this.ngZone.run(() => this.graphComponent.nzNodeClick.emit(this.node));
+      });
   }
 
   ngOnDestroy(): void {

--- a/components/modal/modal-container.directive.ts
+++ b/components/modal/modal-container.directive.ts
@@ -22,13 +22,13 @@ import {
   Renderer2,
   inject
 } from '@angular/core';
-import { Subject, fromEvent } from 'rxjs';
+import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzConfigService } from 'ng-zorro-antd/core/config';
 import { reqAnimFrame } from 'ng-zorro-antd/core/polyfill';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
-import { getElementOffset, isNotNil } from 'ng-zorro-antd/core/util';
+import { fromEventOutsideAngular, getElementOffset, isNotNil } from 'ng-zorro-antd/core/util';
 
 import { FADE_CLASS_NAME_MAP, MODAL_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME, ZOOM_CLASS_NAME_MAP } from './modal-config';
 import { NzModalRef } from './modal-ref';
@@ -328,22 +328,20 @@ export class BaseModalContainerComponent extends BasePortalOutlet implements OnD
   }
 
   protected setupMouseListeners(modalContainer: ElementRef<HTMLElement>): void {
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.host.nativeElement, 'mouseup')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(() => {
-          if (this.mouseDown) {
-            setTimeout(() => {
-              this.mouseDown = false;
-            });
-          }
-        });
+    fromEventOutsideAngular(this.host.nativeElement, 'mouseup')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if (this.mouseDown) {
+          setTimeout(() => {
+            this.mouseDown = false;
+          });
+        }
+      });
 
-      fromEvent(modalContainer.nativeElement, 'mousedown')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.mouseDown = true;
-        });
-    });
+    fromEventOutsideAngular(modalContainer.nativeElement, 'mousedown')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.mouseDown = true;
+      });
   }
 }

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -415,24 +415,21 @@ describe('NzModal', () => {
     expect(overlayContainerElement.querySelector('nz-modal-container')).toBeNull();
   }));
 
-  it('should close when clicking on the modal wrap', fakeAsync(() => {
+  it('should close when clicking on the modal wrap', (done: () => void) => {
     modalService.create({
       nzContent: TestWithModalContentComponent
     });
 
     fixture.detectChanges();
-
     const modalWrapElement = overlayContainerElement.querySelector('nz-modal-container') as HTMLElement;
-    const modalElement = overlayContainerElement.querySelector('nz-modal-container .ant-modal') as HTMLElement;
-    dispatchMouseEvent(modalElement, 'mousedown');
-    fixture.detectChanges();
-    dispatchMouseEvent(modalWrapElement, 'mouseup');
-    flush();
     modalWrapElement.click();
-    fixture.detectChanges();
-    flush();
-    expect(overlayContainerElement.querySelector('nz-modal-container')).toBeFalsy();
-  }));
+
+    setTimeout(() => {
+      fixture.detectChanges();
+      expect(overlayContainerElement.querySelector('nz-modal-container')).toBeFalsy();
+      done();
+    }, 16);
+  });
 
   it("should close when clicking on the modal's close button", fakeAsync(() => {
     modalService.create({
@@ -520,10 +517,9 @@ describe('NzModal', () => {
     configService.set('modal', { nzMask: true });
     fixture.detectChanges();
 
-    expect(modalRef.getBackdropElement()?.classList).toContain(
-      'ant-modal-mask',
-      'should add class when global config changed'
-    );
+    expect(modalRef.getBackdropElement()?.classList)
+      .withContext('should add class when global config changed')
+      .toContain('ant-modal-mask');
 
     modalRef.close();
     fixture.detectChanges();

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -27,12 +27,12 @@ import {
   numberAttribute
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { fromEvent } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
 import { NgClassType } from 'ng-zorro-antd/core/types';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 
 import { NzRateItemComponent } from './rate-item.component';
@@ -171,25 +171,23 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
 
     this.dir = this.directionality.value;
 
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent<FocusEvent>(this.ulElement.nativeElement, 'focus')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => {
-          this.isFocused = true;
-          if (this.nzOnFocus.observers.length) {
-            this.ngZone.run(() => this.nzOnFocus.emit(event));
-          }
-        });
+    fromEventOutsideAngular<FocusEvent>(this.ulElement.nativeElement, 'focus')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        this.isFocused = true;
+        if (this.nzOnFocus.observers.length) {
+          this.ngZone.run(() => this.nzOnFocus.emit(event));
+        }
+      });
 
-      fromEvent<FocusEvent>(this.ulElement.nativeElement, 'blur')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => {
-          this.isFocused = false;
-          if (this.nzOnBlur.observers.length) {
-            this.ngZone.run(() => this.nzOnBlur.emit(event));
-          }
-        });
-    });
+    fromEventOutsideAngular<FocusEvent>(this.ulElement.nativeElement, 'blur')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        this.isFocused = false;
+        if (this.nzOnBlur.observers.length) {
+          this.ngZone.run(() => this.nzOnBlur.emit(event));
+        }
+      });
   }
 
   onItemClick(index: number, isHalf: boolean): void {

--- a/components/resizable/resizable.directive.ts
+++ b/components/resizable/resizable.directive.ts
@@ -17,11 +17,10 @@ import {
   Output,
   Renderer2
 } from '@angular/core';
-import { fromEvent } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
-import { ensureInBounds } from 'ng-zorro-antd/core/util';
+import { ensureInBounds, fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { getEventWithPoint } from './resizable-utils';
 import { NzResizableService } from './resizable.service';
@@ -287,19 +286,17 @@ export class NzResizableDirective implements AfterViewInit, OnDestroy {
     this.el = this.elementRef.nativeElement;
     this.setPosition();
 
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.el, 'mouseenter')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.nzResizableService.mouseEnteredOutsideAngular$.next(true);
-        });
+    fromEventOutsideAngular(this.el, 'mouseenter')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.nzResizableService.mouseEnteredOutsideAngular$.next(true);
+      });
 
-      fromEvent(this.el, 'mouseleave')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.nzResizableService.mouseEnteredOutsideAngular$.next(false);
-        });
-    });
+    fromEventOutsideAngular(this.el, 'mouseleave')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.nzResizableService.mouseEnteredOutsideAngular$.next(false);
+      });
   }
 
   ngOnDestroy(): void {

--- a/components/resizable/resizable.spec.ts
+++ b/components/resizable/resizable.spec.ts
@@ -1,5 +1,5 @@
 import { ApplicationRef, Component, ElementRef, NgZone, ViewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { dispatchMouseEvent, dispatchTouchEvent, MockNgZone } from 'ng-zorro-antd/core/testing';
@@ -76,7 +76,7 @@ describe('resizable', () => {
       expect(appRef.tick).toHaveBeenCalledTimes(0);
     });
 
-    it('should maximum size work', fakeAsync(() => {
+    it('should maximum size work', (done: () => void) => {
       const rect = resizableEle.getBoundingClientRect();
       const handel = resizableEle.querySelector('.nz-resizable-handle-bottomRight') as HTMLElement;
       mouseMoveTrigger(
@@ -93,13 +93,15 @@ describe('resizable', () => {
       zone.simulateZoneExit();
       fixture.detectChanges();
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.width).toBe(600);
-      expect(testComponent.height).toBe(200);
-    }));
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        expect(testComponent.width).toBe(600);
+        expect(testComponent.height).toBe(200);
+        done();
+      });
+    });
 
-    it('should minimum size work', fakeAsync(() => {
+    it('should minimum size work', (done: () => void) => {
       const rect = resizableEle.getBoundingClientRect();
       const handel = resizableEle.querySelector('.nz-resizable-handle-bottomRight') as HTMLElement;
       mouseMoveTrigger(
@@ -114,11 +116,13 @@ describe('resizable', () => {
         }
       );
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.width).toBe(80);
-      expect(testComponent.height).toBe(80);
-    }));
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        expect(testComponent.width).toBe(80);
+        expect(testComponent.height).toBe(80);
+        done();
+      });
+    });
 
     describe('should resize work', () => {
       let rect: DOMRect;
@@ -132,7 +136,7 @@ describe('resizable', () => {
         expect(testComponent.height).toBe(200);
       });
 
-      it('should touch event work', fakeAsync(() => {
+      it('should touch event work', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-top') as HTMLElement;
         touchMoveTrigger(
           handle,
@@ -146,19 +150,21 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.height).toBeLessThanOrEqual(200);
-        expect(testComponent.height).toBeGreaterThanOrEqual(100);
-        expect(testComponent.resizeDirection).toEqual('top');
-      }));
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.height).toBeLessThanOrEqual(200);
+          expect(testComponent.height).toBeGreaterThanOrEqual(100);
+          expect(testComponent.resizeDirection).toEqual('top');
+          done();
+        });
+      });
 
       /**
        *  +---↓---+
        *  |       |
        *  +-------+
        */
-      it('top', fakeAsync(() => {
+      it('top', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-top') as HTMLElement;
         mouseMoveTrigger(
           handle,
@@ -172,19 +178,21 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.height).toBeLessThanOrEqual(200);
-        expect(testComponent.height).toBeGreaterThanOrEqual(100);
-        expect(testComponent.resizeDirection).toEqual('top');
-      }));
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.height).toBeLessThanOrEqual(200);
+          expect(testComponent.height).toBeGreaterThanOrEqual(100);
+          expect(testComponent.resizeDirection).toEqual('top');
+          done();
+        });
+      });
 
       /**
        *  +-------+
        *  |       |
        *  +---↑---+
        */
-      it('bottom', fakeAsync(() => {
+      it('bottom', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-bottom') as HTMLElement;
         mouseMoveTrigger(
           handle,
@@ -198,19 +206,21 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.height).toBeLessThanOrEqual(200);
-        expect(testComponent.height).toBeGreaterThanOrEqual(100);
-        expect(testComponent.resizeDirection).toEqual('bottom');
-      }));
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.height).toBeLessThanOrEqual(200);
+          expect(testComponent.height).toBeGreaterThanOrEqual(100);
+          expect(testComponent.resizeDirection).toEqual('bottom');
+          done();
+        });
+      });
 
       /**
        *  +-------+
        *  →       |
        *  +-------+
        */
-      it('left', fakeAsync(() => {
+      it('left', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-left') as HTMLElement;
         mouseMoveTrigger(
           handle,
@@ -224,19 +234,21 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.width).toBeLessThanOrEqual(400);
-        expect(testComponent.width).toBeGreaterThanOrEqual(300);
-        expect(testComponent.resizeDirection).toEqual('left');
-      }));
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.width).toBeLessThanOrEqual(400);
+          expect(testComponent.width).toBeGreaterThanOrEqual(300);
+          expect(testComponent.resizeDirection).toEqual('left');
+          done();
+        });
+      });
 
       /**
        *  +-------+
        *  |       ←
        *  +-------+
        */
-      it('right', fakeAsync(() => {
+      it('right', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-right') as HTMLElement;
         mouseMoveTrigger(
           handle,
@@ -250,19 +262,21 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.width).toBeLessThanOrEqual(400);
-        expect(testComponent.width).toBeGreaterThanOrEqual(300);
-        expect(testComponent.resizeDirection).toEqual('right');
-      }));
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.width).toBeLessThanOrEqual(400);
+          expect(testComponent.width).toBeGreaterThanOrEqual(300);
+          expect(testComponent.resizeDirection).toEqual('right');
+          done();
+        });
+      });
 
       /**
        *  +-------↙
        *  |       |
        *  +------+
        */
-      it('topRight', fakeAsync(() => {
+      it('topRight', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-topRight') as HTMLElement;
         mouseMoveTrigger(
           handle,
@@ -276,21 +290,23 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.width).toBeLessThanOrEqual(400);
-        expect(testComponent.width).toBeGreaterThanOrEqual(300);
-        expect(testComponent.height).toBeLessThanOrEqual(210);
-        expect(testComponent.height).toBeGreaterThanOrEqual(100);
-        expect(testComponent.resizeDirection).toEqual('topRight');
-      }));
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.width).toBeLessThanOrEqual(400);
+          expect(testComponent.width).toBeGreaterThanOrEqual(300);
+          expect(testComponent.height).toBeLessThanOrEqual(210);
+          expect(testComponent.height).toBeGreaterThanOrEqual(100);
+          expect(testComponent.resizeDirection).toEqual('topRight');
+          done();
+        });
+      });
 
       /**
        *  ↘-------+
        *  |       |
        *  +-------+
        */
-      it('topLeft', fakeAsync(() => {
+      it('topLeft', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-topLeft') as HTMLElement;
         mouseMoveTrigger(
           handle,
@@ -304,21 +320,23 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.width).toBeLessThanOrEqual(400);
-        expect(testComponent.width).toBeGreaterThanOrEqual(300);
-        expect(testComponent.height).toBeLessThanOrEqual(200);
-        expect(testComponent.height).toBeGreaterThanOrEqual(100);
-        expect(testComponent.resizeDirection).toEqual('topLeft');
-      }));
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.width).toBeLessThanOrEqual(400);
+          expect(testComponent.width).toBeGreaterThanOrEqual(300);
+          expect(testComponent.height).toBeLessThanOrEqual(200);
+          expect(testComponent.height).toBeGreaterThanOrEqual(100);
+          expect(testComponent.resizeDirection).toEqual('topLeft');
+          done();
+        });
+      });
 
       /**
        *  +-------+
        *  |       |
        *  +-------↖
        */
-      it('bottomRight', fakeAsync(() => {
+      it('bottomRight', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-bottomRight') as HTMLElement;
         mouseMoveTrigger(
           handle,
@@ -332,21 +350,23 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.width).toBeLessThanOrEqual(400);
-        expect(testComponent.width).toBeGreaterThanOrEqual(300);
-        expect(testComponent.height).toBeLessThanOrEqual(190);
-        expect(testComponent.height).toBeGreaterThanOrEqual(100);
-        expect(testComponent.resizeDirection).toEqual('bottomRight');
-      }));
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.width).toBeLessThanOrEqual(400);
+          expect(testComponent.width).toBeGreaterThanOrEqual(300);
+          expect(testComponent.height).toBeLessThanOrEqual(190);
+          expect(testComponent.height).toBeGreaterThanOrEqual(100);
+          expect(testComponent.resizeDirection).toEqual('bottomRight');
+          done();
+        });
+      });
 
       /**
        *  +-------+
        *  |       |
        *  ↗-------+
        */
-      it('bottomLeft', fakeAsync(() => {
+      it('bottomLeft', (done: () => void) => {
         const handle = resizableEle.querySelector('.nz-resizable-handle-bottomLeft') as HTMLElement;
         mouseMoveTrigger(
           handle,
@@ -360,17 +380,20 @@ describe('resizable', () => {
           }
         );
         fixture.detectChanges();
-        tick(16);
-        fixture.detectChanges();
-        expect(testComponent.width).toBeLessThanOrEqual(400);
-        expect(testComponent.width).toBeGreaterThanOrEqual(300);
-        expect(testComponent.height).toBeLessThanOrEqual(200);
-        expect(testComponent.height).toBeGreaterThanOrEqual(100);
-        expect(testComponent.resizeDirection).toEqual('bottomLeft');
-      }));
+
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.width).toBeLessThanOrEqual(400);
+          expect(testComponent.width).toBeGreaterThanOrEqual(300);
+          expect(testComponent.height).toBeLessThanOrEqual(200);
+          expect(testComponent.height).toBeGreaterThanOrEqual(100);
+          expect(testComponent.resizeDirection).toEqual('bottomLeft');
+          done();
+        });
+      });
     });
 
-    it('should disabled work', fakeAsync(() => {
+    it('should disabled work', (done: () => void) => {
       testComponent.disabled = true;
       fixture.detectChanges();
       expect(resizableEle.classList).toContain(`nz-resizable-disabled`);
@@ -389,10 +412,12 @@ describe('resizable', () => {
         }
       );
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.width).toBe(400);
-    }));
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        expect(testComponent.width).toBe(400);
+        done();
+      });
+    });
   });
 
   describe('customize', () => {
@@ -407,7 +432,7 @@ describe('resizable', () => {
       fixture.detectChanges();
     });
 
-    it('should customize handles', fakeAsync(() => {
+    it('should customize handles', (done: () => void) => {
       const bottomRightHandel = resizableEle.querySelector('.nz-resizable-handle-bottomRight') as HTMLElement;
       expect(bottomRightHandel.querySelector('.bottom-right')).toBeTruthy();
       const rightHandel = resizableEle.querySelector('.nz-resizable-handle-right') as HTMLElement;
@@ -428,12 +453,14 @@ describe('resizable', () => {
       zone.simulateZoneExit();
       fixture.detectChanges();
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      zone.simulateZoneExit();
-      fixture.detectChanges();
-      expect(testComponent.width).toBeGreaterThanOrEqual(600);
-    }));
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        fixture.detectChanges();
+        expect(testComponent.width).toBeGreaterThanOrEqual(600);
+        done();
+      });
+    });
   });
 
   describe('lock aspect ratio', () => {
@@ -448,7 +475,7 @@ describe('resizable', () => {
       fixture.detectChanges();
     });
 
-    it('should lock aspect ratio when resize', fakeAsync(() => {
+    it('should lock aspect ratio when resize', (done: () => void) => {
       const rect = resizableEle.getBoundingClientRect();
       const leftHandel = resizableEle.querySelector('.nz-resizable-handle-right') as HTMLElement;
       const topHandel = resizableEle.querySelector('.nz-resizable-handle-top') as HTMLElement;
@@ -466,38 +493,42 @@ describe('resizable', () => {
         }
       );
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      mouseMoveTrigger(
-        bottomRightHandel,
-        {
-          x: rect.right,
-          y: rect.bottom
-        },
-        {
-          x: rect.right - 123,
-          y: rect.bottom - 321
-        }
-      );
-      fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      mouseMoveTrigger(
-        topHandel,
-        {
-          x: rect.right,
-          y: rect.top
-        },
-        {
-          x: rect.right,
-          y: rect.top + 100
-        }
-      );
-      fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(Math.round(testComponent.width / testComponent.height)).toBe(ratio);
-    }));
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        mouseMoveTrigger(
+          bottomRightHandel,
+          {
+            x: rect.right,
+            y: rect.bottom
+          },
+          {
+            x: rect.right - 123,
+            y: rect.bottom - 321
+          }
+        );
+        fixture.detectChanges();
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          mouseMoveTrigger(
+            topHandel,
+            {
+              x: rect.right,
+              y: rect.top
+            },
+            {
+              x: rect.right,
+              y: rect.top + 100
+            }
+          );
+          fixture.detectChanges();
+          afterNextFrameRender(() => {
+            fixture.detectChanges();
+            expect(Math.round(testComponent.width / testComponent.height)).toBe(ratio);
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('preview', () => {
@@ -510,7 +541,7 @@ describe('resizable', () => {
       fixture.detectChanges();
     });
 
-    it('should preview work', fakeAsync(() => {
+    it('should preview work', () => {
       const rect = resizableEle.getBoundingClientRect();
       const handle = resizableEle.querySelector('.nz-resizable-handle-bottomRight') as HTMLElement;
       dispatchMouseEvent(handle, 'mousedown', rect.right, rect.bottom);
@@ -518,11 +549,7 @@ describe('resizable', () => {
       fixture.detectChanges();
       const preview = resizableEle.querySelector('.nz-resizable-preview') as HTMLElement;
       expect(preview).toBeTruthy();
-      dispatchMouseEvent(window.document, 'mouseup');
-      fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-    }));
+    });
   });
 
   describe('grid', () => {
@@ -537,7 +564,7 @@ describe('resizable', () => {
       fixture.detectChanges();
     });
 
-    it('should grid work', fakeAsync(() => {
+    it('should grid work', (done: () => void) => {
       const rect = resizableEle.getBoundingClientRect();
       const handle = resizableEle.querySelector('.nz-resizable-handle-right') as HTMLElement;
       mouseMoveTrigger(
@@ -552,25 +579,28 @@ describe('resizable', () => {
         }
       );
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.col).toBe(3);
-      mouseMoveTrigger(
-        handle,
-        {
-          x: rect.right,
-          y: rect.bottom
-        },
-        {
-          x: 9999,
-          y: rect.bottom
-        }
-      );
-      fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.col).toBe(20);
-    }));
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        expect(testComponent.col).toBe(3);
+        mouseMoveTrigger(
+          handle,
+          {
+            x: rect.right,
+            y: rect.bottom
+          },
+          {
+            x: 9999,
+            y: rect.bottom
+          }
+        );
+        fixture.detectChanges();
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.col).toBe(20);
+          done();
+        });
+      });
+    });
 
     it('should cursor type work', () => {
       expect(resizableEle.querySelector('.nz-resizable-handle-cursor-type-window')).toBeFalsy();
@@ -599,7 +629,7 @@ describe('resizable', () => {
       fixture.detectChanges();
     });
 
-    it('should parent bounds work', fakeAsync(() => {
+    it('should parent bounds work', (done: () => void) => {
       const rect = resizableEle.getBoundingClientRect();
       const handle = resizableEle.querySelector('.nz-resizable-handle-bottomRight') as HTMLElement;
       mouseMoveTrigger(
@@ -614,13 +644,16 @@ describe('resizable', () => {
         }
       );
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.width).toBe(200);
-      expect(testComponent.height).toBe(200);
-    }));
 
-    it('should element ref bounds work', fakeAsync(() => {
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        expect(testComponent.width).toBe(200);
+        expect(testComponent.height).toBe(200);
+        done();
+      });
+    });
+
+    it('should element ref bounds work', (done: () => void) => {
       const rect = resizableEle.getBoundingClientRect();
       testComponent.bounds = testComponent.boxRef;
       fixture.detectChanges();
@@ -637,13 +670,16 @@ describe('resizable', () => {
         }
       );
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.width).toBe(256);
-      expect(testComponent.height).toBe(256);
-    }));
 
-    it('should window bounds work', fakeAsync(() => {
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        expect(testComponent.width).toBe(256);
+        expect(testComponent.height).toBe(256);
+        done();
+      });
+    });
+
+    it('should window bounds work', (done: () => void) => {
       const rect = resizableEle.getBoundingClientRect();
       testComponent.bounds = 'window';
       fixture.detectChanges();
@@ -660,30 +696,35 @@ describe('resizable', () => {
         }
       );
       fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.width).toBe(300);
-      expect(testComponent.height).toBe(300);
-      testComponent.maxHeight = window.innerHeight * 2;
-      testComponent.maxWidth = window.innerWidth * 2;
-      fixture.detectChanges();
-      mouseMoveTrigger(
-        handle,
-        {
-          x: rect.right,
-          y: rect.bottom
-        },
-        {
-          x: rect.right + window.innerWidth,
-          y: rect.bottom + window.innerHeight
-        }
-      );
-      fixture.detectChanges();
-      tick(16);
-      fixture.detectChanges();
-      expect(testComponent.width).toBe(window.innerWidth);
-      expect(testComponent.height).toBe(window.innerHeight);
-    }));
+
+      afterNextFrameRender(() => {
+        fixture.detectChanges();
+        expect(testComponent.width).toBe(300);
+        expect(testComponent.height).toBe(300);
+        testComponent.maxHeight = window.innerHeight * 2;
+        testComponent.maxWidth = window.innerWidth * 2;
+        fixture.detectChanges();
+        mouseMoveTrigger(
+          handle,
+          {
+            x: rect.right,
+            y: rect.bottom
+          },
+          {
+            x: rect.right + window.innerWidth,
+            y: rect.bottom + window.innerHeight
+          }
+        );
+        fixture.detectChanges();
+
+        afterNextFrameRender(() => {
+          fixture.detectChanges();
+          expect(testComponent.width).toBe(window.innerWidth);
+          expect(testComponent.height).toBe(window.innerHeight);
+          done();
+        });
+      });
+    });
   });
 });
 
@@ -697,6 +738,10 @@ function touchMoveTrigger(el: HTMLElement, from: { x: number; y: number }, to: {
   dispatchTouchEvent(el, 'touchstart', from.x, from.y);
   dispatchTouchEvent(window.document, 'touchmove', to.x, to.y);
   dispatchTouchEvent(window.document, 'touchend');
+}
+
+function afterNextFrameRender(callbackFn: () => void): void {
+  setTimeout(callbackFn, 16);
 }
 
 @Component({

--- a/components/resizable/resize-handle.component.ts
+++ b/components/resizable/resize-handle.component.ts
@@ -11,15 +11,15 @@ import {
   EventEmitter,
   HostListener,
   Input,
-  NgZone,
   OnInit,
   Output,
   Renderer2
 } from '@angular/core';
-import { fromEvent, merge } from 'rxjs';
+import { merge } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzResizableService } from './resizable.service';
 
@@ -71,7 +71,6 @@ export class NzResizeHandleComponent implements OnInit {
   @Output() readonly nzMouseDown = new EventEmitter<NzResizeHandleMouseDownEvent>();
 
   constructor(
-    private ngZone: NgZone,
     private nzResizableService: NzResizableService,
     private renderer: Renderer2,
     private host: ElementRef<HTMLElement>,
@@ -87,21 +86,19 @@ export class NzResizeHandleComponent implements OnInit {
       }
     });
 
-    this.ngZone.runOutsideAngular(() => {
-      // Note: since Chrome 56 defaults document level `touchstart` listener to passive.
-      // The element `touchstart` listener is not passive by default
-      // We never call `preventDefault()` on it, so we're safe making it passive too.
-      merge(
-        fromEvent<MouseEvent>(this.host.nativeElement, 'mousedown', passiveEventListenerOptions),
-        fromEvent<TouchEvent>(this.host.nativeElement, 'touchstart', passiveEventListenerOptions)
-      )
-        .pipe(takeUntil(this.destroy$))
-        .subscribe((event: MouseEvent | TouchEvent) => {
-          this.nzResizableService.handleMouseDownOutsideAngular$.next(
-            new NzResizeHandleMouseDownEvent(this.nzDirection, event)
-          );
-        });
-    });
+    // Note: since Chrome 56 defaults document level `touchstart` listener to passive.
+    // The element `touchstart` listener is not passive by default
+    // We never call `preventDefault()` on it, so we're safe making it passive too.
+    merge(
+      fromEventOutsideAngular<MouseEvent>(this.host.nativeElement, 'mousedown', passiveEventListenerOptions),
+      fromEventOutsideAngular<TouchEvent>(this.host.nativeElement, 'touchstart', passiveEventListenerOptions)
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((event: MouseEvent | TouchEvent) => {
+        this.nzResizableService.handleMouseDownOutsideAngular$.next(
+          new NzResizeHandleMouseDownEvent(this.nzDirection, event)
+        );
+      });
   }
 
   @HostListener('pointerdown', ['$event'])

--- a/components/select/option-item.component.ts
+++ b/components/select/option-item.component.ts
@@ -18,11 +18,11 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { fromEvent } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
@@ -94,22 +94,20 @@ export class NzOptionItemComponent implements OnChanges, OnInit {
   }
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.elementRef.nativeElement, 'click')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(() => {
-          if (!this.disabled) {
-            this.ngZone.run(() => this.itemClick.emit(this.value));
-          }
-        });
+    fromEventOutsideAngular(this.elementRef.nativeElement, 'click')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if (!this.disabled) {
+          this.ngZone.run(() => this.itemClick.emit(this.value));
+        }
+      });
 
-      fromEvent(this.elementRef.nativeElement, 'mouseenter')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(() => {
-          if (!this.disabled) {
-            this.ngZone.run(() => this.itemHover.emit(this.value));
-          }
-        });
-    });
+    fromEventOutsideAngular(this.elementRef.nativeElement, 'mouseenter')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if (!this.disabled) {
+          this.ngZone.run(() => this.itemHover.emit(this.value));
+        }
+      });
   }
 }

--- a/components/select/select-top-control.component.ts
+++ b/components/select/select-top-control.component.ts
@@ -22,11 +22,12 @@ import {
   inject,
   numberAttribute
 } from '@angular/core';
-import { Subject, fromEvent } from 'rxjs';
+import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzSelectItemComponent } from './select-item.component';
 import { NzSelectPlaceholderComponent } from './select-placeholder.component';
@@ -233,35 +234,28 @@ export class NzSelectTopControlComponent implements OnChanges, OnInit, OnDestroy
   }
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent<MouseEvent>(this.elementRef.nativeElement, 'click')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => {
-          // `HTMLElement.focus()` is a native DOM API which doesn't require Angular to run change detection.
-          if (event.target !== this.nzSelectSearchComponent.inputElement.nativeElement) {
-            this.nzSelectSearchComponent.focus();
-          }
-        });
+    fromEventOutsideAngular<MouseEvent>(this.elementRef.nativeElement, 'click')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        // `HTMLElement.focus()` is a native DOM API which doesn't require Angular to run change detection.
+        if (event.target !== this.nzSelectSearchComponent.inputElement.nativeElement) {
+          this.nzSelectSearchComponent.focus();
+        }
+      });
 
-      fromEvent<KeyboardEvent>(this.elementRef.nativeElement, 'keydown')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => {
-          if (event.target instanceof HTMLInputElement) {
-            const inputValue = event.target.value;
+    fromEventOutsideAngular<KeyboardEvent>(this.elementRef.nativeElement, 'keydown')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        if (event.target instanceof HTMLInputElement) {
+          const inputValue = event.target.value;
 
-            if (
-              event.keyCode === BACKSPACE &&
-              this.mode !== 'default' &&
-              !inputValue &&
-              this.listOfTopItem.length > 0
-            ) {
-              event.preventDefault();
-              // Run change detection only if the user has pressed the `Backspace` key and the following condition is met.
-              this.ngZone.run(() => this.onDeleteItem(this.listOfTopItem[this.listOfTopItem.length - 1]));
-            }
+          if (event.keyCode === BACKSPACE && this.mode !== 'default' && !inputValue && this.listOfTopItem.length > 0) {
+            event.preventDefault();
+            // Run change detection only if the user has pressed the `Backspace` key and the following condition is met.
+            this.ngZone.run(() => this.onDeleteItem(this.listOfTopItem[this.listOfTopItem.length - 1]));
           }
-        });
-    });
+        }
+      });
   }
 
   ngOnDestroy(): void {

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -41,7 +41,7 @@ import {
   signal
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { BehaviorSubject, combineLatest, fromEvent, merge, of as observableOf } from 'rxjs';
+import { BehaviorSubject, combineLatest, merge, of as observableOf } from 'rxjs';
 import { distinctUntilChanged, map, startWith, switchMap, takeUntil, withLatestFrom } from 'rxjs/operators';
 
 import { slideMotion } from 'ng-zorro-antd/core/animation';
@@ -60,7 +60,7 @@ import {
   OnChangeType,
   OnTouchedType
 } from 'ng-zorro-antd/core/types';
-import { getStatusClassNames, isNotNil } from 'ng-zorro-antd/core/util';
+import { fromEventOutsideAngular, getStatusClassNames, isNotNil } from 'ng-zorro-antd/core/util';
 import { NZ_SPACE_COMPACT_ITEM_TYPE, NZ_SPACE_COMPACT_SIZE, NzSpaceCompactItemDirective } from 'ng-zorro-antd/space';
 
 import { NzOptionContainerComponent } from './option-container.component';
@@ -758,17 +758,15 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
 
     this.dir = this.directionality.value;
 
-    this.ngZone.runOutsideAngular(() =>
-      fromEvent(this.host.nativeElement, 'click')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(() => {
-          if ((this.nzOpen && this.nzShowSearch) || this.nzDisabled) {
-            return;
-          }
+    fromEventOutsideAngular(this.host.nativeElement, 'click')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        if ((this.nzOpen && this.nzShowSearch) || this.nzDisabled) {
+          return;
+        }
 
-          this.ngZone.run(() => this.setOpenState(!this.nzOpen));
-        })
-    );
+        this.ngZone.run(() => this.setOpenState(!this.nzOpen));
+      });
 
     // Caretaker note: we could've added this listener within the template `(overlayKeydown)="..."`,
     // but with this approach, it'll run change detection on each keyboard click, and also it'll run

--- a/components/steps/step.component.ts
+++ b/components/steps/step.component.ts
@@ -10,19 +10,19 @@ import {
   Component,
   ElementRef,
   Input,
-  NgZone,
   OnInit,
   TemplateRef,
   ViewChild,
   ViewEncapsulation,
   booleanAttribute
 } from '@angular/core';
-import { Subject, fromEvent } from 'rxjs';
+import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
 import { NgClassType, NzSizeDSType } from 'ng-zorro-antd/core/types';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzProgressFormatter, NzProgressModule } from 'ng-zorro-antd/progress';
 
@@ -197,21 +197,18 @@ export class NzStepComponent implements OnInit {
 
   constructor(
     private cdr: ChangeDetectorRef,
-    private ngZone: NgZone,
     private destroy$: NzDestroyService
   ) {}
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() =>
-      fromEvent(this.itemContainer.nativeElement, 'click')
-        .pipe(
-          filter(() => this.clickable && this.currentIndex !== this.index && !this.nzDisabled),
-          takeUntil(this.destroy$)
-        )
-        .subscribe(() => {
-          this.clickOutsideAngular$.next(this.index);
-        })
-    );
+    fromEventOutsideAngular(this.itemContainer.nativeElement, 'click')
+      .pipe(
+        filter(() => this.clickable && this.currentIndex !== this.index && !this.nzDisabled),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        this.clickOutsideAngular$.next(this.index);
+      });
   }
 
   enable(): void {

--- a/components/table/src/addon/filter-trigger.component.ts
+++ b/components/table/src/addon/filter-trigger.component.ts
@@ -10,18 +10,17 @@ import {
   ElementRef,
   EventEmitter,
   Input,
-  NgZone,
   OnInit,
   Output,
   ViewChild,
   ViewEncapsulation,
   booleanAttribute
 } from '@angular/core';
-import { fromEvent } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzDropDownDirective, NzDropDownModule, NzDropdownMenuComponent } from 'ng-zorro-antd/dropdown';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'filterTrigger';
@@ -83,18 +82,15 @@ export class NzFilterTriggerComponent implements OnInit {
 
   constructor(
     public readonly nzConfigService: NzConfigService,
-    private ngZone: NgZone,
     private cdr: ChangeDetectorRef,
     private destroy$: NzDestroyService
   ) {}
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.nzDropdown.nativeElement, 'click')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => {
-          event.stopPropagation();
-        });
-    });
+    fromEventOutsideAngular(this.nzDropdown.nativeElement, 'click')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        event.stopPropagation();
+      });
   }
 }

--- a/components/table/src/cell/th-addon.component.ts
+++ b/components/table/src/cell/th-addon.component.ts
@@ -21,11 +21,12 @@ import {
   ViewEncapsulation,
   booleanAttribute
 } from '@angular/core';
-import { Subject, fromEvent } from 'rxjs';
+import { Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzTableFilterComponent } from '../addon/filter.component';
 import { NzTableSortersComponent } from '../addon/sorters.component';
@@ -148,20 +149,18 @@ export class NzThAddOnComponent<T> implements OnChanges, OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() =>
-      fromEvent(this.host.nativeElement, 'click')
-        .pipe(
-          filter(() => this.nzShowSort),
-          takeUntil(this.destroy$)
-        )
-        .subscribe(() => {
-          const nextOrder = this.getNextSortDirection(this.sortDirections, this.sortOrder!);
-          this.ngZone.run(() => {
-            this.setSortOrder(nextOrder);
-            this.manualClickOrder$.next(this);
-          });
-        })
-    );
+    fromEventOutsideAngular(this.host.nativeElement, 'click')
+      .pipe(
+        filter(() => this.nzShowSort),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        const nextOrder = this.getNextSortDirection(this.sortDirections, this.sortOrder!);
+        this.ngZone.run(() => {
+          this.setSortOrder(nextOrder);
+          this.manualClickOrder$.next(this);
+        });
+      });
 
     this.sortOrderChange$.pipe(takeUntil(this.destroy$)).subscribe(order => {
       if (this.sortOrder !== order) {

--- a/components/table/src/table/table-inner-scroll.component.ts
+++ b/components/table/src/table/table-inner-scroll.component.ts
@@ -22,11 +22,12 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { fromEvent, merge, Subject } from 'rxjs';
+import { merge, Subject } from 'rxjs';
 import { delay, filter, startWith, switchMap, takeUntil } from 'rxjs/operators';
 
 import { NzResizeService } from 'ng-zorro-antd/core/services';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzTableSummaryFixedType } from '../table.types';
 import { NzTableContentComponent } from './table-content.component';
@@ -191,7 +192,9 @@ export class NzTableInnerScrollComponent<T> implements OnChanges, AfterViewInit,
         const scrollEvent$ = this.scroll$.pipe(
           startWith(null),
           delay(0),
-          switchMap(() => fromEvent<MouseEvent>(this.tableBodyElement.nativeElement, 'scroll').pipe(startWith(true))),
+          switchMap(() =>
+            fromEventOutsideAngular<MouseEvent>(this.tableBodyElement.nativeElement, 'scroll').pipe(startWith(true))
+          ),
           takeUntil(this.destroy$)
         );
         const resize$ = this.resizeService.subscribe().pipe(takeUntil(this.destroy$));

--- a/components/time-picker/time-picker-panel.component.ts
+++ b/components/time-picker/time-picker-panel.component.ts
@@ -26,12 +26,12 @@ import {
   numberAttribute
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { Subject, fromEvent } from 'rxjs';
+import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { reqAnimFrame } from 'ng-zorro-antd/core/polyfill';
-import { isNotNil } from 'ng-zorro-antd/core/util';
+import { fromEventOutsideAngular, isNotNil } from 'ng-zorro-antd/core/util';
 import { DateHelperService, NzI18nModule } from 'ng-zorro-antd/i18n';
 
 import { TimeHolder } from './time-holder';
@@ -548,13 +548,13 @@ export class NzTimePickerPanelComponent implements ControlValueAccessor, OnInit,
         this.scrollToTime();
         this.firstScrolled = true;
       });
-
-      fromEvent(this.elementRef.nativeElement, 'mousedown')
-        .pipe(takeUntil(this.unsubscribe$))
-        .subscribe(event => {
-          event.preventDefault();
-        });
     });
+
+    fromEventOutsideAngular(this.elementRef.nativeElement, 'mousedown')
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(event => {
+        event.preventDefault();
+      });
   }
 
   ngOnDestroy(): void {

--- a/components/tree-view/checkbox.ts
+++ b/components/tree-view/checkbox.ts
@@ -15,10 +15,10 @@ import {
   Output,
   booleanAttribute
 } from '@angular/core';
-import { fromEvent } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 @Component({
   selector: 'nz-tree-node-checkbox:not([builtin])',
@@ -48,17 +48,15 @@ export class NzTreeNodeCheckboxComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() =>
-      fromEvent<MouseEvent>(this.host.nativeElement, 'click')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe((event: MouseEvent) => {
-          if (!this.nzDisabled && this.nzClick.observers.length) {
-            this.ngZone.run(() => {
-              this.nzClick.emit(event);
-              this.ref.markForCheck();
-            });
-          }
-        })
-    );
+    fromEventOutsideAngular<MouseEvent>(this.host.nativeElement, 'click')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((event: MouseEvent) => {
+        if (!this.nzDisabled && this.nzClick.observers.length) {
+          this.ngZone.run(() => {
+            this.nzClick.emit(event);
+            this.ref.markForCheck();
+          });
+        }
+      });
   }
 }

--- a/components/tree-view/option.ts
+++ b/components/tree-view/option.ts
@@ -16,10 +16,10 @@ import {
   SimpleChanges,
   booleanAttribute
 } from '@angular/core';
-import { fromEvent } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzTreeNodeComponent } from './node';
 
@@ -71,15 +71,13 @@ export class NzTreeNodeOptionComponent<T> implements OnChanges, OnInit {
   }
 
   ngOnInit(): void {
-    this.ngZone.runOutsideAngular(() =>
-      fromEvent<MouseEvent>(this.host.nativeElement, 'click')
-        .pipe(
-          filter(() => !this.nzDisabled && this.nzClick.observers.length > 0),
-          takeUntil(this.destroy$)
-        )
-        .subscribe(event => {
-          this.ngZone.run(() => this.nzClick.emit(event));
-        })
-    );
+    fromEventOutsideAngular<MouseEvent>(this.host.nativeElement, 'click')
+      .pipe(
+        filter(() => !this.nzDisabled && this.nzClick.observers.length > 0),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(event => {
+        this.ngZone.run(() => this.nzClick.emit(event));
+      });
   }
 }

--- a/components/tree/tree-node.component.ts
+++ b/components/tree/tree-node.component.ts
@@ -21,7 +21,7 @@ import {
   booleanAttribute,
   inject
 } from '@angular/core';
-import { Observable, Subject, fromEvent } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
@@ -32,6 +32,7 @@ import {
   NzTreeNode,
   NzTreeNodeOptions
 } from 'ng-zorro-antd/core/tree';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzTreeIndentComponent } from './tree-indent.component';
 import { NzTreeNodeBuiltinCheckboxComponent } from './tree-node-checkbox.component';
@@ -372,33 +373,31 @@ export class NzTreeNodeBuiltinComponent implements OnInit, OnChanges, OnDestroy 
    * Listening to dragging events.
    */
   handDragEvent(): void {
-    this.ngZone.runOutsideAngular(() => {
-      if (this.nzDraggable) {
-        const nativeElement = this.elementRef.nativeElement;
-        this.destroy$ = new Subject();
-        fromEvent<DragEvent>(nativeElement, 'dragstart')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe((e: DragEvent) => this.handleDragStart(e));
-        fromEvent<DragEvent>(nativeElement, 'dragenter')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe((e: DragEvent) => this.handleDragEnter(e));
-        fromEvent<DragEvent>(nativeElement, 'dragover')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe((e: DragEvent) => this.handleDragOver(e));
-        fromEvent<DragEvent>(nativeElement, 'dragleave')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe((e: DragEvent) => this.handleDragLeave(e));
-        fromEvent<DragEvent>(nativeElement, 'drop')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe((e: DragEvent) => this.handleDragDrop(e));
-        fromEvent<DragEvent>(nativeElement, 'dragend')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe((e: DragEvent) => this.handleDragEnd(e));
-      } else {
-        this.destroy$.next(true);
-        this.destroy$.complete();
-      }
-    });
+    if (this.nzDraggable) {
+      const nativeElement = this.elementRef.nativeElement;
+      this.destroy$ = new Subject();
+      fromEventOutsideAngular<DragEvent>(nativeElement, 'dragstart')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((e: DragEvent) => this.handleDragStart(e));
+      fromEventOutsideAngular<DragEvent>(nativeElement, 'dragenter')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((e: DragEvent) => this.handleDragEnter(e));
+      fromEventOutsideAngular<DragEvent>(nativeElement, 'dragover')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((e: DragEvent) => this.handleDragOver(e));
+      fromEventOutsideAngular<DragEvent>(nativeElement, 'dragleave')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((e: DragEvent) => this.handleDragLeave(e));
+      fromEventOutsideAngular<DragEvent>(nativeElement, 'drop')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((e: DragEvent) => this.handleDragDrop(e));
+      fromEventOutsideAngular<DragEvent>(nativeElement, 'dragend')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((e: DragEvent) => this.handleDragEnd(e));
+    } else {
+      this.destroy$.next(true);
+      this.destroy$.complete();
+    }
   }
 
   markForCheck(): void {
@@ -418,15 +417,13 @@ export class NzTreeNodeBuiltinComponent implements OnInit, OnChanges, OnDestroy 
   ngOnInit(): void {
     this.nzTreeNode.component = this;
 
-    this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.elementRef.nativeElement, 'mousedown')
-        .pipe(takeUntil(this.destroy$))
-        .subscribe(event => {
-          if (this.nzSelectMode) {
-            event.preventDefault();
-          }
-        });
-    });
+    fromEventOutsideAngular(this.elementRef.nativeElement, 'mousedown')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(event => {
+        if (this.nzSelectMode) {
+          event.preventDefault();
+        }
+      });
   }
 
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }): void {

--- a/components/typography/text-edit.component.ts
+++ b/components/typography/text-edit.component.ts
@@ -20,13 +20,14 @@ import {
   afterNextRender,
   inject
 } from '@angular/core';
-import { BehaviorSubject, EMPTY, Observable, fromEvent } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { first, switchMap, takeUntil } from 'rxjs/operators';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
 import { NzTransButtonModule } from 'ng-zorro-antd/core/trans-button';
 import { NzTSType } from 'ng-zorro-antd/core/types';
+import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzI18nService, NzTextI18nInterface } from 'ng-zorro-antd/i18n';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzAutosizeDirective, NzInputModule } from 'ng-zorro-antd/input';
@@ -104,18 +105,7 @@ export class NzTextEditComponent implements OnInit {
 
     this.textarea$
       .pipe(
-        switchMap(textarea =>
-          // Caretaker note: we explicitly should call `subscribe()` within the root zone.
-          // `runOutsideAngular(() => fromEvent(...))` will just create an observable within the root zone,
-          // but `addEventListener` is called when the `fromEvent` is subscribed.
-          textarea
-            ? new Observable<KeyboardEvent>(subscriber =>
-                this.ngZone.runOutsideAngular(() =>
-                  fromEvent<KeyboardEvent>(textarea.nativeElement, 'keydown').subscribe(subscriber)
-                )
-              )
-            : EMPTY
-        ),
+        switchMap(textarea => fromEventOutsideAngular<KeyboardEvent>(textarea?.nativeElement, 'keydown')),
         takeUntil(this.destroy$)
       )
       .subscribe(event => {
@@ -139,15 +129,7 @@ export class NzTextEditComponent implements OnInit {
 
     this.textarea$
       .pipe(
-        switchMap(textarea =>
-          textarea
-            ? new Observable<KeyboardEvent>(subscriber =>
-                this.ngZone.runOutsideAngular(() =>
-                  fromEvent<KeyboardEvent>(textarea.nativeElement, 'input').subscribe(subscriber)
-                )
-              )
-            : EMPTY
-        ),
+        switchMap(textarea => fromEventOutsideAngular<KeyboardEvent>(textarea?.nativeElement, 'input')),
         takeUntil(this.destroy$)
       )
       .subscribe(event => {

--- a/components/upload/upload.component.ts
+++ b/components/upload/upload.component.ts
@@ -13,7 +13,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -25,11 +24,11 @@ import {
   inject,
   numberAttribute
 } from '@angular/core';
-import { Observable, Subject, Subscription, fromEvent, of } from 'rxjs';
+import { Observable, Subject, Subscription, of } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { BooleanInput, NzSafeAny } from 'ng-zorro-antd/core/types';
-import { toBoolean } from 'ng-zorro-antd/core/util';
+import { fromEventOutsideAngular, toBoolean } from 'ng-zorro-antd/core/util';
 import { NzI18nService, NzUploadI18nInterface } from 'ng-zorro-antd/i18n';
 
 import {
@@ -178,7 +177,6 @@ export class NzUploadComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   // #endregion
 
   constructor(
-    private ngZone: NgZone,
     private cdr: ChangeDetectorRef,
     private i18n: NzI18nService,
     private directionality: Directionality
@@ -351,14 +349,12 @@ export class NzUploadComponent implements OnInit, AfterViewInit, OnChanges, OnDe
   ngAfterViewInit(): void {
     if (this.platform.FIREFOX) {
       // fix firefox drop open new tab
-      this.ngZone.runOutsideAngular(() =>
-        fromEvent<MouseEvent>(this.document.body, 'drop')
-          .pipe(takeUntil(this.destroy$))
-          .subscribe(event => {
-            event.preventDefault();
-            event.stopPropagation();
-          })
-      );
+      fromEventOutsideAngular<MouseEvent>(this.document.body, 'drop')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(event => {
+          event.preventDefault();
+          event.stopPropagation();
+        });
     }
   }
 


### PR DESCRIPTION
In this commit, we introduce a helper function, `fromEventOutsideAngular`, as a replacement for
`ngZone.runOutsideAngular + fromEvent`. Using this helper function simplifies things, as there is
no longer a need to inject the `NgZone` service everywhere.

Note that there are no functional changes—only formatting changes, as indentation has been
shifted to the left.