### PR TITLE
fix(module:tree-view): nzTreeNodePadding not works in virtual scroll

### DIFF
--- a/components/tree-view/tree-virtual-scroll-view.ts
+++ b/components/tree-view/tree-virtual-scroll-view.ts
@@ -103,7 +103,7 @@ export class NzTreeVirtualScrollViewComponent<T> extends NzTreeView<T> implement
    * @note
    * angular/cdk v18.2.0 breaking changes: https://github.com/angular/components/pull/29062
    * Temporary workaround: revert to old method of getting level
-   * TODO: refactor tree-view, remove #treeControl instead of #levelAccessor or #childrenAccessor
+   * TODO: refactor tree-view, remove #treeControl and adopt #levelAccessor and #childrenAccessor
    * */
   override _getLevel(nodeData: T): number | undefined {
     if (this.treeControl.getLevel) {

--- a/components/tree-view/tree-virtual-scroll-view.ts
+++ b/components/tree-view/tree-virtual-scroll-view.ts
@@ -99,6 +99,19 @@ export class NzTreeVirtualScrollViewComponent<T> extends NzTreeView<T> implement
     this.changeDetectorRef.markForCheck();
   }
 
+  /**
+   * @note
+   * angular/cdk v18.2.0 breaking changes: https://github.com/angular/components/pull/29062
+   * Temporary workaround: revert to old method of getting level
+   * TODO: refactor tree-view, remove #treeControl instead of #levelAccessor or #childrenAccessor
+   * */
+  override _getLevel(nodeData: T): number | undefined {
+    if (this.treeControl.getLevel) {
+      return this.treeControl.getLevel(nodeData);
+    }
+    return;
+  }
+
   private createNode(nodeData: T, index: number): NzTreeVirtualNodeData<T> {
     const node = this._getNodeDef(nodeData, index);
     const context = new CdkTreeNodeOutletContext<T>(nodeData);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: close #8915 


## What is the new behavior?

nzTreeNodePadding works in virtual scroll

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
