### PR TITLE
fix(module:auto-complete): click input field can not popup option panel when it was focused

### DIFF
--- a/components/auto-complete/autocomplete-trigger.directive.ts
+++ b/components/auto-complete/autocomplete-trigger.directive.ts
@@ -61,7 +61,8 @@ export function getNzAutocompleteMissingPanelError(): Error {
     '(focusin)': 'handleFocus()',
     '(blur)': 'handleBlur()',
     '(input)': 'handleInput($event)',
-    '(keydown)': 'handleKeydown($event)'
+    '(keydown)': 'handleKeydown($event)',
+    '(click)': 'handleClick($event)'
   }
 })
 export class NzAutocompleteTriggerDirective implements AfterViewInit, ControlValueAccessor, OnDestroy {
@@ -214,6 +215,12 @@ export class NzAutocompleteTriggerDirective implements AfterViewInit, ControlVal
 
   handleFocus(): void {
     if (this.canOpen()) {
+      this.openPanel();
+    }
+  }
+
+  handleClick(): void {
+    if (this.canOpen() && !this.panelOpen) {
       this.openPanel();
     }
   }

--- a/components/auto-complete/autocomplete.spec.ts
+++ b/components/auto-complete/autocomplete.spec.ts
@@ -227,6 +227,23 @@ describe('auto-complete', () => {
       expect(overlayContainerElement.textContent).toEqual('');
     }));
 
+    it('should open the panel when click the input that has been focused', fakeAsync(() => {
+      dispatchFakeEvent(input, 'focusin');
+      fixture.detectChanges();
+      flush();
+
+      const option = overlayContainerElement.querySelector('nz-auto-option') as HTMLElement;
+      option.click();
+      fixture.detectChanges();
+
+      tick(500);
+      expect(fixture.componentInstance.trigger.panelOpen).toBe(false);
+
+      dispatchFakeEvent(input, 'click');
+      fixture.detectChanges();
+      expect(fixture.componentInstance.trigger.panelOpen).toBe(true);
+    }));
+
     it('should close the panel when an option is tap', fakeAsync(() => {
       dispatchFakeEvent(input, 'focusin');
       fixture.detectChanges();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

like the video below:

step1: click the input field and then click one option (e.g. Lucy)
step2: option panel will close after click, then we still click the input field, no response.

ps: In step2, if we re-click input field of the auto-complete component of [Ant Design](https://ant.design/components/auto-complete), the option panel will pop up.

https://github.com/user-attachments/assets/15f851d8-3667-4530-a4ae-7dcb567908d1



## What is the new behavior?

solved the above issue: if we re-click the input field which has been focused, the option panel still able to pop up

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
