### PR TITLE
feat(module:cascader): support multiple selection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@ components/tabs/**                        @hsuanxyz
 components/breadcrumb/**                  @simplejason
 components/empty/**                       @simplejason
 components/carousel/**                    @simplejason
-components/cascader/**                    @simplejason
+components/cascader/**                    @laffery
 components/descriptions/**                @simplejason
 components/icon/**                        @simplejason
 components/message/**                     @simplejason
@@ -86,7 +86,7 @@ components/core/outlet/**                 @vthinkxie
 components/core/time/**                   @wenqi73
 components/core/trans-button/**           @hsuanxyz
 components/core/transition-patch/**       @vthinkxie
-components/core/tree/**                   @simplejason @hsuanxyz
+components/core/tree/**                   @simplejason @laffery
 components/core/wave/**                   @hsuanxyz
 
 # Misc

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -17,7 +17,8 @@ import {
   numberAttribute,
   inject,
   Output,
-  EventEmitter
+  EventEmitter,
+  booleanAttribute
 } from '@angular/core';
 
 import { NzCascaderService } from 'ng-zorro-antd/cascader/cascader.service';
@@ -26,6 +27,7 @@ import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import { NzCascaderOption } from './typings';
+import { getOptionKey } from './utils';
 
 @Component({
   standalone: true,
@@ -88,13 +90,13 @@ export class NzCascaderOptionComponent implements OnInit {
   @Input({ transform: numberAttribute }) columnIndex!: number;
   @Input() expandIcon: string | TemplateRef<void> = '';
   @Input() dir: Direction = 'ltr';
-  @Input() checkable?: boolean = false;
+  @Input({ transform: booleanAttribute }) checkable?: boolean = false;
 
-  // eslint-disable-next-line @angular-eslint/no-output-on-prefix
   @Output() readonly check = new EventEmitter<void>();
 
-  readonly nativeElement: HTMLElement = inject(ElementRef).nativeElement;
-  public cascaderService = inject(NzCascaderService);
+  // public key!: string;
+  public readonly nativeElement: HTMLElement = inject(ElementRef).nativeElement;
+  private cascaderService = inject(NzCascaderService);
 
   constructor(private cdr: ChangeDetectorRef) {}
 
@@ -106,12 +108,20 @@ export class NzCascaderOptionComponent implements OnInit {
     }
   }
 
+  // ngOnChanges(changes: SimpleChanges): void {
+  //   const { option, prevValuePath } = changes;
+  //   if ((option || prevValuePath) && option?.currentValue && prevValuePath?.currentValue) {
+  //     const fullPath = [...prevValuePath.currentValue, this.cascaderService.getOptionValue(option.currentValue)];
+  //     this.key = toPathKey(fullPath);
+  //   }
+  // }
+
   get checked(): boolean {
-    return this.cascaderService.checkedOptionsKeySet.has(this.option.value);
+    return this.cascaderService.checkedOptionsKeySet.has(getOptionKey(this.option));
   }
 
   get halfChecked(): boolean {
-    return this.cascaderService.halfCheckedOptionsKeySet.has(this.option.value);
+    return this.cascaderService.halfCheckedOptionsKeySet.has(getOptionKey(this.option));
   }
 
   get disabled(): boolean {

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -83,7 +83,6 @@ import { NzCascaderOption } from './typings';
 export class NzCascaderOptionComponent implements OnInit {
   @Input() optionTemplate: TemplateRef<NzCascaderOption> | null = null;
   @Input() node!: NzTreeNode;
-  @Input() option!: NzCascaderOption;
   @Input() activated = false;
   @Input() highlightText!: string;
   @Input() nzLabelProperty = 'label';

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -130,6 +130,7 @@ export class NzCascaderOptionComponent implements OnInit {
 
   onCheckboxClick(event: MouseEvent): void {
     event.preventDefault();
+    event.stopPropagation();
     if (!this.checkable) {
       return;
     }

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -91,7 +91,7 @@ export class NzCascaderOptionComponent implements OnInit {
   @Input() checkable?: boolean = false;
 
   // eslint-disable-next-line @angular-eslint/no-output-on-prefix
-  @Output() readonly onCheckboxChange = new EventEmitter<void>();
+  @Output() readonly check = new EventEmitter<void>();
 
   readonly nativeElement: HTMLElement = inject(ElementRef).nativeElement;
   public cascaderService = inject(NzCascaderService);
@@ -131,6 +131,6 @@ export class NzCascaderOptionComponent implements OnInit {
     if (!this.checkable) {
       return;
     }
-    this.onCheckboxChange.emit();
+    this.check.emit();
   }
 }

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -27,7 +27,7 @@ import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import { NzCascaderOption } from './typings';
-import { getOptionKey } from './utils';
+import { getOptionKey, isDisabledOption } from './utils';
 
 @Component({
   standalone: true,
@@ -108,14 +108,6 @@ export class NzCascaderOptionComponent implements OnInit {
     }
   }
 
-  // ngOnChanges(changes: SimpleChanges): void {
-  //   const { option, prevValuePath } = changes;
-  //   if ((option || prevValuePath) && option?.currentValue && prevValuePath?.currentValue) {
-  //     const fullPath = [...prevValuePath.currentValue, this.cascaderService.getOptionValue(option.currentValue)];
-  //     this.key = toPathKey(fullPath);
-  //   }
-  // }
-
   get checked(): boolean {
     return this.cascaderService.checkedOptionsKeySet.has(getOptionKey(this.option));
   }
@@ -125,7 +117,7 @@ export class NzCascaderOptionComponent implements OnInit {
   }
 
   get disabled(): boolean {
-    return false;
+    return isDisabledOption(this.option);
   }
 
   get optionLabel(): string {

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -21,13 +21,12 @@ import {
   booleanAttribute
 } from '@angular/core';
 
-import { NzCascaderService } from 'ng-zorro-antd/cascader/cascader.service';
 import { NzHighlightModule } from 'ng-zorro-antd/core/highlight';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
+import { NzTreeNode } from 'ng-zorro-antd/core/tree';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import { NzCascaderOption } from './typings';
-import { getOptionKey, isDisabledOption } from './utils';
 
 @Component({
   standalone: true,
@@ -50,7 +49,7 @@ import { getOptionKey, isDisabledOption } from './utils';
     @if (optionTemplate) {
       <ng-template
         [ngTemplateOutlet]="optionTemplate"
-        [ngTemplateOutletContext]="{ $implicit: option, index: columnIndex }"
+        [ngTemplateOutletContext]="{ $implicit: node.origin, index: columnIndex }"
       />
     } @else {
       <div
@@ -59,9 +58,9 @@ import { getOptionKey, isDisabledOption } from './utils';
       ></div>
     }
 
-    @if (!option.isLeaf || option.children?.length || option.loading) {
+    @if (!node.isLeaf || node.children?.length || node.isLoading) {
       <div class="ant-cascader-menu-item-expand-icon">
-        @if (option.loading) {
+        @if (node.isLoading) {
           <span nz-icon nzType="loading"></span>
         } @else {
           <ng-container *nzStringTemplateOutlet="expandIcon">
@@ -73,16 +72,17 @@ import { getOptionKey, isDisabledOption } from './utils';
   `,
   host: {
     class: 'ant-cascader-menu-item ant-cascader-menu-item-expanded',
-    '[attr.title]': 'option.title || optionLabel',
+    '[attr.title]': 'node',
     '[class.ant-cascader-menu-item-active]': 'activated',
-    '[class.ant-cascader-menu-item-expand]': '!option.isLeaf',
-    '[class.ant-cascader-menu-item-disabled]': 'option.disabled'
+    '[class.ant-cascader-menu-item-expand]': '!node.isLeaf',
+    '[class.ant-cascader-menu-item-disabled]': 'node.isDisabled'
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzCascaderOptionComponent implements OnInit {
   @Input() optionTemplate: TemplateRef<NzCascaderOption> | null = null;
+  @Input() node!: NzTreeNode;
   @Input() option!: NzCascaderOption;
   @Input() activated = false;
   @Input() highlightText!: string;
@@ -94,9 +94,7 @@ export class NzCascaderOptionComponent implements OnInit {
 
   @Output() readonly check = new EventEmitter<void>();
 
-  // public key!: string;
   public readonly nativeElement: HTMLElement = inject(ElementRef).nativeElement;
-  private cascaderService = inject(NzCascaderService);
 
   constructor(private cdr: ChangeDetectorRef) {}
 
@@ -109,15 +107,15 @@ export class NzCascaderOptionComponent implements OnInit {
   }
 
   get checked(): boolean {
-    return this.cascaderService.checkedOptionsKeySet.has(getOptionKey(this.option));
+    return this.node.isChecked;
   }
 
   get halfChecked(): boolean {
-    return this.cascaderService.halfCheckedOptionsKeySet.has(getOptionKey(this.option));
+    return this.node.isHalfChecked;
   }
 
   get disabled(): boolean {
-    return isDisabledOption(this.option);
+    return this.node.isDisabled || this.node.isDisableCheckbox;
   }
 
   get optionLabel(): string {

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -54,7 +54,7 @@ import { NzCascaderOption } from './typings';
     } @else {
       <div
         class="ant-cascader-menu-item-content"
-        [innerHTML]="optionLabel | nzHighlight: highlightText : 'g' : 'ant-cascader-menu-item-keyword'"
+        [innerHTML]="node.title | nzHighlight: highlightText : 'g' : 'ant-cascader-menu-item-keyword'"
       ></div>
     }
 
@@ -72,7 +72,7 @@ import { NzCascaderOption } from './typings';
   `,
   host: {
     class: 'ant-cascader-menu-item ant-cascader-menu-item-expanded',
-    '[attr.title]': 'node',
+    '[attr.title]': 'node.title',
     '[class.ant-cascader-menu-item-active]': 'activated',
     '[class.ant-cascader-menu-item-expand]': '!node.isLeaf',
     '[class.ant-cascader-menu-item-disabled]': 'node.isDisabled'
@@ -116,10 +116,6 @@ export class NzCascaderOptionComponent implements OnInit {
 
   get disabled(): boolean {
     return this.node.isDisabled || this.node.isDisableCheckbox;
-  }
-
-  get optionLabel(): string {
-    return this.option[this.nzLabelProperty];
   }
 
   markForCheck(): void {

--- a/components/cascader/cascader-tree.service.ts
+++ b/components/cascader/cascader-tree.service.ts
@@ -1,0 +1,113 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { Injectable } from '@angular/core';
+
+import { NzCascaderOption } from 'ng-zorro-antd/cascader/typings';
+import { NzTreeBaseService, NzTreeNode, NzTreeNodeKey } from 'ng-zorro-antd/core/tree';
+import { arraysEqual } from 'ng-zorro-antd/core/util';
+
+interface InternalFieldNames extends Required<Pick<NzCascaderOption, 'label' | 'value'>> {}
+
+@Injectable()
+export class NzCascaderTreeService extends NzTreeBaseService {
+  fieldNames: InternalFieldNames = {
+    label: 'label',
+    value: 'value'
+  };
+
+  override treeNodePostProcessor = (node: NzTreeNode): void => {
+    // if (node.parentNode) {
+    //   // node.key = toPathKey([node.parentNode.key, node.origin[this.fieldNames.value]]);
+    // } else {
+    //   node.key = toPathKey([node.origin[this.fieldNames.value]]);
+    // }
+    node.key = node.origin[this.fieldNames.value];
+    node.title = node.origin[this.fieldNames.label];
+  };
+
+  constructor() {
+    super();
+  }
+
+  toOption(option: NzTreeNode): NzCascaderOption {
+    return option.origin;
+  }
+
+  toOptions(options: NzTreeNode[]): NzCascaderOption[] {
+    return options.map(option => this.toOption(option));
+  }
+
+  getAncestorNodeList(node: NzTreeNode | null): NzTreeNode[] {
+    if (!node) {
+      return [];
+    }
+    if (node.parentNode) {
+      return [...this.getAncestorNodeList(node.parentNode), node];
+    }
+    return [node];
+  }
+
+  /**
+   * Render by nzCheckedKeys
+   * When keys equals null, just render with checkStrictly
+   *
+   * @param paths
+   * @param checkStrictly
+   */
+  conductCheckPaths(paths: NzTreeNodeKey[][] | null, checkStrictly: boolean): void {
+    this.checkedNodeList = [];
+    this.halfCheckedNodeList = [];
+    const calc = (nodes: NzTreeNode[]): void => {
+      nodes.forEach(node => {
+        if (paths === null) {
+          // render tree if no default checked keys found
+          node.isChecked = !!node.origin.checked;
+        } else {
+          // if node is in checked path
+          const nodePath = this.getAncestorNodeList(node).map(n => n.key);
+          if (paths.some(keys => arraysEqual(nodePath, keys))) {
+            node.isChecked = true;
+            node.isHalfChecked = false;
+          } else {
+            node.isChecked = false;
+            node.isHalfChecked = false;
+          }
+        }
+        if (node.children.length > 0) {
+          calc(node.children);
+        }
+      });
+    };
+    calc(this.rootNodes);
+    this.refreshCheckState(checkStrictly);
+  }
+
+  conductSelectedPaths(paths: NzTreeNodeKey[][], isMulti: boolean): void {
+    this.selectedNodeList.forEach(node => (node.isSelected = false));
+    this.selectedNodeList = [];
+    const calc = (nodes: NzTreeNode[]): boolean =>
+      nodes.every(node => {
+        // if node is in selected path
+        const nodePath = this.getAncestorNodeList(node).map(n => n.key);
+        if (paths.some(keys => arraysEqual(nodePath, keys))) {
+          node.isSelected = true;
+          this.setSelectedNodeList(node);
+          if (!isMulti) {
+            // if not support multi select
+            return false;
+          }
+        } else {
+          node.isSelected = false;
+        }
+        if (node.children.length > 0) {
+          // Recursion
+          return calc(node.children);
+        }
+        return true;
+      });
+    calc(this.rootNodes);
+  }
+}

--- a/components/cascader/cascader-tree.service.ts
+++ b/components/cascader/cascader-tree.service.ts
@@ -7,9 +7,13 @@ import { Injectable } from '@angular/core';
 
 import { NzCascaderOption } from 'ng-zorro-antd/cascader/typings';
 import { NzTreeBaseService, NzTreeNode, NzTreeNodeKey } from 'ng-zorro-antd/core/tree';
+import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { arraysEqual } from 'ng-zorro-antd/core/util';
 
-interface InternalFieldNames extends Required<Pick<NzCascaderOption, 'label' | 'value'>> {}
+interface InternalFieldNames {
+  label: string;
+  value: string;
+}
 
 @Injectable()
 export class NzCascaderTreeService extends NzTreeBaseService {
@@ -19,14 +23,17 @@ export class NzCascaderTreeService extends NzTreeBaseService {
   };
 
   override treeNodePostProcessor = (node: NzTreeNode): void => {
-    // if (node.parentNode) {
-    //   // node.key = toPathKey([node.parentNode.key, node.origin[this.fieldNames.value]]);
-    // } else {
-    //   node.key = toPathKey([node.origin[this.fieldNames.value]]);
-    // }
     node.key = node.origin[this.fieldNames.value];
     node.title = node.origin[this.fieldNames.label];
   };
+
+  get children(): NzTreeNode[] {
+    return this.rootNodes;
+  }
+
+  set children(value: Array<NzTreeNode | NzSafeAny>) {
+    this.rootNodes = value.map(v => (v instanceof NzTreeNode ? v : new NzTreeNode(v, null)));
+  }
 
   constructor() {
     super();

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -88,148 +88,146 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
   exportAs: 'nzCascader',
   preserveWhitespaces: false,
   template: `
-    <div #origin="cdkOverlayOrigin" cdkOverlayOrigin #trigger>
-      @if (nzShowInput) {
-        <div #selectContainer class="ant-select-selector">
-          @if (nzMultiple) {
-            @for (node of selectedNodes | slice: 0 : nzMaxTagCount; track node) {
-              <nz-select-item
-                [deletable]="true"
-                [disabled]="nzDisabled"
-                [label]="nzDisplayWith(getAncestorOptionList(node))"
-                (delete)="removeSelected(node)"
-              ></nz-select-item>
-            }
-            @if (selectedNodes.length > nzMaxTagCount) {
-              <nz-select-item
-                [deletable]="false"
-                [disabled]="false"
-                [label]="'+ ' + (selectedNodes.length - nzMaxTagCount) + ' ...'"
-              ></nz-select-item>
-            }
-          }
-
-          <nz-select-search
-            [showInput]="!!nzShowSearch"
-            (isComposingChange)="isComposingChange($event)"
-            [value]="inputValue"
-            (valueChange)="inputValue = $event"
-            [mirrorSync]="nzMultiple"
-            [disabled]="nzDisabled"
-            [autofocus]="nzAutoFocus"
-            [focusTrigger]="menuVisible"
-          ></nz-select-search>
-
-          @if (showPlaceholder) {
-            <nz-select-placeholder
-              [placeholder]="nzPlaceHolder || locale?.placeholder!"
-              [style.display]="inputValue || isComposing ? 'none' : 'block'"
-            ></nz-select-placeholder>
-          }
-
-          @if (!nzMultiple && selectedNodes.length) {
+    @if (nzShowInput) {
+      <div #selectContainer class="ant-select-selector">
+        @if (nzMultiple) {
+          @for (node of selectedNodes | slice: 0 : nzMaxTagCount; track node) {
             <nz-select-item
-              [deletable]="false"
+              [deletable]="true"
               [disabled]="nzDisabled"
-              [label]="labelRenderText"
-              [contentTemplateOutlet]="isLabelRenderTemplate ? nzLabelRender : null"
-              [contentTemplateOutletContext]="labelRenderContext"
+              [label]="nzDisplayWith(getAncestorOptionList(node))"
+              (delete)="removeSelected(node)"
             ></nz-select-item>
           }
-        </div>
-
-        @if (nzShowArrow) {
-          <span class="ant-select-arrow" [class.ant-select-arrow-loading]="isLoading">
-            @if (!isLoading) {
-              <span nz-icon [nzType]="$any(nzSuffixIcon)" [class.ant-cascader-picker-arrow-expand]="menuVisible"></span>
-            } @else {
-              <span nz-icon nzType="loading"></span>
-            }
-
-            @if (hasFeedback && !!status) {
-              <nz-form-item-feedback-icon [status]="status" />
-            }
-          </span>
+          @if (selectedNodes.length > nzMaxTagCount) {
+            <nz-select-item
+              [deletable]="false"
+              [disabled]="false"
+              [label]="'+ ' + (selectedNodes.length - nzMaxTagCount) + ' ...'"
+            ></nz-select-item>
+          }
         }
-        @if (clearIconVisible) {
-          <nz-select-clear (clear)="clearSelection($event)"></nz-select-clear>
+
+        <nz-select-search
+          [showInput]="!!nzShowSearch"
+          (isComposingChange)="isComposingChange($event)"
+          [value]="inputValue"
+          (valueChange)="inputValue = $event"
+          [mirrorSync]="nzMultiple"
+          [disabled]="nzDisabled"
+          [autofocus]="nzAutoFocus"
+          [focusTrigger]="menuVisible"
+        ></nz-select-search>
+
+        @if (showPlaceholder) {
+          <nz-select-placeholder
+            [placeholder]="nzPlaceHolder || locale?.placeholder!"
+            [style.display]="inputValue || isComposing ? 'none' : 'block'"
+          ></nz-select-placeholder>
         }
+
+        @if (!nzMultiple && selectedNodes.length) {
+          <nz-select-item
+            [deletable]="false"
+            [disabled]="nzDisabled"
+            [label]="labelRenderText"
+            [contentTemplateOutlet]="isLabelRenderTemplate ? nzLabelRender : null"
+            [contentTemplateOutletContext]="labelRenderContext"
+          ></nz-select-item>
+        }
+      </div>
+
+      @if (nzShowArrow) {
+        <span class="ant-select-arrow" [class.ant-select-arrow-loading]="isLoading">
+          @if (!isLoading) {
+            <span nz-icon [nzType]="$any(nzSuffixIcon)" [class.ant-cascader-picker-arrow-expand]="menuVisible"></span>
+          } @else {
+            <span nz-icon nzType="loading"></span>
+          }
+
+          @if (hasFeedback && !!status) {
+            <nz-form-item-feedback-icon [status]="status" />
+          }
+        </span>
       }
-      <ng-content></ng-content>
+      @if (clearIconVisible) {
+        <nz-select-clear (clear)="clearSelection($event)"></nz-select-clear>
+      }
+    }
+    <ng-content></ng-content>
 
-      <ng-template
-        cdkConnectedOverlay
-        nzConnectedOverlay
-        [cdkConnectedOverlayHasBackdrop]="nzBackdrop"
-        [cdkConnectedOverlayOrigin]="origin"
-        [cdkConnectedOverlayPositions]="positions"
-        [cdkConnectedOverlayTransformOriginOn]="'.ant-cascader-dropdown'"
-        [cdkConnectedOverlayOpen]="menuVisible"
-        (overlayOutsideClick)="onClickOutside($event)"
-        (detach)="closeMenu()"
+    <ng-template
+      cdkConnectedOverlay
+      nzConnectedOverlay
+      [cdkConnectedOverlayHasBackdrop]="nzBackdrop"
+      [cdkConnectedOverlayOrigin]="overlayOrigin"
+      [cdkConnectedOverlayPositions]="positions"
+      [cdkConnectedOverlayTransformOriginOn]="'.ant-cascader-dropdown'"
+      [cdkConnectedOverlayOpen]="menuVisible"
+      (overlayOutsideClick)="onClickOutside($event)"
+      (detach)="closeMenu()"
+    >
+      <div
+        class="ant-select-dropdown ant-cascader-dropdown ant-select-dropdown-placement-bottomLeft"
+        [class.ant-cascader-dropdown-rtl]="dir === 'rtl'"
+        [@slideMotion]="'enter'"
+        [@.disabled]="!!noAnimation?.nzNoAnimation"
+        [nzNoAnimation]="noAnimation?.nzNoAnimation"
+        (mouseenter)="onTriggerMouseEnter()"
+        (mouseleave)="onTriggerMouseLeave($event)"
       >
         <div
-          class="ant-select-dropdown ant-cascader-dropdown ant-select-dropdown-placement-bottomLeft"
-          [class.ant-cascader-dropdown-rtl]="dir === 'rtl'"
-          [@slideMotion]="'enter'"
-          [@.disabled]="!!noAnimation?.nzNoAnimation"
-          [nzNoAnimation]="noAnimation?.nzNoAnimation"
-          (mouseenter)="onTriggerMouseEnter()"
-          (mouseleave)="onTriggerMouseLeave($event)"
+          #menu
+          class="ant-cascader-menus"
+          [class.ant-cascader-rtl]="dir === 'rtl'"
+          [class.ant-cascader-menus-hidden]="!menuVisible"
+          [class.ant-cascader-menu-empty]="shouldShowEmpty"
+          [class]="nzMenuClassName"
+          [style]="nzMenuStyle"
         >
-          <div
-            #menu
-            class="ant-cascader-menus"
-            [class.ant-cascader-rtl]="dir === 'rtl'"
-            [class.ant-cascader-menus-hidden]="!menuVisible"
-            [class.ant-cascader-menu-empty]="shouldShowEmpty"
-            [class]="nzMenuClassName"
-            [style]="nzMenuStyle"
-          >
-            @if (shouldShowEmpty) {
-              <ul class="ant-cascader-menu" [style.width]="dropdownWidthStyle" [style.height]="dropdownHeightStyle">
-                <li class="ant-cascader-menu-item ant-cascader-menu-item-disabled">
-                  <nz-embed-empty
-                    class="ant-cascader-menu-item-content"
-                    [nzComponentName]="'cascader'"
-                    [specificContent]="nzNotFoundContent"
-                  />
-                </li>
+          @if (shouldShowEmpty) {
+            <ul class="ant-cascader-menu" [style.width]="dropdownWidthStyle" [style.height]="dropdownHeightStyle">
+              <li class="ant-cascader-menu-item ant-cascader-menu-item-disabled">
+                <nz-embed-empty
+                  class="ant-cascader-menu-item-content"
+                  [nzComponentName]="'cascader'"
+                  [specificContent]="nzNotFoundContent"
+                />
+              </li>
+            </ul>
+          } @else {
+            @for (options of cascaderService.columns; track options; let i = $index) {
+              <ul
+                class="ant-cascader-menu"
+                role="menuitemcheckbox"
+                [class]="nzColumnClassName"
+                [style.height]="dropdownHeightStyle"
+                [style.width]="dropdownWidthStyle"
+              >
+                @for (option of options; track option) {
+                  <li
+                    nz-cascader-option
+                    [expandIcon]="nzExpandIcon"
+                    [columnIndex]="i"
+                    [nzLabelProperty]="nzLabelProperty"
+                    [optionTemplate]="nzOptionRender"
+                    [activated]="isOptionActivated(option, i)"
+                    [highlightText]="inSearchingMode ? inputValue : ''"
+                    [node]="option"
+                    [dir]="dir"
+                    [checkable]="nzMultiple"
+                    (mouseenter)="onOptionMouseEnter(option, i, $event)"
+                    (mouseleave)="onOptionMouseLeave(option, i, $event)"
+                    (click)="onOptionClick(option, i, $event)"
+                    (check)="onOptionCheck(option, i)"
+                  ></li>
+                }
               </ul>
-            } @else {
-              @for (options of cascaderService.columns; track options; let i = $index) {
-                <ul
-                  class="ant-cascader-menu"
-                  role="menuitemcheckbox"
-                  [class]="nzColumnClassName"
-                  [style.height]="dropdownHeightStyle"
-                  [style.width]="dropdownWidthStyle"
-                >
-                  @for (option of options; track option) {
-                    <li
-                      nz-cascader-option
-                      [expandIcon]="nzExpandIcon"
-                      [columnIndex]="i"
-                      [nzLabelProperty]="nzLabelProperty"
-                      [optionTemplate]="nzOptionRender"
-                      [activated]="isOptionActivated(option, i)"
-                      [highlightText]="inSearchingMode ? inputValue : ''"
-                      [node]="option"
-                      [dir]="dir"
-                      [checkable]="nzMultiple"
-                      (mouseenter)="onOptionMouseEnter(option, i, $event)"
-                      (mouseleave)="onOptionMouseLeave(option, i, $event)"
-                      (click)="onOptionClick(option, i, $event)"
-                      (check)="onOptionCheck(option, i)"
-                    ></li>
-                  }
-                </ul>
-              }
             }
-          </div>
+          }
         </div>
-      </ng-template>
-    </div>
+      </div>
+    </ng-template>
   `,
   animations: [slideMotion],
   providers: [
@@ -399,6 +397,10 @@ export class NzCascaderComponent
   dir: Direction = 'ltr';
 
   isComposing = false;
+
+  protected get overlayOrigin(): ElementRef {
+    return this.elementRef;
+  }
 
   protected finalSize = computed(() => {
     if (this.compactSize) {

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -841,7 +841,7 @@ export class NzCascaderComponent
     }
 
     if (this.inSearchingMode) {
-      this.cascaderService.prepareSearchOptions(this.inputValue);
+      this.cascaderService.prepareSearchOptions(this.inputValue, this.nzMultiple);
     }
   }
 

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -725,7 +725,7 @@ export class NzCascaderComponent
 
     this.el.focus();
     this.inSearchingMode
-      ? this.cascaderService.setSearchOptionSelected(option as NzCascaderSearchOption)
+      ? this.cascaderService.setSearchOptionSelected(option as NzCascaderSearchOption, this.nzMultiple)
       : this.cascaderService.setOptionActivated(option, columnIndex, !this.nzMultiple);
   }
 
@@ -741,7 +741,7 @@ export class NzCascaderComponent
     } else {
       // check
       this.inSearchingMode
-        ? this.cascaderService.setSearchOptionSelected(option as NzCascaderSearchOption)
+        ? this.cascaderService.setSearchOptionSelected(option as NzCascaderSearchOption, true)
         : this.cascaderService.setOptionActivated(option, columnIndex, true, true);
     }
   }

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -77,7 +77,7 @@ import {
   NzCascaderTriggerType,
   NzShowSearchOptions
 } from './typings';
-import { getOptionKey } from './utils';
+import { getOptionKey, isDisabledOption } from './utils';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'cascader';
 const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
@@ -730,14 +730,14 @@ export class NzCascaderComponent
   }
 
   onOptionCheck(option: NzCascaderOption, columnIndex: number): void {
-    if (!this.nzMultiple || (option && option.disabled)) {
+    if (!this.nzMultiple || (option && isDisabledOption(option))) {
       return;
     }
 
     const key = getOptionKey(option);
     if (this.cascaderService.checkedOptionsKeySet.has(key)) {
       // uncheck
-      this.cascaderService.removeSelectedOption(option, columnIndex, this.nzMultiple);
+      this.cascaderService.removeSelectedOption(option);
     } else {
       // check
       this.inSearchingMode
@@ -747,8 +747,7 @@ export class NzCascaderComponent
   }
 
   removeSelectedItem(node: NzCascaderOption[]): void {
-    const columnIndex = node.length - 1;
-    this.cascaderService.removeSelectedOption(node[columnIndex], columnIndex, true);
+    this.cascaderService.removeSelectedOption(node[node.length - 1]);
   }
 
   onClickOutside(event: MouseEvent): void {

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -126,7 +126,7 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
           ></nz-select-placeholder>
         }
 
-        @if (!nzMultiple && selectedNodes.length) {
+        @if (showLabelRender) {
           <nz-select-item
             [deletable]="false"
             [disabled]="nzDisabled"
@@ -436,6 +436,10 @@ export class NzCascaderComponent
 
   private get hasValue(): boolean {
     return this.cascaderService.values && this.cascaderService.values.length > 0;
+  }
+
+  get showLabelRender(): boolean {
+    return !this.hasInput && !this.nzMultiple && !!this.selectedNodes.length;
   }
 
   get showPlaceholder(): boolean {

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -362,7 +362,6 @@ export class NzCascaderComponent
 
   @Output() readonly nzVisibleChange = new EventEmitter<boolean>();
   @Output() readonly nzSelectionChange = new EventEmitter<NzCascaderOption[]>();
-  @Output() readonly nzSelect = new EventEmitter<{ option: NzCascaderOption; index: number } | null>();
   @Output() readonly nzRemoved = new EventEmitter<NzCascaderOption>();
   @Output() readonly nzClear = new EventEmitter<void>();
 

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -522,7 +522,7 @@ export class NzCascaderComponent
     });
 
     srv.$quitSearching.pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.inputString = '';
+      this.inputValue = '';
       this.dropdownWidthStyle = '';
     });
 
@@ -757,7 +757,7 @@ export class NzCascaderComponent
       if (!node.isLeaf) {
         this.delaySetOptionActivated(node, columnIndex, false);
       } else {
-        this.cascaderService.setOptionDeactivatedSinceColumn(columnIndex);
+        this.cascaderService.setNodeDeactivatedSinceColumn(columnIndex);
       }
     }
   }
@@ -987,7 +987,7 @@ export class NzCascaderComponent
     const options = this.cascaderService.activatedNodes;
     if (options.length) {
       options.pop(); // Remove the last one
-      this.cascaderService.setOptionDeactivatedSinceColumn(options.length); // collapse menu
+      this.cascaderService.setNodeDeactivatedSinceColumn(options.length); // collapse menu
     }
   }
 

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -135,26 +135,6 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
               [contentTemplateOutletContext]="labelRenderContext"
             ></nz-select-item>
           }
-
-          <!--        <div #selectContainer #origin="cdkOverlayOrigin" cdkOverlayOrigin class="ant-select-selector">-->
-          <!--          <span class="ant-select-selection-search">-->
-          <!--            <input-->
-          <!--              #input-->
-          <!--              type="search"-->
-          <!--              class="ant-select-selection-search-input"-->
-          <!--              [style.opacity]="nzShowSearch ? '' : '0'"-->
-          <!--              [attr.autoComplete]="'off'"-->
-          <!--              [attr.expanded]="menuVisible"-->
-          <!--              [attr.autofocus]="nzAutoFocus ? 'autofocus' : null"-->
-          <!--              [readonly]="!nzShowSearch"-->
-          <!--              [disabled]="nzDisabled"-->
-          <!--              [(ngModel)]="inputValue"-->
-          <!--              (blur)="handleInputBlur()"-->
-          <!--              (focus)="handleInputFocus()"-->
-          <!--              (compositionstart)="handleInputCompositionstart()"-->
-          <!--              (compositionend)="handleInputCompositionend()"-->
-          <!--            />-->
-          <!--          </span>-->
         </div>
 
         @if (nzShowArrow) {
@@ -239,7 +219,7 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
                       (mouseenter)="onOptionMouseEnter(option, i, $event)"
                       (mouseleave)="onOptionMouseLeave(option, i, $event)"
                       (click)="onOptionClick(option, i, $event)"
-                      (onCheckboxChange)="onOptionCheck(option, i)"
+                      (check)="onOptionCheck(option, i)"
                     ></li>
                   }
                 </ul>
@@ -748,14 +728,10 @@ export class NzCascaderComponent
       return;
     }
 
-    console.log('onOptionCheck');
     if (this.cascaderService.checkedOptionsKeySet.has(option.value)) {
-      console.log(`uncheck ${option.value}`);
       // uncheck
       this.cascaderService.removeSelectedOption(option, columnIndex, this.nzMultiple);
-      this.cascaderService.checkedOptionsKeySet.delete(option.value);
     } else {
-      console.log(`check ${option.value}`);
       // check
       this.inSearchingMode
         ? this.cascaderService.setSearchOptionSelected(option as NzCascaderSearchOption)

--- a/components/cascader/cascader.module.ts
+++ b/components/cascader/cascader.module.ts
@@ -5,7 +5,7 @@
 
 import { NgModule } from '@angular/core';
 
-import { NzCascaderOptionComponent } from './cascader-li.component';
+import { NzCascaderOptionComponent } from './cascader-option.component';
 import { NzCascaderComponent } from './cascader.component';
 
 @NgModule({

--- a/components/cascader/cascader.module.ts
+++ b/components/cascader/cascader.module.ts
@@ -5,11 +5,10 @@
 
 import { NgModule } from '@angular/core';
 
-import { NzCascaderOptionComponent } from './cascader-option.component';
 import { NzCascaderComponent } from './cascader.component';
 
 @NgModule({
-  imports: [NzCascaderComponent, NzCascaderOptionComponent],
+  imports: [NzCascaderComponent],
   exports: [NzCascaderComponent]
 })
 export class NzCascaderModule {}

--- a/components/cascader/cascader.service.ts
+++ b/components/cascader/cascader.service.ts
@@ -407,7 +407,7 @@ export class NzCascaderService implements OnDestroy {
    * @param nodes Options to insert
    * @param columnIndex Position
    */
-  private setColumnData(nodes: NzTreeNode[], columnIndex: number): void {
+  setColumnData(nodes: NzTreeNode[], columnIndex: number): void {
     this.column[columnIndex] = nodes;
     this.dropBehindColumns(columnIndex);
   }
@@ -464,6 +464,10 @@ export class NzCascaderService implements OnDestroy {
                 const nodes = option.children.map(o => new NzTreeNode(o as NzTreeNodeOptions, node));
                 node.children = nodes;
                 this.setColumnData(nodes, columnIndex + 1);
+              } else {
+                const nodes = this.cascaderComponent.coerceTreeNodes(option.children);
+                this.cascaderComponent.treeService.initTree(nodes);
+                this.setColumnData(nodes, 0);
               }
               onLoaded?.(option.children);
             }
@@ -475,7 +479,7 @@ export class NzCascaderService implements OnDestroy {
     }
   }
 
-  // private isLoaded(index: number): boolean {
-  //   return this.columns[index] && this.columns[index].length > 0;
-  // }
+  isLoaded(index: number): boolean {
+    return this.column[index] && this.column[index].length > 0;
+  }
 }

--- a/components/cascader/cascader.service.ts
+++ b/components/cascader/cascader.service.ts
@@ -149,7 +149,7 @@ export class NzCascaderService implements OnDestroy {
     }
   }
 
-  setOptionDeactivatedSinceColumn(column: number): void {
+  setNodeDeactivatedSinceColumn(column: number): void {
     this.dropBehindActivatedNodes(column - 1);
     this.dropBehindColumns(column);
     this.$redraw.next();

--- a/components/cascader/cascader.service.ts
+++ b/components/cascader/cascader.service.ts
@@ -87,7 +87,7 @@ export class NzCascaderService implements OnDestroy {
    * @param node Cascader option node
    * @param columnIndex Of which column this option is in
    * @param performSelect Select
-   * @param multiple Multiple Select
+   * @param multiple Multiple mode
    * @param loadingChildren Try to load children asynchronously.
    */
   setNodeActivated(
@@ -162,7 +162,6 @@ export class NzCascaderService implements OnDestroy {
    * @param multiple
    */
   setSearchOptionSelected(node: NzTreeNode, multiple = false): void {
-    this.activatedNodes = [node];
     this.setNodeSelected(node, node.level, multiple);
 
     setTimeout(() => {

--- a/components/cascader/cascader.service.ts
+++ b/components/cascader/cascader.service.ts
@@ -623,13 +623,6 @@ export class NzCascaderService implements OnDestroy {
     if (!parentNode || index < 0) {
       return;
     }
-    console.log(
-      'ConductUp',
-      parentNode.value,
-      index,
-      this.checkedOptionsKeySet.has(parentNode.value),
-      this.halfCheckedOptionsKeySet.has(parentNode.value)
-    );
 
     if (!parentNode.disabled) {
       let allSiblingChecked = true;
@@ -640,16 +633,9 @@ export class NzCascaderService implements OnDestroy {
         const checked = this.checkedOptionsKeySet.has(child.value);
         const halfChecked = this.halfCheckedOptionsKeySet.has(child.value);
 
-        console.log(this.checkedOptionsKeySet);
-        console.log(this.halfCheckedOptionsKeySet);
-        console.log(this.checkedLeafOptionsKeySet);
-        console.log('ConductUp', child.value, disabled, checked, halfChecked);
-
         allSiblingChecked = allSiblingChecked && (disabled || (!halfChecked && checked));
         someSiblingChecked = someSiblingChecked || checked || halfChecked;
       });
-
-      console.log('ConductUp', parentNode.value, allSiblingChecked, someSiblingChecked);
 
       // if all the siblings are checked (or disabled), set the parent checked
       if (allSiblingChecked) {
@@ -696,7 +682,6 @@ export class NzCascaderService implements OnDestroy {
   }
 
   addCheckedOptions(option: NzCascaderOption): void {
-    console.log('check', option.value);
     this.checkedOptionsKeySet.add(option.value);
     if (option.isLeaf) {
       this.checkedLeafOptionsKeySet.add(option.value);

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -1556,7 +1556,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
-      expect(testComponent.cascader.cascaderService.columns[0][0].disabled).toBe(true);
+      expect(testComponent.cascader.cascaderService.columns[0][0].isDisabled).toBe(true);
 
       itemEl1.click();
       tick(300);
@@ -1573,9 +1573,9 @@ describe('cascader', () => {
       testComponent.cascader.inputValue = 'o';
       testComponent.cascader.setMenuVisible(true);
       fixture.detectChanges();
-      expect(testComponent.cascader.cascaderService.columns[0][0].disabled).toBe(true);
-      expect(testComponent.cascader.cascaderService.columns[0][1].disabled).toBe(undefined);
-      expect(testComponent.cascader.cascaderService.columns[0][2].disabled).toBe(true);
+      expect(testComponent.cascader.cascaderService.columns[0][0].isDisabled).toBe(true);
+      expect(testComponent.cascader.cascaderService.columns[0][1].isDisabled).toBe(false);
+      expect(testComponent.cascader.cascaderService.columns[0][2].isDisabled).toBe(true);
     });
 
     it('should support arrow in search mode', done => {

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -542,7 +542,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(getLabelText().trim()).toBe('Zhejiang | Hangzhou | West Lake');
       // fix clear
-      testComponent.clearSelection();
+      testComponent.cascader.clearSelection();
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       testComponent.nzLabelRender = testComponent.renderTpl;
       fixture.detectChanges();
@@ -2247,7 +2247,6 @@ const options5: NzSafeAny[] = [];
       [nzBackdrop]="nzBackdrop"
       (ngModelChange)="onValueChanges($event)"
       (nzVisibleChange)="onVisibleChange($event)"
-      (nzSelect)="onSelect($event)"
       (nzClear)="onClear()"
     ></nz-cascader>
 
@@ -2291,15 +2290,8 @@ export class NzDemoCascaderDefaultComponent {
 
   onVisibleChange = jasmine.createSpy<(visible: boolean) => void>('open change');
   onValueChanges = jasmine.createSpy('value change');
-
-  fakeChangeOn = (node: NzSafeAny, _index: number): boolean => node.value === 'zhejiang';
-
-  clearSelection(): void {
-    this.cascader.clearSelection();
-  }
-
-  onSelect(_d: { option: NzCascaderOption; index: number } | null): void {}
   onClear(): void {}
+  fakeChangeOn = (node: NzSafeAny, _index: number): boolean => node.value === 'zhejiang';
 }
 
 @Component({

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -82,10 +82,14 @@ describe('cascader', () => {
     overlayContainer.ngOnDestroy();
   }));
 
-  xdescribe('default', () => {
+  describe('default', () => {
     let fixture: ComponentFixture<NzDemoCascaderDefaultComponent>;
     let cascader: DebugElement;
     let testComponent: NzDemoCascaderDefaultComponent;
+
+    function getLabelElement(): HTMLElement | null {
+      return cascader.nativeElement.querySelector('.ant-select-selection-item');
+    }
 
     function getLabelText(): string {
       return cascader.nativeElement.querySelector('.ant-select-selection-item').innerText.trim();
@@ -169,8 +173,7 @@ describe('cascader', () => {
       testComponent.nzLabelProperty = 'name';
       fixture.detectChanges();
       // label will not show if no item selected
-      const label: HTMLElement = cascader.nativeElement.querySelector('.ant-select-selection-item');
-      expect(label).toBeNull();
+      expect(getLabelElement()).toBeNull();
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('');
       testComponent.values = [1, 2, 3];
       fixture.detectChanges();
@@ -184,8 +187,7 @@ describe('cascader', () => {
       testComponent.nzValueProperty = null!;
       testComponent.nzLabelProperty = null!;
       fixture.detectChanges();
-      const label: HTMLElement = cascader.nativeElement.querySelector('.ant-select-selection-item');
-      expect(label).toBeNull();
+      expect(getLabelElement()).toBeNull();
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('');
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       fixture.detectChanges();
@@ -222,7 +224,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-open');
       expect(testComponent.onVisibleChange).toHaveBeenCalledTimes(1);
-      expect(testComponent.cascader.nzOptions).toBe(options1);
+      expect(testComponent.cascader.nzOptions).toEqual(options1);
     });
 
     it('should click toggle open', fakeAsync(() => {
@@ -290,10 +292,6 @@ describe('cascader', () => {
     }));
 
     it('should clear timer on option mouseenter and mouseleave', fakeAsync(() => {
-      // const mouseenter = createMouseEvent('mouseenter');
-      // const mouseleave = createMouseEvent('mouseleave');
-      // const option = options1[0]; // zhejiang
-
       testComponent.nzExpandTrigger = 'hover';
       fixture.detectChanges();
       expect(testComponent.cascader.menuVisible).toBe(false);
@@ -306,20 +304,17 @@ describe('cascader', () => {
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(optionEl, 'mouseenter');
-      // testComponent.cascader.onOptionMouseEnter(option, 0, mouseenter);
       fixture.detectChanges();
       tick(10);
       fixture.detectChanges();
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(optionEl, 'mouseleave');
-      // testComponent.cascader.onOptionMouseLeave(option, 0, mouseleave);
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(optionEl, 'mouseenter');
-      // testComponent.cascader.onOptionMouseEnter(option, 0, mouseenter);
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();
@@ -521,7 +516,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
-      expect(testComponent.cascader.nzOptions).toBe(options1);
+      expect(testComponent.cascader.nzOptions).toEqual(options1);
       expect(cascader.nativeElement.querySelector('.ant-select-selection-search-input')).toBeNull();
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeNull();
       expect(cascader.nativeElement.querySelector('.ant-select-selection-item')).toBeNull();
@@ -587,18 +582,6 @@ describe('cascader', () => {
       expect(values![0]).toBe('zhejiang');
       expect(values![1]).toBe('hangzhou');
       expect(values![2]).toBe('xihu');
-      control.writeValue([
-        { value: 'zhejiang', text: 'Zj' },
-        { value: 'hangzhou', text: 'Hz' },
-        { value: 'xihu', text: 'Xh' }
-      ]);
-      fixture.detectChanges();
-      expect(control.getSubmitValue().length).toBe(3);
-      const values2 = control.getSubmitValue();
-      expect(values2[0]).toBe('zhejiang');
-      expect(values2[1]).toBe('hangzhou');
-      expect(values2[2]).toBe('xihu');
-      expect(control.labelRenderText).toBe('Zhejiang / Hangzhou / West Lake');
 
       testComponent.nzOptions = []; // empty collection
       fixture.detectChanges();
@@ -610,19 +593,6 @@ describe('cascader', () => {
       expect(values3[1]).toBe('hangzhou');
       expect(values3[2]).toBe('xihu');
       expect(control.labelRenderText).toBe('zhejiang / hangzhou / xihu');
-
-      control.writeValue([
-        { value: 'zhejiang', label: 'ZJ' },
-        { value: 'hangzhou', label: 'HZ' },
-        { value: 'xihu', label: 'XH' }
-      ]); // so these values are not match
-      fixture.detectChanges();
-      expect(control.getSubmitValue().length).toBe(3);
-      const values4 = control.getSubmitValue();
-      expect(values4[0]).toBe('zhejiang');
-      expect(values4[1]).toBe('hangzhou');
-      expect(values4[2]).toBe('xihu');
-      expect(control.labelRenderText).toBe('ZJ / HZ / XH');
     }));
 
     it('should write value work on setting `nzOptions` async', fakeAsync(() => {
@@ -1438,14 +1408,18 @@ describe('cascader', () => {
       testComponent.nzShowSearch = true;
       fixture.detectChanges();
       cascader.nativeElement.click();
-      testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
       flush();
+      fixture.detectChanges();
+
+      // input search value
+      testComponent.cascader.inputValue = 'o';
       fixture.detectChanges();
       expect(testComponent.cascader.menuVisible).toBe(true);
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
+
+      // clear search value
       testComponent.cascader.inputValue = '';
       fixture.detectChanges();
       flush();
@@ -1697,12 +1671,12 @@ describe('cascader', () => {
       cascader = fixture.debugElement.query(By.directive(NzCascaderComponent));
     });
 
-    xit('should have correct classes', () => {
+    it('should have correct classes', () => {
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-multiple');
     });
 
-    xit('should maxTagCount work', fakeAsync(() => {
+    it('should maxTagCount work', fakeAsync(() => {
       // not exceed
       setValues(3);
       tick();
@@ -1718,7 +1692,7 @@ describe('cascader', () => {
       expect(tags.length).toBe(4); // maxTagCount + 1
     }));
 
-    xit('should remove item work', fakeAsync(() => {
+    it('should remove item work', fakeAsync(() => {
       setValues(4);
       tick();
       fixture.detectChanges();
@@ -1743,7 +1717,7 @@ describe('cascader', () => {
 
       const rootEl = getCheckboxAtColumnAndRow(1, 2)!;
       const parentEl = getCheckboxAtColumnAndRow(2, 1)!;
-      const children = getCheckboxesAtColumn(3);
+      const children = getCheckboxesAtColumn(3).filter(c => !c.classList.contains('ant-cascader-checkbox-disabled'));
 
       // check parent option
       parentEl.click();
@@ -1781,7 +1755,7 @@ describe('cascader', () => {
     }));
   });
 
-  xdescribe('load data lazily', () => {
+  describe('load data lazily', () => {
     let fixture: ComponentFixture<NzDemoCascaderLoadDataComponent>;
     let cascader: DebugElement;
     let testComponent: NzDemoCascaderLoadDataComponent;
@@ -1797,7 +1771,7 @@ describe('cascader', () => {
       cascader = fixture.debugElement.query(By.directive(NzCascaderComponent));
     });
 
-    it('should LOAD DATA work', fakeAsync(() => {
+    it('should nzLoadData work', fakeAsync(() => {
       spyOn(testComponent, 'addCallTimes');
 
       fixture.detectChanges();
@@ -1809,7 +1783,6 @@ describe('cascader', () => {
       testComponent.cascader.setMenuVisible(true);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(1);
-      expect(getAllColumns().length).toBe(0); // 0列
       tick(1000); // wait for first row to load finish
       fixture.detectChanges();
 
@@ -1867,7 +1840,7 @@ describe('cascader', () => {
       expect(testComponent.values![2]).toBe('xihu');
     }));
 
-    it('should LOAD DATA work when specifies default value', fakeAsync(() => {
+    it('should nzLoadData work when specifies default value', fakeAsync(() => {
       spyOn(testComponent, 'addCallTimes');
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       fixture.detectChanges();
@@ -1918,7 +1891,7 @@ describe('cascader', () => {
     }));
   });
 
-  xdescribe('RTL', () => {
+  describe('RTL', () => {
     let fixture: ComponentFixture<NzDemoCascaderRtlComponent>;
     let cascader: DebugElement;
     let testComponent: NzDemoCascaderRtlComponent;
@@ -1965,7 +1938,7 @@ describe('cascader', () => {
     }));
   });
 
-  xdescribe('Status', () => {
+  describe('Status', () => {
     let fixture: ComponentFixture<NzDemoCascaderStatusComponent>;
     let cascader: DebugElement;
 
@@ -1988,7 +1961,7 @@ describe('cascader', () => {
     });
   });
 
-  xdescribe('In form', () => {
+  describe('In form', () => {
     let fixture: ComponentFixture<NzDemoCascaderInFormComponent>;
     let formGroup: FormGroup<{
       demo: FormControl<string[] | null>;
@@ -2316,7 +2289,7 @@ export class NzDemoCascaderDefaultComponent {
   nzExpandIcon = 'right';
   nzBackdrop = false;
 
-  onVisibleChange = jasmine.createSpy('open change');
+  onVisibleChange = jasmine.createSpy<(visible: boolean) => void>('open change');
   onValueChanges = jasmine.createSpy('value change');
 
   fakeChangeOn = (node: NzSafeAny, _index: number): boolean => node.value === 'zhejiang';
@@ -2340,14 +2313,7 @@ export class NzDemoCascaderDefaultComponent {
       (ngModelChange)="onValueChanges($event)"
       (nzVisibleChange)="onVisibleChange($event)"
     ></nz-cascader>
-  `,
-  styles: [
-    `
-      .ant-cascader-picker {
-        width: 300px;
-      }
-    `
-  ]
+  `
 })
 export class NzDemoCascaderLoadDataComponent {
   @ViewChild(NzCascaderComponent, { static: true }) cascader!: NzCascaderComponent;
@@ -2392,8 +2358,7 @@ export class NzDemoCascaderLoadDataComponent {
   };
 
   addCallTimes(): void {}
-
-  onVisibleChange = jasmine.createSpy('open change');
+  onVisibleChange = jasmine.createSpy<(visible: boolean) => void>('open change');
   onValueChanges = jasmine.createSpy('value change');
 }
 

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -27,7 +27,6 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { NzDemoCascaderMultipleComponent } from 'ng-zorro-antd/cascader/demo/multiple';
 import {
   createFakeEvent,
-  createMouseEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent
@@ -291,9 +290,9 @@ describe('cascader', () => {
     }));
 
     it('should clear timer on option mouseenter and mouseleave', fakeAsync(() => {
-      const mouseenter = createMouseEvent('mouseenter');
-      const mouseleave = createMouseEvent('mouseleave');
-      const option = options1[0]; // zhejiang
+      // const mouseenter = createMouseEvent('mouseenter');
+      // const mouseleave = createMouseEvent('mouseleave');
+      // const option = options1[0]; // zhejiang
 
       testComponent.nzExpandTrigger = 'hover';
       fixture.detectChanges();
@@ -306,18 +305,21 @@ describe('cascader', () => {
       const optionEl = getItemAtColumnAndRow(1, 1)!;
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
-      testComponent.cascader.onOptionMouseEnter(option, 0, mouseenter);
+      dispatchMouseEvent(optionEl, 'mouseenter');
+      // testComponent.cascader.onOptionMouseEnter(option, 0, mouseenter);
       fixture.detectChanges();
       tick(10);
       fixture.detectChanges();
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
-      testComponent.cascader.onOptionMouseLeave(option, 0, mouseleave);
+      dispatchMouseEvent(optionEl, 'mouseleave');
+      // testComponent.cascader.onOptionMouseLeave(option, 0, mouseleave);
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
-      testComponent.cascader.onOptionMouseEnter(option, 0, mouseenter);
+      dispatchMouseEvent(optionEl, 'mouseenter');
+      // testComponent.cascader.onOptionMouseEnter(option, 0, mouseenter);
       fixture.detectChanges();
       tick(400);
       fixture.detectChanges();

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -1709,7 +1709,7 @@ describe('cascader', () => {
       tick(600);
       fixture.detectChanges();
 
-      // first expand all columns (for convenience)
+      // firstly, expand all columns (for convenience)
       getItemAtColumnAndRow(1, 2)!.click();
       fixture.detectChanges();
       getItemAtColumnAndRow(2, 1)!.click();
@@ -1752,6 +1752,52 @@ describe('cascader', () => {
       expect(children.every(c => !c.classList.contains('ant-cascader-checkbox-checked'))).toBe(true);
       // Conduct Up: and its parent should be unchecked too
       expect(rootEl.classList).not.toContain('ant-cascader-checkbox-checked');
+    }));
+
+    it('should click checkbox not set option activated', fakeAsync(() => {
+      cascader.componentInstance.setMenuVisible(true);
+      fixture.detectChanges();
+      tick(600);
+      fixture.detectChanges();
+
+      const option = getItemAtColumnAndRow(1, 1)!;
+      const checkbox = getCheckboxAtColumnAndRow(1, 1)!;
+      expect(option.classList).not.toContain('ant-cascader-menu-item-active');
+
+      checkbox.click();
+      fixture.detectChanges();
+
+      expect(option.classList).not.toContain('ant-cascader-menu-item-active');
+      expect(checkbox.classList).toContain('ant-cascader-checkbox-checked');
+    }));
+
+    it('should change check state when click leaf node', fakeAsync(() => {
+      cascader.componentInstance.setMenuVisible(true);
+      fixture.detectChanges();
+      tick(600);
+      fixture.detectChanges();
+
+      // firstly, expand all columns (for convenience)
+      getItemAtColumnAndRow(1, 2)!.click();
+      fixture.detectChanges();
+      getItemAtColumnAndRow(2, 1)!.click();
+      fixture.detectChanges();
+
+      const leaf = getItemAtColumnAndRow(3, 2)!;
+      const checkbox = getCheckboxAtColumnAndRow(3, 2)!;
+      // click leaf node
+      expect(leaf.classList).not.toContain('ant-cascader-menu-item-active');
+      expect(checkbox.classList).not.toContain('ant-cascader-checkbox-checked');
+
+      leaf.click();
+      fixture.detectChanges();
+      expect(leaf.classList).toContain('ant-cascader-menu-item-active');
+      expect(checkbox.classList).toContain('ant-cascader-checkbox-checked');
+
+      leaf.click();
+      fixture.detectChanges();
+      expect(leaf.classList).toContain('ant-cascader-menu-item-active');
+      expect(checkbox.classList).not.toContain('ant-cascader-checkbox-checked');
     }));
   });
 

--- a/components/cascader/demo/basic.ts
+++ b/components/cascader/demo/basic.ts
@@ -95,7 +95,7 @@ const otherOptions: NzCascaderOption[] = [
       .change-options {
         display: inline-block;
         font-size: 12px;
-        margin-top: 8px;
+        margin-left: 8px;
       }
     `
   ]

--- a/components/cascader/demo/custom-render.md
+++ b/components/cascader/demo/custom-render.md
@@ -1,5 +1,5 @@
 ---
-order: 7
+order: 9
 title:
   zh-CN: 自定义已选项
   en-US: Custom render

--- a/components/cascader/demo/multiple.md
+++ b/components/cascader/demo/multiple.md
@@ -1,0 +1,14 @@
+---
+order: 6
+title:
+  zh-CN: 多选
+  en-US: Multiple
+---
+
+## zh-CN
+
+一次性选择多个选项。通过添加 `disableCheckbox` 属性，选择具体某一个 `checkbox` 禁用。
+
+## en-US
+
+Select multiple options. Disable the `checkbox` by adding the `disableCheckbox` property and selecting a specific item.

--- a/components/cascader/demo/multiple.ts
+++ b/components/cascader/demo/multiple.ts
@@ -1,0 +1,65 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { NzCascaderModule, NzCascaderOption } from 'ng-zorro-antd/cascader';
+import { NzSafeAny } from 'ng-zorro-antd/core/types';
+
+const options: NzCascaderOption[] = [
+  {
+    label: 'Light',
+    value: 'light',
+    children: new Array(20).fill(null).map((_, index) => ({ label: `Number ${index}`, value: index, isLeaf: true }))
+  },
+  {
+    label: 'Bamboo',
+    value: 'bamboo',
+    children: [
+      {
+        label: 'Little',
+        value: 'little',
+        children: [
+          {
+            label: 'Toy Fish',
+            value: 'fish',
+            isLeaf: true,
+            disableCheckbox: true
+          },
+          {
+            label: 'Toy Cards',
+            value: 'cards',
+            isLeaf: true
+          },
+          {
+            label: 'Toy Bird',
+            value: 'bird',
+            isLeaf: true
+          }
+        ]
+      }
+    ]
+  }
+];
+
+@Component({
+  selector: 'nz-demo-cascader-multiple',
+  standalone: true,
+  imports: [FormsModule, NzCascaderModule],
+  template: `
+    <nz-cascader
+      style="width: 100%;"
+      [nzOptions]="nzOptions"
+      [(ngModel)]="values"
+      (ngModelChange)="onChanges($event)"
+      nzMultiple
+      [nzMaxTagCount]="3"
+    ></nz-cascader>
+  `
+})
+export class NzDemoCascaderMultipleComponent {
+  nzOptions: NzCascaderOption[] = options;
+  values: NzSafeAny[][] | null = null;
+
+  onChanges(values: NzSafeAny[][]): void {
+    console.log(values, this.values);
+  }
+}

--- a/components/cascader/demo/search.ts
+++ b/components/cascader/demo/search.ts
@@ -101,7 +101,7 @@ const otherOptions = [
       .change-options {
         display: inline-block;
         font-size: 12px;
-        margin-top: 8px;
+        margin-left: 8px;
       }
     `
   ]

--- a/components/cascader/demo/size.md
+++ b/components/cascader/demo/size.md
@@ -1,5 +1,5 @@
 ---
-order: 6
+order: 8
 title:
   zh-CN: 大小
   en-US: Size

--- a/components/cascader/doc/index.en-US.md
+++ b/components/cascader/doc/index.en-US.md
@@ -26,7 +26,7 @@ import { NzCascaderModule } from 'ng-zorro-antd/cascader';
 ### nz-cascader
 
 | Property              | Description                                                                                                                            | Type                                                                  | Default           | Global Config |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------- | ------------- |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|-------------------|---------------|
 | `[ngModel]`           | selected value                                                                                                                         | `any[]`                                                               | -                 |
 | `[nzAllowClear]`      | whether allow clear                                                                                                                    | `boolean`                                                             | `true`            |
 | `[nzAutoFocus]`       | whether auto focus the input box                                                                                                       | `boolean`                                                             | `false`           |
@@ -41,7 +41,10 @@ import { NzCascaderModule } from 'ng-zorro-antd/cascader';
 | `[nzLabelRender]`     | render template of displaying selected options                                                                                         | `TemplateRef<any>`                                                    | -                 |
 | `[nzLoadData]`        | to load option lazily. Lazy load will be called immediately if the setting is `ngModel` with an array value and `nzOptions` is not set | `(option: any, index?: index) => PromiseLike<any> \| Observable<any>` | -                 |
 | `[nzMenuClassName]`   | additional className of popup overlay                                                                                                  | `string`                                                              | -                 |
+| `[nzMouseEnterDelay]` | duration in milliseconds before opening the popup overlay when the mouse enters the trigger                                            | `number`                                                              | 150               |
+| `[nzMouseLeaveDelay]` | duration in milliseconds before closing the popup overlay when the mouse leaves the trigger                                            | `number`                                                              | 150               |
 | `[nzMenuStyle]`       | additional css style of popup overlay                                                                                                  | `object`                                                              | -                 |
+| `[nzMultiple]`        | support multiple or not                                                                                                                | `boolean`                                                             | `false`           |
 | `[nzNotFoundContent]` | specify content to show when no result matches                                                                                         | `string\|TemplateRef<void>`                                           | -                 |
 | `[nzOptionRender]`    | render template of cascader options                                                                                                    | `TemplateRef<{ $implicit: NzCascaderOption, index: number }>`         |                   |
 | `[nzOptions]`         | data options of cascade                                                                                                                | `object[]`                                                            | -                 |
@@ -56,12 +59,34 @@ import { NzCascaderModule } from 'ng-zorro-antd/cascader';
 | `(ngModelChange)`     | emit on values change                                                                                                                  | `EventEmitter<any[]>`                                                 | -                 |
 | `(nzClear)`           | emit on clear values                                                                                                                   | `EventEmitter<void>`                                                  | -                 |
 | `(nzVisibleChange)`   | emit on popup menu visible or hide                                                                                                     | `EventEmitter<boolean>`                                               | -                 |
+| `(nzRemoved)`         | emit on selected item removed when `nzMultiple` is `true`                                                                              | `EventEmitter<NzCascaderOption>`                                      | -                 |
 | `(nzSelectionChange)` | emit on values change                                                                                                                  | `EventEmitter<NzCascaderOption[]>`                                    | -                 |
 
-When `nzShowSearch` is an object it should implements `NzShowSearchOptions`：
+### Interfaces
+
+#### NzCascaderOption
+
+```ts
+export interface NzCascaderOption {
+  value?: any;
+  label?: string;
+  title?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  isLeaf?: boolean;
+  children?: NzCascaderOption[];
+  disableCheckbox?: boolean;
+
+  [key: string]: any;
+}
+```
+
+#### NzShowSearchOptions
+
+When `nzShowSearch` is an object it should implement `NzShowSearchOptions`:
 
 | Params   | Explanation                                                            | Type                                                                         | Default |
-| -------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------- |
+|----------|------------------------------------------------------------------------|------------------------------------------------------------------------------|---------|
 | `filter` | Optional. Be aware that all non-leaf CascaderOptions would be filtered | `(inputValue: string, path: NzCascaderOption[]): boolean`                    | -       |
 | `sorter` | Optional                                                               | `(a: NzCascaderOption[], b: NzCascaderOption[], inputValue: string): number` | -       |
 
@@ -89,14 +114,16 @@ const filter: NzCascaderFilter = (i, p) => {
 
 #### Methods
 
-| Name        | Description   |
-| ----------- | ------------- |
-| blur()      | remove focus  |
-| focus()     | get focus     |
-| closeMenu() | hide the menu |
+| Name          | Description   |
+|---------------|---------------|
+| `blur()`      | remove focus  |
+| `focus()`     | get focus     |
+| `closeMenu()` | hide the menu |
 
 ## FAQ
 
 ### Q: An error is thrown when `nzLoadData` is used.
 
-When you pass a function to `nzLoadData`, the function becomes a `NzCascaderComponent` property. When the component calls the `nzLoadData` function, `this` is bound to nothing. You have to pass an arrow function or use `Function.bind` to bind `this` to the parent component; [see example](https://stackoverflow.com/questions/60320913/ng-zorro-cascader-lazy-load-data-nzloaddata-function-got-this-undefined/60928983#60928983).
+When you pass a function to `nzLoadData`, the function becomes a `NzCascaderComponent` property.
+When the component calls the `nzLoadData` function, `this` is bound to nothing. You have to pass an arrow function or use `Function.bind` to bind `this` to the parent component.
+[see example](https://stackoverflow.com/questions/60320913/ng-zorro-cascader-lazy-load-data-nzloaddata-function-got-this-undefined/60928983#60928983).

--- a/components/cascader/doc/index.zh-CN.md
+++ b/components/cascader/doc/index.zh-CN.md
@@ -26,45 +26,77 @@ import { NzCascaderModule } from 'ng-zorro-antd/cascader';
 
 ### nz-cascader
 
-| 参数                  | 说明                                                                                       | 类型                                                                  | 默认值      | 支持全局配置 |
-| --------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- | ----------- | ------------ |
-| `[ngModel]`           | 指定选中项                                                                                 | `any[]`                                                               | -           |
-| `[nzAllowClear]`      | 是否支持清除                                                                               | `boolean`                                                             | `true`      |
-| `[nzAutoFocus]`       | 是否自动聚焦，当存在输入框时                                                               | `boolean`                                                             | `false`     |
-| `[nzBackdrop]`        | 浮层是否应带有背景板                                                                       | `boolean`                                                             | `false`     |
-| `[nzChangeOn]`        | 点击父级菜单选项时，可通过该函数判断是否允许值的变化                                       | `(option: any, index: number) => boolean`                             | -           |
-| `[nzChangeOnSelect]`  | 当此项为 true 时，点选每级菜单选项值都会发生变化，具体见上面的演示                         | `boolean`                                                             | `false`     |
-| `[nzColumnClassName]` | 自定义浮层列类名                                                                           | `string`                                                              | -           |
-| `[nzDisabled]`        | 禁用                                                                                       | `boolean`                                                             | `false`     |
-| `[nzExpandIcon]`      | 自定义次级菜单展开图标                                                                     | `string\|TemplateRef<void>`                                           | -           |
-| `[nzExpandTrigger]`   | 次级菜单的展开方式，可选 'click' 和 'hover'                                                | `'click'\|'hover'`                                                    | `'click'`   |
-| `[nzLabelProperty]`   | 选项的显示值的属性名                                                                       | `string`                                                              | `'label'`   |
-| `[nzLabelRender]`     | 选择后展示的渲染模板                                                                       | `TemplateRef<any>`                                                    | -           |
+| 参数                    | 说明                                                      | 类型                                                                    | 默认值         | 支持全局配置 |
+|-----------------------|---------------------------------------------------------|-----------------------------------------------------------------------|-------------|--------|
+| `[ngModel]`           | 指定选中项                                                   | `any[]`                                                               | -           |
+| `[nzAllowClear]`      | 是否支持清除                                                  | `boolean`                                                             | `true`      |
+| `[nzAutoFocus]`       | 是否自动聚焦，当存在输入框时                                          | `boolean`                                                             | `false`     |
+| `[nzBackdrop]`        | 浮层是否应带有背景板                                              | `boolean`                                                             | `false`     |
+| `[nzChangeOn]`        | 点击父级菜单选项时，可通过该函数判断是否允许值的变化                              | `(option: any, index: number) => boolean`                             | -           |
+| `[nzChangeOnSelect]`  | 当此项为 true 时，点选每级菜单选项值都会发生变化，具体见上面的演示                    | `boolean`                                                             | `false`     |
+| `[nzColumnClassName]` | 自定义浮层列类名                                                | `string`                                                              | -           |
+| `[nzDisabled]`        | 禁用                                                      | `boolean`                                                             | `false`     |
+| `[nzExpandIcon]`      | 自定义次级菜单展开图标                                             | `string\|TemplateRef<void>`                                           | -           |
+| `[nzExpandTrigger]`   | 次级菜单的展开方式，可选 `'click'` 和 `'hover'`                      | `'click'\|'hover'`                                                    | `'click'`   |
+| `[nzLabelProperty]`   | 选项的显示值的属性名                                              | `string`                                                              | `'label'`   |
+| `[nzLabelRender]`     | 选择后展示的渲染模板                                              | `TemplateRef<any>`                                                    | -           |
 | `[nzLoadData]`        | 用于动态加载选项。如果提供了`ngModel`初始值，且未提供`nzOptions`值，则会立即触发动态加载。 | `(option: any, index?: index) => PromiseLike<any> \| Observable<any>` | -           |
-| `[nzMenuClassName]`   | 自定义浮层类名                                                                             | `string`                                                              | -           |
-| `[nzMenuStyle]`       | 自定义浮层样式                                                                             | `object`                                                              | -           |
-| `[nzNotFoundContent]` | 当下拉列表为空时显示的内容                                                                 | `string\|TemplateRef<void>`                                           | -           |
-| `[nzOptionRender]`    | 选项的渲染模板                                                                             | `TemplateRef<{ $implicit: NzCascaderOption, index: number }>`         |             |
-| `[nzOptions]`         | 可选项数据源                                                                               | `object[]`                                                            | -           |
-| `[nzPlaceHolder]`     | 输入框占位文本                                                                             | `string`                                                              | `'请选择'`  |
-| `[nzShowArrow]`       | 是否显示箭头                                                                               | `boolean`                                                             | `true`      |
-| `[nzShowInput]`       | 显示输入框                                                                                 | `boolean`                                                             | `true`      |
-| `[nzShowSearch]`      | 是否支持搜索，默认情况下对 `label` 进行全匹配搜索，不能和 `[nzLoadData]` 同时使用          | `boolean\|NzShowSearchOptions`                                        | `false`     |
-| `[nzSize]`            | 输入框大小，可选 `large` `default` `small`                                                 | `'large'\|'small'\|'default'`                                         | `'default'` | ✅            |
-| `[nzStatus]`          | 设置校验状态                                                                               | `'error' \| 'warning'`                                                | -           |
-| `[nzSuffixIcon]`      | 自定义的选择框后缀图标                                                                     | `string\|TemplateRef<void>`                                           | -           |
-| `[nzValueProperty]`   | 选项的实际值的属性名                                                                       | `string`                                                              | `'value'`   |
-| `(ngModelChange)`     | 值发生变化时触发                                                                           | `EventEmitter<any[]>`                                                 | -           |
-| `(nzClear)`           | 清除值时触发                                                                               | `EventEmitter<void>`                                                  | -           |
-| `(nzVisibleChange)`   | 菜单浮层的显示/隐藏                                                                        | `EventEmitter<boolean>`                                               | -           |
-| `(nzSelectionChange)` | 值发生变化时触发                                                                           | `EventEmitter<NzCascaderOption[]>`                                    | -           |
+| `[nzMenuClassName]`   | 自定义浮层类名                                                 | `string`                                                              | -           |
+| `[nzMenuStyle]`       | 自定义浮层样式                                                 | `object`                                                              | -           |
+| `[nzMouseEnterDelay]` | 鼠标进入触发器后打开浮层的延迟时间（毫秒）                                   | `number`                                                              | 150         |
+| `[nzMouseLeaveDelay]` | 鼠标离开触发器后关闭浮层的延迟时间（毫秒）                                   | `number`                                                              | 150         |
+| `[nzMultiple]`        | 是否支持多选                                                  | `boolean`                                                             | `false`     |
+| `[nzNotFoundContent]` | 当下拉列表为空时显示的内容                                           | `string\|TemplateRef<void>`                                           | -           |
+| `[nzOptionRender]`    | 选项的渲染模板                                                 | `TemplateRef<{ $implicit: NzCascaderOption, index: number }>`         |             |
+| `[nzOptions]`         | 可选项数据源                                                  | `object[]`                                                            | -           |
+| `[nzPlaceHolder]`     | 输入框占位文本                                                 | `string`                                                              | `'请选择'`     |
+| `[nzShowArrow]`       | 是否显示箭头                                                  | `boolean`                                                             | `true`      |
+| `[nzShowInput]`       | 显示输入框                                                   | `boolean`                                                             | `true`      |
+| `[nzShowSearch]`      | 是否支持搜索，默认情况下对 `label` 进行全匹配搜索，不能和 `[nzLoadData]` 同时使用   | `boolean \| NzShowSearchOptions`                                      | `false`     |
+| `[nzSize]`            | 输入框大小，可选 `large` `default` `small`                      | `'large' \| 'small' \| 'default'`                                     | `'default'` | ✅      |
+| `[nzStatus]`          | 设置校验状态                                                  | `'error' \| 'warning'`                                                | -           |
+| `[nzSuffixIcon]`      | 自定义的选择框后缀图标                                             | `string \| TemplateRef<void>`                                         | -           |
+| `[nzValueProperty]`   | 选项的实际值的属性名                                              | `string`                                                              | `'value'`   |
+| `(ngModelChange)`     | 值发生变化时触发                                                | `EventEmitter<any[]>`                                                 | -           |
+| `(nzClear)`           | 清除值时触发                                                  | `EventEmitter<void>`                                                  | -           |
+| `(nzVisibleChange)`   | 菜单浮层的显示/隐藏                                              | `EventEmitter<boolean>`                                               | -           |
+| `(nzRemoved)`         | 多选模式下，移除值时触发                                            | `EventEmitter<NzCascaderOption>`                                      | -           |
+| `(nzSelectionChange)` | 值发生变化时触发                                                | `EventEmitter<NzCascaderOption[]>`                                    | -           |
+
+### Interfaces
+
+#### NzCascaderOption
+
+```ts
+export interface NzCascaderOption {
+  value?: any;
+  label?: string;
+  title?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  isLeaf?: boolean;
+  children?: NzCascaderOption[];
+  disableCheckbox?: boolean;
+
+  [key: string]: any;
+}
+```
+
+#### NzShowSearchOptions
+
+```ts
+export type NzShowSearchOptions = boolean | {
+  filter?: NzCascaderFilter;
+  sorter?: NzCascaderSorter;
+};
+```
 
 `nzShowSearch` 为对象时需遵守 `NzShowSearchOptions` 接口：
 
-| 参数     | 说明                                                           | 类型                                                                         | 默认值 |
-| -------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------ |
-| `filter` | 可选，选择是否保留选项的过滤函数，每级菜单的选项都会被匹配     | `(inputValue: string, path: NzCascaderOption[]): boolean`                    | -      |
-| `sorter` | 可选，按照到每个最终选项的路径进行排序，默认按照原始数据的顺序 | `(a: NzCascaderOption[], b: NzCascaderOption[], inputValue: string): number` | -      |
+| 参数       | 说明                              | 类型                                                                           | 默认值 |
+|----------|---------------------------------|------------------------------------------------------------------------------|-----|
+| `filter` | 可选，选择是否保留选项的过滤函数，每级菜单的选项都会被匹配   | `(inputValue: string, path: NzCascaderOption[]): boolean`                    | -   |
+| `sorter` | 可选，按照到每个最终选项的路径进行排序，默认按照原始数据的顺序 | `(a: NzCascaderOption[], b: NzCascaderOption[], inputValue: string): number` | -   |
 
 默认的 filter 如下所示：
 
@@ -90,11 +122,11 @@ const filter: NzCascaderFilter = (i, p) => {
 
 #### 方法
 
-| 名称        | 描述     |
-| ----------- | -------- |
-| blur()      | 移除焦点 |
-| focus()     | 获取焦点 |
-| closeMenu() | 隐藏菜单 |
+| 名称            | 描述   |
+|---------------|------|
+| `blur()`      | 移除焦点 |
+| `focus()`     | 获取焦点 |
+| `closeMenu()` | 隐藏菜单 |
 
 > 注意，如果需要获得中国省市区数据，可以参考 [china-division](https://gist.github.com/afc163/7582f35654fd03d5be7009444345ea17)。
 
@@ -102,4 +134,6 @@ const filter: NzCascaderFilter = (i, p) => {
 
 ### Q: 为什么使用 `nzLoadData` 时报了一个错误 this === undefined ？
 
-对传递给 Cascader 组件的 `nzLoadData` 参数会成为 `NzCasacderComponent` 对象的一个属性，调用这个函数时，函数中的 `this` 没有指向任何对象。因此，正确的做法是传递剪头函数，或者使用 `Function.bind` 将 `nzLoadData` 参数和你的对象绑定。[这里](https://stackoverflow.com/questions/60320913/ng-zorro-cascader-lazy-load-data-nzloaddata-function-got-this-undefined/60928983#60928983)是一个比较有代表性的例子。
+对传递给 Cascader 组件的 `nzLoadData` 参数会成为 `NzCasacderComponent` 对象的一个属性，调用这个函数时，函数中的 `this` 没有指向任何对象。
+因此，正确的做法是传递剪头函数，或者使用 `Function.bind` 将 `nzLoadData` 参数和你的对象绑定。
+[这里](https://stackoverflow.com/questions/60320913/ng-zorro-cascader-lazy-load-data-nzloaddata-function-got-this-undefined/60928983#60928983)是一个比较有代表性的例子。

--- a/components/cascader/public-api.ts
+++ b/components/cascader/public-api.ts
@@ -8,4 +8,4 @@ export * from './utils';
 export * from './cascader.component';
 export * from './cascader.module';
 export * from './cascader.service';
-export * from './cascader-li.component';
+export * from './cascader-option.component';

--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -23,6 +23,7 @@ export interface NzCascaderOption {
   isLeaf?: boolean;
   parent?: NzCascaderOption;
   children?: NzCascaderOption[];
+  disableCheckbox?: boolean;
 
   [key: string]: NzSafeAny;
 }

--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -53,6 +53,7 @@ export interface NzCascaderComponentAsSource {
   nzLabelProperty: string;
   nzValueProperty: string;
   nzChangeOnSelect: boolean;
+  selectedNodes: NzTreeNode[];
 
   get treeService(): NzCascaderTreeService;
 

--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -11,7 +11,6 @@ import { NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 export type NzCascaderExpandTrigger = 'click' | 'hover';
 export type NzCascaderTriggerType = 'click' | 'hover';
 export type NzCascaderSize = NzSizeLDSType;
-export type NzCascaderShowCheckedStrategy = 'parent' | 'child';
 
 export type NzCascaderFilter = (searchValue: string, path: NzCascaderOption[]) => boolean;
 export type NzCascaderSorter = (a: NzCascaderOption[], b: NzCascaderOption[], inputValue: string) => number;

--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -5,6 +5,7 @@
 
 import { Observable } from 'rxjs';
 
+import { NzCascaderTreeService } from 'ng-zorro-antd/cascader/cascader-tree.service';
 import { NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 
 export type NzCascaderExpandTrigger = 'click' | 'hover';
@@ -52,6 +53,10 @@ export interface NzCascaderComponentAsSource {
   nzLabelProperty: string;
   nzValueProperty: string;
   nzChangeOnSelect: boolean;
+
+  get treeService(): NzCascaderTreeService;
+
+  updateSelectedNodes(): void;
 
   nzChangeOn?(option: NzCascaderOption, level: number): boolean;
 

--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -5,9 +5,10 @@
 
 import { Observable } from 'rxjs';
 
-import { NzCascaderTreeService } from 'ng-zorro-antd/cascader/cascader-tree.service';
 import { NzTreeNode } from 'ng-zorro-antd/core/tree';
 import { NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
+
+import { NzCascaderTreeService } from './cascader-tree.service';
 
 export type NzCascaderExpandTrigger = 'click' | 'hover';
 export type NzCascaderTriggerType = 'click' | 'hover';
@@ -23,15 +24,10 @@ export interface NzCascaderOption {
   disabled?: boolean;
   loading?: boolean;
   isLeaf?: boolean;
-  parent?: NzCascaderOption;
   children?: NzCascaderOption[];
   disableCheckbox?: boolean;
 
   [key: string]: NzSafeAny;
-}
-
-export interface NzCascaderSearchOption extends NzCascaderOption {
-  path: NzCascaderOption[];
 }
 
 export interface NzShowSearchOptions {

--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -6,6 +6,7 @@
 import { Observable } from 'rxjs';
 
 import { NzCascaderTreeService } from 'ng-zorro-antd/cascader/cascader-tree.service';
+import { NzTreeNode } from 'ng-zorro-antd/core/tree';
 import { NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 
 export type NzCascaderExpandTrigger = 'click' | 'hover';
@@ -54,6 +55,8 @@ export interface NzCascaderComponentAsSource {
   nzChangeOnSelect: boolean;
 
   get treeService(): NzCascaderTreeService;
+
+  coerceTreeNodes(value: NzSafeAny[]): NzTreeNode[];
 
   updateSelectedNodes(): void;
 

--- a/components/cascader/typings.ts
+++ b/components/cascader/typings.ts
@@ -10,6 +10,7 @@ import { NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 export type NzCascaderExpandTrigger = 'click' | 'hover';
 export type NzCascaderTriggerType = 'click' | 'hover';
 export type NzCascaderSize = NzSizeLDSType;
+export type NzCascaderShowCheckedStrategy = 'parent' | 'child';
 
 export type NzCascaderFilter = (searchValue: string, path: NzCascaderOption[]) => boolean;
 export type NzCascaderSorter = (a: NzCascaderOption[], b: NzCascaderOption[], inputValue: string) => number;

--- a/components/cascader/utils.ts
+++ b/components/cascader/utils.ts
@@ -3,12 +3,21 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { NzTreeNode } from 'ng-zorro-antd/core/tree';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 import { NzCascaderOption } from './typings';
 
 export function isChildOption(o: NzCascaderOption): boolean {
   return o.isLeaf || !o.children || !o.children.length;
+}
+
+export function isChildNode(node: NzTreeNode): boolean {
+  return node.isLeaf || !node.children || !node.children.length;
+}
+
+export function isParentNode(node: NzTreeNode): boolean {
+  return !!node.children && !!node.children.length && !node.isLeaf;
 }
 
 export function isParentOption(o: NzCascaderOption): boolean {

--- a/components/cascader/utils.ts
+++ b/components/cascader/utils.ts
@@ -15,6 +15,15 @@ export function isParentOption(o: NzCascaderOption): boolean {
   return !!o.children && !!o.children.length && !o.isLeaf;
 }
 
+/**
+ * Whether an option is disabled in multiple mode.
+ * @param o option
+ * @param multiple whether multiple mode
+ */
+export function isDisabledOption(o: NzCascaderOption, multiple = true): boolean {
+  return o.disabled || (multiple && !!o.disableCheckbox);
+}
+
 const VALUE_SPLIT = '__CASCADER_SPLIT__';
 const KEY_PROPERTY = '__cascader_key';
 
@@ -23,13 +32,6 @@ const KEY_PROPERTY = '__cascader_key';
  */
 export function toPathKey(value: NzSafeAny[]): string {
   return value.join(VALUE_SPLIT);
-}
-
-/**
- * Convert string to value array, split by `VALUE_SPLIT`
- */
-export function toKeyValues(value: string): string[] {
-  return value.split(VALUE_SPLIT);
 }
 
 export function getOptionKey(option: NzCascaderOption): string {

--- a/components/cascader/utils.ts
+++ b/components/cascader/utils.ts
@@ -4,13 +4,6 @@
  */
 
 import { NzTreeNode } from 'ng-zorro-antd/core/tree';
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
-
-import { NzCascaderOption } from './typings';
-
-export function isChildOption(o: NzCascaderOption): boolean {
-  return o.isLeaf || !o.children || !o.children.length;
-}
 
 export function isChildNode(node: NzTreeNode): boolean {
   return node.isLeaf || !node.children || !node.children.length;
@@ -18,42 +11,4 @@ export function isChildNode(node: NzTreeNode): boolean {
 
 export function isParentNode(node: NzTreeNode): boolean {
   return !!node.children && !!node.children.length && !node.isLeaf;
-}
-
-export function isParentOption(o: NzCascaderOption): boolean {
-  return !!o.children && !!o.children.length && !o.isLeaf;
-}
-
-/**
- * Whether an option is disabled in multiple mode.
- * @param o option
- * @param multiple whether multiple mode
- */
-export function isDisabledOption(o: NzCascaderOption, multiple = true): boolean {
-  return o.disabled || (multiple && !!o.disableCheckbox);
-}
-
-const VALUE_SPLIT = '__CASCADER_SPLIT__';
-const KEY_PROPERTY = '__cascader_key';
-
-/**
- * Will convert value to string, and join with `VALUE_SPLIT`
- */
-export function toPathKey(value: NzSafeAny[]): string {
-  return value.join(VALUE_SPLIT);
-}
-
-/**
- * Will split key to array, and convert to number
- */
-export function toPathArray(key: string): string[] {
-  return key.split(VALUE_SPLIT);
-}
-
-export function getOptionKey(option: NzCascaderOption): string {
-  return option[KEY_PROPERTY];
-}
-
-export function setOptionKey(option: NzCascaderOption, key: string): void {
-  option[KEY_PROPERTY] = key;
 }

--- a/components/cascader/utils.ts
+++ b/components/cascader/utils.ts
@@ -34,6 +34,13 @@ export function toPathKey(value: NzSafeAny[]): string {
   return value.join(VALUE_SPLIT);
 }
 
+/**
+ * Will split key to array, and convert to number
+ */
+export function toPathArray(key: string): string[] {
+  return key.split(VALUE_SPLIT);
+}
+
 export function getOptionKey(option: NzCascaderOption): string {
   return option[KEY_PROPERTY];
 }

--- a/components/cascader/utils.ts
+++ b/components/cascader/utils.ts
@@ -3,6 +3,8 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
+import { NzSafeAny } from 'ng-zorro-antd/core/types';
+
 import { NzCascaderOption } from './typings';
 
 export function isChildOption(o: NzCascaderOption): boolean {
@@ -11,4 +13,29 @@ export function isChildOption(o: NzCascaderOption): boolean {
 
 export function isParentOption(o: NzCascaderOption): boolean {
   return !!o.children && !!o.children.length && !o.isLeaf;
+}
+
+const VALUE_SPLIT = '__CASCADER_SPLIT__';
+const KEY_PROPERTY = '__cascader_key';
+
+/**
+ * Will convert value to string, and join with `VALUE_SPLIT`
+ */
+export function toPathKey(value: NzSafeAny[]): string {
+  return value.join(VALUE_SPLIT);
+}
+
+/**
+ * Convert string to value array, split by `VALUE_SPLIT`
+ */
+export function toKeyValues(value: string): string[] {
+  return value.split(VALUE_SPLIT);
+}
+
+export function getOptionKey(option: NzCascaderOption): string {
+  return option[KEY_PROPERTY];
+}
+
+export function setOptionKey(option: NzCascaderOption, key: string): void {
+  option[KEY_PROPERTY] = key;
 }

--- a/components/core/tree/nz-tree-base-node.ts
+++ b/components/core/tree/nz-tree-base-node.ts
@@ -70,9 +70,9 @@ export class NzTreeNode {
   /**
    * Init nzTreeNode
    *
-   * @param option: user's input
-   * @param parent
-   * @param service: base nzTreeService
+   * @param option option user's input
+   * @param parent parent node
+   * @param service base nzTreeService
    */
   constructor(
     option: NzTreeNodeOptions | NzTreeNode,
@@ -109,9 +109,21 @@ export class NzTreeNode {
     } else {
       this.level = 0;
     }
+
+    const s = this.treeService;
+
+    /**
+     * post process of current treeNode
+     */
+    if (s && s.treeNodePostProcessor) {
+      s.treeNodePostProcessor(this);
+    }
+
+    /**
+     * instantiate children tree nodes
+     */
     if (typeof option.children !== 'undefined' && option.children !== null) {
       option.children.forEach(nodeOptions => {
-        const s = this.treeService;
         if (
           s &&
           !s.isCheckStrictly &&

--- a/components/core/tree/nz-tree-base-node.ts
+++ b/components/core/tree/nz-tree-base-node.ts
@@ -115,9 +115,7 @@ export class NzTreeNode {
     /**
      * post process of current treeNode
      */
-    if (s && s.treeNodePostProcessor) {
-      s.treeNodePostProcessor(this);
-    }
+    s?.treeNodePostProcessor?.(this);
 
     /**
      * instantiate children tree nodes

--- a/components/core/tree/nz-tree-base.service.ts
+++ b/components/core/tree/nz-tree-base.service.ts
@@ -27,6 +27,10 @@ export class NzTreeBaseService {
   checkedNodeList: NzTreeNode[] = [];
   halfCheckedNodeList: NzTreeNode[] = [];
   matchedNodeList: NzTreeNode[] = [];
+  /**
+   * handle to post process a tree node when it's instantiating, note that its children haven't been initiated yet
+   */
+  treeNodePostProcessor?: (node: NzTreeNode) => void;
 
   /**
    * reset tree nodes will clear default node list

--- a/components/select/select-item.component.ts
+++ b/components/select/select-item.component.ts
@@ -23,7 +23,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <ng-container *nzStringTemplateOutlet="contentTemplateOutlet; context: { $implicit: contentTemplateOutletContext }">
+    <ng-container *nzStringTemplateOutlet="contentTemplateOutlet; context: templateOutletContext">
       @if (deletable) {
         <div class="ant-select-selection-item-content">{{ label }}</div>
       } @else {
@@ -57,7 +57,12 @@ export class NzSelectItemComponent {
   @Input() contentTemplateOutlet: string | TemplateRef<NzSafeAny> | null = null;
   @Output() readonly delete = new EventEmitter<MouseEvent>();
 
-  constructor() {}
+  protected get templateOutletContext(): NzSafeAny {
+    return {
+      $implicit: this.contentTemplateOutletContext,
+      ...this.contentTemplateOutletContext
+    };
+  }
 
   onDelete(e: MouseEvent): void {
     e.preventDefault();

--- a/components/select/select-placeholder.component.ts
+++ b/components/select/select-placeholder.component.ts
@@ -23,6 +23,4 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
 })
 export class NzSelectPlaceholderComponent {
   @Input() placeholder: TemplateRef<NzSafeAny> | string | null = null;
-
-  constructor() {}
 }

--- a/components/select/select-top-control.component.ts
+++ b/components/select/select-top-control.component.ts
@@ -84,7 +84,7 @@ import { NzSelectItemInterface, NzSelectModeType, NzSelectTopControlItemType } f
           [disabled]="disabled"
           [value]="inputValue!"
           [autofocus]="autofocus"
-          [showInput]="true"
+          [showInput]="false"
           [mirrorSync]="true"
           [focusTrigger]="open"
           (isComposingChange)="isComposingChange($event)"

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -595,7 +595,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   }
 
   noAnimation = inject(NzNoAnimationDirective, { host: true, optional: true });
-  private nzFormStatusService = inject(NzFormStatusService, { optional: true });
+  protected nzFormStatusService = inject(NzFormStatusService, { optional: true });
   private nzFormNoStatusService = inject(NzFormNoStatusService, { optional: true });
 
   constructor(

--- a/components/space/demo/compact.ts
+++ b/components/space/demo/compact.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 
 import { NzAutocompleteModule } from 'ng-zorro-antd/auto-complete';
 import { NzButtonModule } from 'ng-zorro-antd/button';
-import { NzCascaderModule } from 'ng-zorro-antd/cascader';
+import { NzCascaderModule, NzCascaderOption } from 'ng-zorro-antd/cascader';
 import { NzDatePickerModule } from 'ng-zorro-antd/date-picker';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzInputModule } from 'ng-zorro-antd/input';
@@ -220,7 +220,7 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
   ]
 })
 export class NzDemoSpaceCompactComponent {
-  cascaderOptions = [
+  cascaderOptions: NzCascaderOption[] = [
     {
       value: 'zhejiang',
       label: 'Zhejiang',
@@ -231,7 +231,8 @@ export class NzDemoSpaceCompactComponent {
           children: [
             {
               value: 'xihu',
-              label: 'West Lake'
+              label: 'West Lake',
+              isLeaf: true
             }
           ]
         }
@@ -247,7 +248,8 @@ export class NzDemoSpaceCompactComponent {
           children: [
             {
               value: 'zhonghuamen',
-              label: 'Zhong Hua Men'
+              label: 'Zhong Hua Men',
+              isLeaf: true
             }
           ]
         }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: close #6981 #8853


## What is the new behavior?

Redesign the cascader component (which option list is now based on `NzTreeBase`) and support multiple selection

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


**BREAKING CHANGE**

In the past, the cascader component kept a trick that if you wrote value with `NzCascaderOption[]` type, it extracted value by mapping each item to its value property, for example:

```ts
@Component({
	template: `<nz-cascader [nzOptions]="options" [ngModel]="value"></nz-cascader>`
})
export class ExampleComponent {
	value = [{ label: 'NG ZORRO', value: 'ng-zorro-antd' }]
}
```

then the value of cascader would be `'ng-zorro-antd'`.

It's strange that the input and output values don't match when we haven't changed the values and it's hard to maintain. We expect that the value passed in should be the value in the list of options.

In v19, this trick is removed and if you're already using this trick in your code, please consider the add a `map` function to pass the actual value.

---

旧版本中，在表单中为 Cascader 组件赋值为 `NzCascaderOption[]` 类型时，Cascader 组件会根据提供的 `nzValueProperty` 映射成实际的值并写入，例如：

```ts
@Component({
	template: `<nz-cascader [nzOptions]="options" [ngModel]="value"></nz-cascader>`
})
export class ExampleComponent {
	value = [{ label: 'NG ZORRO', value: 'ng-zorro-antd' }]
}
```

此时 Cascader 组件输出的值将为 `'ng-zorro-antd'`。这就导致输入与输出的值不一致，可能存在潜在的数据问题。

在 v19 中，我们将移除该特性，如果您已经在代码中运用了该特性，请考虑增加一个 `map` 方法将其映射到实际的值。

## Other information
