### PR TITLE
fix(module:i18n): add missing translations to `vi_VN`

### DIFF
--- a/components/i18n/languages/vi_VN.ts
+++ b/components/i18n/languages/vi_VN.ts
@@ -27,6 +27,7 @@ export default {
       weekPlaceholder: 'Chọn tuần',
       rangePlaceholder: ['Ngày bắt đầu', 'Ngày kết thúc'],
       rangeYearPlaceholder: ['Năm bắt đầu', 'Năm kết thúc'],
+      rangeQuarterPlaceholder: ['Qúy bắt đầu', 'Quý kết thúc'],
       rangeMonthPlaceholder: ['Tháng bắt đầu', 'Tháng kết thúc'],
       rangeWeekPlaceholder: ['Tuần bắt đầu', 'Tuần kết thúc'],
       locale: 'vi_VN',


### PR DESCRIPTION
Add rangeQuarterPlaceholder: ['Quý bắt đầu', 'Quý kết thúc'], in vi_VN.ts

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Add rangeQuarterPlaceholder: ['Quý bắt đầu', 'Quý kết thúc'], in vi_VN.ts

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
