### PR TITLE
refactor: use <nz-icon> to instead of [nz-icon]

### DIFF
--- a/components/alert/alert.component.ts
+++ b/components/alert/alert.component.ts
@@ -56,7 +56,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'alert';
             @if (nzIcon) {
               <ng-container *nzStringTemplateOutlet="nzIcon"></ng-container>
             } @else {
-              <span nz-icon [nzType]="nzIconType || inferredIconType" [nzTheme]="iconTheme"></span>
+              <nz-icon [nzType]="nzIconType || inferredIconType" [nzTheme]="iconTheme" />
             }
           </div>
         }
@@ -89,7 +89,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'alert';
                 <span class="ant-alert-close-text">{{ nzCloseText }}</span>
               </ng-container>
             } @else {
-              <span nz-icon nzType="close"></span>
+              <nz-icon nzType="close" />
             }
           </button>
         }

--- a/components/auto-complete/demo/certain-category.ts
+++ b/components/auto-complete/demo/certain-category.ts
@@ -27,7 +27,7 @@ interface AutocompleteOptionGroups {
         />
       </nz-input-group>
       <ng-template #suffixIcon>
-        <span nz-icon nzType="search"></span>
+        <nz-icon nzType="search" />
       </ng-template>
       <nz-autocomplete #auto>
         @for (group of optionGroups; track group.title) {

--- a/components/auto-complete/demo/uncertain-category.ts
+++ b/components/auto-complete/demo/uncertain-category.ts
@@ -22,7 +22,7 @@ import { NzInputModule } from 'ng-zorro-antd/input';
     </nz-input-group>
     <ng-template #suffixIconButton>
       <button nz-button nzType="primary" nzSize="large" nzSearch>
-        <span nz-icon nzType="search" nzTheme="outline"></span>
+        <nz-icon nzType="search" nzTheme="outline" />
       </button>
     </ng-template>
     <nz-autocomplete #auto>

--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -31,7 +31,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
   imports: [NzIconModule, PlatformModule],
   template: `
     @if (nzIcon && hasIcon) {
-      <span nz-icon [nzType]="nzIcon"></span>
+      <nz-icon [nzType]="nzIcon" />
     } @else if (nzSrc && hasSrc) {
       <img [src]="nzSrc" [attr.srcset]="nzSrcSet" [attr.alt]="nzAlt" (error)="imgError($event)" />
     } @else if (nzText && hasText) {

--- a/components/back-top/back-top.component.ts
+++ b/components/back-top/back-top.component.ts
@@ -49,7 +49,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
         <ng-template #defaultContent>
           <div class="ant-back-top-content">
             <div class="ant-back-top-icon">
-              <span nz-icon nzType="vertical-align-top"></span>
+              <nz-icon nzType="vertical-align-top" />
             </div>
           </div>
         </ng-template>

--- a/components/badge/demo/basic.ts
+++ b/components/badge/demo/basic.ts
@@ -17,7 +17,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       <a class="head-example"></a>
     </nz-badge>
     <ng-template #iconTemplate>
-      <span nz-icon nzType="clock-circle" class="ant-scroll-number-custom-component" style="color: #f5222d"></span>
+      <nz-icon nzType="clock-circle" class="ant-scroll-number-custom-component" style="color: #f5222d" />
     </ng-template>
   `,
   styles: [

--- a/components/badge/demo/change.ts
+++ b/components/badge/demo/change.ts
@@ -15,8 +15,8 @@ import { NzSwitchModule } from 'ng-zorro-antd/switch';
         <a class="head-example"></a>
       </nz-badge>
       <nz-button-group>
-        <button nz-button (click)="minusCount()"><span nz-icon nzType="minus"></span></button>
-        <button nz-button (click)="addCount()"><span nz-icon nzType="plus"></span></button>
+        <button nz-button (click)="minusCount()"><nz-icon nzType="minus" /></button>
+        <button nz-button (click)="addCount()"><nz-icon nzType="plus" /></button>
       </nz-button-group>
     </div>
     <br />

--- a/components/badge/demo/dot.ts
+++ b/components/badge/demo/dot.ts
@@ -8,10 +8,10 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   imports: [NzBadgeModule, NzIconModule],
   template: `
     <nz-badge nzDot>
-      <span nz-icon nzType="notification"></span>
+      <nz-icon nzType="notification" />
     </nz-badge>
     <nz-badge nzDot [nzShowDot]="false">
-      <span nz-icon nzType="notification"></span>
+      <nz-icon nzType="notification" />
     </nz-badge>
     <nz-badge nzDot>
       <a>Link something</a>
@@ -23,7 +23,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
         margin-right: 20px;
       }
 
-      [nz-icon] {
+      nz-icon {
         width: 16px;
         height: 16px;
         line-height: 16px;

--- a/components/badge/demo/no-wrapper.ts
+++ b/components/badge/demo/no-wrapper.ts
@@ -20,7 +20,7 @@ import { NzSwitchModule } from 'ng-zorro-antd/switch';
       <a class="head-example"></a>
     </nz-badge>
     <ng-template #iconTemplate>
-      <span nz-icon nzType="clock-circle" class="ant-scroll-number-custom-component" style="color: #f5222d"></span>
+      <nz-icon nzType="clock-circle" class="ant-scroll-number-custom-component" style="color: #f5222d" />
     </ng-template>
     <nz-badge nzStandalone [nzCount]="show ? 109 : 0" [nzStyle]="{ backgroundColor: '#52c41a' }"></nz-badge>
   `,

--- a/components/breadcrumb/breadcrumb-item.component.ts
+++ b/components/breadcrumb/breadcrumb-item.component.ts
@@ -24,7 +24,7 @@ import { NzBreadCrumbSeparatorComponent } from './breadcrumb-separator.component
     @if (!!nzOverlay) {
       <span class="ant-breadcrumb-overlay-link" nz-dropdown [nzDropdownMenu]="nzOverlay">
         <ng-template [ngTemplateOutlet]="noMenuTpl"></ng-template>
-        <span nz-icon nzType="down"></span>
+        <nz-icon nzType="down" />
       </span>
     } @else {
       <ng-template [ngTemplateOutlet]="noMenuTpl" />

--- a/components/breadcrumb/demo/separator.ts
+++ b/components/breadcrumb/demo/separator.ts
@@ -24,7 +24,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       </nz-breadcrumb-item>
       <nz-breadcrumb-item>An Application</nz-breadcrumb-item>
     </nz-breadcrumb>
-    <ng-template #iconTemplate><span nz-icon nzType="arrow-right"></span></ng-template>
+    <ng-template #iconTemplate><nz-icon nzType="arrow-right" /></ng-template>
   `,
   styles: [
     `

--- a/components/breadcrumb/demo/with-icon.ts
+++ b/components/breadcrumb/demo/with-icon.ts
@@ -9,11 +9,11 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   template: `
     <nz-breadcrumb>
       <nz-breadcrumb-item>
-        <span nz-icon nzType="home"></span>
+        <nz-icon nzType="home" />
       </nz-breadcrumb-item>
       <nz-breadcrumb-item>
         <a>
-          <span nz-icon nzType="user"></span>
+          <nz-icon nzType="user" />
           <span>Application List</span>
         </a>
       </nz-breadcrumb-item>

--- a/components/button/button.component.ts
+++ b/components/button/button.component.ts
@@ -48,7 +48,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'button';
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzLoading) {
-      <span nz-icon nzType="loading"></span>
+      <nz-icon nzType="loading" />
     }
     <ng-content></ng-content>
   `,
@@ -121,7 +121,7 @@ export class NzButtonComponent implements OnChanges, AfterViewInit, AfterContent
     // ignore icon and comment
     const noSpan =
       listOfNode.filter(node => {
-        return !(node.nodeName === '#comment' || !!(node as HTMLElement)?.attributes?.getNamedItem('nz-icon'));
+        return !(node.nodeName === '#comment' || !!(node as HTMLElement)?.classList?.contains('anticon'));
       }).length == 0;
     return !!this.nzIconDirectiveElement && noSpan && noText;
   }

--- a/components/button/button.spec.ts
+++ b/components/button/button.spec.ts
@@ -321,7 +321,7 @@ export class TestButtonComponent {
   imports: [NzIconModule, NzButtonModule],
   template: `
     <button nz-button nzType="primary" (click)="load()" [nzLoading]="loading">
-      <span nz-icon nzType="poweroff"></span>
+      <nz-icon nzType="poweroff" />
       {{ 'Click me!' }}
     </button>
   `
@@ -340,7 +340,7 @@ export class TestButtonBindingComponent {
   template: `
     <button nz-button>
       {{ title }}
-      <span nz-icon nzType="caret-down"></span>
+      <nz-icon nzType="caret-down" />
     </button>
   `
 })
@@ -355,7 +355,7 @@ export class TestButtonWithIconComponent implements OnInit {
   imports: [NzIconModule, NzButtonModule],
   template: `
     <button nz-button>
-      <span nz-icon nzType="caret-down"></span>
+      <nz-icon nzType="caret-down" />
     </button>
   `
 })
@@ -407,7 +407,7 @@ export class TestButtonIconOnlyWithoutIconComponent {}
   imports: [NzIconModule, NzButtonModule],
   template: `
     <button nz-button nzLoading>
-      <span nz-icon nzType="caret-down"></span>
+      <nz-icon nzType="caret-down" />
     </button>
   `
 })

--- a/components/button/demo/button-group.ts
+++ b/components/button/demo/button-group.ts
@@ -26,17 +26,17 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     <h4>With Icon</h4>
     <nz-button-group>
       <button nz-button nzType="primary">
-        <span nz-icon nzType="left"></span>
+        <nz-icon nzType="left" />
         Go back
       </button>
       <button nz-button nzType="primary">
         Go forward
-        <span nz-icon nzType="right"></span>
+        <nz-icon nzType="right" />
       </button>
     </nz-button-group>
     <nz-button-group>
-      <button nz-button nzType="primary"><span nz-icon nzType="cloud"></span></button>
-      <button nz-button nzType="primary"><span nz-icon nzType="cloud-download"></span></button>
+      <button nz-button nzType="primary"><nz-icon nzType="cloud" /></button>
+      <button nz-button nzType="primary"><nz-icon nzType="cloud-download" /></button>
     </nz-button-group>
   `,
   styles: [

--- a/components/button/demo/icon.ts
+++ b/components/button/demo/icon.ts
@@ -8,29 +8,29 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   imports: [NzButtonModule, NzIconModule],
   template: `
     <button nz-button nzType="primary" nzShape="circle">
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
     </button>
     <button nz-button nzType="primary" nzShape="circle">A</button>
     <button nz-button nzType="primary">
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
       Search
     </button>
     <button nz-button nzType="default" nzShape="circle">
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
     </button>
     <button nz-button nzType="default">
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
       Search
     </button>
     <br />
-    <button nz-button nzType="default" nzShape="circle"><span nz-icon nzType="search"></span></button>
+    <button nz-button nzType="default" nzShape="circle"><nz-icon nzType="search" /></button>
     <button nz-button nzType="default">
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
       Search
     </button>
-    <button nz-button nzType="dashed" nzShape="circle"><span nz-icon nzType="search"></span></button>
+    <button nz-button nzType="dashed" nzShape="circle"><nz-icon nzType="search" /></button>
     <button nz-button nzType="dashed">
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
       Search
     </button>
   `,

--- a/components/button/demo/loading.ts
+++ b/components/button/demo/loading.ts
@@ -8,14 +8,14 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   imports: [NzButtonModule, NzIconModule],
   template: `
     <button nz-button nzType="primary" nzLoading>
-      <span nz-icon nzType="poweroff"></span>
+      <nz-icon nzType="poweroff" />
       Loading
     </button>
     <button nz-button nzType="primary" nzSize="small" nzLoading>Loading</button>
     <br />
     <button nz-button nzType="primary" (click)="loadOne()" [nzLoading]="isLoadingOne">Click me!</button>
     <button nz-button nzType="primary" (click)="loadTwo()" [nzLoading]="isLoadingTwo">
-      <span nz-icon nzType="poweroff"></span>
+      <nz-icon nzType="poweroff" />
       Click me!
     </button>
     <br />

--- a/components/button/demo/multiple.ts
+++ b/components/button/demo/multiple.ts
@@ -12,7 +12,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     <button nz-button nzType="default">secondary</button>
     <button nz-button nz-dropdown [nzDropdownMenu]="menu">
       Actions
-      <span nz-icon nzType="down"></span>
+      <nz-icon nzType="down" />
     </button>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu>

--- a/components/button/demo/size.ts
+++ b/components/button/demo/size.ts
@@ -22,31 +22,31 @@ import { NzRadioModule } from 'ng-zorro-antd/radio';
     <a nz-button [nzSize]="size" nzType="link">Link</a>
     <br />
     <button nz-button nzType="primary" [nzSize]="size">
-      <span nz-icon nzType="download"></span>
+      <nz-icon nzType="download" />
     </button>
     <button nz-button nzType="primary" [nzSize]="size" nzShape="circle">
-      <span nz-icon nzType="download"></span>
+      <nz-icon nzType="download" />
     </button>
     <button nz-button nzType="primary" [nzSize]="size" nzShape="round">
-      <span nz-icon nzType="download"></span>
+      <nz-icon nzType="download" />
     </button>
     <button nz-button nzType="primary" [nzSize]="size" nzShape="round">
-      <span nz-icon nzType="download"></span>
+      <nz-icon nzType="download" />
       Download
     </button>
     <button nz-button nzType="primary" [nzSize]="size">
-      <span nz-icon nzType="download"></span>
+      <nz-icon nzType="download" />
       Download
     </button>
     <br />
     <nz-button-group [nzSize]="size">
       <button nz-button nzType="primary">
-        <span nz-icon nzType="left"></span>
+        <nz-icon nzType="left" />
         Backward
       </button>
       <button nz-button nzType="primary">
         Forward
-        <span nz-icon nzType="right"></span>
+        <nz-icon nzType="right" />
       </button>
     </nz-button-group>
   `,

--- a/components/card/demo/loading.ts
+++ b/components/card/demo/loading.ts
@@ -32,13 +32,13 @@ import { NzSwitchModule } from 'ng-zorro-antd/switch';
       <nz-avatar nzSrc="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png"></nz-avatar>
     </ng-template>
     <ng-template #actionSetting>
-      <span nz-icon nzType="setting"></span>
+      <nz-icon nzType="setting" />
     </ng-template>
     <ng-template #actionEdit>
-      <span nz-icon nzType="edit"></span>
+      <nz-icon nzType="edit" />
     </ng-template>
     <ng-template #actionEllipsis>
-      <span nz-icon nzType="ellipsis"></span>
+      <nz-icon nzType="ellipsis" />
     </ng-template>
   `
 })

--- a/components/card/demo/meta.ts
+++ b/components/card/demo/meta.ts
@@ -22,13 +22,13 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       <img alt="example" src="https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png" />
     </ng-template>
     <ng-template #actionSetting>
-      <span nz-icon nzType="setting"></span>
+      <nz-icon nzType="setting" />
     </ng-template>
     <ng-template #actionEdit>
-      <span nz-icon nzType="edit"></span>
+      <nz-icon nzType="edit" />
     </ng-template>
     <ng-template #actionEllipsis>
-      <span nz-icon nzType="ellipsis"></span>
+      <nz-icon nzType="ellipsis" />
     </ng-template>
   `
 })

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -10,15 +10,15 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   Input,
   OnInit,
+  Output,
   TemplateRef,
   ViewEncapsulation,
-  numberAttribute,
+  booleanAttribute,
   inject,
-  Output,
-  EventEmitter,
-  booleanAttribute
+  numberAttribute
 } from '@angular/core';
 
 import { NzHighlightModule } from 'ng-zorro-antd/core/highlight';
@@ -60,10 +60,10 @@ import { NzCascaderOption } from './typings';
     @if (!node.isLeaf || node.children?.length || node.isLoading) {
       <div class="ant-cascader-menu-item-expand-icon">
         @if (node.isLoading) {
-          <span nz-icon nzType="loading"></span>
+          <nz-icon nzType="loading" />
         } @else {
           <ng-container *nzStringTemplateOutlet="expandIcon">
-            <span nz-icon [nzType]="$any(expandIcon)"></span>
+            <nz-icon [nzType]="$any(expandIcon)" />
           </ng-container>
         }
       </div>

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -9,31 +9,31 @@ import { CdkConnectedOverlay, ConnectionPositionPair, OverlayModule } from '@ang
 import { _getEventTarget } from '@angular/cdk/platform';
 import { SlicePipe } from '@angular/common';
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   ElementRef,
   EventEmitter,
+  forwardRef,
   HostListener,
+  inject,
   Input,
   NgZone,
+  numberAttribute,
   OnChanges,
   OnDestroy,
   OnInit,
   Output,
   QueryList,
   Renderer2,
+  signal,
   SimpleChanges,
   TemplateRef,
   ViewChild,
   ViewChildren,
-  ViewEncapsulation,
-  booleanAttribute,
-  computed,
-  forwardRef,
-  inject,
-  numberAttribute,
-  signal
+  ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BehaviorSubject, merge, Observable, of } from 'rxjs';
@@ -140,9 +140,9 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
       @if (nzShowArrow) {
         <span class="ant-select-arrow" [class.ant-select-arrow-loading]="isLoading">
           @if (!isLoading) {
-            <span nz-icon [nzType]="$any(nzSuffixIcon)" [class.ant-cascader-picker-arrow-expand]="menuVisible"></span>
+            <nz-icon [nzType]="$any(nzSuffixIcon)" [class.ant-cascader-picker-arrow-expand]="menuVisible" />
           } @else {
-            <span nz-icon nzType="loading"></span>
+            <nz-icon nzType="loading" />
           }
 
           @if (hasFeedback && !!status) {

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -407,7 +407,7 @@ describe('cascader', () => {
       expect(testComponent.values!.length).toBe(3);
       fixture.detectChanges();
       spyOn(testComponent, 'onClear');
-      cascader.nativeElement.querySelector('.ant-select-clear span[nz-icon]').click();
+      cascader.nativeElement.querySelector('.ant-select-clear nz-icon').click();
       fixture.detectChanges();
       expect(testComponent.values!.length).toBe(0);
       expect(testComponent.onClear).toHaveBeenCalled();

--- a/components/code-editor/demo/config.ts
+++ b/components/code-editor/demo/config.ts
@@ -21,10 +21,10 @@ import { NzTypographyModule } from 'ng-zorro-antd/typography';
       ></nz-switch>
     </p>
     <ng-template #unchecked>
-      <span nz-icon nzType="bulb"></span>
+      <nz-icon nzType="bulb" />
     </ng-template>
     <ng-template #checked>
-      <span nz-icon nzType="poweroff"></span>
+      <nz-icon nzType="poweroff" />
     </ng-template>
     <nz-code-editor style="height: 200px" [ngModel]="code" [nzEditorOption]="{ language: 'markdown' }"></nz-code-editor>
   `

--- a/components/code-editor/style/index.less
+++ b/components/code-editor/style/index.less
@@ -31,7 +31,8 @@
     background: transparent;
 
     i,
-    span[nz-icon] {
+    span[nz-icon],
+    nz-icon {
       position: relative;
       right: 4px;
       cursor: pointer;

--- a/components/collapse/collapse.spec.ts
+++ b/components/collapse/collapse.spec.ts
@@ -249,7 +249,7 @@ export class NzTestCollapseTemplateComponent {}
         <p>Panel01</p>
       </nz-collapse-panel>
       <ng-template #expandedIcon>
-        <span nz-icon nzType="caret-right" class="ant-collapse-arrow"></span>
+        <nz-icon nzType="caret-right" class="ant-collapse-arrow" />
       </ng-template>
     </nz-collapse>
   `

--- a/components/collapse/demo/custom.ts
+++ b/components/collapse/demo/custom.ts
@@ -26,7 +26,7 @@ interface Panel {
           <p>{{ panel.name }} content</p>
           <ng-template #expandedIcon let-active>
             {{ active }}
-            <span nz-icon nzType="caret-right" class="ant-collapse-arrow" [nzRotate]="p.nzActive ? 90 : -90"></span>
+            <nz-icon nzType="caret-right" class="ant-collapse-arrow" [nzRotate]="p.nzActive ? 90 : -90" />
           </ng-template>
         </nz-collapse-panel>
       }

--- a/components/collapse/demo/extra.ts
+++ b/components/collapse/demo/extra.ts
@@ -26,7 +26,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
     </nz-collapse>
     <ng-template #extraTpl>
       <!-- You can use stopPropagation if you don't want the panel to toggle -->
-      <span nz-icon nzType="setting" (click)="$event.stopPropagation()"></span>
+      <nz-icon nzType="setting" (click)="$event.stopPropagation()" />
     </ng-template>
     <br />
     <span>Expand Icon Position: </span>

--- a/components/core/form/nz-form-item-feedback-icon.component.ts
+++ b/components/core/form/nz-form-item-feedback-icon.component.ts
@@ -32,7 +32,7 @@ const iconTypeMap = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (iconType) {
-      <span nz-icon [nzType]="iconType"></span>
+      <nz-icon [nzType]="iconType" />
     }
   `,
   host: {

--- a/components/core/transition-patch/transition-patch.directive.ts
+++ b/components/core/transition-patch/transition-patch.directive.ts
@@ -14,7 +14,7 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
  */
 @Directive({
   selector:
-    '[nz-button], nz-button-group, [nz-icon], [nz-menu-item], [nz-submenu], nz-select-top-control, nz-select-placeholder, nz-input-group'
+    '[nz-button], nz-button-group, [nz-icon], nz-icon, [nz-menu-item], [nz-submenu], nz-select-top-control, nz-select-placeholder, nz-input-group'
 })
 export class NzTransitionPatchDirective implements AfterViewInit, OnChanges {
   @Input() hidden: NzSafeAny = null;

--- a/components/cron-expression/cron-expression-preview.component.ts
+++ b/components/cron-expression/cron-expression-preview.component.ts
@@ -51,9 +51,9 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 
     <ul class="ant-cron-expression-preview-icon">
       @if (isExpand) {
-        <li><span nz-icon nzType="down" nzTheme="outline" (click)="setExpand()"></span></li>
+        <li><nz-icon nzType="down" nzTheme="outline" (click)="setExpand()" /></li>
       } @else {
-        <li><span nz-icon nzType="up" nzTheme="outline" (click)="setExpand()"></span></li>
+        <li><nz-icon nzType="up" nzTheme="outline" (click)="setExpand()" /></li>
       }
     </ul>
   </div>`,

--- a/components/cron-expression/demo/shortcuts.ts
+++ b/components/cron-expression/demo/shortcuts.ts
@@ -18,7 +18,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     <ng-template #shortcuts>
       <button nz-button nz-dropdown [nzDropdownMenu]="menu">
         Shortcuts
-        <span nz-icon nzType="down"></span>
+        <nz-icon nzType="down" />
       </button>
       <nz-dropdown-menu #menu="nzDropdownMenu">
         <ul nz-menu nzSelectable>

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -130,7 +130,7 @@ export type NzPlacement = 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight';
               @if (nzSeparator) {
                 {{ nzSeparator }}
               } @else {
-                <span nz-icon nzType="swap-right" nzTheme="outline"></span>
+                <nz-icon nzType="swap-right" nzTheme="outline" />
               }
             </ng-container>
           </span>
@@ -167,13 +167,13 @@ export type NzPlacement = 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight';
       <div class="{{ prefixCls }}-active-bar" [style]="activeBarStyle"></div>
       @if (showClear) {
         <span class="{{ prefixCls }}-clear" (click)="onClickClear($event)">
-          <span nz-icon nzType="close-circle" nzTheme="fill"></span>
+          <nz-icon nzType="close-circle" nzTheme="fill" />
         </span>
       }
 
       <span class="{{ prefixCls }}-suffix">
         <ng-container *nzStringTemplateOutlet="nzSuffixIcon; let suffixIcon">
-          <span nz-icon [nzType]="suffixIcon"></span>
+          <nz-icon [nzType]="suffixIcon" />
         </ng-container>
         @if (hasFeedback && !!status) {
           <nz-form-item-feedback-icon [status]="status" />

--- a/components/divider/demo/horizontal.ts
+++ b/components/divider/demo/horizontal.ts
@@ -24,7 +24,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       </p>
       <nz-divider nzDashed [nzText]="text">
         <ng-template #text>
-          <span nz-icon nzType="plus"></span>
+          <nz-icon nzType="plus" />
           Add
         </ng-template>
       </nz-divider>

--- a/components/divider/divider.spec.ts
+++ b/components/divider/divider.spec.ts
@@ -113,7 +113,7 @@ class TestDividerComponent {
   template: `
     <nz-divider nzDashed [nzText]="text">
       <ng-template #text>
-        <span nz-icon nzType="plus"></span>
+        <nz-icon nzType="plus" />
         Add
       </ng-template>
     </nz-divider>

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -96,7 +96,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
                     @if (nzClosable) {
                       <button (click)="closeClick()" aria-label="Close" class="ant-drawer-close">
                         <ng-container *nzStringTemplateOutlet="nzCloseIcon; let closeIcon">
-                          <span nz-icon [nzType]="closeIcon"></span>
+                          <nz-icon [nzType]="closeIcon" />
                         </ng-container>
                       </button>
                     }

--- a/components/drawer/drawer.spec.ts
+++ b/components/drawer/drawer.spec.ts
@@ -804,7 +804,7 @@ describe('NzDrawerService', () => {
   template: `
     <button (click)="open()">Open</button>
     <ng-template #closeIconTemplate>
-      <span nz-icon nzType="close-square" nzTheme="outline"></span>
+      <nz-icon nzType="close-square" nzTheme="outline" />
     </ng-template>
     <ng-template #titleTemplate>
       <span class="custom-title">title</span>

--- a/components/dropdown/demo/basic.ts
+++ b/components/dropdown/demo/basic.ts
@@ -9,7 +9,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   template: `
     <a nz-dropdown [nzDropdownMenu]="menu">
       Hover me
-      <span nz-icon nzType="down"></span>
+      <nz-icon nzType="down" />
     </a>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu nzSelectable>

--- a/components/dropdown/demo/dropdown-button.ts
+++ b/components/dropdown/demo/dropdown-button.ts
@@ -11,24 +11,24 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     <nz-button-group>
       <button nz-button (click)="log()">DropDown</button>
       <button nz-button nz-dropdown [nzDropdownMenu]="menu1" nzPlacement="bottomRight">
-        <span nz-icon nzType="ellipsis"></span>
+        <nz-icon nzType="ellipsis" />
       </button>
     </nz-button-group>
     <nz-button-group>
       <button nz-button (click)="log()">DropDown</button>
       <button nz-button nz-dropdown [nzDropdownMenu]="menu2" nzPlacement="bottomRight">
-        <span nz-icon nzType="user"></span>
+        <nz-icon nzType="user" />
       </button>
     </nz-button-group>
     <nz-button-group>
       <button nz-button disabled>DropDown</button>
       <button nz-button disabled nz-dropdown [nzDropdownMenu]="menu3" nzPlacement="bottomRight">
-        <span nz-icon nzType="ellipsis"></span>
+        <nz-icon nzType="ellipsis" />
       </button>
     </nz-button-group>
     <button nz-button nz-dropdown [nzDropdownMenu]="menu4">
       Button
-      <span nz-icon nzType="down"></span>
+      <nz-icon nzType="down" />
     </button>
     <nz-dropdown-menu #menu1="nzDropdownMenu">
       <ul nz-menu>

--- a/components/dropdown/demo/event.ts
+++ b/components/dropdown/demo/event.ts
@@ -9,7 +9,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   template: `
     <a nz-dropdown [nzDropdownMenu]="menu">
       Hover me, Click menu item
-      <span nz-icon nzType="down"></span>
+      <nz-icon nzType="down" />
     </a>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu>

--- a/components/dropdown/demo/item.ts
+++ b/components/dropdown/demo/item.ts
@@ -9,7 +9,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   template: `
     <a nz-dropdown [nzDropdownMenu]="menu">
       Hover me
-      <span nz-icon nzType="down"></span>
+      <nz-icon nzType="down" />
     </a>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu>

--- a/components/dropdown/demo/overlay-visible.ts
+++ b/components/dropdown/demo/overlay-visible.ts
@@ -9,7 +9,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   template: `
     <a nz-dropdown [nzDropdownMenu]="menu" [nzClickHide]="false" [(nzVisible)]="visible">
       Hover me
-      <span nz-icon nzType="down"></span>
+      <nz-icon nzType="down" />
     </a>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu>

--- a/components/dropdown/demo/sub-menu.ts
+++ b/components/dropdown/demo/sub-menu.ts
@@ -9,7 +9,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   template: `
     <a nz-dropdown [nzDropdownMenu]="menu" (nzVisibleChange)="change($event)">
       Cascading menu
-      <span nz-icon nzType="down"></span>
+      <nz-icon nzType="down" />
     </a>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu>

--- a/components/dropdown/demo/trigger.ts
+++ b/components/dropdown/demo/trigger.ts
@@ -9,7 +9,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   template: `
     <a nz-dropdown nzTrigger="click" [nzDropdownMenu]="menu">
       Click me
-      <span nz-icon nzType="down"></span>
+      <nz-icon nzType="down" />
     </a>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       <ul nz-menu>

--- a/components/empty/demo/config.ts
+++ b/components/empty/demo/config.ts
@@ -66,7 +66,7 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
 
     <ng-template #customTpl let-name>
       <div style="text-align: center;">
-        <span nz-icon nzType="smile" style="font-size: 20px;"></span>
+        <nz-icon nzType="smile" style="font-size: 20px;" />
         <p>Data Not Found in {{ name }}</p>
       </div>
     </ng-template>

--- a/components/float-button/float-button-content.component.ts
+++ b/components/float-button/float-button-content.component.ts
@@ -32,7 +32,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
           }
         } @else {
           <div class="ant-float-btn-icon">
-            <span nz-icon nzType="file-text" nzTheme="outline"></span>
+            <nz-icon nzType="file-text" nzTheme="outline" />
           </div>
         }
       </div>

--- a/components/float-button/float-button-group.component.spec.ts
+++ b/components/float-button/float-button-group.component.spec.ts
@@ -128,7 +128,7 @@ describe('nz-float-button-group RTL', () => {
     >
     </nz-float-button-group>
     <ng-template #icon>
-      <span nz-icon nzType="question-circle" nzTheme="outline"></span>
+      <nz-icon nzType="question-circle" nzTheme="outline" />
     </ng-template>
   `
 })

--- a/components/float-button/float-button-group.component.ts
+++ b/components/float-button/float-button-group.component.ts
@@ -56,7 +56,7 @@ import { NzFloatButtonComponent } from './float-button.component';
       }
     }
     <ng-template #close>
-      <span nz-icon nzType="close" nzTheme="outline"></span>
+      <nz-icon nzType="close" nzTheme="outline" />
     </ng-template>
   `,
   host: {

--- a/components/float-button/float-button-top.component.ts
+++ b/components/float-button/float-button-top.component.ts
@@ -55,7 +55,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
         [nzShape]="nzShape"
       ></nz-float-button>
       <ng-template #top>
-        <span nz-icon nzType="vertical-align-top" nzTheme="outline"></span>
+        <nz-icon nzType="vertical-align-top" nzTheme="outline" />
       </ng-template>
     </div>
   `,

--- a/components/float-button/float-button.component.spec.ts
+++ b/components/float-button/float-button.component.spec.ts
@@ -97,7 +97,7 @@ describe('nz-float-button RTL', () => {
       (nzOnClick)="onClick($event)"
     ></nz-float-button>
     <ng-template #icon>
-      <span nz-icon nzType="question-circle" nzTheme="outline"></span>
+      <nz-icon nzType="question-circle" nzTheme="outline" />
     </ng-template>
     <ng-template #description>HELP</ng-template>
   `

--- a/components/form/demo/advanced-search.ts
+++ b/components/form/demo/advanced-search.ts
@@ -34,7 +34,7 @@ import { NzInputModule } from 'ng-zorro-antd/input';
           <button nz-button (click)="resetForm()">Clear</button>
           <a class="collapse" (click)="toggleCollapse()">
             Collapse
-            <span nz-icon [nzType]="isCollapse ? 'down' : 'up'"></span>
+            <nz-icon [nzType]="isCollapse ? 'down' : 'up'" />
           </a>
         </div>
       </div>

--- a/components/form/demo/dynamic-form-item.ts
+++ b/components/form/demo/dynamic-form-item.ts
@@ -42,7 +42,7 @@ import { NzInputModule } from 'ng-zorro-antd/input';
       <nz-form-item>
         <nz-form-control [nzXs]="{ span: 24, offset: 0 }" [nzSm]="{ span: 20, offset: 4 }">
           <button nz-button nzType="dashed" class="add-button" (click)="addField($event)">
-            <span nz-icon nzType="plus"></span>
+            <nz-icon nzType="plus" />
             Add field
           </button>
         </nz-form-control>

--- a/components/form/form-label.component.ts
+++ b/components/form/form-label.component.ts
@@ -47,7 +47,7 @@ function toTooltipIcon(value: string | NzFormTooltipIcon): Required<NzFormToolti
       @if (nzTooltipTitle) {
         <span class="ant-form-item-tooltip" nz-tooltip [nzTooltipTitle]="nzTooltipTitle">
           <ng-container *nzStringTemplateOutlet="tooltipIcon.type; let tooltipIconType">
-            <span nz-icon [nzType]="tooltipIconType" [nzTheme]="tooltipIcon.theme"></span>
+            <nz-icon [nzType]="tooltipIconType" [nzTheme]="tooltipIcon.theme" />
           </ng-container>
         </span>
       }

--- a/components/hash-code/hash-code.component.ts
+++ b/components/hash-code/hash-code.component.ts
@@ -30,7 +30,7 @@ import { NzModeType } from './typings';
       <div class="ant-hashCode-header">
         <div class="ant-hashCode-header-title">{{ nzTitle }}</div>
         <div class="ant-hashCode-header-copy" (click)="copyHandle()">
-          <span nz-icon nzType="copy" nzTheme="outline"></span>
+          <nz-icon nzType="copy" nzTheme="outline" />
         </div>
         <div class="ant-hashCode-header-logo">
           <ng-template [nzStringTemplateOutlet]="nzLogo">{{ nzLogo }}</ng-template>
@@ -40,7 +40,7 @@ import { NzModeType } from './typings';
 
     @if (nzMode === 'single' || nzMode === 'rect') {
       <div class="ant-hashCode-header-copy" (click)="copyHandle()">
-        <span nz-icon nzType="copy" nzTheme="outline"></span>
+        <nz-icon nzType="copy" nzTheme="outline" />
       </div>
     }
 

--- a/components/icon/icon.directive.ts
+++ b/components/icon/icon.directive.ts
@@ -11,7 +11,6 @@ import {
   NgZone,
   OnChanges,
   OnDestroy,
-  OnInit,
   Renderer2,
   SimpleChanges,
   booleanAttribute,
@@ -31,10 +30,10 @@ import { NzIconPatchService, NzIconService } from './icon.service';
   selector: 'nz-icon,[nz-icon]',
   exportAs: 'nzIcon',
   host: {
-    '[class.anticon]': 'true'
+    class: 'anticon'
   }
 })
-export class NzIconDirective extends IconDirective implements OnInit, OnChanges, AfterContentChecked, OnDestroy {
+export class NzIconDirective extends IconDirective implements OnChanges, AfterContentChecked, OnDestroy {
   cacheClassName: string | null = null;
   @Input({ transform: booleanAttribute })
   set nzSpin(value: boolean) {
@@ -97,10 +96,6 @@ export class NzIconDirective extends IconDirective implements OnInit, OnChanges,
     } else {
       this._setSVGElement(this.iconService.createIconfontIcon(`#${this.iconfont}`));
     }
-  }
-
-  ngOnInit(): void {
-    this.renderer.setAttribute(this.el, 'class', `anticon ${this.el.className}`.trim());
   }
 
   /**

--- a/components/image/image-preview.component.ts
+++ b/components/image/image-preview.component.ts
@@ -65,14 +65,14 @@ const NZ_DEFAULT_ROTATE = 0;
           [class.ant-image-preview-switch-left-disabled]="index <= 0"
           (click)="onSwitchLeft($event)"
         >
-          <span nz-icon nzType="left" nzTheme="outline"></span>
+          <nz-icon nzType="left" nzTheme="outline" />
         </div>
         <div
           class="ant-image-preview-switch-right"
           [class.ant-image-preview-switch-right-disabled]="index >= images.length - 1"
           (click)="onSwitchRight($event)"
         >
-          <span nz-icon nzType="right" nzTheme="outline"></span>
+          <nz-icon nzType="right" nzTheme="outline" />
         </div>
       }
 

--- a/components/input-number-legacy/demo/group.ts
+++ b/components/input-number-legacy/demo/group.ts
@@ -42,7 +42,7 @@ import { NzSpaceModule } from 'ng-zorro-antd/space';
       <nz-input-number-group *nzSpaceItem nzCompact>
         <nz-input-number [ngModel]="1234" [nzStep]="1" style="width: calc(100% - 200px)"></nz-input-number>
         <button nz-button>
-          <span nz-icon nzType="copy" nzTheme="outline"></span>
+          <nz-icon nzType="copy" nzTheme="outline" />
         </button>
       </nz-input-number-group>
       <nz-input-number-group *nzSpaceItem nzCompact>

--- a/components/input-number-legacy/input-number-group-slot.component.ts
+++ b/components/input-number-legacy/input-number-group-slot.component.ts
@@ -18,7 +18,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (icon) {
-      <span nz-icon [nzType]="icon"></span>
+      <nz-icon [nzType]="icon" />
     }
     <ng-container *nzStringTemplateOutlet="template">{{ template }}</ng-container>
     <ng-content></ng-content>

--- a/components/input-number-legacy/input-number-group.spec.ts
+++ b/components/input-number-legacy/input-number-group.spec.ts
@@ -419,7 +419,7 @@ export class NzTestInputNumberGroupMixComponent {}
         <nz-input-number />
       </nz-input-number-group>
       <ng-template #prefixTemplateClock>
-        <span nz-icon nzType="clock-circle" nzTheme="outline"></span>
+        <nz-icon nzType="clock-circle" nzTheme="outline" />
       </ng-template>
     } @else {
       <nz-input-number-group nzAddOnAfterIcon="setting" [nzStatus]="status">

--- a/components/input-number-legacy/input-number.component.ts
+++ b/components/input-number-legacy/input-number.component.ts
@@ -63,7 +63,7 @@ import { NZ_SPACE_COMPACT_ITEM_TYPE, NZ_SPACE_COMPACT_SIZE, NzSpaceCompactItemDi
         (mousedown)="up($event)"
         [class.ant-input-number-handler-up-disabled]="disabledUp"
       >
-        <span nz-icon nzType="up" class="ant-input-number-handler-up-inner"></span>
+        <nz-icon nzType="up" class="ant-input-number-handler-up-inner" />
       </span>
       <span
         #downHandler
@@ -72,7 +72,7 @@ import { NZ_SPACE_COMPACT_ITEM_TYPE, NZ_SPACE_COMPACT_SIZE, NzSpaceCompactItemDi
         (mousedown)="down($event)"
         [class.ant-input-number-handler-down-disabled]="disabledDown"
       >
-        <span nz-icon nzType="down" class="ant-input-number-handler-down-inner"></span>
+        <nz-icon nzType="down" class="ant-input-number-handler-down-inner" />
       </span>
     </div>
     <div class="ant-input-number-input-wrap">

--- a/components/input/demo/presuffix.ts
+++ b/components/input/demo/presuffix.ts
@@ -11,9 +11,9 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
     <nz-input-group [nzSuffix]="suffixTemplateInfo" [nzPrefix]="prefixTemplateUser">
       <input type="text" nz-input placeholder="Enter your username" />
     </nz-input-group>
-    <ng-template #prefixTemplateUser><span nz-icon nzType="user"></span></ng-template>
+    <ng-template #prefixTemplateUser><nz-icon nzType="user" /></ng-template>
     <ng-template #suffixTemplateInfo>
-      <span nz-icon nz-tooltip nzTooltipTitle="Extra information" nzType="info-circle"></span>
+      <nz-icon nz-tooltip nzTooltipTitle="Extra information" nzType="info-circle" />
     </ng-template>
     <br />
     <br />

--- a/components/input/demo/search-input.ts
+++ b/components/input/demo/search-input.ts
@@ -13,7 +13,7 @@ import { NzInputModule } from 'ng-zorro-antd/input';
       <input type="text" nz-input placeholder="input search text" />
     </nz-input-group>
     <ng-template #suffixIconSearch>
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
     </ng-template>
     <br />
     <br />
@@ -21,7 +21,7 @@ import { NzInputModule } from 'ng-zorro-antd/input';
       <input type="text" nz-input placeholder="input search text" />
     </nz-input-group>
     <ng-template #suffixIconButton>
-      <button nz-button nzType="primary" nzSearch><span nz-icon nzType="search"></span></button>
+      <button nz-button nzType="primary" nzSearch><nz-icon nzType="search" /></button>
     </ng-template>
     <br />
     <br />

--- a/components/input/demo/status.ts
+++ b/components/input/demo/status.ts
@@ -19,7 +19,7 @@ import { NzSpaceModule } from 'ng-zorro-antd/space';
         <input type="text" nz-input placeholder="Warning with prefix" />
       </nz-input-group>
       <ng-template #prefixTemplateClock>
-        <span nz-icon nzType="clock-circle" nzTheme="outline"></span>
+        <nz-icon nzType="clock-circle" nzTheme="outline" />
       </ng-template>
     </nz-space>
   `

--- a/components/input/input-group-slot.component.ts
+++ b/components/input/input-group-slot.component.ts
@@ -15,7 +15,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (icon) {
-      <span nz-icon [nzType]="icon"></span>
+      <nz-icon [nzType]="icon" />
     }
     <ng-container *nzStringTemplateOutlet="template">{{ template }}</ng-container>
     <ng-content></ng-content>

--- a/components/input/input-group.spec.ts
+++ b/components/input/input-group.spec.ts
@@ -398,7 +398,7 @@ export class NzTestInputGroupColComponent {}
         <input type="text" nz-input />
       </nz-input-group>
       <ng-template #prefixTemplateClock>
-        <span nz-icon nzType="clock-circle" nzTheme="outline"></span>
+        <nz-icon nzType="clock-circle" nzTheme="outline" />
       </ng-template>
     } @else {
       <nz-input-group nzAddOnAfterIcon="setting" [nzStatus]="status">

--- a/components/layout/demo/custom-trigger.ts
+++ b/components/layout/demo/custom-trigger.ts
@@ -27,7 +27,7 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
             </ul>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="file"></span>
+            <nz-icon nzType="file" />
             <span>File</span>
           </li>
         </ul>

--- a/components/layout/demo/fixed-sider.ts
+++ b/components/layout/demo/fixed-sider.ts
@@ -13,35 +13,35 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
         <div class="logo"></div>
         <ul nz-menu nzTheme="dark" nzMode="inline">
           <li nz-menu-item>
-            <span nz-icon nzType="file"></span>
+            <nz-icon nzType="file" />
             <span>nav 1</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="video-camera"></span>
+            <nz-icon nzType="video-camera" />
             <span>nav 2</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="upload"></span>
+            <nz-icon nzType="upload" />
             <span>nav 3</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="bar-chart"></span>
+            <nz-icon nzType="bar-chart" />
             <span>nav 4</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="cloud-o"></span>
+            <nz-icon nzType="cloud-o" />
             <span>nav 5</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="appstore-o"></span>
+            <nz-icon nzType="appstore-o" />
             <span>nav 6</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="team"></span>
+            <nz-icon nzType="team" />
             <span>nav 7</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="shop"></span>
+            <nz-icon nzType="shop" />
             <span>nav 8</span>
           </li>
         </ul>

--- a/components/layout/demo/responsive.ts
+++ b/components/layout/demo/responsive.ts
@@ -13,19 +13,19 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
         <div class="logo"></div>
         <ul nz-menu nzTheme="dark" nzMode="inline">
           <li nz-menu-item>
-            <span nz-icon nzType="user"></span>
+            <nz-icon nzType="user" />
             <span>nav 1</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="video-camera"></span>
+            <nz-icon nzType="video-camera" />
             <span>nav 2</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="upload"></span>
+            <nz-icon nzType="upload" />
             <span>nav 3</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="user"></span>
+            <nz-icon nzType="user" />
             <span>nav 4</span>
           </li>
         </ul>

--- a/components/layout/demo/side.ts
+++ b/components/layout/demo/side.ts
@@ -14,11 +14,11 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
         <div class="logo"></div>
         <ul nz-menu nzTheme="dark" nzMode="inline">
           <li nz-menu-item>
-            <span nz-icon nzType="pie-chart"></span>
+            <nz-icon nzType="pie-chart" />
             <span>Option 1</span>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="desktop"></span>
+            <nz-icon nzType="desktop" />
             <span>Option 2</span>
           </li>
           <li nz-submenu nzTitle="User" nzIcon="user">
@@ -35,7 +35,7 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
             </ul>
           </li>
           <li nz-menu-item>
-            <span nz-icon nzType="file"></span>
+            <nz-icon nzType="file" />
             <span>File</span>
           </li>
         </ul>

--- a/components/layout/layout.spec.ts
+++ b/components/layout/layout.spec.ts
@@ -255,7 +255,7 @@ describe('nz-layout', () => {
       </nz-layout>
     </nz-layout>
     <ng-template #trigger>
-      <span nz-icon nzType="up"></span>
+      <nz-icon nzType="up" />
     </ng-template>
   `
 })
@@ -316,7 +316,7 @@ export class NzLayoutSideComponent {
       </nz-layout>
     </nz-layout>
     <ng-template #zeroTrigger>
-      <span nz-icon nzType="menu-fold" nzTheme="outline"></span>
+      <nz-icon nzType="menu-fold" nzTheme="outline" />
     </ng-template>
   `
 })

--- a/components/layout/sider-trigger.component.ts
+++ b/components/layout/sider-trigger.component.ts
@@ -33,13 +33,13 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     }
     <ng-template #defaultTrigger>
       @if (nzReverseArrow) {
-        <span nz-icon [nzType]="nzCollapsed ? 'left' : 'right'"></span>
+        <nz-icon [nzType]="nzCollapsed ? 'left' : 'right'" />
       } @else {
-        <span nz-icon [nzType]="nzCollapsed ? 'right' : 'left'"></span>
+        <nz-icon [nzType]="nzCollapsed ? 'right' : 'left'" />
       }
     </ng-template>
     <ng-template #defaultZeroTrigger>
-      <span nz-icon nzType="bars"></span>
+      <nz-icon nzType="bars" />
     </ng-template>
   `,
   host: {

--- a/components/list/demo/vertical.ts
+++ b/components/list/demo/vertical.ts
@@ -30,15 +30,15 @@ interface ItemData {
           {{ item.content }}
           <ul nz-list-item-actions>
             <nz-list-item-action>
-              <span nz-icon nzType="star-o" style="margin-right: 8px;"></span>
+              <nz-icon nzType="star-o" style="margin-right: 8px;" />
               156
             </nz-list-item-action>
             <nz-list-item-action>
-              <span nz-icon nzType="star-o" style="margin-right: 8px;"></span>
+              <nz-icon nzType="star-o" style="margin-right: 8px;" />
               156
             </nz-list-item-action>
             <nz-list-item-action>
-              <span nz-icon nzType="star-o" style="margin-right: 8px;"></span>
+              <nz-icon nzType="star-o" style="margin-right: 8px;" />
               2
             </nz-list-item-action>
           </ul>

--- a/components/list/list.spec.ts
+++ b/components/list/list.spec.ts
@@ -327,7 +327,7 @@ class TestListWithTemplateComponent {
     <nz-list id="item-string">
       <nz-list-item [nzContent]="'content'" [nzActions]="[action]" [nzExtra]="extra" [nzNoFlex]="noFlex">
         <ng-template #action>
-          <span nz-icon nzType="star-o" style="margin-right: 8px;"></span>
+          <nz-icon nzType="star-o" style="margin-right: 8px;" />
           156
         </ng-template>
         <ng-template #extra>

--- a/components/mention/mention.component.ts
+++ b/components/mention/mention.component.ts
@@ -102,7 +102,7 @@ export type MentionPlacement = 'top' | 'bottom';
           @if (filteredSuggestions.length === 0) {
             <li class="ant-mentions-dropdown-menu-item ant-mentions-dropdown-menu-item-disabled">
               @if (nzLoading) {
-                <span><span nz-icon nzType="loading"></span></span>
+                <span><nz-icon nzType="loading" /></span>
               } @else {
                 <span>
                   <nz-embed-empty nzComponentName="select" [specificContent]="nzNotFoundContent!" />

--- a/components/menu/demo/horizontal.ts
+++ b/components/menu/demo/horizontal.ts
@@ -9,11 +9,11 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
   template: `
     <ul nz-menu nzMode="horizontal">
       <li nz-menu-item nzSelected>
-        <span nz-icon nzType="mail"></span>
+        <nz-icon nzType="mail" />
         Navigation One
       </li>
       <li nz-menu-item nzDisabled>
-        <span nz-icon nzType="appstore"></span>
+        <nz-icon nzType="appstore" />
         Navigation Two
       </li>
       <li nz-submenu nzTitle="Navigation Three - Submenu" nzIcon="setting">

--- a/components/menu/demo/inline-collapsed.ts
+++ b/components/menu/demo/inline-collapsed.ts
@@ -11,7 +11,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
   template: `
     <div class="wrapper">
       <button nz-button nzType="primary" (click)="toggleCollapsed()">
-        <span nz-icon [nzType]="isCollapsed ? 'menu-unfold' : 'menu-fold'"></span>
+        <nz-icon [nzType]="isCollapsed ? 'menu-unfold' : 'menu-fold'" />
       </button>
       <ul nz-menu nzMode="inline" nzTheme="dark" [nzInlineCollapsed]="isCollapsed">
         <li
@@ -21,7 +21,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
           [nzTooltipTitle]="isCollapsed ? 'Navigation One' : ''"
           nzSelected
         >
-          <span nz-icon nzType="mail"></span>
+          <nz-icon nzType="mail" />
           <span>Navigation One</span>
         </li>
         <li nz-submenu nzTitle="Navigation Two" nzIcon="appstore">

--- a/components/menu/demo/recursive.ts
+++ b/components/menu/demo/recursive.ts
@@ -20,7 +20,7 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
               [nzSelected]="menu.selected"
             >
               @if (menu.icon) {
-                <span nz-icon [nzType]="menu.icon"></span>
+                <nz-icon [nzType]="menu.icon" />
               }
               <span>{{ menu.title }}</span>
             </li>

--- a/components/menu/menu.spec.ts
+++ b/components/menu/menu.spec.ts
@@ -568,7 +568,7 @@ describe('menu', () => {
         [style.width.px]="width"
       >
         <span title>
-          <span nz-icon nzType="setting"></span>
+          <nz-icon nzType="setting" />
           Navigation Three - Submenu
         </span>
         <ul>
@@ -622,7 +622,7 @@ export class NzTestMenuHorizontalComponent {
     <ul nz-menu [nzMode]="'inline'" [nzInlineCollapsed]="collapse">
       <li nz-submenu [nzMenuClassName]="submenuClassName" [nzDisabled]="disabled">
         <span title>
-          <span nz-icon nzType="mail"></span>
+          <nz-icon nzType="mail" />
           Navigation One
         </span>
         <ul>
@@ -648,7 +648,7 @@ export class NzTestMenuInlineComponent {
       @for (l1 of menus; track l1) {
         <li nz-submenu>
           <span title>
-            <span nz-icon nzType="appstore"></span>
+            <nz-icon nzType="appstore" />
             {{ l1.text }}
           </span>
           <ul>
@@ -687,11 +687,11 @@ export class NzTestMenuNgForComponent {
   template: `
     <ul nz-menu nzMode="horizontal">
       <li nz-menu-item>
-        <span nz-icon nzType="mail"></span>
+        <nz-icon nzType="mail" />
         Navigation One
       </li>
       <li nz-menu-item nzDisabled>
-        <span nz-icon nzType="appstore"></span>
+        <nz-icon nzType="appstore" />
         Navigation Two
       </li>
       <li nz-submenu nzTitle="Navigation Three - Submenu" nzIcon="setting">
@@ -808,7 +808,7 @@ export class NzTestNgIfMenuComponent {
   template: `
     <ul nz-menu nzMode="inline" nzTheme="dark" nzInlineCollapsed>
       <li nz-menu-item>
-        <span nz-icon nzType="mail"></span>
+        <nz-icon nzType="mail" />
         <span>Navigation One</span>
       </li>
       <li nz-submenu nzTitle="Navigation Two" nzIcon="appstore">
@@ -827,11 +827,11 @@ export class NzTestSubMenuSelectedComponent {}
   template: `
     <div class="wrapper">
       <button nz-button nzType="primary" (click)="toggleCollapsed()">
-        <span nz-icon [nzType]="isCollapsed ? 'menu-unfold' : 'menu-fold'"></span>
+        <nz-icon [nzType]="isCollapsed ? 'menu-unfold' : 'menu-fold'" />
       </button>
       <ul nz-menu nzMode="inline" nzTheme="dark" [nzInlineCollapsed]="isCollapsed">
         <li nz-menu-item nzSelected>
-          <span nz-icon nzType="mail"></span>
+          <nz-icon nzType="mail" />
           <span>Navigation One</span>
         </li>
         <li nz-submenu nzTitle="Navigation Two" nzIcon="appstore">

--- a/components/menu/submenu-title.component.ts
+++ b/components/menu/submenu-title.component.ts
@@ -31,7 +31,7 @@ import { NzMenuModeType, NzSubmenuTrigger } from './menu.types';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (nzIcon) {
-      <span nz-icon [nzType]="nzIcon"></span>
+      <nz-icon [nzType]="nzIcon" />
     }
     <ng-container *nzStringTemplateOutlet="nzTitle">
       <span class="ant-menu-title-content">{{ nzTitle }}</span>
@@ -41,10 +41,10 @@ import { NzMenuModeType, NzSubmenuTrigger } from './menu.types';
       <span class="ant-dropdown-menu-submenu-expand-icon">
         @switch (dir) {
           @case ('rtl') {
-            <span nz-icon nzType="left" class="ant-dropdown-menu-submenu-arrow-icon"></span>
+            <nz-icon nzType="left" class="ant-dropdown-menu-submenu-arrow-icon" />
           }
           @default {
-            <span nz-icon nzType="right" class="ant-dropdown-menu-submenu-arrow-icon"></span>
+            <nz-icon nzType="right" class="ant-dropdown-menu-submenu-arrow-icon" />
           }
         }
       </span>

--- a/components/message/message.component.ts
+++ b/components/message/message.component.ts
@@ -41,19 +41,19 @@ import { NzMessageData } from './typings';
         <div class="ant-message-custom-content" [class]="'ant-message-' + instance.type">
           @switch (instance.type) {
             @case ('success') {
-              <span nz-icon nzType="check-circle"></span>
+              <nz-icon nzType="check-circle" />
             }
             @case ('info') {
-              <span nz-icon nzType="info-circle"></span>
+              <nz-icon nzType="info-circle" />
             }
             @case ('warning') {
-              <span nz-icon nzType="exclamation-circle"></span>
+              <nz-icon nzType="exclamation-circle" />
             }
             @case ('error') {
-              <span nz-icon nzType="close-circle"></span>
+              <nz-icon nzType="close-circle" />
             }
             @case ('loading') {
-              <span nz-icon nzType="loading"></span>
+              <nz-icon nzType="loading" />
             }
           }
           <ng-container *nzStringTemplateOutlet="instance.content">

--- a/components/modal/modal-close.component.ts
+++ b/components/modal/modal-close.component.ts
@@ -16,7 +16,7 @@ import { ModalOptions } from './modal-types';
   template: `
     <span class="ant-modal-close-x">
       <ng-container *nzStringTemplateOutlet="config.nzCloseIcon; let closeIcon">
-        <span nz-icon [nzType]="closeIcon" class="ant-modal-close-icon"></span>
+        <nz-icon [nzType]="closeIcon" class="ant-modal-close-icon" />
       </ng-container>
     </span>
   `,

--- a/components/modal/modal-confirm-container.component.ts
+++ b/components/modal/modal-confirm-container.component.ts
@@ -47,7 +47,7 @@ import { BaseModalContainerComponent } from './modal-container.directive';
         <div class="ant-modal-body" [style]="config.nzBodyStyle!">
           <div class="ant-modal-confirm-body-wrapper">
             <div class="ant-modal-confirm-body">
-              <span nz-icon [nzType]="config.nzIconType!"></span>
+              <nz-icon [nzType]="config.nzIconType!" />
               <span class="ant-modal-confirm-title">
                 <ng-container *nzStringTemplateOutlet="config.nzTitle">
                   <span [innerHTML]="config.nzTitle"></span>

--- a/components/notification/demo/custom-icon.ts
+++ b/components/notification/demo/custom-icon.ts
@@ -12,7 +12,7 @@ import { NzNotificationService } from 'ng-zorro-antd/notification';
       <div class="ant-notification-notice-content">
         <div class="ant-notification-notice-with-icon">
           <span class="ant-notification-notice-icon">
-            <span nz-icon nzType="smile" style="color: rgb(16, 142, 233);"></span>
+            <nz-icon nzType="smile" style="color: rgb(16, 142, 233);" />
           </span>
           <div class="ant-notification-notice-message">Notification Title</div>
           <div class="ant-notification-notice-description">

--- a/components/notification/demo/placement.ts
+++ b/components/notification/demo/placement.ts
@@ -10,29 +10,29 @@ import { NzNotificationPlacement, NzNotificationService } from 'ng-zorro-antd/no
   imports: [NzButtonModule, NzDividerModule, NzIconModule],
   template: `
     <button nz-button (click)="createNotification('top')" nzType="primary">
-      <span nz-icon nzType="border-top" nzTheme="outline"></span>
+      <nz-icon nzType="border-top" nzTheme="outline" />
       top
     </button>
     <button nz-button (click)="createNotification('bottom')" nzType="primary">
-      <span nz-icon nzType="border-bottom" nzTheme="outline"></span>
+      <nz-icon nzType="border-bottom" nzTheme="outline" />
       bottom
     </button>
     <nz-divider></nz-divider>
     <button nz-button (click)="createNotification('topLeft')" nzType="primary">
-      <span nz-icon nzType="radius-upleft"></span>
+      <nz-icon nzType="radius-upleft" />
       topLeft
     </button>
     <button nz-button (click)="createNotification('topRight')" nzType="primary">
-      <span nz-icon nzType="radius-upright"></span>
+      <nz-icon nzType="radius-upright" />
       topRight
     </button>
     <nz-divider></nz-divider>
     <button nz-button (click)="createNotification('bottomLeft')" nzType="primary">
-      <span nz-icon nzType="radius-bottomleft"></span>
+      <nz-icon nzType="radius-bottomleft" />
       bottomLeft
     </button>
     <button nz-button (click)="createNotification('bottomRight')" nzType="primary">
-      <span nz-icon nzType="radius-bottomright"></span>
+      <nz-icon nzType="radius-bottomright" />
       bottomRight
     </button>
   `,

--- a/components/notification/notification.component.ts
+++ b/components/notification/notification.component.ts
@@ -92,10 +92,10 @@ import { NzNotificationData } from './typings';
         <span class="ant-notification-notice-close-x">
           @if (instance.options?.nzCloseIcon) {
             <ng-container *nzStringTemplateOutlet="instance.options?.nzCloseIcon; let closeIcon">
-              <span nz-icon [nzType]="closeIcon"></span>
+              <nz-icon [nzType]="closeIcon" />
             </ng-container>
           } @else {
-            <span nz-icon nzType="close" class="ant-notification-close-icon"></span>
+            <nz-icon nzType="close" class="ant-notification-close-icon" />
           }
         </span>
       </a>

--- a/components/page-header/demo/content.ts
+++ b/components/page-header/demo/content.ts
@@ -67,7 +67,7 @@ import { NzTypographyModule } from 'ng-zorro-antd/typography';
             nzPlacement="bottomRight"
             style="border: none; padding: 0"
           >
-            <span nz-icon nzType="more" nzTheme="outline" style="font-size: 20px; vertical-align: top;"></span>
+            <nz-icon nzType="more" nzTheme="outline" style="font-size: 20px; vertical-align: top;" />
           </button>
         </nz-space>
         <nz-dropdown-menu #menu="nzDropdownMenu">

--- a/components/page-header/page-header.component.ts
+++ b/components/page-header/page-header.component.ts
@@ -47,7 +47,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'pageHeader';
           <div (click)="onBack()" class="ant-page-header-back">
             <div role="button" tabindex="0" class="ant-page-header-back-button">
               <ng-container *nzStringTemplateOutlet="nzBackIcon; let backIcon">
-                <span nz-icon [nzType]="backIcon || getBackIcon()" nzTheme="outline"></span>
+                <nz-icon [nzType]="backIcon || getBackIcon()" nzTheme="outline" />
               </ng-container>
             </div>
           </div>

--- a/components/page-header/page-header.spec.ts
+++ b/components/page-header/page-header.spec.ts
@@ -98,7 +98,7 @@ describe('NzPageHeaderComponent', () => {
     const fixture = TestBed.createComponent(NzDemoPageHeaderBasicComponent);
     const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
     fixture.detectChanges();
-    expect(pageHeader.nativeElement.querySelector('.ant-page-header-back span.anticon-arrow-left')).toBeTruthy();
+    expect(pageHeader.nativeElement.querySelector('.ant-page-header-back .anticon-arrow-left')).toBeTruthy();
   });
 
   it('should does not have an default back icon', () => {
@@ -147,7 +147,7 @@ describe('NzPageHeaderComponent', () => {
 
     it('should have an default back icon', () => {
       fixture.detectChanges();
-      expect(pageHeader.nativeElement.querySelector('.ant-page-header-back span.anticon-arrow-right')).toBeTruthy();
+      expect(pageHeader.nativeElement.querySelector('.ant-page-header-back .anticon-arrow-right')).toBeTruthy();
     });
   });
 });

--- a/components/pagination/pagination-item.component.ts
+++ b/components/pagination/pagination-item.component.ts
@@ -22,11 +22,11 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { PaginationItemRenderContext, PaginationItemType } from './pagination.types';
 
 @Component({
-    selector: 'li[nz-pagination-item]',
-    preserveWhitespaces: false,
-    encapsulation: ViewEncapsulation.None,
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    template: `
+  selector: 'li[nz-pagination-item]',
+  preserveWhitespaces: false,
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
     <ng-template #renderItemTemplate let-type let-page="page">
       @switch (type) {
         @case ('page') {
@@ -35,18 +35,18 @@ import { PaginationItemRenderContext, PaginationItemType } from './pagination.ty
         @case ('prev') {
           <button type="button" [disabled]="disabled" [attr.title]="locale.prev_page" class="ant-pagination-item-link">
             @if (direction === 'rtl') {
-              <span nz-icon nzType="right"></span>
+              <nz-icon nzType="right" />
             } @else {
-              <span nz-icon nzType="left"></span>
+              <nz-icon nzType="left" />
             }
           </button>
         }
         @case ('next') {
           <button type="button" [disabled]="disabled" [attr.title]="locale.next_page" class="ant-pagination-item-link">
             @if (direction === 'rtl') {
-              <span nz-icon nzType="left"></span>
+              <nz-icon nzType="left" />
             } @else {
-              <span nz-icon nzType="right"></span>
+              <nz-icon nzType="right" />
             }
           </button>
         }
@@ -62,7 +62,7 @@ import { PaginationItemRenderContext, PaginationItemType } from './pagination.ty
                       class="ant-pagination-item-link-icon"
                     ></span>
                   } @else {
-                    <span nz-icon nzType="double-left" class="ant-pagination-item-link-icon"></span>
+                    <nz-icon nzType="double-left" class="ant-pagination-item-link-icon" />
                   }
                 }
                 @case ('next_5') {
@@ -70,7 +70,7 @@ import { PaginationItemRenderContext, PaginationItemType } from './pagination.ty
                     <span nz-icon nzType="double-left"
                           class="ant-pagination-item-link-icon"></span>
                   } @else {
-                    <span nz-icon nzType="double-right" class="ant-pagination-item-link-icon"></span>
+                    <nz-icon nzType="double-right" class="ant-pagination-item-link-icon" />
                   }
                 }
               }
@@ -85,20 +85,20 @@ import { PaginationItemRenderContext, PaginationItemType } from './pagination.ty
       [ngTemplateOutletContext]="{ $implicit: type, page: index }"
     />
   `,
-    host: {
-        '[class.ant-pagination-prev]': `type === 'prev'`,
-        '[class.ant-pagination-next]': `type === 'next'`,
-        '[class.ant-pagination-item]': `type === 'page'`,
-        '[class.ant-pagination-jump-prev]': `type === 'prev_5'`,
-        '[class.ant-pagination-jump-prev-custom-icon]': `type === 'prev_5'`,
-        '[class.ant-pagination-jump-next]': `type === 'next_5'`,
-        '[class.ant-pagination-jump-next-custom-icon]': `type === 'next_5'`,
-        '[class.ant-pagination-disabled]': 'disabled',
-        '[class.ant-pagination-item-active]': 'active',
-        '[attr.title]': 'title',
-        '(click)': 'clickItem()'
-    },
-    imports: [NzIconModule, NgTemplateOutlet]
+  host: {
+    '[class.ant-pagination-prev]': `type === 'prev'`,
+    '[class.ant-pagination-next]': `type === 'next'`,
+    '[class.ant-pagination-item]': `type === 'page'`,
+    '[class.ant-pagination-jump-prev]': `type === 'prev_5'`,
+    '[class.ant-pagination-jump-prev-custom-icon]': `type === 'prev_5'`,
+    '[class.ant-pagination-jump-next]': `type === 'next_5'`,
+    '[class.ant-pagination-jump-next-custom-icon]': `type === 'next_5'`,
+    '[class.ant-pagination-disabled]': 'disabled',
+    '[class.ant-pagination-item-active]': 'active',
+    '[attr.title]': 'title',
+    '(click)': 'clickItem()'
+  },
+  imports: [NzIconModule, NgTemplateOutlet]
 })
 export class NzPaginationItemComponent implements OnChanges {
   @Input() active = false;

--- a/components/popconfirm/demo/custom-icon.ts
+++ b/components/popconfirm/demo/custom-icon.ts
@@ -9,7 +9,7 @@ import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
   template: `
     <a nz-popconfirm nzPopconfirmTitle="Are you sure?" [nzIcon]="iconTpl">Delete</a>
     <ng-template #iconTpl>
-      <span nz-icon nzType="question-circle-o" style="color: red;"></span>
+      <nz-icon nzType="question-circle-o" style="color: red;" />
     </ng-template>
   `
 })

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -164,7 +164,7 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
                   <ng-container *nzStringTemplateOutlet="nzTitle; context: nzTitleContext">
                     <ng-container *nzStringTemplateOutlet="nzIcon; let icon">
                       <span class="ant-popover-message-icon">
-                        <span nz-icon [nzType]="icon || 'exclamation-circle'" nzTheme="fill"></span>
+                        <nz-icon [nzType]="icon || 'exclamation-circle'" nzTheme="fill" />
                       </span>
                     </ng-container>
                     <div class="ant-popover-message-title">{{ nzTitle }}</div>

--- a/components/popover/demo/template.ts
+++ b/components/popover/demo/template.ts
@@ -12,11 +12,11 @@ import { NzPopoverModule } from 'ng-zorro-antd/popover';
       Render Template
     </button>
     <ng-template #titleTemplate>
-      <span nz-icon nzType="close"></span>
+      <nz-icon nzType="close" />
       Title
     </ng-template>
     <ng-template #contentTemplate>
-      <span nz-icon nzType="check"></span>
+      <nz-icon nzType="check" />
       Content
     </ng-template>
   `

--- a/components/progress/demo/circle-dynamic.ts
+++ b/components/progress/demo/circle-dynamic.ts
@@ -10,8 +10,8 @@ import { NzProgressModule } from 'ng-zorro-antd/progress';
   template: `
     <nz-progress [nzPercent]="percent" nzType="circle"></nz-progress>
     <nz-button-group>
-      <button nz-button (click)="decline()"><span nz-icon nzType="minus"></span></button>
-      <button nz-button (click)="increase()"><span nz-icon nzType="plus"></span></button>
+      <button nz-button (click)="decline()"><nz-icon nzType="minus" /></button>
+      <button nz-button (click)="increase()"><nz-icon nzType="plus" /></button>
     </nz-button-group>
   `,
   styles: [

--- a/components/progress/demo/dynamic.ts
+++ b/components/progress/demo/dynamic.ts
@@ -10,8 +10,8 @@ import { NzProgressModule } from 'ng-zorro-antd/progress';
   template: `
     <nz-progress [nzPercent]="percent"></nz-progress>
     <nz-button-group>
-      <button nz-button (click)="decline()"><span nz-icon nzType="minus"></span></button>
-      <button nz-button (click)="increase()"><span nz-icon nzType="plus"></span></button>
+      <button nz-button (click)="decline()"><nz-icon nzType="minus" /></button>
+      <button nz-button (click)="increase()"><nz-icon nzType="plus" /></button>
     </nz-button-group>
   `
 })

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -66,7 +66,7 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
       @if (nzShowInfo) {
         <span class="ant-progress-text">
           @if ((status === 'exception' || status === 'success') && !nzFormat) {
-            <span nz-icon [nzType]="icon"></span>
+            <nz-icon [nzType]="icon" />
           } @else {
             <ng-container *nzStringTemplateOutlet="formatter; context: { $implicit: nzPercent }; let formatter">
               {{ formatter(nzPercent) }}

--- a/components/qr-code/demo/custom-status.ts
+++ b/components/qr-code/demo/custom-status.ts
@@ -11,7 +11,7 @@ import { NzQRCodeModule } from 'ng-zorro-antd/qr-code';
     <nz-qrcode nzValue="https://ng.ant.design/" [nzStatusRender]="customTemplate"></nz-qrcode>
     <ng-template #customTemplate>
       <div>
-        <span nz-icon nzType="check-circle" nzTheme="outline" style="color: red"></span>
+        <nz-icon nzType="check-circle" nzTheme="outline" style="color: red" />
         success
       </div>
     </ng-template>

--- a/components/qr-code/qrcode.component.ts
+++ b/components/qr-code/qrcode.component.ts
@@ -54,7 +54,7 @@ import { drawCanvas, ERROR_LEVEL_MAP, plotQRCodeData } from './qrcode';
             <div>
               <p class="ant-qrcode-expired">{{ locale.expired }}</p>
               <button nz-button nzType="link" (click)="reloadQRCode()">
-                <span nz-icon nzType="reload" nzTheme="outline"></span>
+                <nz-icon nzType="reload" nzTheme="outline" />
                 <span>{{ locale.refresh }}</span>
               </button>
             </div>

--- a/components/rate/demo/character.ts
+++ b/components/rate/demo/character.ts
@@ -13,7 +13,7 @@ import { NzRateModule } from 'ng-zorro-antd/rate';
     <nz-rate [ngModel]="0" nzAllowHalf class="large" [nzCharacter]="characterEnLetter"></nz-rate>
     <br />
     <nz-rate [ngModel]="0" nzAllowHalf [nzCharacter]="characterZhLetter"></nz-rate>
-    <ng-template #characterIcon><span nz-icon nzType="heart"></span></ng-template>
+    <ng-template #characterIcon><nz-icon nzType="heart" /></ng-template>
     <ng-template #characterZhLetter>好</ng-template>
     <ng-template #characterEnLetter>A</ng-template>
   `,

--- a/components/rate/demo/customize.ts
+++ b/components/rate/demo/customize.ts
@@ -18,19 +18,19 @@ import { NzRateModule } from 'ng-zorro-antd/rate';
     <ng-template #characterIcon let-index>
       @switch (index) {
         @case (0) {
-          <span nz-icon nzType="frown"></span>
+          <nz-icon nzType="frown" />
         }
         @case (1) {
-          <span nz-icon nzType="frown"></span>
+          <nz-icon nzType="frown" />
         }
         @case (2) {
-          <span nz-icon nzType="meh"></span>
+          <nz-icon nzType="meh" />
         }
         @case (3) {
-          <span nz-icon nzType="smile"></span>
+          <nz-icon nzType="smile" />
         }
         @case (4) {
-          <span nz-icon nzType="smile"></span>
+          <nz-icon nzType="smile" />
         }
       }
     </ng-template>

--- a/components/rate/rate-item.component.ts
+++ b/components/rate/rate-item.component.ts
@@ -41,7 +41,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     </div>
 
     <ng-template #defaultCharacter>
-      <span nz-icon nzType="star" nzTheme="fill"></span>
+      <nz-icon nzType="star" nzTheme="fill" />
     </ng-template>
   `,
   imports: [NgTemplateOutlet, NzIconModule]

--- a/components/result/demo/error.ts
+++ b/components/result/demo/error.ts
@@ -18,12 +18,12 @@ import { NzTypographyModule } from 'ng-zorro-antd/typography';
         <div class="desc">
           <h4 nz-title>The content you submitted has the following error:</h4>
           <p nz-paragraph>
-            <span nz-icon nzType="close-circle"></span>
+            <nz-icon nzType="close-circle" />
             Your account has been frozen
             <a>Thaw immediately &gt;</a>
           </p>
           <p nz-paragraph>
-            <span nz-icon nzType="close-circle"></span>
+            <nz-icon nzType="close-circle" />
             Your account is not yet eligible to apply
             <a>Apply immediately &gt;</a>
           </p>

--- a/components/result/result.component.ts
+++ b/components/result/result.component.ts
@@ -47,7 +47,7 @@ const ExceptionStatus = ['404', '500', '403'];
       @if (!isException) {
         @if (icon) {
           <ng-container *nzStringTemplateOutlet="icon; let icon">
-            <span nz-icon [nzType]="icon" nzTheme="fill"></span>
+            <nz-icon [nzType]="icon" nzTheme="fill" />
           </ng-container>
         } @else {
           <ng-content select="[nz-result-icon]"></ng-content>

--- a/components/result/result.spec.ts
+++ b/components/result/result.spec.ts
@@ -14,7 +14,7 @@ import { NzResultModule } from './result.module';
   imports: [NzIconModule, NzResultModule],
   template: `
     <nz-result [nzIcon]="icon" [nzStatus]="status" [nzTitle]="title" [nzSubTitle]="subtitle" [nzExtra]="extra">
-      <span nz-icon nz-result-icon nzType="up" nzTheme="outline"></span>
+      <nz-icon nz-result-icon nzType="up" nzTheme="outline" />
       <div nz-result-title>Content Title</div>
       <div nz-result-subtitle>Content SubTitle</div>
       <div nz-result-content>Content</div>

--- a/components/segmented/segmented-item.component.ts
+++ b/components/segmented/segmented-item.component.ts
@@ -28,7 +28,7 @@ import { NzSegmentedService } from './segmented.service';
     <input class="ant-segmented-item-input" type="radio" [checked]="isChecked" (click)="$event.stopPropagation()" />
     <div class="ant-segmented-item-label">
       @if (nzIcon) {
-        <span class="ant-segmented-item-icon"><span nz-icon [nzType]="nzIcon"></span></span>
+        <span class="ant-segmented-item-icon"><nz-icon [nzType]="nzIcon" /></span>
         <span>
           <ng-template [ngTemplateOutlet]="content" />
         </span>

--- a/components/select/demo/custom-content.ts
+++ b/components/select/demo/custom-content.ts
@@ -10,15 +10,15 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
   template: `
     <nz-select nzShowSearch nzAllowClear nzPlaceHolder="Select OS" [(ngModel)]="selectedValue">
       <nz-option nzCustomContent nzLabel="Windows" nzValue="windows">
-        <span nz-icon nzType="windows"></span>
+        <nz-icon nzType="windows" />
         Windows
       </nz-option>
       <nz-option nzCustomContent nzLabel="Mac" nzValue="mac">
-        <span nz-icon nzType="apple"></span>
+        <nz-icon nzType="apple" />
         Mac
       </nz-option>
       <nz-option nzCustomContent nzLabel="Android" nzValue="android">
-        <span nz-icon nzType="android"></span>
+        <nz-icon nzType="android" />
         Android
       </nz-option>
     </nz-select>

--- a/components/select/demo/custom-dropdown-menu.ts
+++ b/components/select/demo/custom-dropdown-menu.ts
@@ -19,7 +19,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
       <div class="container">
         <input type="text" nz-input #inputElement />
         <a class="add-item" (click)="addItem(inputElement)">
-          <span nz-icon nzType="plus"></span>
+          <nz-icon nzType="plus" />
           Add item
         </a>
       </div>

--- a/components/select/demo/custom-template.ts
+++ b/components/select/demo/custom-template.ts
@@ -13,7 +13,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
       <nz-option nzLabel="Android" nzValue="android"></nz-option>
     </nz-select>
     <ng-template #defaultTemplate let-selected>
-      <span nz-icon [nzType]="selected.nzValue"></span>
+      <nz-icon [nzType]="selected.nzValue" />
       {{ selected.nzLabel }}
     </ng-template>
     <br />
@@ -25,7 +25,7 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
     </nz-select>
     <ng-template #multipleTemplate let-selected>
       <div class="ant-select-selection-item-content">
-        <span nz-icon [nzType]="selected.nzValue"></span>
+        <nz-icon [nzType]="selected.nzValue" />
         {{ selected.nzLabel }}
       </div>
     </ng-template>

--- a/components/select/demo/select-users.ts
+++ b/components/select/demo/select-users.ts
@@ -32,7 +32,7 @@ interface MockUser {
         }
       } @else {
         <nz-option nzDisabled nzCustomContent>
-          <span nz-icon nzType="loading" class="loading-icon"></span>
+          <nz-icon nzType="loading" class="loading-icon" />
           Loading Data...
         </nz-option>
       }

--- a/components/select/option-item.component.ts
+++ b/components/select/option-item.component.ts
@@ -39,7 +39,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     @if (showState && selected) {
       <div class="ant-select-item-option-state" unselectable="on">
         @if (!icon) {
-          <span nz-icon nzType="check" class="ant-select-selected-icon"></span>
+          <nz-icon nzType="check" class="ant-select-selected-icon" />
         } @else {
           <ng-template [ngTemplateOutlet]="icon"></ng-template>
         }

--- a/components/select/select-arrow.component.ts
+++ b/components/select/select-arrow.component.ts
@@ -25,18 +25,18 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       <span>{{ listOfValue.length }} / {{ nzMaxMultipleCount }}</span>
     }
     @if (loading) {
-      <span nz-icon nzType="loading"></span>
+      <nz-icon nzType="loading" />
     } @else {
       @if (showArrow && !suffixIcon) {
         @if (search) {
-          <span nz-icon nzType="search"></span>
+          <nz-icon nzType="search" />
         } @else {
-          <span nz-icon nzType="down"></span>
+          <nz-icon nzType="down" />
         }
       } @else {
         <ng-container *nzStringTemplateOutlet="suffixIcon; let suffixIcon">
           @if (suffixIcon) {
-            <span nz-icon [nzType]="suffixIcon"></span>
+            <nz-icon [nzType]="suffixIcon" />
           }
         </ng-container>
       }

--- a/components/select/select-clear.component.ts
+++ b/components/select/select-clear.component.ts
@@ -25,7 +25,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     @if (clearIcon) {
       <ng-template [ngTemplateOutlet]="clearIcon"></ng-template>
     } @else {
-      <span nz-icon nzType="close-circle" nzTheme="fill" class="ant-select-close-icon"></span>
+      <nz-icon nzType="close-circle" nzTheme="fill" class="ant-select-close-icon" />
     }
   `,
   host: {

--- a/components/select/select-item.component.ts
+++ b/components/select/select-item.component.ts
@@ -33,7 +33,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     @if (deletable && !disabled) {
       <span class="ant-select-selection-item-remove" (click)="onDelete($event)">
         @if (!removeIcon) {
-          <span nz-icon nzType="close"></span>
+          <nz-icon nzType="close" />
         } @else {
           <ng-template [ngTemplateOutlet]="removeIcon"></ng-template>
         }

--- a/components/skeleton/demo/list.ts
+++ b/components/skeleton/demo/list.ts
@@ -20,15 +20,15 @@ import { NzSwitchModule } from 'ng-zorro-antd/switch';
         >
           <nz-skeleton [nzLoading]="loading" [nzActive]="true" [nzAvatar]="true">
             <ng-template #starAction>
-              <span nz-icon nzType="star-o" style="margin-right: 8px;"></span>
+              <nz-icon nzType="star-o" style="margin-right: 8px;" />
               156
             </ng-template>
             <ng-template #likeAction>
-              <span nz-icon nzType="like-o" style="margin-right: 8px;"></span>
+              <nz-icon nzType="like-o" style="margin-right: 8px;" />
               156
             </ng-template>
             <ng-template #msgAction>
-              <span nz-icon nzType="message" style="margin-right: 8px;"></span>
+              <nz-icon nzType="message" style="margin-right: 8px;" />
               2
             </ng-template>
             <nz-list-item-meta [nzAvatar]="item.avatar" [nzTitle]="nzTitle" [nzDescription]="item.description">

--- a/components/slider/demo/icon-slider.ts
+++ b/components/slider/demo/icon-slider.ts
@@ -9,9 +9,9 @@ import { NzSliderModule } from 'ng-zorro-antd/slider';
   imports: [FormsModule, NzIconModule, NzSliderModule],
   template: `
     <div class="icon-wrapper test-class">
-      <span nz-icon nzType="frown" [class.icon-highlight]="preHighLight"></span>
+      <nz-icon nzType="frown" [class.icon-highlight]="preHighLight" />
       <nz-slider [nzMin]="0" [nzMax]="20" [(ngModel)]="sliderValue"></nz-slider>
-      <span nz-icon nzType="smile" [class.icon-highlight]="nextHighLight"></span>
+      <nz-icon nzType="smile" [class.icon-highlight]="nextHighLight" />
     </div>
   `,
   styles: [
@@ -21,7 +21,7 @@ import { NzSliderModule } from 'ng-zorro-antd/slider';
         padding: 0 30px;
       }
 
-      [nz-icon] {
+      nz-icon {
         position: absolute;
         top: -2px;
         width: 16px;
@@ -31,11 +31,11 @@ import { NzSliderModule } from 'ng-zorro-antd/slider';
         color: rgba(0, 0, 0, 0.25);
       }
 
-      [nz-icon]:first-child {
+      nz-icon:first-child {
         left: 0;
       }
 
-      [nz-icon]:last-child {
+      nz-icon:last-child {
         right: 0;
       }
 

--- a/components/space/demo/basic.ts
+++ b/components/space/demo/basic.ts
@@ -14,7 +14,7 @@ import { NzUploadModule } from 'ng-zorro-antd/upload';
       <button *nzSpaceItem nz-button nzType="primary">Button</button>
       <nz-upload *nzSpaceItem nzAction="https://www.mocky.io/v2/5cc8019d300000980a055e76">
         <button nz-button>
-          <span nz-icon nzType="upload"></span>
+          <nz-icon nzType="upload" />
           Click to Upload
         </button>
       </nz-upload>

--- a/components/space/demo/compact-buttons.ts
+++ b/components/space/demo/compact-buttons.ts
@@ -12,22 +12,22 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
   template: `
     <nz-space-compact nzBlock>
       <button nz-button nz-tooltip nzTooltipTitle="Like">
-        <span nz-icon nzType="like"></span>
+        <nz-icon nzType="like" />
       </button>
       <button nz-button nz-tooltip nzTooltipTitle="Comment">
-        <span nz-icon nzType="comment"></span>
+        <nz-icon nzType="comment" />
       </button>
       <button nz-button nz-tooltip nzTooltipTitle="Star">
-        <span nz-icon nzType="star"></span>
+        <nz-icon nzType="star" />
       </button>
       <button nz-button nz-tooltip nzTooltipTitle="Heart">
-        <span nz-icon nzType="heart"></span>
+        <nz-icon nzType="heart" />
       </button>
       <button nz-button nz-tooltip nzTooltipTitle="Share">
-        <span nz-icon nzType="share-alt"></span>
+        <nz-icon nzType="share-alt" />
       </button>
       <button nz-button nz-tooltip nzTooltipTitle="Download">
-        <span nz-icon nzType="download"></span>
+        <nz-icon nzType="download" />
       </button>
       <nz-dropdown-menu #menu>
         <ul nz-menu>
@@ -43,7 +43,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
         </ul>
       </nz-dropdown-menu>
       <button nz-button nz-dropdown [nzDropdownMenu]="menu">
-        <span nz-icon nzType="ellipsis"></span>
+        <nz-icon nzType="ellipsis" />
       </button>
     </nz-space-compact>
     <br />
@@ -53,10 +53,10 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
       <button nz-button nzType="primary">Button 3</button>
       <button nz-button nzType="primary">Button 4</button>
       <button nz-button nzType="primary" disabled nz-tooltip nzTooltipTitle="Tooltip">
-        <span nz-icon nzType="download"></span>
+        <nz-icon nzType="download" />
       </button>
       <button nz-button nzType="primary" nz-tooltip nzTooltipTitle="Tooltip">
-        <span nz-icon nzType="download"></span>
+        <nz-icon nzType="download" />
       </button>
     </nz-space-compact>
     <br />
@@ -65,10 +65,10 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
       <button nz-button>Button 2</button>
       <button nz-button>Button 3</button>
       <button nz-button disabled nz-tooltip nzTooltipTitle="Tooltip">
-        <span nz-icon nzType="download"></span>
+        <nz-icon nzType="download" />
       </button>
       <button nz-button nz-tooltip nzTooltipTitle="Tooltip">
-        <span nz-icon nzType="download"></span>
+        <nz-icon nzType="download" />
       </button>
       <button nz-button nzType="primary">Button 4</button>
       <nz-dropdown-menu #menu>
@@ -85,7 +85,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
         </ul>
       </nz-dropdown-menu>
       <button nz-button nzType="primary" nz-dropdown [nzDropdownMenu]="menu">
-        <span nz-icon nzType="ellipsis"></span>
+        <nz-icon nzType="ellipsis" />
       </button>
     </nz-space-compact>
   `

--- a/components/space/demo/compact.ts
+++ b/components/space/demo/compact.ts
@@ -50,7 +50,7 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
     <nz-space-compact nzBlock>
       <input nz-input value="git@github.com:NG-ZORRO/ng-zorro-antd.git" [style.width]="'calc(100% - 200px)'" />
       <button nz-button nz-tooltip nzTooltipTitle="copy git url">
-        <span nz-icon nzType="copy"></span>
+        <nz-icon nzType="copy" />
       </button>
     </nz-space-compact>
     <br />
@@ -67,7 +67,7 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
         <input nz-input value="0571" />
         <ng-template #addonTmpl>
           <button nz-button class="ant-input-search-button">
-            <span nz-icon nzType="search"></span>
+            <nz-icon nzType="search" />
           </button>
         </ng-template>
       </nz-input-group>
@@ -75,7 +75,7 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
         <input nz-input value="26888888" />
         <ng-template #addonTmpl>
           <button nz-button class="ant-input-search-button">
-            <span nz-icon nzType="search"></span>
+            <nz-icon nzType="search" />
           </button>
         </ng-template>
       </nz-input-group>
@@ -83,7 +83,7 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
         <input nz-input value="+1" />
         <ng-template #addonTmpl>
           <button nz-button class="ant-input-search-button">
-            <span nz-icon nzType="search"></span>
+            <nz-icon nzType="search" />
           </button>
         </ng-template>
       </nz-input-group>

--- a/components/spin/demo/custom-indicator.ts
+++ b/components/spin/demo/custom-indicator.ts
@@ -7,12 +7,12 @@ import { NzSpinModule } from 'ng-zorro-antd/spin';
   selector: 'nz-demo-spin-custom-indicator',
   imports: [NzIconModule, NzSpinModule],
   template: `
-    <ng-template #indicatorTemplate><span nz-icon nzType="loading"></span></ng-template>
+    <ng-template #indicatorTemplate><nz-icon nzType="loading" /></ng-template>
     <nz-spin nzSimple [nzIndicator]="indicatorTemplate"></nz-spin>
   `,
   styles: [
     `
-      span[nz-icon] {
+      nz-icon {
         font-size: 24px;
       }
     `

--- a/components/spin/spin.spec.ts
+++ b/components/spin/spin.spec.ts
@@ -153,7 +153,7 @@ describe('spin', () => {
   selector: 'nz-test-basic-spin',
   imports: [NzIconModule, NzSpinModule],
   template: `
-    <ng-template #indicatorTemplate><span nz-icon nzType="loading" style="font-size: 24px;"></span></ng-template>
+    <ng-template #indicatorTemplate><nz-icon nzType="loading" style="font-size: 24px;" /></ng-template>
     <nz-spin
       [nzTip]="tip"
       [nzSize]="size"

--- a/components/statistic/demo/card.ts
+++ b/components/statistic/demo/card.ts
@@ -21,7 +21,7 @@ import { NzStatisticModule } from 'ng-zorro-antd/statistic';
               nzSuffix="%"
               [nzValueStyle]="{ color: '#3F8600' }"
             ></nz-statistic>
-            <ng-template #prefixTplOne><span nz-icon nzType="arrow-up"></span></ng-template>
+            <ng-template #prefixTplOne><nz-icon nzType="arrow-up" /></ng-template>
           </nz-card>
         </nz-col>
         <nz-col [nzSpan]="12">
@@ -33,7 +33,7 @@ import { NzStatisticModule } from 'ng-zorro-antd/statistic';
               nzSuffix="%"
               [nzValueStyle]="{ color: '#CF1322' }"
             ></nz-statistic>
-            <ng-template #prefixTplTwo><span nz-icon nzType="arrow-down"></span></ng-template>
+            <ng-template #prefixTplTwo><nz-icon nzType="arrow-down" /></ng-template>
           </nz-card>
         </nz-col>
       </nz-row>

--- a/components/statistic/demo/unit.ts
+++ b/components/statistic/demo/unit.ts
@@ -12,7 +12,7 @@ import { NzStatisticModule } from 'ng-zorro-antd/statistic';
     <nz-row [nzGutter]="16">
       <nz-col [nzSpan]="12">
         <nz-statistic [nzValue]="(1128 | number)!" nzTitle="Feedback" [nzPrefix]="prefixTpl"></nz-statistic>
-        <ng-template #prefixTpl><span nz-icon nzType="like"></span></ng-template>
+        <ng-template #prefixTpl><nz-icon nzType="like" /></ng-template>
       </nz-col>
       <nz-col [nzSpan]="12">
         <nz-statistic [nzValue]="93" nzTitle="Unmerged" nzSuffix="/ 100"></nz-statistic>

--- a/components/steps/demo/icon.ts
+++ b/components/steps/demo/icon.ts
@@ -12,7 +12,7 @@ import { NzStepsModule } from 'ng-zorro-antd/steps';
       <nz-step nzTitle="Verification" nzStatus="finish" nzIcon="solution"></nz-step>
       <nz-step nzTitle="Pay" nzStatus="process" nzIcon="loading"></nz-step>
       <nz-step nzTitle="Done" nzStatus="wait" [nzIcon]="iconTemplate"></nz-step>
-      <ng-template #iconTemplate><span nz-icon nzType="smile"></span></ng-template>
+      <ng-template #iconTemplate><nz-icon nzType="smile" /></ng-template>
     </nz-steps>
   `
 })

--- a/components/steps/step.component.ts
+++ b/components/steps/step.component.ts
@@ -56,10 +56,10 @@ import { NzProgressFormatter, NzProgressModule } from 'ng-zorro-antd/progress';
             </div>
           }
           @if (nzStatus === 'finish' && !nzIcon) {
-            <span class="ant-steps-icon"><span nz-icon nzType="check"></span></span>
+            <span class="ant-steps-icon"><nz-icon nzType="check" /></span>
           }
           @if (nzStatus === 'error') {
-            <span class="ant-steps-icon"><span nz-icon nzType="close"></span></span>
+            <span class="ant-steps-icon"><nz-icon nzType="close" /></span>
           }
           @if ((nzStatus === 'process' || nzStatus === 'wait') && !nzIcon) {
             <span class="ant-steps-icon">
@@ -69,7 +69,7 @@ import { NzProgressFormatter, NzProgressModule } from 'ng-zorro-antd/progress';
           @if (nzIcon) {
             <span class="ant-steps-icon">
               <ng-container *nzStringTemplateOutlet="nzIcon; let icon">
-                <span nz-icon [nzType]="icon"></span>
+                <nz-icon [nzType]="icon" />
               </ng-container>
             </span>
           }

--- a/components/steps/steps.spec.ts
+++ b/components/steps/steps.spec.ts
@@ -554,7 +554,7 @@ export class NzTestOuterStepsComponent {
     </nz-steps>
     <ng-template #titleTemplate>titleTemplate</ng-template>
     <ng-template #descriptionTemplate>descriptionTemplate</ng-template>
-    <ng-template #iconTemplate><span nz-icon nzType="smile-o"></span></ng-template>
+    <ng-template #iconTemplate><nz-icon nzType="smile-o" /></ng-template>
   `
 })
 export class NzTestInnerStepStringComponent {
@@ -578,7 +578,7 @@ export class NzTestInnerStepStringComponent {
     </nz-steps>
     <ng-template #titleTemplate>titleTemplate</ng-template>
     <ng-template #descriptionTemplate>descriptionTemplate</ng-template>
-    <ng-template #iconTemplate><span nz-icon nzType="smile-o"></span></ng-template>
+    <ng-template #iconTemplate><nz-icon nzType="smile-o" /></ng-template>
   `
 })
 export class NzTestInnerStepTemplateComponent {}

--- a/components/switch/demo/text.ts
+++ b/components/switch/demo/text.ts
@@ -19,8 +19,8 @@ import { NzSwitchModule } from 'ng-zorro-antd/switch';
       [nzCheckedChildren]="checkedTemplate"
       [nzUnCheckedChildren]="unCheckedTemplate"
     ></nz-switch>
-    <ng-template #checkedTemplate><span nz-icon nzType="check"></span></ng-template>
-    <ng-template #unCheckedTemplate><span nz-icon nzType="close"></span></ng-template>
+    <ng-template #checkedTemplate><nz-icon nzType="check" /></ng-template>
+    <ng-template #unCheckedTemplate><nz-icon nzType="close" /></ng-template>
   `
 })
 export class NzDemoSwitchTextComponent {}

--- a/components/switch/switch.component.ts
+++ b/components/switch/switch.component.ts
@@ -65,7 +65,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'switch';
     >
       <span class="ant-switch-handle">
         @if (nzLoading) {
-          <span nz-icon nzType="loading" class="ant-switch-loading-icon"></span>
+          <nz-icon nzType="loading" class="ant-switch-loading-icon" />
         }
       </span>
       <span class="ant-switch-inner">

--- a/components/switch/switch.spec.ts
+++ b/components/switch/switch.spec.ts
@@ -312,8 +312,8 @@ describe('switch', () => {
 @Component({
   imports: [FormsModule, NzIconModule, NzSwitchModule],
   template: `
-    <ng-template #checkedChildrenTemplate><span nz-icon nzType="check"></span></ng-template>
-    <ng-template #unCheckedChildrenTemplate><span nz-icon nzType="closs"></span></ng-template>
+    <ng-template #checkedChildrenTemplate><nz-icon nzType="check" /></ng-template>
+    <ng-template #unCheckedChildrenTemplate><nz-icon nzType="closs" /></ng-template>
     <nz-switch
       [(ngModel)]="value"
       (ngModelChange)="modelChange($event)"
@@ -343,8 +343,8 @@ export class NzTestSwitchBasicComponent {
 @Component({
   imports: [NzIconModule, NzSwitchModule],
   template: `
-    <ng-template #checkedChildrenTemplate><span nz-icon nzType="check"></span></ng-template>
-    <ng-template #unCheckedChildrenTemplate><span nz-icon nzType="close"></span></ng-template>
+    <ng-template #checkedChildrenTemplate><nz-icon nzType="check" /></ng-template>
+    <ng-template #unCheckedChildrenTemplate><nz-icon nzType="close" /></ng-template>
     <nz-switch
       [nzCheckedChildren]="checkedChildrenTemplate"
       [nzUnCheckedChildren]="unCheckedChildrenTemplate"

--- a/components/table/demo/custom-column.ts
+++ b/components/table/demo/custom-column.ts
@@ -36,7 +36,7 @@ interface CustomColumn extends NzCustomColumn {
   ],
   template: `
     <button nz-button nzType="primary" nzSize="small" (click)="showModal()" style="margin-bottom: 8px;">
-      <span nz-icon nzType="setting" nzTheme="outline"></span>
+      <nz-icon nzType="setting" nzTheme="outline" />
     </button>
     <nz-table #basicTable [nzData]="listOfData" [nzCustomColumn]="customColumn">
       <thead>
@@ -87,7 +87,7 @@ interface CustomColumn extends NzCustomColumn {
                 @for (item of fix; track item; let i = $index) {
                   <div class="example-box" cdkDrag>
                     {{ item.name }}
-                    <span nz-icon nzType="minus-circle" nzTheme="outline" (click)="deleteCustom(item, i)"></span>
+                    <nz-icon nzType="minus-circle" nzTheme="outline" (click)="deleteCustom(item, i)" />
                   </div>
                 }
               </div>
@@ -112,7 +112,7 @@ interface CustomColumn extends NzCustomColumn {
                 @for (item of notFix; track item; let i = $index) {
                   <div class="example-box" cdkDrag>
                     {{ item.name }}
-                    <span nz-icon nzType="plus-circle" nzTheme="outline" (click)="addCustom(item, i)"></span>
+                    <nz-icon nzType="plus-circle" nzTheme="outline" (click)="addCustom(item, i)" />
                   </div>
                 }
               </div>

--- a/components/table/demo/custom-filter-panel.ts
+++ b/components/table/demo/custom-filter-panel.ts
@@ -22,7 +22,7 @@ interface DataItem {
           <th nzCustomFilter>
             Name
             <nz-filter-trigger [(nzVisible)]="visible" [nzActive]="searchValue.length > 0" [nzDropdownMenu]="menu">
-              <span nz-icon nzType="search"></span>
+              <nz-icon nzType="search" />
             </nz-filter-trigger>
           </th>
           <th>Age</th>

--- a/components/table/demo/expand-icon.ts
+++ b/components/table/demo/expand-icon.ts
@@ -29,9 +29,9 @@ import { NzTableModule } from 'ng-zorro-antd/table';
           </tr>
           <ng-template #expandIcon>
             @if (!expandSet.has(data.id)) {
-              <span nz-icon nzType="plus-circle" nzTheme="outline" (click)="onExpandChange(data.id, true)"></span>
+              <nz-icon nzType="plus-circle" nzTheme="outline" (click)="onExpandChange(data.id, true)" />
             } @else {
-              <span nz-icon nzType="minus-circle" nzTheme="outline" (click)="onExpandChange(data.id, false)"></span>
+              <nz-icon nzType="minus-circle" nzTheme="outline" (click)="onExpandChange(data.id, false)" />
             }
           </ng-template>
         }

--- a/components/table/demo/nested-table.ts
+++ b/components/table/demo/nested-table.ts
@@ -79,7 +79,7 @@ interface ChildrenItemData {
                       <span class="table-operation">
                         <a nz-dropdown class="operation" [nzDropdownMenu]="menu">
                           Pause
-                          <span nz-icon nzType="down"></span>
+                          <nz-icon nzType="down" />
                         </a>
                         <nz-dropdown-menu #menu="nzDropdownMenu">
                           <ul nz-menu>

--- a/components/table/src/addon/filter.component.ts
+++ b/components/table/src/addon/filter.component.ts
@@ -56,7 +56,7 @@ interface NzThItemInterface {
         [nzDropdownMenu]="filterMenu"
         (nzVisibleChange)="onVisibleChange($event)"
       >
-        <span nz-icon nzType="filter" nzTheme="fill"></span>
+        <nz-icon nzType="filter" nzTheme="fill" />
       </nz-filter-trigger>
       <nz-dropdown-menu #filterMenu="nzDropdownMenu">
         <div class="ant-table-filter-dropdown">

--- a/components/table/src/addon/selection.component.ts
+++ b/components/table/src/addon/selection.component.ts
@@ -31,7 +31,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     @if (showRowSelection) {
       <div class="ant-table-selection-extra">
         <span nz-dropdown class="ant-table-selection-down" nzPlacement="bottomLeft" [nzDropdownMenu]="selectionMenu">
-          <span nz-icon nzType="down"></span>
+          <nz-icon nzType="down" />
         </span>
         <nz-dropdown-menu #selectionMenu="nzDropdownMenu">
           <ul nz-menu class="ant-table-selection-menu">

--- a/components/tabs/demo/icon.ts
+++ b/components/tabs/demo/icon.ts
@@ -11,7 +11,7 @@ import { NzTabsModule } from 'ng-zorro-antd/tabs';
       @for (tab of tabs; track tab) {
         <nz-tab [nzTitle]="titleTemplate">
           <ng-template #titleTemplate>
-            <span nz-icon [nzType]="tab.icon"></span>
+            <nz-icon [nzType]="tab.icon" />
             {{ tab.name }}
           </ng-template>
           {{ tab.name }}

--- a/components/tabs/tab-add-button.component.ts
+++ b/components/tabs/tab-add-button.component.ts
@@ -13,7 +13,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   selector: 'nz-tab-add-button, button[nz-tab-add-button]',
   template: `
     <ng-container *nzStringTemplateOutlet="addIcon; let icon">
-      <span nz-icon [nzType]="icon" nzTheme="outline"></span>
+      <nz-icon [nzType]="icon" nzTheme="outline" />
     </ng-container>
   `,
   host: {

--- a/components/tabs/tab-close-button.component.ts
+++ b/components/tabs/tab-close-button.component.ts
@@ -13,7 +13,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   selector: 'nz-tab-close-button, button[nz-tab-close-button]',
   template: `
     <ng-container *nzStringTemplateOutlet="closeIcon; let icon">
-      <span nz-icon [nzType]="icon" nzTheme="outline"></span>
+      <nz-icon [nzType]="icon" nzTheme="outline" />
     </ng-container>
   `,
   host: {

--- a/components/tabs/tab-nav-operation.component.ts
+++ b/components/tabs/tab-nav-operation.component.ts
@@ -47,7 +47,7 @@ import { NzTabNavItemDirective } from './tab-nav-item.directive';
       (nzVisibleChange)="menuVisChange($event)"
       (mouseenter)="showItems()"
     >
-      <span nz-icon nzType="ellipsis"></span>
+      <nz-icon nzType="ellipsis" />
     </button>
     <nz-dropdown-menu #menu="nzDropdownMenu">
       @if (menuOpened) {

--- a/components/tag/demo/control.ts
+++ b/components/tag/demo/control.ts
@@ -18,7 +18,7 @@ import { NzTagModule } from 'ng-zorro-antd/tag';
 
     @if (!inputVisible) {
       <nz-tag class="editable-tag" nzNoAnimation (click)="showInput()">
-        <span nz-icon nzType="plus"></span>
+        <nz-icon nzType="plus" />
         New Tag
       </nz-tag>
     } @else {

--- a/components/tag/demo/icon.ts
+++ b/components/tag/demo/icon.ts
@@ -8,19 +8,19 @@ import { NzTagModule } from 'ng-zorro-antd/tag';
   imports: [NzIconModule, NzTagModule],
   template: `
     <nz-tag nzColor="#55acee">
-      <span nz-icon nzType="twitter"></span>
+      <nz-icon nzType="twitter" />
       <span>Twitter</span>
     </nz-tag>
     <nz-tag nzColor="#cd201f">
-      <span nz-icon nzType="youtube"></span>
+      <nz-icon nzType="youtube" />
       <span>Youtube</span>
     </nz-tag>
     <nz-tag nzColor="#3b5999">
-      <span nz-icon nzType="facebook"></span>
+      <nz-icon nzType="facebook" />
       <span>Facebook</span>
     </nz-tag>
     <nz-tag nzColor="#55acee">
-      <span nz-icon nzType="linkedin"></span>
+      <nz-icon nzType="linkedin" />
       <span>LinkedIn</span>
     </nz-tag>
   `

--- a/components/tag/demo/status.ts
+++ b/components/tag/demo/status.ts
@@ -18,23 +18,23 @@ import { NzTagModule } from 'ng-zorro-antd/tag';
     <div>
       <h4>With icon</h4>
       <nz-tag nzColor="success">
-        <span nz-icon nzType="check-circle"></span>
+        <nz-icon nzType="check-circle" />
         <span>success</span>
       </nz-tag>
       <nz-tag nzColor="processing">
-        <span nz-icon nzType="sync" nzSpin></span>
+        <nz-icon nzType="sync" nzSpin />
         <span>processing</span>
       </nz-tag>
       <nz-tag nzColor="error">
-        <span nz-icon nzType="close-circle"></span>
+        <nz-icon nzType="close-circle" />
         <span>error</span>
       </nz-tag>
       <nz-tag nzColor="warning">
-        <span nz-icon nzType="exclamation-circle"></span>
+        <nz-icon nzType="exclamation-circle" />
         <span>warning</span>
       </nz-tag>
       <nz-tag nzColor="default">
-        <span nz-icon nzType="clock-circle"></span>
+        <nz-icon nzType="clock-circle" />
         <span>default</span>
       </nz-tag>
     </div>

--- a/components/tag/tag.component.ts
+++ b/components/tag/tag.component.ts
@@ -40,7 +40,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   template: `
     <ng-content></ng-content>
     @if (nzMode === 'closeable') {
-      <span nz-icon nzType="close" class="ant-tag-close-icon" tabindex="-1" (click)="closeTag($event)"></span>
+      <nz-icon nzType="close" class="ant-tag-close-icon" tabindex="-1" (click)="closeTag($event)" />
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/components/time-picker/time-picker.component.ts
+++ b/components/time-picker/time-picker.component.ts
@@ -77,7 +77,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'timePicker';
       />
       <span class="ant-picker-suffix">
         <ng-container *nzStringTemplateOutlet="nzSuffixIcon; let suffixIcon">
-          <span nz-icon [nzType]="suffixIcon"></span>
+          <nz-icon [nzType]="suffixIcon" />
         </ng-container>
         @if (hasFeedback && !!status) {
           <nz-form-item-feedback-icon [status]="status"></nz-form-item-feedback-icon>

--- a/components/timeline/demo/alternate.ts
+++ b/components/timeline/demo/alternate.ts
@@ -19,7 +19,7 @@ import { NzTimelineModule } from 'ng-zorro-antd/timeline';
       <nz-timeline-item [nzDot]="dotTemplate">Technical testing 2015-09-01</nz-timeline-item>
     </nz-timeline>
     <ng-template #dotTemplate>
-      <span nz-icon nzType="clock-circle-o" style="font-size: 16px;"></span>
+      <nz-icon nzType="clock-circle-o" style="font-size: 16px;" />
     </ng-template>
   `
 })

--- a/components/timeline/demo/custom.ts
+++ b/components/timeline/demo/custom.ts
@@ -14,7 +14,7 @@ import { NzTimelineModule } from 'ng-zorro-antd/timeline';
       <nz-timeline-item>Network problems being solved 2015-09-01</nz-timeline-item>
     </nz-timeline>
     <ng-template #dotTemplate>
-      <span nz-icon nzType="clock-circle-o" style="font-size: 16px;"></span>
+      <nz-icon nzType="clock-circle-o" style="font-size: 16px;" />
     </ng-template>
   `
 })

--- a/components/timeline/demo/right.ts
+++ b/components/timeline/demo/right.ts
@@ -14,7 +14,7 @@ import { NzTimelineModule } from 'ng-zorro-antd/timeline';
       <nz-timeline-item>Network problems being solved 2015-09-01</nz-timeline-item>
     </nz-timeline>
     <ng-template #dotTemplate>
-      <span nz-icon nzType="clock-circle-o" style="font-size: 16px;"></span>
+      <nz-icon nzType="clock-circle-o" style="font-size: 16px;" />
     </ng-template>
   `
 })

--- a/components/timeline/timeline.component.ts
+++ b/components/timeline/timeline.component.ts
@@ -70,7 +70,7 @@ import { NzTimelineMode, NzTimelinePosition } from './typings';
             <ng-container *nzStringTemplateOutlet="nzPendingDot">
               {{ nzPendingDot }}
               @if (!nzPendingDot) {
-                <span nz-icon nzType="loading"></span>
+                <nz-icon nzType="loading" />
               }
             </ng-container>
           </div>

--- a/components/tooltip/demo/template.ts
+++ b/components/tooltip/demo/template.ts
@@ -11,7 +11,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
       >This Tooltip has an Icon</a
     >
     <ng-template #titleTemplate let-thing>
-      <span nz-icon nzType="file"></span>
+      <nz-icon nzType="file" />
       <span>Tooltip With {{ thing }}</span>
     </ng-template>
   `,

--- a/components/transfer/demo/custom-item.ts
+++ b/components/transfer/demo/custom-item.ts
@@ -15,7 +15,7 @@ import { NzTransferModule, TransferItem } from 'ng-zorro-antd/transfer';
       (nzChange)="change($event)"
     >
       <ng-template #render let-item>
-        <span nz-icon nzType="{{ item.icon }}"></span>
+        <nz-icon nzType="{{ item.icon }}" />
         {{ item.title }}
       </ng-template>
     </nz-transfer>

--- a/components/transfer/transfer-list.component.ts
+++ b/components/transfer/transfer-list.component.ts
@@ -132,7 +132,7 @@ import { NzTransferSearchComponent } from './transfer-search.component';
                       [class]="{ 'ant-transfer-list-content-item-disabled': disabled || item.disabled }"
                       (click)="!(disabled || item.disabled) ? deleteItem(item) : null"
                     >
-                      <span nz-icon nzType="delete" nzTheme="outline"></span>
+                      <nz-icon nzType="delete" nzTheme="outline" />
                     </div>
                   } @else {
                     <ng-template

--- a/components/transfer/transfer-search.component.ts
+++ b/components/transfer/transfer-search.component.ts
@@ -24,7 +24,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   preserveWhitespaces: false,
   template: `
     <span class="ant-input-prefix">
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
     </span>
     <input
       [(ngModel)]="value"
@@ -36,7 +36,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     />
     @if (value && value.length > 0) {
       <span class="ant-input-suffix" (click)="_clear()">
-        <span nz-icon nzType="close-circle" nzTheme="fill" class="ant-input-clear-icon"></span>
+        <nz-icon nzType="close-circle" nzTheme="fill" class="ant-input-clear-icon" />
       </span>
     }
   `,

--- a/components/transfer/transfer.component.ts
+++ b/components/transfer/transfer.component.ts
@@ -83,7 +83,7 @@ import { NzTransferListComponent } from './transfer-list.component';
             [nzType]="'primary'"
             [nzSize]="'small'"
           >
-            <span nz-icon nzType="left"></span>
+            <nz-icon nzType="left" />
             @if (nzOperations[1]) {
               <span>{{ nzOperations[1] }}</span>
             }
@@ -97,7 +97,7 @@ import { NzTransferListComponent } from './transfer-list.component';
           [nzType]="'primary'"
           [nzSize]="'small'"
         >
-          <span nz-icon nzType="right"></span>
+          <nz-icon nzType="right" />
           @if (nzOperations[0]) {
             <span>{{ nzOperations[0] }}</span>
           }
@@ -113,7 +113,7 @@ import { NzTransferListComponent } from './transfer-list.component';
           [nzType]="'primary'"
           [nzSize]="'small'"
         >
-          <span nz-icon nzType="left"></span>
+          <nz-icon nzType="left" />
           @if (nzOperations[0]) {
             <span>{{ nzOperations[0] }}</span>
           }
@@ -127,7 +127,7 @@ import { NzTransferListComponent } from './transfer-list.component';
             [nzType]="'primary'"
             [nzSize]="'small'"
           >
-            <span nz-icon nzType="right"></span>
+            <nz-icon nzType="right" />
             @if (nzOperations[1]) {
               <span>{{ nzOperations[1] }}</span>
             }

--- a/components/transfer/transfer.spec.ts
+++ b/components/transfer/transfer.spec.ts
@@ -667,7 +667,7 @@ class TestTransferComponent implements OnInit, AbstractTestTransferComponent {
   template: `
     <nz-transfer #comp nzShowSearch [nzRender]="render" [nzDataSource]="nzDataSource">
       <ng-template #render let-item>
-        <span nz-icon nzType="{{ item.icon }}"></span>
+        <nz-icon nzType="{{ item.icon }}" />
         {{ item.title }}
       </ng-template>
     </nz-transfer>

--- a/components/tree-select/demo/customized-icon.ts
+++ b/components/tree-select/demo/customized-icon.ts
@@ -25,7 +25,7 @@ import { NzTreeSelectModule } from 'ng-zorro-antd/tree-select';
       <ng-template #nzTreeTemplate let-node>
         <span class="ant-tree-node-content-wrapper" [class.ant-tree-node-selected]="node.isSelected">
           <span>
-            <span nz-icon [nzType]="node.isExpanded ? 'folder-open' : 'folder'"></span>
+            <nz-icon [nzType]="node.isExpanded ? 'folder-open' : 'folder'" />
             {{ node.title }}
           </span>
         </span>

--- a/components/tree-select/tree-select.spec.ts
+++ b/components/tree-select/tree-select.spec.ts
@@ -605,7 +605,7 @@ describe('tree-select component', () => {
       treeSelect.nativeElement.click();
       flush();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('span.anticon.anticon-frown-o')).toBeTruthy();
+      expect(overlayContainerElement.querySelector('.anticon.anticon-frown-o')).toBeTruthy();
     }));
   });
 

--- a/components/tree-view/demo/basic.ts
+++ b/components/tree-view/demo/basic.ts
@@ -53,7 +53,7 @@ interface FlatNode {
 
       <nz-tree-node *nzTreeNodeDef="let node; when: hasChild" nzTreeNodePadding>
         <nz-tree-node-toggle>
-          <span nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon></span>
+          <nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon />
         </nz-tree-node-toggle>
         <nz-tree-node-option
           [nzDisabled]="node.disabled"

--- a/components/tree-view/demo/checkbox.ts
+++ b/components/tree-view/demo/checkbox.ts
@@ -58,7 +58,7 @@ interface FlatNode {
 
       <nz-tree-node *nzTreeNodeDef="let node; when: hasChild" nzTreeNodePadding>
         <nz-tree-node-toggle>
-          <span nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon></span>
+          <nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon />
         </nz-tree-node-toggle>
         <nz-tree-node-checkbox
           [nzDisabled]="node.disabled"

--- a/components/tree-view/demo/directory.ts
+++ b/components/tree-view/demo/directory.ts
@@ -51,21 +51,21 @@ interface ExampleFlatNode {
           [nzSelected]="selectListSelection.isSelected(node)"
           (nzClick)="selectListSelection.toggle(node)"
         >
-          <span nz-icon nzType="file" nzTheme="outline"></span>
+          <nz-icon nzType="file" nzTheme="outline" />
           {{ node.name }}
         </nz-tree-node-option>
       </nz-tree-node>
 
       <nz-tree-node *nzTreeNodeDef="let node; when: hasChild" nzTreeNodePadding>
         <nz-tree-node-toggle>
-          <span nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon></span>
+          <nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon />
         </nz-tree-node-toggle>
         <nz-tree-node-option
           [nzDisabled]="node.disabled"
           [nzSelected]="selectListSelection.isSelected(node)"
           (nzClick)="selectListSelection.toggle(node)"
         >
-          <span nz-icon [nzType]="treeControl.isExpanded(node) ? 'folder-open' : 'folder'" nzTheme="outline"></span>
+          <nz-icon [nzType]="treeControl.isExpanded(node) ? 'folder-open' : 'folder'" nzTheme="outline" />
           {{ node.name }}
         </nz-tree-node-option>
       </nz-tree-node>

--- a/components/tree-view/demo/dynamic.ts
+++ b/components/tree-view/demo/dynamic.ts
@@ -135,11 +135,11 @@ class DynamicDatasource implements DataSource<FlatNode> {
       <nz-tree-node *nzTreeNodeDef="let node; when: hasChild" nzTreeNodePadding>
         @if (!node.loading) {
           <nz-tree-node-toggle>
-            <span nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon></span>
+            <nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon />
           </nz-tree-node-toggle>
         } @else {
           <nz-tree-node-toggle nzTreeNodeNoopToggle>
-            <span nz-icon nzType="loading" nzTreeNodeToggleActiveIcon></span>
+            <nz-icon nzType="loading" nzTreeNodeToggleActiveIcon />
           </nz-tree-node-toggle>
         }
         {{ node.label }}

--- a/components/tree-view/demo/editable.ts
+++ b/components/tree-view/demo/editable.ts
@@ -61,7 +61,7 @@ interface FlatNode {
           {{ node.name }}
         </nz-tree-node-option>
         <button nz-button nzType="text" nzSize="small" (click)="delete(node)">
-          <span nz-icon nzType="minus" nzTheme="outline"></span>
+          <nz-icon nzType="minus" nzTheme="outline" />
         </button>
       </nz-tree-node>
 
@@ -73,11 +73,11 @@ interface FlatNode {
 
       <nz-tree-node *nzTreeNodeDef="let node; when: hasChild" nzTreeNodeIndentLine>
         <nz-tree-node-toggle>
-          <span nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon></span>
+          <nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon />
         </nz-tree-node-toggle>
         {{ node.name }}
         <button nz-button nzType="text" nzSize="small" (click)="addNewNode(node)">
-          <span nz-icon nzType="plus" nzTheme="outline"></span>
+          <nz-icon nzType="plus" nzTheme="outline" />
         </button>
       </nz-tree-node>
     </nz-tree-view>

--- a/components/tree-view/demo/line.ts
+++ b/components/tree-view/demo/line.ts
@@ -55,7 +55,7 @@ interface FlatNode {
       <nz-tree-node *nzTreeNodeDef="let node" nzTreeNodeIndentLine>
         @if (showLeafIcon) {
           <nz-tree-node-toggle nzTreeNodeNoopToggle>
-            <span nz-icon nzType="file" nzTheme="outline"></span>
+            <nz-icon nzType="file" nzTheme="outline" />
           </nz-tree-node-toggle>
         }
         <nz-tree-node-option>

--- a/components/tree-view/demo/search.ts
+++ b/components/tree-view/demo/search.ts
@@ -80,7 +80,7 @@ function filterTreeData(data: TreeNode[], value: string): FilteredTreeResult {
       <input type="text" nz-input placeholder="Search" ngModel (ngModelChange)="searchValue$.next($event)" />
     </nz-input-group>
     <ng-template #suffixIcon>
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
     </ng-template>
 
     <nz-tree-view [nzTreeControl]="treeControl" [nzDataSource]="dataSource" nzNoAnimation>
@@ -91,7 +91,7 @@ function filterTreeData(data: TreeNode[], value: string): FilteredTreeResult {
 
       <nz-tree-node *nzTreeNodeDef="let node; when: hasChild" nzTreeNodePadding>
         <nz-tree-node-toggle>
-          <span nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon></span>
+          <nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon />
         </nz-tree-node-toggle>
         <span [innerHTML]="node.name | nzHighlight: searchValue : 'i' : 'highlight'"></span>
       </nz-tree-node>

--- a/components/tree-view/demo/virtual-scroll.ts
+++ b/components/tree-view/demo/virtual-scroll.ts
@@ -47,7 +47,7 @@ interface ExampleFlatNode {
 
       <nz-tree-node *nzTreeNodeDef="let node; when: hasChild" nzTreeNodePadding>
         <nz-tree-node-toggle>
-          <span nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon></span>
+          <nz-icon nzType="caret-down" nzTreeNodeToggleRotateIcon />
         </nz-tree-node-toggle>
         {{ node.name }}
       </nz-tree-node>

--- a/components/tree-view/doc/index.en-US.md
+++ b/components/tree-view/doc/index.en-US.md
@@ -81,11 +81,11 @@ A toggle which is used to expand / collapse the node.
 
 A toggle that does no actions. This can be used for placeholders or displays icons.
 
-### [nz-icon][nztreenodetogglerotateicon]
+### [nzTreeNodeToggleRotateIcon]
 
 Define an icon in the toggle, which it will automatically rotate depending on the collapse/expand state.
 
-### [nz-icon][nztreenodetoggleactiveicon]
+### [nzTreeNodeToggleActiveIcon]
 
 Define an icon in the toggle for an active style, which it can be used for the loading state.
 

--- a/components/tree-view/doc/index.zh-CN.md
+++ b/components/tree-view/doc/index.zh-CN.md
@@ -79,11 +79,11 @@ import { NzTreeViewModule } from 'ng-zorro-antd/tree-view';
 
 不做任何操作的切换部分，可用于占位或者显示图标。
 
-### [nz-icon][nztreenodetogglerotateicon]
+### [nztreenodetogglerotateicon]
 
 定义切换部分中的图标，会随着展开收起状态自动旋转。
 
-### [nz-icon][nztreenodetoggleactiveicon]
+### [nztreenodetoggleactiveicon]
 
 定义切换部分中的图标，使其具有激活状态的样式，可用于 loading 图标。
 

--- a/components/tree-view/toggle.ts
+++ b/components/tree-view/toggle.ts
@@ -32,7 +32,7 @@ export class NzTreeNodeToggleDirective<T> extends CdkTreeNodeToggle<T> {
 }
 
 @Directive({
-  selector: '[nz-icon][nzTreeNodeToggleRotateIcon]',
+  selector: '[nzTreeNodeToggleRotateIcon]',
   host: {
     class: 'ant-tree-switcher-icon'
   }
@@ -40,7 +40,7 @@ export class NzTreeNodeToggleDirective<T> extends CdkTreeNodeToggle<T> {
 export class NzTreeNodeToggleRotateIconDirective {}
 
 @Directive({
-  selector: '[nz-icon][nzTreeNodeToggleActiveIcon]',
+  selector: '[nzTreeNodeToggleActiveIcon]',
   host: {
     class: 'ant-tree-switcher-loading-icon'
   }

--- a/components/tree/demo/customized-icon.ts
+++ b/components/tree/demo/customized-icon.ts
@@ -17,7 +17,7 @@ import { NzTreeModule } from 'ng-zorro-antd/tree';
             class="ant-tree-switcher-line-icon"
           ></span>
         } @else {
-          <span nz-icon nzType="file" class="ant-tree-switcher-line-icon"></span>
+          <nz-icon nzType="file" class="ant-tree-switcher-line-icon" />
         }
       </ng-template>
     </nz-tree>

--- a/components/tree/demo/directory.ts
+++ b/components/tree/demo/directory.ts
@@ -20,13 +20,13 @@ import { NzFormatEmitEvent, NzTreeModule, NzTreeNode } from 'ng-zorro-antd/tree'
       <span class="custom-node">
         @if (!node.isLeaf) {
           <span (contextmenu)="contextMenu($event, menu)">
-            <span nz-icon [nzType]="node.isExpanded ? 'folder-open' : 'folder'" (click)="openFolder(node)"></span>
+            <nz-icon [nzType]="node.isExpanded ? 'folder-open' : 'folder'" (click)="openFolder(node)" />
             <span class="folder-name">{{ node.title }}</span>
             <span class="folder-desc">created by {{ origin.author | lowercase }}</span>
           </span>
         } @else {
           <span (contextmenu)="contextMenu($event, menu)">
-            <span nz-icon nzType="file"></span>
+            <nz-icon nzType="file" />
             <span class="file-name">{{ node.title }}</span>
             <span class="file-desc">modified by {{ origin.author | lowercase }}</span>
           </span>

--- a/components/tree/demo/search.ts
+++ b/components/tree/demo/search.ts
@@ -13,7 +13,7 @@ import { NzFormatEmitEvent, NzTreeModule } from 'ng-zorro-antd/tree';
       <input type="text" nz-input placeholder="Search" [(ngModel)]="searchValue" />
     </nz-input-group>
     <ng-template #suffixIcon>
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
     </ng-template>
     <br />
     <nz-tree

--- a/components/tree/tree-node-switcher.component.ts
+++ b/components/tree/tree-node-switcher.component.ts
@@ -23,7 +23,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
           ></span>
         </ng-container>
       } @else {
-        <span nz-icon nzType="loading" [nzSpin]="true" class="ant-tree-switcher-loading-icon"></span>
+        <nz-icon nzType="loading" [nzSpin]="true" class="ant-tree-switcher-loading-icon" />
       }
     }
     @if (nzShowLine) {
@@ -36,11 +36,11 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
               class="ant-tree-switcher-line-icon"
             ></span>
           } @else {
-            <span nz-icon nzType="file" class="ant-tree-switcher-line-icon"></span>
+            <nz-icon nzType="file" class="ant-tree-switcher-line-icon" />
           }
         </ng-container>
       } @else {
-        <span nz-icon nzType="loading" [nzSpin]="true" class="ant-tree-switcher-loading-icon"></span>
+        <nz-icon nzType="loading" [nzSpin]="true" class="ant-tree-switcher-loading-icon" />
       }
     }
   `,

--- a/components/tree/tree-node-title.component.ts
+++ b/components/tree/tree-node-title.component.ts
@@ -43,7 +43,7 @@ import { NzTreeDropIndicatorComponent } from './tree-drop-indicator.component';
             [class.ant-tree-iconEle]="!selectMode"
             [class.ant-tree-icon__customize]="!selectMode"
           >
-            <span nz-icon [nzType]="icon"></span>
+            <nz-icon [nzType]="icon" />
           </span>
         </span>
       }

--- a/components/tree/tree.spec.ts
+++ b/components/tree/tree.spec.ts
@@ -640,7 +640,7 @@ describe('tree', () => {
       (nzCheckBoxChange)="nzEvent($event)"
     ></nz-tree>
     <ng-template #expandedIconTpl let-node>
-      <span nz-icon nzType="smile" class="ant-tree-switcher-icon"></span>
+      <nz-icon nzType="smile" class="ant-tree-switcher-icon" />
     </ng-template>
   `
 })

--- a/components/typography/demo/interactive.ts
+++ b/components/typography/demo/interactive.ts
@@ -26,7 +26,7 @@ import { NzTypographyModule } from 'ng-zorro-antd/typography';
       [nzCopyIcons]="['meh', 'smile']"
     ></p>
     <ng-template #copedIcon>
-      <span nz-icon nzType="smile" nzTheme="fill"></span>
+      <nz-icon nzType="smile" nzTheme="fill" />
       you clicked!!
     </ng-template>
     <p nz-typography nzCopyable [nzCopyTooltips]="null" nzContent="Hide copy tooltips."></p>

--- a/components/typography/text-copy.component.ts
+++ b/components/typography/text-copy.component.ts
@@ -42,7 +42,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
       (click)="onClick()"
     >
       <ng-container *nzStringTemplateOutlet="copied ? copedIcon : copyIcon; let icon">
-        <span nz-icon [nzType]="icon"></span>
+        <nz-icon [nzType]="icon" />
       </ng-container>
     </button>
   `,

--- a/components/typography/text-edit.component.ts
+++ b/components/typography/text-edit.component.ts
@@ -40,7 +40,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
     @if (editing) {
       <textarea #textarea nz-input nzAutosize (blur)="confirm()"></textarea>
       <button nz-trans-button class="ant-typography-edit-content-confirm" (click)="confirm()">
-        <span nz-icon nzType="enter"></span>
+        <nz-icon nzType="enter" />
       </button>
     } @else {
       <button
@@ -51,7 +51,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
         (click)="onClick()"
       >
         <ng-container *nzStringTemplateOutlet="icon; let icon">
-          <span nz-icon [nzType]="icon"></span>
+          <nz-icon [nzType]="icon" />
         </ng-container>
       </button>
     }

--- a/components/upload/demo/basic.ts
+++ b/components/upload/demo/basic.ts
@@ -15,7 +15,7 @@ import { NzUploadChangeParam, NzUploadModule } from 'ng-zorro-antd/upload';
       (nzChange)="handleChange($event)"
     >
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Click to Upload
       </button>
     </nz-upload>

--- a/components/upload/demo/default-file-list.ts
+++ b/components/upload/demo/default-file-list.ts
@@ -10,7 +10,7 @@ import { NzUploadFile, NzUploadModule } from 'ng-zorro-antd/upload';
   template: `
     <nz-upload nzAction="https://www.mocky.io/v2/5cc8019d300000980a055e76" [nzFileList]="fileList">
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Upload
       </button>
     </nz-upload>

--- a/components/upload/demo/directory.ts
+++ b/components/upload/demo/directory.ts
@@ -10,7 +10,7 @@ import { NzUploadModule } from 'ng-zorro-antd/upload';
   template: `
     <nz-upload nzAction="https://www.mocky.io/v2/5cc8019d300000980a055e76" nzDirectory>
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Upload Directory
       </button>
     </nz-upload>

--- a/components/upload/demo/drag.ts
+++ b/components/upload/demo/drag.ts
@@ -16,7 +16,7 @@ import { NzUploadChangeParam, NzUploadModule } from 'ng-zorro-antd/upload';
       (nzChange)="handleChange($event)"
     >
       <p class="ant-upload-drag-icon">
-        <span nz-icon nzType="inbox"></span>
+        <nz-icon nzType="inbox" />
       </p>
       <p class="ant-upload-text">Click or drag file to this area to upload</p>
       <p class="ant-upload-hint">

--- a/components/upload/demo/file-list.ts
+++ b/components/upload/demo/file-list.ts
@@ -14,7 +14,7 @@ import { NzUploadChangeParam, NzUploadFile, NzUploadModule } from 'ng-zorro-antd
       (nzChange)="handleChange($event)"
     >
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Upload
       </button>
     </nz-upload>

--- a/components/upload/demo/picture-card.ts
+++ b/components/upload/demo/picture-card.ts
@@ -24,7 +24,7 @@ const getBase64 = (file: File): Promise<string | ArrayBuffer | null> =>
       [nzPreview]="handlePreview"
     >
       <div>
-        <span nz-icon nzType="plus"></span>
+        <nz-icon nzType="plus" />
         <div style="margin-top: 8px">Upload</div>
       </div>
     </nz-upload>

--- a/components/upload/demo/picture-style.ts
+++ b/components/upload/demo/picture-style.ts
@@ -14,7 +14,7 @@ import { NzUploadFile, NzUploadModule } from 'ng-zorro-antd/upload';
       [(nzFileList)]="fileList1"
     >
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Upload
       </button>
     </nz-upload>
@@ -28,7 +28,7 @@ import { NzUploadFile, NzUploadModule } from 'ng-zorro-antd/upload';
     >
       <button nz-button>
         <span>
-          <span nz-icon nzType="upload"></span>
+          <nz-icon nzType="upload" />
           Upload
         </span>
       </button>

--- a/components/upload/demo/preview-file.ts
+++ b/components/upload/demo/preview-file.ts
@@ -17,7 +17,7 @@ import { NzUploadFile, NzUploadModule } from 'ng-zorro-antd/upload';
       [nzPreviewFile]="previewFile"
     >
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Upload
       </button>
     </nz-upload>

--- a/components/upload/demo/transform-file.ts
+++ b/components/upload/demo/transform-file.ts
@@ -11,7 +11,7 @@ import { NzUploadFile, NzUploadModule } from 'ng-zorro-antd/upload';
   template: `
     <nz-upload nzAction="https://www.mocky.io/v2/5cc8019d300000980a055e76" [nzTransformFile]="transformFile">
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Upload
       </button>
     </nz-upload>

--- a/components/upload/demo/upload-manually.ts
+++ b/components/upload/demo/upload-manually.ts
@@ -13,7 +13,7 @@ import { NzUploadFile, NzUploadModule } from 'ng-zorro-antd/upload';
   template: `
     <nz-upload [(nzFileList)]="fileList" [nzBeforeUpload]="beforeUpload">
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Select File
       </button>
     </nz-upload>

--- a/components/upload/demo/upload-with-aliyun-oss.ts
+++ b/components/upload/demo/upload-with-aliyun-oss.ts
@@ -18,7 +18,7 @@ import { NzUploadChangeParam, NzUploadFile, NzUploadModule } from 'ng-zorro-antd
     >
       Photos:
       <button nz-button>
-        <span nz-icon nzType="upload"></span>
+        <nz-icon nzType="upload" />
         Click to Upload
       </button>
     </nz-upload>

--- a/components/upload/upload-list.component.html
+++ b/components/upload/upload-list.component.html
@@ -46,20 +46,20 @@
           @switch (listType) {
             @case ('picture') {
               @if (file.isUploading) {
-                <span nz-icon nzType="loading"></span>
+                <nz-icon nzType="loading" />
               } @else {
-                <span nz-icon [nzType]="file.isImageUrl ? 'picture' : 'file'" nzTheme="twotone"></span>
+                <nz-icon [nzType]="file.isImageUrl ? 'picture' : 'file'" nzTheme="twotone" />
               }
             }
             @case ('picture-card') {
               @if (file.isUploading) {
                 {{ locale.uploading }}
               } @else {
-                <span nz-icon [nzType]="file.isImageUrl ? 'picture' : 'file'" nzTheme="twotone"></span>
+                <nz-icon [nzType]="file.isImageUrl ? 'picture' : 'file'" nzTheme="twotone" />
               }
             }
             @default {
-              <span nz-icon [nzType]="file.isUploading ? 'loading' : 'paper-clip'"></span>
+              <nz-icon [nzType]="file.isUploading ? 'loading' : 'paper-clip'" />
             }
           }
         } @else {
@@ -78,7 +78,7 @@
             [attr.title]="locale.removeFile"
             class="ant-upload-list-item-card-actions-btn"
           >
-            <span nz-icon nzType="delete"></span>
+            <nz-icon nzType="delete" />
           </button>
         }
       </ng-template>
@@ -94,7 +94,7 @@
             [attr.title]="locale.downloadFile"
             class="ant-upload-list-item-card-actions-btn"
           >
-            <span nz-icon nzType="download"></span>
+            <nz-icon nzType="download" />
           </button>
         }
       </ng-template>
@@ -146,7 +146,7 @@
               [style]="!(file.url || file.thumbUrl) ? { opacity: 0.5, 'pointer-events': 'none' } : null"
               (click)="handlePreview(file, $event)"
             >
-              <span nz-icon nzType="eye"></span>
+              <nz-icon nzType="eye" />
             </a>
           }
           @if (file.status === 'done') {

--- a/components/upload/upload.spec.ts
+++ b/components/upload/upload.spec.ts
@@ -1373,7 +1373,7 @@ describe('upload', () => {
         (nzChange)="nzChange($event)"
       >
         <button nz-button>
-          <span nz-icon nzType="upload"></span>
+          <nz-icon nzType="upload" />
           <span>Click to Upload</span>
         </button>
       </nz-upload>

--- a/scripts/site/_site/doc/app/codebox/codebox.component.html
+++ b/scripts/site/_site/doc/app/codebox/codebox.component.html
@@ -19,7 +19,7 @@
     <div class="code-box-title">
       <a (click)="navigateToFragment()">{{ nzTitle }}</a>
       <a class="edit-button" [attr.href]="nzHref" target="_blank" rel="noopener noreferrer">
-        <span nz-icon nzType="edit"></span>
+        <nz-icon nzType="edit" />
       </a>
     </div>
     <div class="code-box-description">
@@ -27,9 +27,15 @@
     </div>
     <div class="code-box-actions">
       <span
-        [nzTooltipTitle]="!onlineIDELoading ?
-        language==='zh' ? '在 StackBlitz 上打开':'Edit On StackBlitz':
-        language==='zh'? '加载中...' : 'Loading...'"
+        [nzTooltipTitle]="
+          !onlineIDELoading
+            ? language === 'zh'
+              ? '在 StackBlitz 上打开'
+              : 'Edit On StackBlitz'
+            : language === 'zh'
+              ? '加载中...'
+              : 'Loading...'
+        "
         nz-tooltip
         nz-icon
         nzType="thunderbolt"
@@ -38,9 +44,9 @@
         (click)="openOnlineIDE()"
       ></span>
       <span
-        [nzTooltipTitle]="!copyLoading ?
-        language==='zh'? '复制代码' : 'Copy Code' :
-        language==='zh'? '加载中...' : 'Loading...'"
+        [nzTooltipTitle]="
+          !copyLoading ? (language === 'zh' ? '复制代码' : 'Copy Code') : language === 'zh' ? '加载中...' : 'Loading...'
+        "
         nz-tooltip
         nz-icon
         [nzType]="copied ? 'check' : 'snippets'"
@@ -50,7 +56,7 @@
       ></span>
       @if (nzGenerateCommand) {
         <span
-          [nzTooltipTitle]="language==='zh'? '复制生成代码命令' : 'Copy Generate Command'"
+          [nzTooltipTitle]="language === 'zh' ? '复制生成代码命令' : 'Copy Generate Command'"
           nz-tooltip
           nz-icon
           [nzType]="commandCopied ? 'check' : 'code'"
@@ -59,11 +65,12 @@
           (click)="copyGenerateCommand(nzGenerateCommand)"
         ></span>
       }
-      <span class="code-expand-icon"
+      <span
+        class="code-expand-icon"
         nz-tooltip
-        [nzTooltipTitle]="nzExpanded ?
-        (language==='zh'? '收起代码' : 'Hide Code') :
-        (language==='zh'? '显示代码' : 'Show Code')"
+        [nzTooltipTitle]="
+          nzExpanded ? (language === 'zh' ? '收起代码' : 'Hide Code') : language === 'zh' ? '显示代码' : 'Show Code'
+        "
         (click)="expandCode(!nzExpanded)"
       >
         @switch (theme) {

--- a/scripts/site/_site/doc/app/components-overview/components-overview.component.html
+++ b/scripts/site/_site/doc/app/components-overview/components-overview.component.html
@@ -10,8 +10,8 @@
     } @else {
       <p>
         <span><code>ng-zorro-antd</code></span>
-        is an Angular UI lib, follow Ant Design specification, to provide high quantity UI components
-        for web development.
+        is an Angular UI lib, follow Ant Design specification, to provide high quantity UI components for web
+        development.
       </p>
     }
   </section>
@@ -28,11 +28,11 @@
           placeholder="{{ language === 'en' ? 'Search in components' : '搜索组件' }}"
           nzSize="large"
           (input)="onSearch(searchBox.value)"
-          />
+        />
       </nz-input-group>
     </nz-affix>
     <ng-template #suffixIconSearch>
-      <span nz-icon nzType="search"></span>
+      <nz-icon nzType="search" />
     </ng-template>
 
     <nz-divider></nz-divider>
@@ -47,21 +47,9 @@
 
           <div nz-row>
             @for (component of group.children; track $index) {
-              <div
-                nz-col
-                nzXs="24"
-                nzSm="12"
-                nzMd="12"
-                nzLg="8"
-                nzXl="6"
-                nzXXl="6"
-                class="components-overview-card"
-              >
+              <div nz-col nzXs="24" nzSm="12" nzMd="12" nzLg="8" nzXl="6" nzXXl="6" class="components-overview-card">
                 <a routerLink="/{{ component.path }}">
-                  <nz-card
-                    nzHoverable
-                    nzTitle="{{ component.label }} {{ language === 'zh' ? component.zh : '' }}"
-                  >
+                  <nz-card nzHoverable nzTitle="{{ component.label }} {{ language === 'zh' ? component.zh : '' }}">
                     <div class="components-overview-img">
                       <img [alt]="component.label" [src]="component.cover" />
                     </div>

--- a/scripts/site/_site/doc/app/footer/footer-item.component.ts
+++ b/scripts/site/_site/doc/app/footer/footer-item.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
-    selector: 'app-footer-item',
+  selector: 'app-footer-item',
   imports: [NzIconModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -11,7 +11,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       @if (icon || imgSrc) {
         <span class="rc-footer-item-icon">
           @if (icon) {
-            <span nz-icon [nzType]="icon"></span>
+            <nz-icon [nzType]="icon" />
           } @else {
             <img [src]="imgSrc" [attr.alt]="imgAlt" />
           }

--- a/scripts/site/_site/doc/app/header/navigation.component.ts
+++ b/scripts/site/_site/doc/app/header/navigation.component.ts
@@ -3,12 +3,13 @@ import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
+import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzMenuModule } from 'ng-zorro-antd/menu';
 
 @Component({
-    selector: 'ul[nz-menu][app-navigation]',
+  selector: 'ul[nz-menu][app-navigation]',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, NgTemplateOutlet, NzMenuModule],
+  imports: [RouterLink, NgTemplateOutlet, NzMenuModule, NzIconModule],
   template: `
     <li nz-menu-item [nzSelected]="page === 'docs'">
       <a [routerLink]="['docs', 'introduce', language]">
@@ -32,7 +33,7 @@ import { NzMenuModule } from 'ng-zorro-antd/menu';
     }
     @if (!isMobile && responsive === 'crowded') {
       <li nz-submenu [nzTitle]="additionalTitle" nzMenuClassName="top-menu-additional">
-        <ng-template #additionalTitle><span nz-icon nzType="unordered-list" nzTheme="outline"></span></ng-template>
+        <ng-template #additionalTitle><nz-icon nzType="unordered-list" nzTheme="outline" /></ng-template>
         <ul>
           <ng-container [ngTemplateOutlet]="additionalItems"></ng-container>
         </ul>

--- a/scripts/site/_site/doc/app/header/searchbar.component.ts
+++ b/scripts/site/_site/doc/app/header/searchbar.component.ts
@@ -22,11 +22,11 @@ import { loadScript } from '../utils/load-script';
 declare const docsearch: any;
 
 @Component({
-    selector: 'div[app-searchbar]',
+  selector: 'div[app-searchbar]',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzIconModule, NzInputModule],
   template: `
-    <span nz-icon nzType="search"></span>
+    <nz-icon nzType="search" />
     <input
       nz-input
       #searchInput
@@ -58,7 +58,7 @@ export class SearchbarComponent implements OnChanges {
     return window && window.location.href.indexOf('/version') === -1;
   }
 
-  constructor(private cdr: ChangeDetectorRef, private platform: Platform) {}
+  constructor(private cdr: ChangeDetectorRef, private platform: Platform) { }
 
   triggerFocus(focus: boolean): void {
     if (this.docsearch) {

--- a/scripts/site/_site/doc/app/nav-bottom/nav-bottom.component.ts
+++ b/scripts/site/_site/doc/app/nav-bottom/nav-bottom.component.ts
@@ -7,23 +7,23 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { ROUTER_LIST } from '../router';
 
 @Component({
-    selector: 'nz-nav-bottom',
+  selector: 'nz-nav-bottom',
   imports: [RouterLink, NzIconModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <section class="prev-next-nav">
       @if (index > 1) {
         <a class="prev-page" [routerLink]="list[index - 1]?.path">
-          <span nz-icon nzType="left" class="footer-nav-icon-before"></span>
+          <nz-icon nzType="left" class="footer-nav-icon-before" />
           {{ list[index - 1]?.label }}
-          <span nz-icon nzType="right" class="footer-nav-icon-after"></span>
+          <nz-icon nzType="right" class="footer-nav-icon-after" />
         </a>
       }
       @if (index < list.length - 1) {
         <a class="next-page" [routerLink]="list[index + 1]?.path">
-          <span nz-icon nzType="left" class="footer-nav-icon-before"></span>
+          <nz-icon nzType="left" class="footer-nav-icon-before" />
           {{ list[index + 1]?.label }}
-          <span nz-icon nzType="right" class="footer-nav-icon-after"></span>
+          <nz-icon nzType="right" class="footer-nav-icon-after" />
         </a>
       }
     </section>
@@ -34,7 +34,7 @@ export class NzNavBottomComponent implements OnInit {
   index = 0;
   language = 'en';
 
-  constructor(private router: Router, private platform: Platform, private cdr: ChangeDetectorRef) {}
+  constructor(private router: Router, private platform: Platform, private cdr: ChangeDetectorRef) { }
 
   ngOnInit(): void {
     if (!this.platform.isBrowser) {

--- a/scripts/site/template/title.template.html
+++ b/scripts/site/template/title.template.html
@@ -1,4 +1,4 @@
 <h1>{{title}}<span class="subtitle">{{subtitle}}</span><span class="widget">{{widget}}</span>
 	<a class="edit-button" aria-label="Edit this page on Github" href="https://github.com/NG-ZORRO/ng-zorro-antd/edit/master/{{path}}" target="_blank" rel="noopener noreferrer">
-		<span nz-icon nzType="edit"></span></a>
+		<nz-icon nzType="edit" /></a>
 </h1>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

将所有 `[nz-icon]` 替换为推荐的 `<nz-icon>` 写法。

如果用户在 CSS 中使用了 `[nz-icon]` 属性选择器去选择 zorro 组件**内部**的 icon，则需要更新为使用元素选择器。

组件内部的 DOM 结构通常不是 **public** 的，这属于 breaking changes 吗？

如果属于 breaking changes，那么应该也可以进入 beta 版本中。

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
