### PR TITLE
fix(module:nzHighlight pipe): node title html parse issue #6477

### DIFF
--- a/components/core/highlight/highlight.pipe.ts
+++ b/components/core/highlight/highlight.pipe.ts
@@ -38,7 +38,7 @@ export class NzHighlightPipe implements PipeTransform {
 
   transform(value: string, highlightValue: string, flags?: string, klass?: string): string | null {
     if (!highlightValue) {
-      return value;
+      return encodeEntities(value);
     }
 
     // Escapes regex keyword to interpret these characters literally


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
when node title is `<axxx>title`, node title will only display `title`

Issue Number: #6477 


## What is the new behavior?

display `<axxx>title`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
