### PR TITLE
fix(module:input-number): correctly render the feedback icon

### DIFF
--- a/components/input-number/input-number.component.ts
+++ b/components/input-number/input-number.component.ts
@@ -91,9 +91,12 @@ import { NZ_SPACE_COMPACT_ITEM_TYPE, NZ_SPACE_COMPACT_SIZE, NzSpaceCompactItemDi
         </span>
       }
       <ng-template [ngTemplateOutlet]="inputNumber" />
-      @if (suffix()) {
+      @if (suffix() || hasFeedback()) {
         <span class="ant-input-number-suffix">
           <ng-content select="[nzInputSuffix]"></ng-content>
+          @if (hasFeedback() && finalStatus().signal()) {
+            <nz-form-item-feedback-icon [status]="finalStatus().signal()" />
+          }
         </span>
       }
     </ng-template>
@@ -152,9 +155,6 @@ import { NZ_SPACE_COMPACT_ITEM_TYPE, NZ_SPACE_COMPACT_SIZE, NzSpaceCompactItemDi
           (change)="onInputChange($event)"
         />
       </div>
-      @if (hasFeedback() && finalStatus().signal()) {
-        <nz-form-item-feedback-icon class="ant-input-number-suffix" [status]="finalStatus().signal()" />
-      }
     </ng-template>
   `,
   providers: [
@@ -237,7 +237,7 @@ export class NzInputNumberComponent implements OnInit, ControlValueAccessor {
   protected suffix = contentChild(NzInputSuffixDirective);
   protected addonBefore = contentChild(NzInputAddonBeforeDirective);
   protected addonAfter = contentChild(NzInputAddonAfterDirective);
-  protected hasAffix = computed(() => !!this.prefix() || !!this.suffix());
+  protected hasAffix = computed(() => !!this.prefix() || !!this.suffix() || this.hasFeedback());
   protected hasAddon = computed(() => !!this.addonBefore() || !!this.addonAfter());
 
   protected class = computed(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

在 antd 中，feedback icon 也属于 suffix，需要将它渲染到正确的位置。

https://4x-ant-design.antgroup.com/components/form-cn/#:~:text=%E8%AF%B7%E9%80%89%E6%8B%A9%E6%97%A5%E6%9C%9F-,Success,-Success


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
