### PR TITLE
refactor(module:*): remove ngClass and ngStyle

### DIFF
--- a/components/anchor/anchor.component.ts
+++ b/components/anchor/anchor.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { normalizePassiveListenerOptions, Platform } from '@angular/cdk/platform';
-import { DOCUMENT, NgClass, NgIf, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
@@ -53,7 +53,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
   exportAs: 'nzAnchor',
   preserveWhitespaces: false,
   standalone: true,
-  imports: [NgClass, NgIf, NgStyle, NgTemplateOutlet, NzAffixModule],
+  imports: [NgTemplateOutlet, NzAffixModule],
   template: `
     @if (nzAffix) {
       <nz-affix [nzOffsetTop]="nzOffsetTop" [nzTarget]="container">
@@ -66,10 +66,10 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
     <ng-template #content>
       <div
         class="ant-anchor-wrapper"
-        [ngClass]="{ 'ant-anchor-wrapper-horizontal': nzDirection === 'horizontal' }"
-        [ngStyle]="wrapperStyle"
+        [class]="{ 'ant-anchor-wrapper-horizontal': nzDirection === 'horizontal' }"
+        [style]="wrapperStyle"
       >
-        <div class="ant-anchor" [ngClass]="{ 'ant-anchor-fixed': !nzAffix && !nzShowInkInFixed }">
+        <div class="ant-anchor" [class]="{ 'ant-anchor-fixed': !nzAffix && !nzShowInkInFixed }">
           <div class="ant-anchor-ink">
             <div class="ant-anchor-ink-ball" #ink></div>
           </div>

--- a/components/auto-complete/autocomplete.component.ts
+++ b/components/auto-complete/autocomplete.component.ts
@@ -5,7 +5,7 @@
 
 import { AnimationEvent } from '@angular/animations';
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgClass, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
   AfterViewInit,
@@ -66,7 +66,7 @@ function normalizeDataSource(value: AutocompleteDataSource): AutocompleteDataSou
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   standalone: true,
-  imports: [NgClass, NgStyle, NgTemplateOutlet, NzAutocompleteOptionComponent, NzNoAnimationDirective],
+  imports: [NgTemplateOutlet, NzAutocompleteOptionComponent, NzNoAnimationDirective],
   template: `
     <ng-template>
       <div
@@ -74,8 +74,8 @@ function normalizeDataSource(value: AutocompleteDataSource): AutocompleteDataSou
         class="ant-select-dropdown ant-select-dropdown-placement-bottomLeft"
         [class.ant-select-dropdown-hidden]="!showPanel"
         [class.ant-select-dropdown-rtl]="dir === 'rtl'"
-        [ngClass]="nzOverlayClassName"
-        [ngStyle]="nzOverlayStyle"
+        [class]="nzOverlayClassName"
+        [style]="nzOverlayStyle"
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         @slideMotion
         (@slideMotion.done)="onAnimationEvent($event)"

--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -20,7 +20,7 @@ import {
 } from '@angular/core';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
-import { NgClassInterface, NzShapeSCType, NzSizeLDSType } from 'ng-zorro-antd/core/types';
+import { NzShapeSCType, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
@@ -72,7 +72,6 @@ export class NzAvatarComponent implements OnChanges {
   hasText: boolean = false;
   hasSrc: boolean = true;
   hasIcon: boolean = false;
-  classMap: NgClassInterface = {};
   customSize: string | null = null;
 
   @ViewChild('textEl', { static: false }) textEl?: ElementRef<HTMLSpanElement>;

--- a/components/avatar/demo/dynamic.ts
+++ b/components/avatar/demo/dynamic.ts
@@ -1,4 +1,3 @@
-import { NgStyle } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
@@ -12,7 +11,7 @@ const colorList = ['#f56a00', '#7265e6', '#ffbf00', '#00a2ae'];
 @Component({
   standalone: true,
   selector: 'nz-demo-avatar-dynamic',
-  imports: [FormsModule, NgStyle, NzAvatarModule, NzButtonModule, NzInputNumberModule],
+  imports: [FormsModule, NzAvatarModule, NzButtonModule, NzInputNumberModule],
   template: `
     <div>
       <label>
@@ -26,7 +25,7 @@ const colorList = ['#f56a00', '#7265e6', '#ffbf00', '#00a2ae'];
 
     <nz-avatar
       [nzGap]="gap"
-      [ngStyle]="{ 'background-color': color }"
+      [style]="{ 'background-color': color }"
       [nzText]="text"
       nzSize="large"
       style="vertical-align: middle;"

--- a/components/badge/badge.component.ts
+++ b/components/badge/badge.component.ts
@@ -4,7 +4,6 @@
  */
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -44,13 +43,13 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'badge';
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [zoomBadgeMotion],
   standalone: true,
-  imports: [NgStyle, NzBadgeSupComponent, NzOutletModule],
+  imports: [NzBadgeSupComponent, NzOutletModule],
   template: `
     @if (nzStatus || nzColor) {
       <span
         class="ant-badge-status-dot ant-badge-status-{{ nzStatus || presetColor }}"
         [style.background]="!presetColor && nzColor"
-        [ngStyle]="nzStyle"
+        [style]="nzStyle"
       ></span>
       <span class="ant-badge-status-text">
         <ng-container *nzStringTemplateOutlet="nzText">{{ nzText }}</ng-container>

--- a/components/card/card.component.ts
+++ b/components/card/card.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -65,7 +65,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'card';
       </div>
     }
 
-    <div class="ant-card-body" [ngStyle]="nzBodyStyle">
+    <div class="ant-card-body" [style]="nzBodyStyle">
       @if (nzLoading) {
         <nz-skeleton [nzActive]="true" [nzTitle]="false" [nzParagraph]="{ rows: 4 }"></nz-skeleton>
       } @else {
@@ -93,7 +93,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'card';
     '[class.ant-card-contain-tabs]': '!!listOfNzCardTabComponent',
     '[class.ant-card-rtl]': `dir === 'rtl'`
   },
-  imports: [NzOutletModule, NgTemplateOutlet, NgStyle, NzSkeletonModule],
+  imports: [NzOutletModule, NgTemplateOutlet, NzSkeletonModule],
   standalone: true
 })
 export class NzCardComponent implements OnDestroy, OnInit {

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -7,7 +7,7 @@ import { Direction, Directionality } from '@angular/cdk/bidi';
 import { BACKSPACE, DOWN_ARROW, ENTER, ESCAPE, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 import { CdkConnectedOverlay, ConnectionPositionPair, OverlayModule } from '@angular/cdk/overlay';
 import { _getEventTarget } from '@angular/cdk/platform';
-import { NgClass, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -47,7 +47,6 @@ import { DEFAULT_CASCADER_POSITIONS, NzOverlayModule } from 'ng-zorro-antd/core/
 import { NzDestroyService } from 'ng-zorro-antd/core/services';
 import {
   NgClassInterface,
-  NgClassType,
   NgStyleInterface,
   NzSafeAny,
   NzSizeLDSType,
@@ -166,8 +165,8 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
             [class.ant-cascader-rtl]="dir === 'rtl'"
             [class.ant-cascader-menus-hidden]="!menuVisible"
             [class.ant-cascader-menu-empty]="shouldShowEmpty"
-            [ngClass]="menuCls"
-            [ngStyle]="nzMenuStyle"
+            [class]="nzMenuClassName"
+            [style]="nzMenuStyle"
           >
             @if (shouldShowEmpty) {
               <ul class="ant-cascader-menu" [style.width]="dropdownWidthStyle" [style.height]="dropdownHeightStyle">
@@ -184,7 +183,7 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
                 <ul
                   class="ant-cascader-menu"
                   role="menuitemcheckbox"
-                  [ngClass]="menuColumnCls"
+                  [class]="nzColumnClassName"
                   [style.height]="dropdownHeightStyle"
                   [style.width]="dropdownWidthStyle"
                 >
@@ -247,8 +246,6 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
     NzFormPatchModule,
     NzOverlayModule,
     NzNoAnimationDirective,
-    NgClass,
-    NgStyle,
     NzEmptyModule,
     NzCascaderOptionComponent
   ],
@@ -377,14 +374,6 @@ export class NzCascaderComponent
 
   get inputValue(): string {
     return this.inputString;
-  }
-
-  get menuCls(): NgClassType {
-    return { [`${this.nzMenuClassName}`]: !!this.nzMenuClassName };
-  }
-
-  get menuColumnCls(): NgClassType {
-    return { [`${this.nzColumnClassName}`]: !!this.nzColumnClassName };
   }
 
   private get hasInput(): boolean {

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -2159,7 +2159,7 @@ const options5: NzSafeAny[] = [];
     ></nz-cascader>
 
     <ng-template #renderTpl let-labels="labels" let-selectedOptions="selectedOptions">
-      @for (label of labels; track labels) {
+      @for (label of labels; track label) {
         {{ label }}{{ $last ? '' : ' | ' }}
       }
     </ng-template>

--- a/components/collapse/demo/custom.ts
+++ b/components/collapse/demo/custom.ts
@@ -1,4 +1,3 @@
-import { NgStyle } from '@angular/common';
 import { Component } from '@angular/core';
 
 import { NzCollapseModule } from 'ng-zorro-antd/collapse';
@@ -14,7 +13,7 @@ interface Panel {
 @Component({
   selector: 'nz-demo-collapse-custom',
   standalone: true,
-  imports: [NgStyle, NzIconModule, NzCollapseModule],
+  imports: [NzIconModule, NzCollapseModule],
   template: `
     <nz-collapse [nzBordered]="false">
       @for (panel of panels; track panel) {
@@ -22,7 +21,7 @@ interface Panel {
           #p
           [nzHeader]="panel.name"
           [nzActive]="panel.active"
-          [ngStyle]="customStyle"
+          [style]="customStyle"
           [nzExpandedIcon]="!$first ? panel.icon || expandedIcon : undefined"
         >
           <p>{{ panel.name }} content</p>

--- a/components/color-picker/src/components/slider.component.ts
+++ b/components/color-picker/src/components/slider.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { DOCUMENT, NgClass } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectorRef,
@@ -42,14 +42,14 @@ function getPosition(e: EventType): { pageX: number; pageY: number } {
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'color-slider',
   standalone: true,
-  imports: [PaletteComponent, GradientComponent, HandlerComponent, NgClass],
+  imports: [PaletteComponent, GradientComponent, HandlerComponent],
   template: `
     <div
       #slider
       (mousedown)="dragStartHandle($event)"
       (touchstart)="dragStartHandle($event)"
       class="ant-color-picker-slider"
-      [ngClass]="'ant-color-picker-slider-' + type"
+      [class]="'ant-color-picker-slider-' + type"
     >
       <color-palette>
         <div

--- a/components/core/types/ng-class.ts
+++ b/components/core/types/ng-class.ts
@@ -5,7 +5,7 @@
 
 import { NzSafeAny } from './any';
 
-export type NgClassType = string | string[] | Set<string> | NgClassInterface;
+export type NgClassType = string | string[] | NgClassInterface;
 
 export interface NgClassInterface {
   [klass: string]: NzSafeAny;

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -14,7 +14,7 @@ import {
   VerticalConnectionPos
 } from '@angular/cdk/overlay';
 import { Platform } from '@angular/cdk/platform';
-import { DOCUMENT, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
@@ -166,7 +166,7 @@ export type NzPlacement = 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight';
 
     <!-- Right operator icons -->
     <ng-template #tplRightRest>
-      <div class="{{ prefixCls }}-active-bar" [ngStyle]="activeBarStyle"></div>
+      <div class="{{ prefixCls }}-active-bar" [style]="activeBarStyle"></div>
       @if (showClear) {
         <span class="{{ prefixCls }}-clear" (click)="onClickClear($event)">
           <span nz-icon nzType="close-circle" nzTheme="fill"></span>
@@ -194,7 +194,7 @@ export type NzPlacement = 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight';
         [class.ant-picker-dropdown-range]="isRange"
         [class.ant-picker-active-left]="datePickerService.activeInput === 'left'"
         [class.ant-picker-active-right]="datePickerService.activeInput === 'right'"
-        [ngStyle]="nzPopupStyle"
+        [style]="nzPopupStyle"
       >
         <date-range-popup
           [isRange]="isRange"
@@ -270,7 +270,6 @@ export type NzPlacement = 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight';
     NgTemplateOutlet,
     NzOutletModule,
     NzIconModule,
-    NgStyle,
     NzFormPatchModule,
     DateRangePopupComponent,
     CdkConnectedOverlay,

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Direction } from '@angular/cdk/bidi';
-import { NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
@@ -61,7 +61,7 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
   template: `
     @if (isRange) {
       <div class="{{ prefixCls }}-range-wrapper {{ prefixCls }}-date-range-wrapper">
-        <div class="{{ prefixCls }}-range-arrow" [ngStyle]="arrowPosition"></div>
+        <div class="{{ prefixCls }}-range-arrow" [style]="arrowPosition"></div>
         <div class="{{ prefixCls }}-panel-container {{ showWeek ? prefixCls + '-week-number' : '' }}">
           <div class="{{ prefixCls }}-panels">
             @if (hasTimePicker) {
@@ -145,7 +145,7 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
       }
     </ng-template>
   `,
-  imports: [InnerPopupComponent, NgTemplateOutlet, CalendarFooterComponent, NgStyle],
+  imports: [InnerPopupComponent, NgTemplateOutlet, CalendarFooterComponent],
   standalone: true
 })
 export class DateRangePopupComponent implements OnInit, OnChanges, OnDestroy {

--- a/components/date-picker/lib/abstract-table.html
+++ b/components/date-picker/lib/abstract-table.html
@@ -14,7 +14,7 @@
 
   <tbody>
     @for (row of bodyRows; track row.trackByIndex) {
-      <tr [ngClass]="row.classMap!" role="row">
+      <tr [class]="row.classMap!" role="row">
         @if (row.weekNum) {
           <td role="gridcell" class="{{ prefixCls }}-cell-week"> {{ row.weekNum }}</td>
         }
@@ -22,7 +22,7 @@
           <td
             [title]="cell.title"
             role="gridcell"
-            [ngClass]="cell.classMap!"
+            [class]="cell.classMap!"
             (click)="cell.isDisabled ? null : cell.onClick()"
             (mouseenter)="cell.onMouseEnter()">
             @switch (prefixCls) {

--- a/components/date-picker/lib/date-header.component.ts
+++ b/components/date-picker/lib/date-header.component.ts
@@ -3,15 +3,14 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { DateHelperService } from 'ng-zorro-antd/i18n';
 
+import { NzDateMode } from '../standard-types';
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
 import { transCompatFormat } from './util';
-import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -19,8 +18,7 @@ import { NzDateMode } from '../standard-types';
   selector: 'date-header', // eslint-disable-line @angular-eslint/component-selector
   exportAs: 'dateHeader',
   templateUrl: './abstract-panel-header.html',
-  standalone: true,
-  imports: [NgForOf, NgIf, NgClass]
+  standalone: true
 })
 export class DateHeaderComponent extends AbstractPanelHeader {
   override mode: NzDateMode = 'date';

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { CandyDate } from 'ng-zorro-antd/core/time';
@@ -23,7 +22,7 @@ import { transCompatFormat } from './util';
   exportAs: 'dateTable',
   templateUrl: './abstract-table.html',
   standalone: true,
-  imports: [NgClass, NzStringTemplateOutletDirective]
+  imports: [NzStringTemplateOutletDirective]
 })
 export class DateTableComponent extends AbstractTable implements OnChanges, OnInit {
   @Input() override locale!: NzCalendarI18nInterface;

--- a/components/date-picker/lib/decade-header.component.ts
+++ b/components/date-picker/lib/decade-header.component.ts
@@ -3,12 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
+import { NzDateMode } from '../standard-types';
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
-import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -16,7 +15,6 @@ import { NzDateMode } from '../standard-types';
   selector: 'decade-header', // eslint-disable-line @angular-eslint/component-selector
   exportAs: 'decadeHeader',
   templateUrl: './abstract-panel-header.html',
-  imports: [NgForOf, NgIf, NgClass],
   standalone: true
 })
 export class DecadeHeaderComponent extends AbstractPanelHeader {

--- a/components/date-picker/lib/decade-table.component.ts
+++ b/components/date-picker/lib/decade-table.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnChanges, ViewEncapsulation } from '@angular/core';
 
 import { NzStringTemplateOutletDirective } from 'ng-zorro-antd/core/outlet';
@@ -21,7 +20,7 @@ const MAX_COL = 3;
   exportAs: 'decadeTable',
   templateUrl: 'abstract-table.html',
   standalone: true,
-  imports: [NgClass, NzStringTemplateOutletDirective]
+  imports: [NzStringTemplateOutletDirective]
 })
 export class DecadeTableComponent extends AbstractTable implements OnChanges {
   get startYear(): number {

--- a/components/date-picker/lib/month-header.component.ts
+++ b/components/date-picker/lib/month-header.component.ts
@@ -7,11 +7,10 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { DateHelperService } from 'ng-zorro-antd/i18n';
 
+import { NzDateMode } from '../standard-types';
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
 import { transCompatFormat } from './util';
-import { NgClass, NgForOf, NgIf } from '@angular/common';
-import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -20,7 +19,6 @@ import { NzDateMode } from '../standard-types';
   exportAs: 'monthHeader',
   templateUrl: './abstract-panel-header.html',
   standalone: true,
-  imports: [NgForOf, NgIf, NgClass]
 })
 export class MonthHeaderComponent extends AbstractPanelHeader {
   override mode: NzDateMode = 'month';

--- a/components/date-picker/lib/month-table.component.ts
+++ b/components/date-picker/lib/month-table.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { CandyDate } from 'ng-zorro-antd/core/time';
@@ -22,7 +21,7 @@ import { DateBodyRow, DateCell } from './interface';
   exportAs: 'monthTable',
   templateUrl: 'abstract-table.html',
   standalone: true,
-  imports: [NgClass, NzStringTemplateOutletDirective]
+  imports: [NzStringTemplateOutletDirective]
 })
 export class MonthTableComponent extends AbstractTable implements OnChanges, OnInit {
   override MAX_ROW = 4;

--- a/components/date-picker/lib/quarter-header.component.ts
+++ b/components/date-picker/lib/quarter-header.component.ts
@@ -3,15 +3,14 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { DateHelperService } from 'ng-zorro-antd/i18n';
 
+import { NzDateMode } from '../standard-types';
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
 import { transCompatFormat } from './util';
-import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -20,7 +19,6 @@ import { NzDateMode } from '../standard-types';
   exportAs: 'quarterHeader',
   templateUrl: './abstract-panel-header.html',
   standalone: true,
-  imports: [NgForOf, NgIf, NgClass]
 })
 export class QuarterHeaderComponent extends AbstractPanelHeader {
   override mode: NzDateMode = 'quarter';

--- a/components/date-picker/lib/quarter-table.component.ts
+++ b/components/date-picker/lib/quarter-table.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { startOfQuarter } from 'date-fns';
@@ -24,7 +23,7 @@ import { DateBodyRow, DateCell } from './interface';
   exportAs: 'quarterTable',
   templateUrl: 'abstract-table.html',
   standalone: true,
-  imports: [NgClass, NzStringTemplateOutletDirective]
+  imports: [NzStringTemplateOutletDirective]
 })
 export class QuarterTableComponent extends AbstractTable implements OnChanges, OnInit {
   override MAX_ROW = 1;

--- a/components/date-picker/lib/year-header.component.ts
+++ b/components/date-picker/lib/year-header.component.ts
@@ -3,12 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
+import { NzDateMode } from '../standard-types';
 import { AbstractPanelHeader } from './abstract-panel-header';
 import { PanelSelector } from './interface';
-import { NzDateMode } from '../standard-types';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -17,7 +16,6 @@ import { NzDateMode } from '../standard-types';
   exportAs: 'yearHeader',
   templateUrl: './abstract-panel-header.html',
   standalone: true,
-  imports: [NgForOf, NgIf, NgClass]
 })
 export class YearHeaderComponent extends AbstractPanelHeader {
   override mode: NzDateMode = 'year';

--- a/components/date-picker/lib/year-table.component.ts
+++ b/components/date-picker/lib/year-table.component.ts
@@ -9,7 +9,6 @@ import { CandyDate } from 'ng-zorro-antd/core/time';
 import { valueFunctionProp } from 'ng-zorro-antd/core/util';
 import { DateHelperService } from 'ng-zorro-antd/i18n';
 
-import { NgClass } from '@angular/common';
 import { NzStringTemplateOutletDirective } from 'ng-zorro-antd/core/outlet';
 import { AbstractTable } from './abstract-table';
 import { DateBodyRow, DateCell, YearCell } from './interface';
@@ -21,7 +20,7 @@ import { DateBodyRow, DateCell, YearCell } from './interface';
   selector: 'year-table',
   exportAs: 'yearTable',
   templateUrl: 'abstract-table.html',
-  imports: [NgClass, NzStringTemplateOutletDirective],
+  imports: [NzStringTemplateOutletDirective],
   standalone: true
 })
 export class YearTableComponent extends AbstractTable {

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -8,7 +8,7 @@ import { Direction, Directionality } from '@angular/cdk/bidi';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { CdkScrollable, Overlay, OverlayConfig, OverlayKeyboardDispatcher, OverlayRef } from '@angular/cdk/overlay';
 import { CdkPortalOutlet, ComponentPortal, PortalModule, TemplatePortal } from '@angular/cdk/portal';
-import { DOCUMENT, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -79,7 +79,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
         [style.zIndex]="nzZIndex"
       >
         @if (nzMask && isOpen) {
-          <div @drawerMaskMotion class="ant-drawer-mask" (click)="maskClick()" [ngStyle]="nzMaskStyle"></div>
+          <div @drawerMaskMotion class="ant-drawer-mask" (click)="maskClick()" [style]="nzMaskStyle"></div>
         }
         <div
           class="ant-drawer-content-wrapper {{ nzWrapClassName }}"
@@ -114,7 +114,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
                   }
                 </div>
               }
-              <div class="ant-drawer-body" [ngStyle]="nzBodyStyle" cdkScrollable>
+              <div class="ant-drawer-body" [style]="nzBodyStyle" cdkScrollable>
                 <ng-template cdkPortalOutlet />
                 @if (nzContent) {
                   @if (isNzContentTemplateRef) {
@@ -140,15 +140,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [drawerMaskMotion],
-  imports: [
-    NzNoAnimationDirective,
-    NgStyle,
-    NzOutletModule,
-    NzIconModule,
-    PortalModule,
-    NgTemplateOutlet,
-    CdkScrollable
-  ],
+  imports: [NzNoAnimationDirective, NzOutletModule, NzIconModule, PortalModule, NgTemplateOutlet, CdkScrollable],
   standalone: true
 })
 export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extends Partial<T> = NzSafeAny>

--- a/components/dropdown/dropdown-menu.component.ts
+++ b/components/dropdown/dropdown-menu.component.ts
@@ -5,7 +5,6 @@
 
 import { AnimationEvent } from '@angular/animations';
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgClass, NgStyle } from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -49,8 +48,8 @@ export type NzPlacementType = 'bottomLeft' | 'bottomCenter' | 'bottomRight' | 't
       <div
         class="ant-dropdown"
         [class.ant-dropdown-rtl]="dir === 'rtl'"
-        [ngClass]="nzOverlayClassName"
-        [ngStyle]="nzOverlayStyle"
+        [class]="nzOverlayClassName"
+        [style]="nzOverlayStyle"
         @slideMotion
         (@slideMotion.done)="onAnimationEvent($event)"
         [@.disabled]="!!noAnimation?.nzNoAnimation"
@@ -65,7 +64,7 @@ export type NzPlacementType = 'bottomLeft' | 'bottomCenter' | 'bottomRight' | 't
   preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgClass, NgStyle, NzNoAnimationDirective],
+  imports: [NzNoAnimationDirective],
   standalone: true
 })
 export class NzDropdownMenuComponent implements AfterContentInit, OnDestroy, OnInit {

--- a/components/form/form-control.component.ts
+++ b/components/form/form-control.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass } from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -49,7 +48,7 @@ import { NzFormDirective } from './form.directive';
     </div>
     @if (innerTip) {
       <div @helpMotion class="ant-form-item-explain ant-form-item-explain-connected">
-        <div role="alert" [ngClass]="['ant-form-item-explain-' + status]">
+        <div role="alert" [class]="['ant-form-item-explain-' + status]">
           <ng-container *nzStringTemplateOutlet="innerTip; context: { $implicit: validateControl }">{{
             innerTip
           }}</ng-container>
@@ -67,7 +66,7 @@ import { NzFormDirective } from './form.directive';
   host: {
     class: 'ant-form-item-control'
   },
-  imports: [NgClass, NzOutletModule],
+  imports: [NzOutletModule],
   standalone: true
 })
 export class NzFormControlComponent implements OnChanges, OnDestroy, OnInit, AfterContentInit, OnDestroy {

--- a/components/hash-code/hash-code.component.ts
+++ b/components/hash-code/hash-code.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -24,7 +23,7 @@ import { NzModeType } from './typings';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [NgStyle, NzIconModule, NzStringTemplateOutletDirective],
+  imports: [NzIconModule, NzStringTemplateOutletDirective],
   selector: 'nz-hash-code',
   exportAs: 'nzHashCode',
   template: `
@@ -53,7 +52,7 @@ import { NzModeType } from './typings';
     >
       <div
         class="ant-hashCode-code-value"
-        [ngStyle]="{ height: nzMode === 'rect' ? '70px' : nzMode === 'single' ? '18px' : '35px' }"
+        [style]="{ height: nzMode === 'rect' ? '70px' : nzMode === 'single' ? '18px' : '35px' }"
       >
         @if (nzMode === 'double') {
           @if (hashDataList.length > 8) {

--- a/components/input-number/input-number-group.component.ts
+++ b/components/input-number/input-number-group.component.ts
@@ -5,7 +5,7 @@
 
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -49,7 +49,7 @@ export class NzInputNumberGroupWhitSuffixOrPrefixDirective {
   selector: 'nz-input-number-group',
   exportAs: 'nzInputNumberGroup',
   standalone: true,
-  imports: [NzInputNumberGroupSlotComponent, NgClass, NgTemplateOutlet, NzFormPatchModule],
+  imports: [NzInputNumberGroupSlotComponent, NgTemplateOutlet, NzFormPatchModule],
   template: `
     @if (isAddOn) {
       <span class="ant-input-number-wrapper ant-input-number-group">
@@ -64,7 +64,7 @@ export class NzInputNumberGroupWhitSuffixOrPrefixDirective {
             [class.ant-input-number-affix-wrapper-sm]="isSmall"
             [class.ant-input-number-affix-wrapper-lg]="isLarge"
             [class.ant-input-number-affix-wrapper-focused]="focused"
-            [ngClass]="affixInGroupStatusCls"
+            [class]="affixInGroupStatusCls"
           >
             <ng-template [ngTemplateOutlet]="affixTemplate"></ng-template>
           </div>

--- a/components/input/input-group.component.ts
+++ b/components/input/input-group.component.ts
@@ -5,7 +5,7 @@
 
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -49,7 +49,7 @@ export class NzInputGroupWhitSuffixOrPrefixDirective {
   selector: 'nz-input-group',
   exportAs: 'nzInputGroup',
   standalone: true,
-  imports: [NzInputGroupSlotComponent, NgClass, NgTemplateOutlet, NzFormPatchModule],
+  imports: [NzInputGroupSlotComponent, NgTemplateOutlet, NzFormPatchModule],
   encapsulation: ViewEncapsulation.None,
   providers: [NzFormNoStatusService, { provide: NZ_SPACE_COMPACT_ITEM_TYPE, useValue: 'input' }],
   template: `
@@ -66,7 +66,7 @@ export class NzInputGroupWhitSuffixOrPrefixDirective {
             [class.ant-input-affix-wrapper-sm]="isSmall"
             [class.ant-input-affix-wrapper-lg]="isLarge"
             [class.ant-input-affix-wrapper-focused]="focused"
-            [ngClass]="affixInGroupStatusCls"
+            [class]="affixInGroupStatusCls"
           >
             <ng-template [ngTemplateOutlet]="affixTemplate"></ng-template>
           </span>

--- a/components/menu/submenu-non-inline-child.component.ts
+++ b/components/menu/submenu-non-inline-child.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -41,7 +41,7 @@ import { NzMenuModeType, NzMenuThemeType, NzSubmenuTrigger } from './menu.types'
       [class.ant-dropdown-menu-sub]="isMenuInsideDropDown"
       [class.ant-menu-sub]="!isMenuInsideDropDown"
       [class.ant-menu-rtl]="dir === 'rtl'"
-      [ngClass]="menuClass"
+      [class]="menuClass"
     >
       <ng-template [ngTemplateOutlet]="templateOutlet"></ng-template>
     </div>
@@ -59,7 +59,7 @@ import { NzMenuModeType, NzMenuThemeType, NzSubmenuTrigger } from './menu.types'
     '(mouseenter)': 'setMouseState(true)',
     '(mouseleave)': 'setMouseState(false)'
   },
-  imports: [NgClass, NgTemplateOutlet],
+  imports: [NgTemplateOutlet],
   standalone: true
 })
 export class NzSubmenuNoneInlineChildComponent implements OnDestroy, OnInit, OnChanges {

--- a/components/message/message.component.ts
+++ b/components/message/message.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -39,7 +38,7 @@ import { NzMessageData } from './typings';
       (mouseleave)="onLeave()"
     >
       <div class="ant-message-notice-content">
-        <div class="ant-message-custom-content" [ngClass]="'ant-message-' + instance.type">
+        <div class="ant-message-custom-content" [class]="'ant-message-' + instance.type">
           @switch (instance.type) {
             @case ('success') {
               <span nz-icon nzType="check-circle"></span>
@@ -64,7 +63,7 @@ import { NzMessageData } from './typings';
       </div>
     </div>
   `,
-  imports: [NgClass, NzIconModule, NzOutletModule],
+  imports: [NzIconModule, NzOutletModule],
   standalone: true
 })
 export class NzMessageComponent extends NzMNComponent implements OnInit, OnDestroy {

--- a/components/modal/modal-confirm-container.component.ts
+++ b/components/modal/modal-confirm-container.component.ts
@@ -5,7 +5,6 @@
 
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { CdkPortalOutlet, PortalModule } from '@angular/cdk/portal';
-import { NgClass, NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -36,8 +35,8 @@ import { BaseModalContainerComponent } from './modal-container.directive';
       #modalElement
       role="document"
       class="ant-modal"
-      [ngClass]="config.nzClassName!"
-      [ngStyle]="config.nzStyle!"
+      [class]="config.nzClassName!"
+      [style]="config.nzStyle!"
       [style.width]="config?.nzWidth! | nzToCssUnit"
     >
       <div class="ant-modal-content">
@@ -45,7 +44,7 @@ import { BaseModalContainerComponent } from './modal-container.directive';
           <button nz-modal-close (click)="onCloseClick()"></button>
         }
 
-        <div class="ant-modal-body" [ngStyle]="config.nzBodyStyle!">
+        <div class="ant-modal-body" [style]="config.nzBodyStyle!">
           <div class="ant-modal-confirm-body-wrapper">
             <div class="ant-modal-confirm-body">
               <span nz-icon [nzType]="config.nzIconType!"></span>
@@ -109,16 +108,7 @@ import { BaseModalContainerComponent } from './modal-container.directive';
     '(@modalContainer.done)': 'onAnimationDone($event)',
     '(click)': 'onContainerClick($event)'
   },
-  imports: [
-    NgClass,
-    NgStyle,
-    NzPipesModule,
-    NzIconModule,
-    NzModalCloseComponent,
-    NzOutletModule,
-    PortalModule,
-    NzButtonModule
-  ],
+  imports: [NzPipesModule, NzIconModule, NzModalCloseComponent, NzOutletModule, PortalModule, NzButtonModule],
   standalone: true
 })
 export class NzModalConfirmContainerComponent extends BaseModalContainerComponent implements OnInit {

--- a/components/modal/modal-container.component.ts
+++ b/components/modal/modal-container.component.ts
@@ -6,7 +6,6 @@
 import { CdkDrag, CdkDragHandle } from '@angular/cdk/drag-drop';
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { CdkPortalOutlet, PortalModule } from '@angular/cdk/portal';
-import { NgClass, NgStyle } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 
 import { NzPipesModule } from 'ng-zorro-antd/pipes';
@@ -29,8 +28,8 @@ import { NzModalTitleComponent } from './modal-title.component';
       [cdkDragDisabled]="!config.nzDraggable"
       role="document"
       class="ant-modal"
-      [ngClass]="config.nzClassName!"
-      [ngStyle]="config.nzStyle!"
+      [class]="config.nzClassName!"
+      [style]="config.nzStyle!"
       [style.width]="config?.nzWidth! | nzToCssUnit"
     >
       <div class="ant-modal-content">
@@ -41,7 +40,7 @@ import { NzModalTitleComponent } from './modal-title.component';
           <div nz-modal-title cdkDragHandle [style.cursor]="config.nzDraggable ? 'move' : 'auto'"></div>
         }
 
-        <div class="ant-modal-body" [ngStyle]="config.nzBodyStyle!">
+        <div class="ant-modal-body" [style]="config.nzBodyStyle!">
           <ng-template cdkPortalOutlet />
           @if (isStringContent) {
             <div [innerHTML]="config.nzContent"></div>
@@ -75,8 +74,6 @@ import { NzModalTitleComponent } from './modal-title.component';
     '(click)': 'onContainerClick($event)'
   },
   imports: [
-    NgClass,
-    NgStyle,
     NzModalCloseComponent,
     NzModalTitleComponent,
     PortalModule,

--- a/components/notification/notification.component.ts
+++ b/components/notification/notification.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, Output, ViewEncapsulation } from '@angular/core';
 
 import { notificationMotion } from 'ng-zorro-antd/core/animation';
@@ -22,8 +22,8 @@ import { NzNotificationData } from './typings';
   template: `
     <div
       class="ant-notification-notice ant-notification-notice-closable"
-      [ngStyle]="instance.options?.nzStyle || null"
-      [ngClass]="instance.options?.nzClass || ''"
+      [style]="instance.options?.nzStyle || null"
+      [class]="instance.options?.nzClass || ''"
       [@notificationMotion]="state"
       (@notificationMotion.done)="animationStateChanged.next($event)"
       (click)="onClick($event)"
@@ -101,7 +101,7 @@ import { NzNotificationData } from './typings';
       </a>
     </div>
   `,
-  imports: [NgStyle, NgClass, NzIconModule, NzOutletModule, NgTemplateOutlet],
+  imports: [NzIconModule, NzOutletModule, NgTemplateOutlet],
   standalone: true
 })
 export class NzNotificationComponent extends NzMNComponent implements OnDestroy {

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -5,7 +5,7 @@
 
 import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
-import { DOCUMENT, NgClass, NgStyle } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -145,9 +145,9 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
         cdkTrapFocus
         [cdkTrapFocusAutoCapture]="nzAutoFocus !== null"
         class="ant-popover"
-        [ngClass]="_classMap"
+        [class]="_classMap"
         [class.ant-popover-rtl]="dir === 'rtl'"
-        [ngStyle]="nzOverlayStyle"
+        [style]="nzOverlayStyle"
         [@.disabled]="!!noAnimation?.nzNoAnimation"
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         [@zoomBigMotion]="'active'"
@@ -214,8 +214,6 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
     OverlayModule,
     NzOverlayModule,
     A11yModule,
-    NgClass,
-    NgStyle,
     NzNoAnimationDirective,
     NzOutletModule,
     NzIconModule,

--- a/components/popover/popover.ts
+++ b/components/popover/popover.ts
@@ -4,7 +4,6 @@
  */
 
 import { OverlayModule } from '@angular/cdk/overlay';
-import { NgClass, NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -99,8 +98,8 @@ export class NzPopoverDirective extends NzTooltipBaseDirective {
       <div
         class="ant-popover"
         [class.ant-popover-rtl]="dir === 'rtl'"
-        [ngClass]="_classMap"
-        [ngStyle]="nzOverlayStyle"
+        [class]="_classMap"
+        [style]="nzOverlayStyle"
         [@.disabled]="!!noAnimation?.nzNoAnimation"
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         [@zoomBigMotion]="'active'"
@@ -125,7 +124,7 @@ export class NzPopoverDirective extends NzTooltipBaseDirective {
       </div>
     </ng-template>
   `,
-  imports: [OverlayModule, NzOverlayModule, NgClass, NgStyle, NzNoAnimationDirective, NzOutletModule],
+  imports: [OverlayModule, NzOverlayModule, NzNoAnimationDirective, NzOutletModule],
   standalone: true
 })
 export class NzPopoverComponent extends NzToolTipComponent {

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgClass, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -61,7 +61,7 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
   exportAs: 'nzProgress',
   preserveWhitespaces: false,
   standalone: true,
-  imports: [NzIconModule, NzOutletModule, NgClass, NgTemplateOutlet, NgStyle],
+  imports: [NzIconModule, NzOutletModule, NgTemplateOutlet],
   template: `
     <ng-template #progressInfoTemplate>
       @if (nzShowInfo) {
@@ -78,7 +78,7 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
     </ng-template>
 
     <div
-      [ngClass]="'ant-progress ant-progress-status-' + status"
+      [class]="'ant-progress ant-progress-status-' + status"
       [class.ant-progress-line]="nzType === 'line'"
       [class.ant-progress-small]="nzSize === 'small'"
       [class.ant-progress-default]="nzSize === 'default'"
@@ -93,7 +93,7 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
           @if (isSteps) {
             <div class="ant-progress-steps-outer">
               @for (step of steps; track step) {
-                <div class="ant-progress-steps-item" [ngStyle]="step"></div>
+                <div class="ant-progress-steps-item" [style]="step"></div>
               }
               <ng-template [ngTemplateOutlet]="progressInfoTemplate" />
             </div>
@@ -151,7 +151,7 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
               fill-opacity="0"
               [attr.stroke-width]="strokeWidth"
               [attr.d]="pathString"
-              [ngStyle]="trailPathStyle"
+              [style]="trailPathStyle"
             ></path>
             @for (p of progressCirclePath; track p) {
               <path
@@ -161,7 +161,7 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
                 [attr.stroke-linecap]="nzStrokeLinecap"
                 [attr.stroke]="p.stroke"
                 [attr.stroke-width]="nzPercent ? strokeWidth : 0"
-                [ngStyle]="p.strokePathStyle"
+                [style]="p.strokePathStyle"
               ></path>
             }
           </svg>

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -5,7 +5,6 @@
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
-import { NgClass } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -51,7 +50,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'rate';
       class="ant-rate"
       [class.ant-rate-disabled]="nzDisabled"
       [class.ant-rate-rtl]="dir === 'rtl'"
-      [ngClass]="classMap"
+      [class]="classMap"
       (keydown)="onKeyDown($event); $event.preventDefault()"
       (mouseleave)="onRateLeave(); $event.stopPropagation()"
       [tabindex]="nzDisabled ? -1 : 1"
@@ -59,7 +58,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'rate';
       @for (star of starArray; track star) {
         <li
           class="ant-rate-star"
-          [ngClass]="starStyleArray[$index] || ''"
+          [class]="starStyleArray[$index] || ''"
           nz-tooltip
           [nzTooltipTitle]="nzTooltips[$index]"
         >
@@ -83,7 +82,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'rate';
       multi: true
     }
   ],
-  imports: [NgClass, NzToolTipModule, NzRateItemComponent, NzToolTipModule],
+  imports: [NzToolTipModule, NzRateItemComponent, NzToolTipModule],
   standalone: true
 })
 export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges {

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -13,7 +13,6 @@ import {
   ConnectionPositionPair
 } from '@angular/cdk/overlay';
 import { Platform, _getEventTarget } from '@angular/cdk/platform';
-import { NgStyle } from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -167,7 +166,7 @@ export type NzSelectSizeType = NzSizeLDSType;
       (positionChange)="onPositionChange($event)"
     >
       <nz-option-container
-        [ngStyle]="nzDropdownStyle"
+        [style]="nzDropdownStyle"
         [itemSize]="nzOptionHeightPx"
         [maxItemLength]="nzOptionOverflowSize"
         [matchWidth]="nzDropdownMatchSelectWidth"
@@ -219,8 +218,7 @@ export type NzSelectSizeType = NzSizeLDSType;
     NzSelectClearComponent,
     CdkConnectedOverlay,
     NzOverlayModule,
-    NzOptionContainerComponent,
-    NgStyle
+    NzOptionContainerComponent
   ],
   standalone: true
 })

--- a/components/skeleton/skeleton-element.component.ts
+++ b/components/skeleton/skeleton-element.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -69,10 +68,9 @@ export class NzSkeletonElementButtonComponent {
       [class.ant-skeleton-avatar-circle]="nzShape === 'circle'"
       [class.ant-skeleton-avatar-lg]="nzSize === 'large'"
       [class.ant-skeleton-avatar-sm]="nzSize === 'small'"
-      [ngStyle]="styleMap"
+      [style]="styleMap"
     ></span>
   `,
-  imports: [NgStyle],
   standalone: true
 })
 export class NzSkeletonElementAvatarComponent implements OnChanges {

--- a/components/slider/demo/vertical.ts
+++ b/components/slider/demo/vertical.ts
@@ -1,4 +1,3 @@
-import { NgStyle } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
@@ -7,16 +6,16 @@ import { NzSliderModule } from 'ng-zorro-antd/slider';
 @Component({
   selector: 'nz-demo-slider-vertical',
   standalone: true,
-  imports: [NgStyle, FormsModule, NzSliderModule],
+  imports: [FormsModule, NzSliderModule],
   template: `
-    <div [ngStyle]="{ height: '300px' }">
-      <div [ngStyle]="style">
+    <div [style]="{ height: '300px' }">
+      <div [style]="style">
         <nz-slider nzVertical [ngModel]="30"></nz-slider>
       </div>
-      <div [ngStyle]="style">
+      <div [style]="style">
         <nz-slider nzVertical nzRange [nzStep]="10" [ngModel]="[20, 50]"></nz-slider>
       </div>
-      <div [ngStyle]="style">
+      <div [style]="style">
         <nz-slider nzVertical nzRange [nzMarks]="marks" [ngModel]="[26, 37]"></nz-slider>
       </div>
     </div>

--- a/components/slider/handle.component.ts
+++ b/components/slider/handle.component.ts
@@ -4,7 +4,6 @@
  */
 
 import { Direction } from '@angular/cdk/bidi';
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -38,7 +37,7 @@ import { NzSliderShowTooltip } from './typings';
       class="ant-slider-handle"
       tabindex="0"
       nz-tooltip
-      [ngStyle]="style"
+      [style]="style"
       [nzTooltipTitle]="tooltipFormatter === null || tooltipVisible === 'never' ? null : tooltipTitle"
       [nzTooltipTitleContext]="{ $implicit: value }"
       [nzTooltipTrigger]="null"
@@ -49,7 +48,7 @@ import { NzSliderShowTooltip } from './typings';
     '(mouseenter)': 'enterHandle()',
     '(mouseleave)': 'leaveHandle()'
   },
-  imports: [NzToolTipModule, NgStyle],
+  imports: [NzToolTipModule],
   standalone: true
 })
 export class NzSliderHandleComponent implements OnChanges {

--- a/components/slider/marks.component.ts
+++ b/components/slider/marks.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -30,12 +29,11 @@ import { NzDisplayedMark, NzExtendedMark, NzMark, NzMarkObj } from './typings';
       <span
         class="ant-slider-mark-text"
         [class.ant-slider-mark-active]="attr.active"
-        [ngStyle]="attr.style"
+        [style]="attr.style"
         [innerHTML]="attr.label"
       ></span>
     }
   `,
-  imports: [NgStyle],
   standalone: true,
   host: {
     class: 'ant-slider-mark'

--- a/components/slider/step.component.ts
+++ b/components/slider/step.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -25,10 +24,9 @@ import { NzDisplayedStep, NzExtendedMark } from './typings';
   preserveWhitespaces: false,
   template: `
     @for (step of steps; track step.value) {
-      <span class="ant-slider-dot" [class.ant-slider-dot-active]="step.active" [ngStyle]="step.style!"></span>
+      <span class="ant-slider-dot" [class.ant-slider-dot-active]="step.active" [style]="step.style!"></span>
     }
   `,
-  imports: [NgStyle],
   standalone: true,
   host: {
     class: 'ant-slider-step'

--- a/components/slider/track.component.ts
+++ b/components/slider/track.component.ts
@@ -4,7 +4,6 @@
  */
 
 import { Direction } from '@angular/cdk/bidi';
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -30,8 +29,7 @@ export interface NzSliderTrackStyle {
   selector: 'nz-slider-track',
   exportAs: 'nzSliderTrack',
   preserveWhitespaces: false,
-  template: ` <div class="ant-slider-track" [ngStyle]="style"></div> `,
-  imports: [NgStyle],
+  template: ` <div class="ant-slider-track" [style]="style"></div> `,
   standalone: true
 })
 export class NzSliderTrackComponent implements OnChanges {

--- a/components/statistic/statistic.component.ts
+++ b/components/statistic/statistic.component.ts
@@ -4,7 +4,6 @@
  */
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -39,7 +38,7 @@ import { NzStatisticValueType } from './typings';
     @if (nzLoading) {
       <nz-skeleton class="ant-statistic-skeleton" [nzParagraph]="false" />
     } @else {
-      <div class="ant-statistic-content" [ngStyle]="nzValueStyle">
+      <div class="ant-statistic-content" [style]="nzValueStyle">
         @if (nzPrefix) {
           <span class="ant-statistic-content-prefix">
             <ng-container *nzStringTemplateOutlet="nzPrefix">{{ nzPrefix }}</ng-container>
@@ -58,7 +57,7 @@ import { NzStatisticValueType } from './typings';
     class: 'ant-statistic',
     '[class.ant-statistic-rtl]': `dir === 'rtl'`
   },
-  imports: [NzSkeletonModule, NzStatisticNumberComponent, NzOutletModule, NgStyle],
+  imports: [NzSkeletonModule, NzStatisticNumberComponent, NzOutletModule],
   standalone: true
 })
 export class NzStatisticComponent implements OnDestroy, OnInit {

--- a/components/steps/step.component.ts
+++ b/components/steps/step.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -69,7 +69,7 @@ import { NzProgressFormatter, NzProgressModule } from 'ng-zorro-antd/progress';
           @if (nzIcon) {
             <span class="ant-steps-icon">
               <ng-container *nzStringTemplateOutlet="nzIcon; let icon">
-                <span nz-icon [nzType]="!oldAPIIcon && icon" [ngClass]="oldAPIIcon && icon"></span>
+                <span nz-icon [nzType]="icon"></span>
               </ng-container>
             </span>
           }
@@ -117,7 +117,7 @@ import { NzProgressFormatter, NzProgressModule } from 'ng-zorro-antd/progress';
     '[class.ant-steps-next-error]': '(outStatus === "error") && (currentIndex === index + 1)'
   },
   providers: [NzDestroyService],
-  imports: [NzProgressModule, NzIconModule, NzOutletModule, NgClass, NgTemplateOutlet],
+  imports: [NzProgressModule, NzIconModule, NzOutletModule, NgTemplateOutlet],
   standalone: true
 })
 export class NzStepComponent implements OnInit {

--- a/components/table/src/table/table-inner-scroll.component.ts
+++ b/components/table/src/table/table-inner-scroll.component.ts
@@ -5,7 +5,7 @@
 
 import { Platform } from '@angular/cdk/platform';
 import { CdkVirtualScrollViewport, ScrollingModule } from '@angular/cdk/scrolling';
-import { NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -38,7 +38,7 @@ import { NzTbodyComponent } from './tbody.component';
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (scrollY) {
-      <div #tableHeaderElement [ngStyle]="headerStyleMap" class="ant-table-header nz-table-hide-scrollbar">
+      <div #tableHeaderElement [style]="headerStyleMap" class="ant-table-header nz-table-hide-scrollbar">
         <table
           nz-table-content
           tableLayout="fixed"
@@ -49,7 +49,7 @@ import { NzTbodyComponent } from './tbody.component';
         ></table>
       </div>
       @if (!virtualTemplate) {
-        <div #tableBodyElement class="ant-table-body" [ngStyle]="bodyStyleMap">
+        <div #tableBodyElement class="ant-table-body" [style]="bodyStyleMap">
           <table
             nz-table-content
             tableLayout="fixed"
@@ -79,7 +79,7 @@ import { NzTbodyComponent } from './tbody.component';
         </cdk-virtual-scroll-viewport>
       }
       @if (tfootFixed === 'bottom') {
-        <div #tableFootElement class="ant-table-summary" [ngStyle]="headerStyleMap">
+        <div #tableFootElement class="ant-table-summary" [style]="headerStyleMap">
           <table
             nz-table-content
             tableLayout="fixed"
@@ -90,7 +90,7 @@ import { NzTbodyComponent } from './tbody.component';
         </div>
       }
     } @else {
-      <div class="ant-table-content" #tableBodyElement [ngStyle]="bodyStyleMap">
+      <div class="ant-table-content" #tableBodyElement [style]="bodyStyleMap">
         <table
           nz-table-content
           tableLayout="fixed"
@@ -104,7 +104,7 @@ import { NzTbodyComponent } from './tbody.component';
     }
   `,
   host: { class: 'ant-table-container' },
-  imports: [NzTableContentComponent, NgStyle, ScrollingModule, NgTemplateOutlet, NzTbodyComponent],
+  imports: [NzTableContentComponent, ScrollingModule, NgTemplateOutlet, NzTbodyComponent],
   standalone: true
 })
 export class NzTableInnerScrollComponent<T> implements OnChanges, AfterViewInit, OnDestroy {

--- a/components/tabs/tabset.component.ts
+++ b/components/tabs/tabset.component.ts
@@ -8,7 +8,7 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { coerceNumberProperty } from '@angular/cdk/coercion';
-import { NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -74,7 +74,7 @@ let nextId = 0;
   template: `
     @if (tabs.length || addable) {
       <nz-tabs-nav
-        [ngStyle]="nzTabBarStyle"
+        [style]="nzTabBarStyle"
         [selectedIndex]="nzSelectedIndex || 0"
         [inkBarAnimated]="inkBarAnimated"
         [addable]="addable"
@@ -183,7 +183,6 @@ let nextId = 0;
   },
   imports: [
     NzTabNavBarComponent,
-    NgStyle,
     NgTemplateOutlet,
     NzTabNavItemDirective,
     A11yModule,

--- a/components/time-picker/time-picker.component.ts
+++ b/components/time-picker/time-picker.component.ts
@@ -6,7 +6,7 @@
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { CdkOverlayOrigin, ConnectionPositionPair, OverlayModule } from '@angular/cdk/overlay';
 import { Platform, _getEventTarget } from '@angular/cdk/platform';
-import { AsyncPipe, NgClass } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -111,7 +111,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'timePicker';
         <div class="ant-picker-panel-container">
           <div tabindex="-1" class="ant-picker-panel">
             <nz-time-picker-panel
-              [ngClass]="nzPopupClassName"
+              [class]="nzPopupClassName"
               [format]="nzFormat"
               [nzHourStep]="nzHourStep"
               [nzMinuteStep]="nzMinuteStep"
@@ -161,7 +161,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'timePicker';
     NzIconModule,
     NzFormPatchModule,
     NzTimePickerPanelComponent,
-    NgClass,
     NzOverlayModule,
     OverlayModule
   ],

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -4,7 +4,6 @@
  */
 
 import { OverlayModule } from '@angular/cdk/overlay';
-import { NgClass, NgStyle } from '@angular/common';
 import {
   booleanAttribute,
   ChangeDetectionStrategy,
@@ -95,17 +94,17 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
       <div
         class="ant-tooltip"
         [class.ant-tooltip-rtl]="dir === 'rtl'"
-        [ngClass]="_classMap"
-        [ngStyle]="nzOverlayStyle"
+        [class]="_classMap"
+        [style]="nzOverlayStyle"
         [@.disabled]="!!noAnimation?.nzNoAnimation"
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         [@zoomBigMotion]="'active'"
       >
         <div class="ant-tooltip-content">
           <div class="ant-tooltip-arrow">
-            <span class="ant-tooltip-arrow-content" [ngStyle]="_contentStyleMap"></span>
+            <span class="ant-tooltip-arrow-content" [style]="_contentStyleMap"></span>
           </div>
-          <div class="ant-tooltip-inner" [ngStyle]="_contentStyleMap">
+          <div class="ant-tooltip-inner" [style]="_contentStyleMap">
             <ng-container *nzStringTemplateOutlet="nzTitle; context: nzTitleContext">{{ nzTitle }}</ng-container>
           </div>
         </div>
@@ -113,7 +112,7 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
     </ng-template>
   `,
   preserveWhitespaces: false,
-  imports: [OverlayModule, NgClass, NgStyle, NzNoAnimationDirective, NzOutletModule, NzOverlayModule],
+  imports: [OverlayModule, NzNoAnimationDirective, NzOutletModule, NzOverlayModule],
   standalone: true
 })
 export class NzToolTipComponent extends NzTooltipBaseComponent {

--- a/components/transfer/transfer-list.component.ts
+++ b/components/transfer/transfer-list.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -65,7 +65,7 @@ import { NzTransferSearchComponent } from './transfer-search.component';
     </div>
     <div
       class="{{ showSearch ? 'ant-transfer-list-body ant-transfer-list-body-with-search' : 'ant-transfer-list-body' }}"
-      [ngClass]="{ 'ant-transfer__nodata': stat.shownCount === 0 }"
+      [class]="{ 'ant-transfer__nodata': stat.shownCount === 0 }"
     >
       @if (showSearch) {
         <div class="ant-transfer-list-body-search-wrapper">
@@ -103,7 +103,7 @@ import { NzTransferSearchComponent } from './transfer-search.component';
               <li
                 (click)="!oneWay ? onItemSelect(item) : null"
                 class="ant-transfer-list-content-item"
-                [ngClass]="{ 'ant-transfer-list-content-item-disabled': disabled || item.disabled }"
+                [class]="{ 'ant-transfer-list-content-item-disabled': disabled || item.disabled }"
               >
                 @if (!oneWay) {
                   <label
@@ -129,7 +129,7 @@ import { NzTransferSearchComponent } from './transfer-search.component';
                     </span>
                     <div
                       class="ant-transfer-list-content-item-remove"
-                      [ngClass]="{ 'ant-transfer-list-content-item-disabled': disabled || item.disabled }"
+                      [class]="{ 'ant-transfer-list-content-item-disabled': disabled || item.disabled }"
                       (click)="!(disabled || item.disabled) ? deleteItem(item) : null"
                     >
                       <span nz-icon nzType="delete" nzTheme="outline"></span>
@@ -163,15 +163,7 @@ import { NzTransferSearchComponent } from './transfer-search.component';
     class: 'ant-transfer-list',
     '[class.ant-transfer-list-with-footer]': '!!footer'
   },
-  imports: [
-    NgClass,
-    NzCheckboxModule,
-    NgTemplateOutlet,
-    NzEmptyModule,
-    NzTransferSearchComponent,
-    NzIconModule,
-    NzButtonModule
-  ],
+  imports: [NzCheckboxModule, NgTemplateOutlet, NzEmptyModule, NzTransferSearchComponent, NzIconModule, NzButtonModule],
   standalone: true
 })
 export class NzTransferListComponent implements AfterViewInit {

--- a/components/transfer/transfer-search.component.ts
+++ b/components/transfer/transfer-search.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NgClass } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -33,7 +32,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       [disabled]="disabled"
       [placeholder]="placeholder"
       class="ant-input"
-      [ngClass]="{ 'ant-input-disabled': disabled }"
+      [class]="{ 'ant-input-disabled': disabled }"
     />
     @if (value && value.length > 0) {
       <span class="ant-input-suffix" (click)="_clear()">
@@ -43,7 +42,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   `,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, NzIconModule, NgClass],
+  imports: [FormsModule, NzIconModule],
   standalone: true
 })
 export class NzTransferSearchComponent implements OnChanges {

--- a/components/transfer/transfer.component.ts
+++ b/components/transfer/transfer.component.ts
@@ -4,7 +4,6 @@
  */
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -52,7 +51,7 @@ import { NzTransferListComponent } from './transfer-list.component';
   template: `
     <nz-transfer-list
       class="ant-transfer-list"
-      [ngStyle]="nzListStyle"
+      [style]="nzListStyle"
       data-direction="left"
       direction="left"
       [titleText]="nzTitles[0]"
@@ -138,7 +137,7 @@ import { NzTransferListComponent } from './transfer-list.component';
     }
     <nz-transfer-list
       class="ant-transfer-list"
-      [ngStyle]="nzListStyle"
+      [style]="nzListStyle"
       data-direction="right"
       direction="right"
       [titleText]="nzTitles[1]"
@@ -170,7 +169,7 @@ import { NzTransferListComponent } from './transfer-list.component';
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NzTransferListComponent, NgStyle, NzIconModule, NzButtonModule],
+  imports: [NzTransferListComponent, NzIconModule, NzButtonModule],
   standalone: true
 })
 export class NzTransferComponent implements OnInit, OnChanges, OnDestroy {

--- a/components/tree-select/tree-select.component.ts
+++ b/components/tree-select/tree-select.component.ts
@@ -13,7 +13,7 @@ import {
   ConnectionPositionPair
 } from '@angular/cdk/overlay';
 import { _getEventTarget } from '@angular/cdk/platform';
-import { NgClass, NgStyle, SlicePipe } from '@angular/common';
+import { SlicePipe } from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
@@ -88,9 +88,7 @@ const listOfPositions = [
   imports: [
     NzOverlayModule,
     CdkConnectedOverlay,
-    NgClass,
     NzNoAnimationDirective,
-    NgStyle,
     NzTreeModule,
     NzEmptyModule,
     CdkOverlayOrigin,
@@ -116,14 +114,14 @@ const listOfPositions = [
     >
       <div
         [@slideMotion]="'enter'"
-        [ngClass]="dropdownClassName"
+        [class]="dropdownClassName"
         [@.disabled]="!!noAnimation?.nzNoAnimation"
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         [class.ant-select-dropdown-placement-bottomLeft]="dropDownPosition === 'bottom'"
         [class.ant-select-dropdown-placement-topLeft]="dropDownPosition === 'top'"
         [class.ant-tree-select-dropdown-rtl]="dir === 'rtl'"
         [dir]="dir"
-        [ngStyle]="nzDropdownStyle"
+        [style]="nzDropdownStyle"
       >
         <nz-tree
           #treeRef

--- a/components/tree/tree.component.ts
+++ b/components/tree/tree.component.ts
@@ -5,7 +5,7 @@
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
-import { NgStyle, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -62,9 +62,9 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'tree';
   animations: [treeCollapseMotion],
   template: `
     <div>
-      <input [ngStyle]="HIDDEN_STYLE" />
+      <input [style]="HIDDEN_STYLE" />
     </div>
-    <div class="ant-tree-treenode" [ngStyle]="HIDDEN_NODE_STYLE">
+    <div class="ant-tree-treenode" [style]="HIDDEN_NODE_STYLE">
       <div class="ant-tree-indent">
         <div class="ant-tree-indent-unit"></div>
       </div>
@@ -174,7 +174,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'tree';
     '[class.draggable-tree]': `nzDraggable`
   },
   imports: [
-    NgStyle,
     CdkVirtualScrollViewport,
     CdkFixedSizeVirtualScroll,
     CdkVirtualForOf,

--- a/components/upload/upload-list.component.html
+++ b/components/upload/upload-list.component.html
@@ -143,7 +143,7 @@
               target="_blank"
               rel="noopener noreferrer"
               [attr.title]="locale.previewFile"
-              [ngStyle]="!(file.url || file.thumbUrl) ? { opacity: 0.5, 'pointer-events': 'none' } : null"
+              [style]="!(file.url || file.thumbUrl) ? { opacity: 0.5, 'pointer-events': 'none' } : null"
               (click)="handlePreview(file, $event)"
             >
               <span nz-icon nzType="eye"></span>

--- a/components/upload/upload-list.component.ts
+++ b/components/upload/upload-list.component.ts
@@ -6,7 +6,7 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { Direction } from '@angular/cdk/bidi';
 import { Platform } from '@angular/cdk/platform';
-import { DOCUMENT, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -65,7 +65,7 @@ interface UploadListFile extends NzUploadFile {
   preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NzToolTipModule, NgTemplateOutlet, NzIconModule, NzButtonModule, NgStyle, NzProgressModule],
+  imports: [NzToolTipModule, NgTemplateOutlet, NzIconModule, NzButtonModule, NzProgressModule],
   standalone: true
 })
 export class NzUploadListComponent implements OnChanges, OnDestroy {

--- a/components/upload/upload.component.html
+++ b/components/upload/upload.component.html
@@ -22,14 +22,14 @@
 </ng-template>
 <ng-template #con><ng-content></ng-content></ng-template>
 <ng-template #btn>
-  <div [ngClass]="classList" [style.display]="nzShowButton ? '' : 'none'">
+  <div [class]="classList" [style.display]="nzShowButton ? '' : 'none'">
     <div nz-upload-btn #uploadComp [options]="_btnOptions!">
       <ng-template [ngTemplateOutlet]="con"></ng-template>
     </div>
   </div>
 </ng-template>
 @if (nzType === 'drag') {
-  <div [ngClass]="classList" (drop)="fileDrop($event)" (dragover)="fileDrop($event)" (dragleave)="fileDrop($event)">
+  <div [class]="classList" (drop)="fileDrop($event)" (dragover)="fileDrop($event)" (dragleave)="fileDrop($event)">
     <div nz-upload-btn #uploadComp [options]="_btnOptions!" class="ant-upload-btn">
       <div class="ant-upload-drag-container">
         <ng-template [ngTemplateOutlet]="con"></ng-template>

--- a/components/upload/upload.component.ts
+++ b/components/upload/upload.component.ts
@@ -5,7 +5,7 @@
 
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { Platform } from '@angular/cdk/platform';
-import { DOCUMENT, NgClass, NgTemplateOutlet } from '@angular/common';
+import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -57,7 +57,7 @@ import { NzUploadListComponent } from './upload-list.component';
   host: {
     '[class.ant-upload-picture-card-wrapper]': 'nzListType === "picture-card"'
   },
-  imports: [NzUploadListComponent, NgTemplateOutlet, NgClass, NzUploadBtnComponent],
+  imports: [NzUploadListComponent, NgTemplateOutlet, NzUploadBtnComponent],
   standalone: true
 })
 export class NzUploadComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

https://github.com/angular/angular/issues/40623
https://github.com/angular/angular/pull/58860


## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

All nzClass / nzStyle input properties no longer support the following features:

- `Set()`: use arrays instead
- Keys which multiple styles/classes separated with keys: split a key with spaces into multiple keys

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
