### PR TITLE
fix(module:space): fix style of compact mode of input & input-number

### DIFF
--- a/components/auto-complete/autocomplete.spec.ts
+++ b/components/auto-complete/autocomplete.spec.ts
@@ -56,7 +56,6 @@ describe('auto-complete', () => {
   let zone: MockNgZone;
 
   beforeEach(waitForAsync(() => {
-    const dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [NzAutocompleteModule, NoopAnimationsModule, FormsModule, ReactiveFormsModule, NzInputModule],
       declarations: [
@@ -71,7 +70,7 @@ describe('auto-complete', () => {
         NzTestAutocompleteWithGroupInputComponent
       ],
       providers: [
-        { provide: Directionality, useFactory: () => ({ value: dir }) },
+        { provide: Directionality, useClass: MockDirectionality },
         { provide: ScrollDispatcher, useFactory: () => ({ scrolled: () => scrolledSubject }) },
         {
           provide: NgZone,
@@ -1219,11 +1218,6 @@ class NzTestAutocompleteWithGroupInputComponent {
   @ViewChild('inputGroupComponent', { static: false, read: ElementRef }) inputGroupComponent!: ElementRef;
 }
 
-class MockDirectionality {
-  value = 'ltr';
-  change = new Subject();
-}
-
 describe('auto-complete', () => {
   let component: NzAutocompleteComponent;
   let fixture: ComponentFixture<NzAutocompleteComponent>;
@@ -1333,3 +1327,8 @@ describe('auto-complete', () => {
     expect(nzOptionSelectionChange.isUserInput).toBeFalsy();
   });
 });
+
+class MockDirectionality {
+  value = 'ltr';
+  change = new Subject();
+}

--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -238,6 +238,8 @@
 
   // ===================== Compact Item Styles =====================
   .compact-item(@input-number-prefix-cls, null, ~'@{input-number-prefix-cls}-focused');
+  .compact-item(~'@{input-number-prefix-cls}-affix-wrapper', null, ~'@{input-number-prefix-cls}-focused');
+  .compact-item(~'@{input-number-prefix-cls}-group-wrapper', ~'@{input-number-prefix-cls}-group-addon', ~'@{input-number-prefix-cls}-focused');
 }
 
 @import './rtl';

--- a/components/input/style/index.less
+++ b/components/input/style/index.less
@@ -81,6 +81,8 @@
 
   // ===================== Compact Item Styles =====================
   .compact-item(@input-prefix-cls);
+  .compact-item(~'@{input-prefix-cls}-affix-wrapper');
+  .compact-item(~'@{input-prefix-cls}-group-wrapper', ~'@{input-prefix-cls}-group-addon');
 }
 
 @import './search-input';

--- a/components/mention/mention.spec.ts
+++ b/components/mention/mention.spec.ts
@@ -32,12 +32,11 @@ describe('mention', () => {
   let zone: MockNgZone;
 
   beforeEach(waitForAsync(() => {
-    const dir = 'ltr';
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
       providers: [
         provideNzIconsTesting(),
-        { provide: Directionality, useFactory: () => ({ value: dir }) },
+        { provide: Directionality, useClass: MockDirectionality },
         { provide: ScrollDispatcher, useFactory: () => ({ scrolled: () => scrolledSubject }) },
         {
           provide: NgZone,
@@ -694,4 +693,9 @@ class NzTestStatusMentionComponent {
 class NzTestMentionInFormComponent {
   status: NzFormControlStatusType = 'error';
   feedback = true;
+}
+
+class MockDirectionality {
+  value = 'ltr';
+  change = new Subject();
 }

--- a/components/space/demo/compact.ts
+++ b/components/space/demo/compact.ts
@@ -67,19 +67,25 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
       <nz-input-group nzSearch [nzAddOnAfter]="addonTmpl" [style.width.%]="30">
         <input nz-input value="0571" />
         <ng-template #addonTmpl>
-          <button nz-button><span nz-icon nzType="search"></span></button>
+          <button nz-button class="ant-input-search-button">
+            <span nz-icon nzType="search"></span>
+          </button>
         </ng-template>
       </nz-input-group>
       <nz-input-group nzSearch [nzAddOnAfter]="addonTmpl" [style.width.%]="50">
         <input nz-input value="26888888" />
         <ng-template #addonTmpl>
-          <button nz-button><span nz-icon nzType="search"></span></button>
+          <button nz-button class="ant-input-search-button">
+            <span nz-icon nzType="search"></span>
+          </button>
         </ng-template>
       </nz-input-group>
       <nz-input-group nzSearch [nzAddOnAfter]="addonTmpl" [style.width.%]="20">
         <input nz-input value="+1" />
         <ng-template #addonTmpl>
-          <button nz-button><span nz-icon nzType="search"></span></button>
+          <button nz-button class="ant-input-search-button">
+            <span nz-icon nzType="search"></span>
+          </button>
         </ng-template>
       </nz-input-group>
     </nz-space-compact>
@@ -173,6 +179,18 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
         [style.width.%]="60"
       ></nz-tree-select>
       <button nz-button nzType="primary">Submit</button>
+    </nz-space-compact>
+    <br />
+    <nz-space-compact nzBlock>
+      <nz-input-group nzAddOnBefore="Http://" nzAddOnAfter=".com" [style.width.%]="50">
+        <input nz-input placeholder="input here" />
+      </nz-input-group>
+      <nz-input-number>
+        <span nzInputPrefix>$</span>
+      </nz-input-number>
+      <nz-input-number>
+        <span nzInputAddonBefore>$</span>
+      </nz-input-number>
     </nz-space-compact>
   `,
   styles: [

--- a/components/space/space-compact.component.ts
+++ b/components/space/space-compact.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, signal } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, inject, input, signal } from '@angular/core';
 
 import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
 
@@ -26,7 +26,8 @@ import { NZ_SPACE_COMPACT_ITEMS, NZ_SPACE_COMPACT_SIZE } from './space-compact.t
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NzSpaceCompactComponent {
-  nzBlock = input(false, { transform: booleanAttribute });
-  nzDirection = input<'vertical' | 'horizontal'>('horizontal');
-  nzSize = input<NzSizeLDSType>('default');
+  readonly nzBlock = input(false, { transform: booleanAttribute });
+  readonly nzDirection = input<'vertical' | 'horizontal'>('horizontal');
+  readonly nzSize = input<NzSizeLDSType>('default');
+  readonly elementRef: ElementRef<HTMLElement> = inject(ElementRef);
 }

--- a/components/style/mixins/compact-item.less
+++ b/components/style/mixins/compact-item.less
@@ -30,28 +30,28 @@
 
   & when (not (@bordered-item-cls = null)) {
     // border-radius
-    &-item:not(&-first-item):not(&-last-item).@{prefix-cls} > .@{bordered-item-cls} {
+    &-item:not(&-first-item):not(&-last-item).@{prefix-cls} .@{bordered-item-cls} {
       border-radius: 0;
     }
 
-    &-item&-first-item.@{prefix-cls}:not(&-last-item):not(&-item-rtl) > .@{bordered-item-cls} {
+    &-item&-first-item.@{prefix-cls}:not(&-last-item):not(&-item-rtl) .@{bordered-item-cls} {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
     }
 
-    &-item&-last-item.@{prefix-cls}:not(&-first-item):not(&-item-rtl) > .@{bordered-item-cls} {
+    &-item&-last-item.@{prefix-cls}:not(&-first-item):not(&-item-rtl) .@{bordered-item-cls} {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
     }
 
     // ----------rtl for first item----------
-    &-item.@{prefix-cls}&-first-item&-item-rtl:not(&-last-item) > .@{bordered-item-cls} {
+    &-item.@{prefix-cls}&-first-item&-item-rtl:not(&-last-item) .@{bordered-item-cls} {
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
     }
 
     // ----------rtl for last item----------
-    &-item.@{prefix-cls}&-last-item&-item-rtl:not(&-first-item) > .@{bordered-item-cls} {
+    &-item.@{prefix-cls}&-last-item&-item-rtl:not(&-first-item) .@{bordered-item-cls} {
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

![86f90129f80491687ec466bcc43e161b](https://github.com/user-attachments/assets/a8d44219-4c4c-4580-9a06-fb6762b93b7a)

antd4 对于附带 affixes 与 addons 的 input 与 input-number 的 compact 样式并不完整，[查看 DEMO](https://stackblitz.com/edit/react-y4avnr?file=demo.tsx)

## What is the new behavior?

![54aa2eabeb4c0533187091a04b3bdf7c](https://github.com/user-attachments/assets/b26afe2c-bddb-4f49-b426-ceac736a91ac)

此 PR 通过更新样式以支持这些情况。

此外，这个 PR 还修复了：
- 支持 RTL 模式
- 当 `space-compact` 作为**祖先**组件但不是**直接**父组件时，应该判定为非 compact 模式。

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
