### PR TITLE
feat(module:checkbox): redesign the checkbox group component

### DIFF
--- a/components/checkbox/checkbox-group.spec.ts
+++ b/components/checkbox/checkbox-group.spec.ts
@@ -1,0 +1,179 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+
+import { NzCheckboxOption } from './checkbox-group.component';
+import { NzCheckboxModule } from './checkbox.module';
+
+describe('checkbox group', () => {
+  let component: CheckboxGroupTestComponent;
+  let fixture: ComponentFixture<CheckboxGroupTestComponent>;
+  let hostElement: HTMLElement;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CheckboxGroupTestComponent);
+    component = fixture.componentInstance;
+    hostElement = fixture.nativeElement.querySelector('nz-checkbox-group');
+    fixture.autoDetectChanges();
+  });
+
+  it('should be render option elements', () => {
+    let elements = getOptionElements();
+    for (let index = 0; index < elements.length; index++) {
+      expect(elements[index].textContent?.trim()).toBe((component.options[index] as NzCheckboxOption).label);
+    }
+    component.options = [1, 2, 3];
+    fixture.detectChanges();
+    elements = getOptionElements();
+    for (let index = 0; index < elements.length; index++) {
+      expect(elements[index].textContent?.trim()).toBe(component.options[index].toString());
+    }
+    component.options = ['a', 'b', 'c'];
+    fixture.detectChanges();
+    elements = getOptionElements();
+    for (let index = 0; index < elements.length; index++) {
+      expect(elements[index].textContent?.trim()).toBe(component.options[index]);
+    }
+  });
+
+  it('should be name work', () => {
+    component.name = 'zorro';
+    fixture.detectChanges();
+    const elements = getOptionElements();
+    for (const element of elements) {
+      expect(element.querySelector<HTMLInputElement>('input[type=checkbox]')!.name).toBe('zorro');
+    }
+  });
+
+  it('should be apply disabled class', () => {
+    component.disabled = true;
+    fixture.detectChanges();
+    for (const element of getOptionElements()) {
+      expect(element.classList).toContain('ant-checkbox-wrapper-disabled');
+    }
+  });
+
+  it('should be change value', async () => {
+    component.value = ['A'];
+    fixture.detectChanges();
+    await fixture.whenStable();
+    let checkedOptionElements = getOptionElements().filter(ele =>
+      ele.classList.contains('ant-checkbox-wrapper-checked')
+    );
+    expect(checkedOptionElements.length).toBe(1);
+    expect(checkedOptionElements[0].textContent?.trim()).toBe('A');
+
+    component.value = ['A', 'B'];
+    fixture.detectChanges();
+    await fixture.whenStable();
+    checkedOptionElements = getOptionElements().filter(ele => ele.classList.contains('ant-checkbox-wrapper-checked'));
+    expect(checkedOptionElements.length).toBe(2);
+    expect(checkedOptionElements[0].textContent?.trim()).toBe('A');
+    expect(checkedOptionElements[1].textContent?.trim()).toBe('B');
+
+    component.value = [];
+    fixture.detectChanges();
+    await fixture.whenStable();
+    checkedOptionElements = getOptionElements().filter(ele => ele.classList.contains('ant-checkbox-wrapper-checked'));
+    expect(checkedOptionElements.length).toBe(0);
+  });
+
+  function getOptionElements(): HTMLElement[] {
+    return Array.from(hostElement.querySelectorAll('.ant-checkbox-group-item'));
+  }
+});
+
+describe('checkbox group with custom layout', () => {
+  let component: CheckboxGroupWithCustomLayoutTestComponent;
+  let fixture: ComponentFixture<CheckboxGroupWithCustomLayoutTestComponent>;
+  let hostElement: HTMLElement;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CheckboxGroupWithCustomLayoutTestComponent);
+    component = fixture.componentInstance;
+    hostElement = fixture.nativeElement.querySelector('nz-checkbox-group');
+    fixture.autoDetectChanges();
+  });
+
+  it('should be apply disabled class', () => {
+    component.disabled = true;
+    fixture.detectChanges();
+    for (const element of getOptionElements()) {
+      expect(element.classList).toContain('ant-checkbox-wrapper-disabled');
+    }
+  });
+
+  it('should be change value', async () => {
+    component.value = ['A'];
+    fixture.detectChanges();
+    await fixture.whenStable();
+    let checkedOptionElements = getOptionElements().filter(ele =>
+      ele.classList.contains('ant-checkbox-wrapper-checked')
+    );
+    expect(checkedOptionElements.length).toBe(1);
+    expect(checkedOptionElements[0].textContent?.trim()).toBe('A');
+
+    component.value = ['A', 'B'];
+    fixture.detectChanges();
+    await fixture.whenStable();
+    checkedOptionElements = getOptionElements().filter(ele => ele.classList.contains('ant-checkbox-wrapper-checked'));
+    expect(checkedOptionElements.length).toBe(2);
+    expect(checkedOptionElements[0].textContent?.trim()).toBe('A');
+    expect(checkedOptionElements[1].textContent?.trim()).toBe('B');
+
+    component.value = [];
+    fixture.detectChanges();
+    await fixture.whenStable();
+    checkedOptionElements = getOptionElements().filter(ele => ele.classList.contains('ant-checkbox-wrapper-checked'));
+    expect(checkedOptionElements.length).toBe(0);
+  });
+
+  it('should be change value by outer checkboxes', () => {
+    const checkboxElements = getOptionElements();
+    checkboxElements[0].click();
+    fixture.detectChanges();
+    expect(component.value).toEqual(['A']);
+
+    checkboxElements[1].click();
+    fixture.detectChanges();
+    expect(component.value).toEqual(['A', 'B']);
+
+    checkboxElements[0].click();
+    fixture.detectChanges();
+    expect(component.value).toEqual(['B']);
+  });
+
+  function getOptionElements(): HTMLElement[] {
+    return Array.from(hostElement.querySelectorAll('.ant-checkbox-group-item'));
+  }
+});
+
+@Component({
+  imports: [NzCheckboxModule, FormsModule],
+  template: ` <nz-checkbox-group [nzOptions]="options" [nzName]="name" [nzDisabled]="disabled" [(ngModel)]="value" /> `
+})
+class CheckboxGroupTestComponent {
+  options: string[] | number[] | NzCheckboxOption[] = [
+    { label: 'A', value: 'A' },
+    { label: 'B', value: 'B' },
+    { label: 'C', value: 'C' }
+  ];
+  value: string[] = [];
+  disabled = false;
+  name: string | null = null;
+}
+
+@Component({
+  imports: [NzCheckboxModule, FormsModule],
+  template: `
+    <nz-checkbox-group [nzDisabled]="disabled" [(ngModel)]="value">
+      <label nz-checkbox nzValue="A">A</label>
+      <label nz-checkbox nzValue="B">B</label>
+      <label nz-checkbox nzValue="C">C</label>
+    </nz-checkbox-group>
+  `
+})
+class CheckboxGroupWithCustomLayoutTestComponent {
+  value: string[] = [];
+  disabled = false;
+}

--- a/components/checkbox/checkbox-wrapper.component.ts
+++ b/components/checkbox/checkbox-wrapper.component.ts
@@ -9,6 +9,9 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 import { NzCheckboxComponent } from './checkbox.component';
 
+/**
+ * @deprecated Deprecated in v19.0.0. It is recommended to use `<nz-checkbox-group>`.
+ */
 @Component({
   selector: 'nz-checkbox-wrapper',
   exportAs: 'nzCheckboxWrapper',

--- a/components/checkbox/checkbox.component.ts
+++ b/components/checkbox/checkbox.component.ts
@@ -20,6 +20,7 @@ import {
   ViewChild,
   ViewEncapsulation,
   booleanAttribute,
+  effect,
   forwardRef,
   inject
 } from '@angular/core';
@@ -32,6 +33,7 @@ import { NzSafeAny, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types
 import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 import { NzCheckboxWrapperComponent } from './checkbox-wrapper.component';
+import { NZ_CHECKBOX_GROUP } from './tokens';
 
 @Component({
   selector: '[nz-checkbox]',
@@ -43,7 +45,7 @@ import { NzCheckboxWrapperComponent } from './checkbox-wrapper.component';
     <span
       class="ant-checkbox"
       [class.ant-checkbox-checked]="nzChecked && !nzIndeterminate"
-      [class.ant-checkbox-disabled]="nzDisabled"
+      [class.ant-checkbox-disabled]="nzDisabled || checkboxGroupComponent?.finalDisabled()"
       [class.ant-checkbox-indeterminate]="nzIndeterminate"
     >
       <input
@@ -52,9 +54,10 @@ import { NzCheckboxWrapperComponent } from './checkbox-wrapper.component';
         class="ant-checkbox-input"
         [attr.autofocus]="nzAutoFocus ? 'autofocus' : null"
         [attr.id]="nzId"
+        [attr.name]="nzName || checkboxGroupComponent?.nzName()"
         [checked]="nzChecked"
         [ngModel]="nzChecked"
-        [disabled]="nzDisabled"
+        [disabled]="nzDisabled || (checkboxGroupComponent?.finalDisabled() ?? false)"
         (ngModelChange)="innerCheckedChange($event)"
       />
       <span class="ant-checkbox-inner"></span>
@@ -70,8 +73,10 @@ import { NzCheckboxWrapperComponent } from './checkbox-wrapper.component';
   ],
   host: {
     class: 'ant-checkbox-wrapper',
+    '[class.ant-checkbox-group-item]': '!!checkboxGroupComponent',
     '[class.ant-checkbox-wrapper-in-form-item]': '!!nzFormStatusService',
     '[class.ant-checkbox-wrapper-checked]': 'nzChecked',
+    '[class.ant-checkbox-wrapper-disabled]': 'nzDisabled || checkboxGroupComponent?.finalDisabled()',
     '[class.ant-checkbox-rtl]': `dir === 'rtl'`
   },
   imports: [FormsModule]
@@ -91,15 +96,13 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, OnDest
   @Input({ transform: booleanAttribute }) nzIndeterminate = false;
   @Input({ transform: booleanAttribute }) nzChecked = false;
   @Input() nzId: string | null = null;
+  @Input() nzName: string | null = null;
 
   innerCheckedChange(checked: boolean): void {
-    if (!this.nzDisabled) {
-      this.nzChecked = checked;
-      this.onChange(this.nzChecked);
-      this.nzCheckedChange.emit(this.nzChecked);
-      if (this.nzCheckboxWrapperComponent) {
-        this.nzCheckboxWrapperComponent.onChange();
-      }
+    if (!this.nzDisabled && !this.checkboxGroupComponent?.finalDisabled()) {
+      this.setValue(checked);
+      this.nzCheckboxWrapperComponent?.onChange();
+      this.checkboxGroupComponent?.onCheckedChange(this.nzValue, checked);
     }
   }
 
@@ -130,8 +133,10 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, OnDest
     this.inputElement.nativeElement.blur();
   }
 
+  /** @deprecated */
   private nzCheckboxWrapperComponent = inject(NzCheckboxWrapperComponent, { optional: true });
-  nzFormStatusService = inject(NzFormStatusService, { optional: true });
+  protected checkboxGroupComponent = inject(NZ_CHECKBOX_GROUP, { optional: true });
+  protected nzFormStatusService = inject(NzFormStatusService, { optional: true });
 
   constructor(
     private ngZone: NgZone,
@@ -139,7 +144,15 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, OnDest
     private cdr: ChangeDetectorRef,
     private focusMonitor: FocusMonitor,
     private directionality: Directionality
-  ) {}
+  ) {
+    if (this.checkboxGroupComponent) {
+      effect(() => {
+        const values = this.checkboxGroupComponent!.value() || [];
+        this.setValue(values.includes(this.nzValue));
+        this.cdr.markForCheck();
+      });
+    }
+  }
 
   ngOnInit(): void {
     this.focusMonitor
@@ -150,9 +163,8 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, OnDest
           Promise.resolve().then(() => this.onTouched());
         }
       });
-    if (this.nzCheckboxWrapperComponent) {
-      this.nzCheckboxWrapperComponent.addCheckbox(this);
-    }
+
+    this.nzCheckboxWrapperComponent?.addCheckbox(this);
 
     this.directionality.change.pipe(takeUntil(this.destroy$)).subscribe((direction: Direction) => {
       this.dir = direction;
@@ -188,11 +200,15 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, OnDest
 
   ngOnDestroy(): void {
     this.focusMonitor.stopMonitoring(this.elementRef);
-    if (this.nzCheckboxWrapperComponent) {
-      this.nzCheckboxWrapperComponent.removeCheckbox(this);
-    }
+    this.nzCheckboxWrapperComponent?.removeCheckbox(this);
 
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private setValue(value: boolean): void {
+    this.nzChecked = value;
+    this.onChange(value);
+    this.nzCheckedChange.emit(value);
   }
 }

--- a/components/checkbox/checkbox.spec.ts
+++ b/components/checkbox/checkbox.spec.ts
@@ -6,7 +6,6 @@ import { By } from '@angular/platform-browser';
 
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
-import { NzCheckBoxOptionInterface, NzCheckboxGroupComponent } from './checkbox-group.component';
 import { NzCheckboxWrapperComponent } from './checkbox-wrapper.component';
 import { NzCheckboxComponent } from './checkbox.component';
 import { NzCheckboxModule } from './checkbox.module';
@@ -143,66 +142,7 @@ describe('checkbox', () => {
       });
     });
   });
-  describe('checkbox group basic', () => {
-    let fixture: ComponentFixture<NzTestCheckboxGroupComponent>;
-    let testComponent: NzTestCheckboxGroupComponent;
-    let checkboxGroup: DebugElement;
-    let checkboxes: HTMLElement[];
 
-    beforeEach(fakeAsync(() => {
-      fixture = TestBed.createComponent(NzTestCheckboxGroupComponent);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      testComponent = fixture.debugElement.componentInstance;
-      checkboxGroup = fixture.debugElement.query(By.directive(NzCheckboxGroupComponent));
-      checkboxes = checkboxGroup.nativeElement.children;
-    }));
-    it('should className correct', fakeAsync(() => {
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      expect(checkboxGroup.nativeElement.classList).toContain('ant-checkbox-group');
-      expect(checkboxes[0].firstElementChild!.classList).toContain('ant-checkbox-checked');
-      expect(checkboxes[1].firstElementChild!.classList).toContain('ant-checkbox-disabled');
-      expect(checkboxes[1].firstElementChild!.classList).not.toContain('ant-checkbox-checked');
-      expect(checkboxes[2].firstElementChild!.classList).not.toContain('ant-checkbox-checked');
-    }));
-    it('should click correct', () => {
-      fixture.detectChanges();
-      fixture.detectChanges();
-      checkboxes[0].click();
-      fixture.detectChanges();
-      expect(testComponent.modelChange).toHaveBeenCalledTimes(1);
-      expect(checkboxes[0].firstElementChild!.classList).not.toContain('ant-checkbox-checked');
-    });
-    it('should sub disabled work', () => {
-      fixture.detectChanges();
-      fixture.detectChanges();
-      checkboxes[1].click();
-      fixture.detectChanges();
-      expect(testComponent.modelChange).toHaveBeenCalledTimes(0);
-      expect(checkboxes[1].firstElementChild!.classList).not.toContain('ant-checkbox-checked');
-    });
-    it('should all disabled work', () => {
-      testComponent.disabled = true;
-      fixture.detectChanges();
-      fixture.detectChanges();
-      checkboxes[2].click();
-      fixture.detectChanges();
-      expect(testComponent.modelChange).toHaveBeenCalledTimes(0);
-      expect(checkboxes[2].firstElementChild!.classList).not.toContain('ant-checkbox-checked');
-    });
-    it('should ngModel work', fakeAsync(() => {
-      fixture.detectChanges();
-      testComponent.options[0].checked = false;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      expect(checkboxes[0].firstElementChild!.classList).not.toContain('ant-checkbox-checked');
-      expect(testComponent.modelChange).toHaveBeenCalledTimes(0);
-    }));
-  });
   describe('checkbox form', () => {
     let fixture: ComponentFixture<NzTestCheckboxFormComponent>;
     let testComponent: NzTestCheckboxFormComponent;
@@ -266,80 +206,7 @@ describe('checkbox', () => {
       expect(testComponent.formControl.value).toBe(true);
     }));
   });
-  describe('checkbox group form', () => {
-    let fixture: ComponentFixture<NzTestCheckboxGroupFormComponent>;
-    let testComponent: NzTestCheckboxGroupFormComponent;
-    beforeEach(fakeAsync(() => {
-      fixture = TestBed.createComponent(NzTestCheckboxGroupFormComponent);
-      testComponent = fixture.componentInstance;
-    }));
-    it('should be in pristine, untouched, and valid states initially', fakeAsync(() => {
-      fixture.detectChanges();
-      flush();
-      const checkboxGroupComponent: NzCheckboxGroupComponent = fixture.debugElement.query(
-        By.directive(NzCheckboxGroupComponent)
-      ).componentInstance;
-      expect(testComponent.formControl.valid).toBe(true);
-      expect(testComponent.formControl.pristine).toBe(true);
-      expect(testComponent.formControl.touched).toBe(false);
-      expect(checkboxGroupComponent.nzDisabled).toBeFalsy();
-    }));
-    it('should be disable if form is disable and nzDisable set to false initially', fakeAsync(() => {
-      testComponent.formControl.disable();
-      fixture.detectChanges();
-      flush();
-      const checkboxGroup = fixture.debugElement.query(By.directive(NzCheckboxGroupComponent));
-      expect(checkboxGroup.componentInstance.nzDisabled).toBeTruthy();
-    }));
-    it('should set disabled work', fakeAsync(() => {
-      testComponent.nzDisabled = true;
-      fixture.detectChanges();
-      flush();
-      const checkboxGroup = fixture.debugElement.query(By.directive(NzCheckboxGroupComponent));
-      const inputElement = checkboxGroup.nativeElement.querySelector('input') as HTMLInputElement;
-      expect(checkboxGroup.componentInstance.nzDisabled).toBeTruthy();
 
-      inputElement.click();
-      fixture.detectChanges();
-      expect(JSON.stringify(testComponent.formControl.value)).toBe(
-        JSON.stringify([
-          { label: 'Apple', value: 'Apple', checked: true },
-          { label: 'Pear', value: 'Pear', disabled: true },
-          { label: 'Orange', value: 'Orange' }
-        ])
-      );
-
-      testComponent.enable();
-      fixture.detectChanges();
-      flush();
-      expect(checkboxGroup.componentInstance.nzDisabled).toBeFalsy();
-
-      inputElement.click();
-      fixture.detectChanges();
-      expect(JSON.stringify(testComponent.formControl.value)).toBe(
-        JSON.stringify([
-          { label: 'Apple', value: 'Apple', checked: false },
-          { label: 'Pear', value: 'Pear', disabled: true },
-          { label: 'Orange', value: 'Orange' }
-        ])
-      );
-
-      testComponent.disable();
-      fixture.detectChanges();
-      flush();
-      expect(checkboxGroup.componentInstance.nzDisabled).toBeTruthy();
-
-      inputElement.click();
-      fixture.detectChanges();
-      expect(JSON.stringify(testComponent.formControl.value)).toBe(
-        JSON.stringify([
-          { label: 'Apple', value: 'Apple', checked: false },
-          { label: 'Pear', value: 'Pear', disabled: true },
-          { label: 'Orange', value: 'Orange' }
-        ])
-      );
-    }));
-  });
   describe('checkbox wrapper', () => {
     let fixture: ComponentFixture<NzTestCheckboxWrapperComponent>;
     let testComponent: NzTestCheckboxWrapperComponent;
@@ -377,17 +244,6 @@ describe('checkbox', () => {
       fixture.detectChanges();
       expect(checkbox.nativeElement.classList).not.toContain('ant-checkbox-rtl');
     });
-
-    it('should group checkbox className correct on dir change', () => {
-      const fixture = TestBed.createComponent(NzTestCheckboxGroupRtlComponent);
-      const checkbox = fixture.debugElement.query(By.directive(NzCheckboxGroupComponent));
-      fixture.detectChanges();
-      expect(checkbox.nativeElement.classList).toContain('ant-checkbox-group-rtl');
-
-      fixture.componentInstance.direction = 'ltr';
-      fixture.detectChanges();
-      expect(checkbox.nativeElement.classList).not.toContain('ant-checkbox-group-rtl');
-    });
   });
 });
 
@@ -413,27 +269,6 @@ export class NzTestCheckboxSingleComponent {
   autoFocus = false;
   checked = false;
   indeterminate = false;
-  modelChange = jasmine.createSpy('change callback');
-}
-
-@Component({
-  imports: [FormsModule, NzCheckboxModule],
-  selector: 'nz-test-group-checkbox',
-  template: `
-    <nz-checkbox-group
-      [nzDisabled]="disabled"
-      [ngModel]="options"
-      (ngModelChange)="modelChange($event)"
-    ></nz-checkbox-group>
-  `
-})
-export class NzTestCheckboxGroupComponent {
-  options = [
-    { label: 'Apple', value: 'Apple', checked: true },
-    { label: 'Pear', value: 'Pear', disabled: true },
-    { label: 'Orange', value: 'Orange' }
-  ];
-  disabled = false;
   modelChange = jasmine.createSpy('change callback');
 }
 
@@ -475,31 +310,6 @@ export class NzTestCheckboxFormComponent {
 }
 
 @Component({
-  imports: [ReactiveFormsModule, NzCheckboxModule],
-  template: `
-    <form>
-      <nz-checkbox-group [formControl]="formControl" [nzDisabled]="nzDisabled"></nz-checkbox-group>
-    </form>
-  `
-})
-export class NzTestCheckboxGroupFormComponent {
-  formControl = new FormControl<NzCheckBoxOptionInterface[] | null>([
-    { label: 'Apple', value: 'Apple', checked: true },
-    { label: 'Pear', value: 'Pear', disabled: true },
-    { label: 'Orange', value: 'Orange' }
-  ]);
-  nzDisabled = false;
-
-  disable(): void {
-    this.formControl.disable();
-  }
-
-  enable(): void {
-    this.formControl.enable();
-  }
-}
-
-@Component({
   imports: [BidiModule, NzTestCheckboxSingleComponent],
   template: `
     <div [dir]="direction">
@@ -508,19 +318,6 @@ export class NzTestCheckboxGroupFormComponent {
   `
 })
 export class NzTestCheckboxSingleRtlComponent {
-  @ViewChild(Dir) dir!: Dir;
-  direction: Direction = 'rtl';
-}
-
-@Component({
-  imports: [BidiModule, NzTestCheckboxGroupComponent],
-  template: `
-    <div [dir]="direction">
-      <nz-test-group-checkbox></nz-test-group-checkbox>
-    </div>
-  `
-})
-export class NzTestCheckboxGroupRtlComponent {
   @ViewChild(Dir) dir!: Dir;
   direction: Direction = 'rtl';
 }
@@ -573,26 +370,6 @@ describe('checkbox component', () => {
       spyOn(component.nzOnChange, 'emit');
       component.onChange();
       expect(component.nzOnChange.emit).toHaveBeenCalledWith(['value 1', 'value 2']);
-    });
-  });
-
-  describe('checkbox group component', () => {
-    let fixture: ComponentFixture<NzCheckboxGroupComponent>;
-    let component: NzCheckboxGroupComponent;
-
-    beforeEach(() => {
-      fixture = TestBed.createComponent(NzCheckboxGroupComponent);
-      component = fixture.componentInstance;
-    });
-
-    it('should have correct initial value', () => {
-      expect(component.onChange).toBeDefined();
-      expect(component.onChange).toEqual(jasmine.any(Function));
-      expect(component.onChange({})).toBeUndefined();
-
-      expect(component.onTouched).toBeDefined();
-      expect(component.onTouched).toEqual(jasmine.any(Function));
-      expect(component.onTouched()).toBeUndefined();
     });
   });
 });

--- a/components/checkbox/demo/basic.ts
+++ b/components/checkbox/demo/basic.ts
@@ -6,7 +6,7 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 @Component({
   selector: 'nz-demo-checkbox-basic',
   imports: [FormsModule, NzCheckboxModule],
-  template: ` <label nz-checkbox [(ngModel)]="checked">Checkbox</label> `
+  template: `<label nz-checkbox [(ngModel)]="checked">Checkbox</label>`
 })
 export class NzDemoCheckboxBasicComponent {
   checked = true;

--- a/components/checkbox/demo/check-all.ts
+++ b/components/checkbox/demo/check-all.ts
@@ -1,59 +1,49 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
+import { NzCheckboxModule, NzCheckboxOption } from 'ng-zorro-antd/checkbox';
+import { NzDividerModule } from 'ng-zorro-antd/divider';
 
 @Component({
   selector: 'nz-demo-checkbox-check-all',
-  imports: [FormsModule, NzCheckboxModule],
+  imports: [FormsModule, NzCheckboxModule, NzDividerModule],
   template: `
-    <div style="border-bottom: 1px solid rgb(233, 233, 233); padding-bottom: 16px">
-      <label
-        nz-checkbox
-        [(ngModel)]="allChecked"
-        (ngModelChange)="updateAllChecked()"
-        [nzIndeterminate]="indeterminate"
-      >
-        Check all
-      </label>
-    </div>
-    <br />
-    <nz-checkbox-group [(ngModel)]="checkOptionsOne" (ngModelChange)="updateSingleChecked()"></nz-checkbox-group>
+    <label
+      nz-checkbox
+      [(ngModel)]="allChecked"
+      (ngModelChange)="updateAllChecked()"
+      [nzIndeterminate]="value.length > 0 && value.length !== options.length"
+    >
+      Check all
+    </label>
+
+    <nz-divider />
+
+    <nz-checkbox-group
+      [nzOptions]="options"
+      [(ngModel)]="value"
+      (ngModelChange)="updateSingleChecked()"
+    ></nz-checkbox-group>
   `
 })
 export class NzDemoCheckboxCheckAllComponent {
+  isAllCheckedFirstChange = true;
   allChecked = false;
-  indeterminate = true;
-  checkOptionsOne = [
-    { label: 'Apple', value: 'Apple', checked: true },
-    { label: 'Pear', value: 'Pear', checked: false },
-    { label: 'Orange', value: 'Orange', checked: false }
+  value: Array<string | number> = ['Apple', 'Orange'];
+  options: NzCheckboxOption[] = [
+    { label: 'Apple', value: 'Apple' },
+    { label: 'Pear', value: 'Pear' },
+    { label: 'Orange', value: 'Orange' }
   ];
 
   updateAllChecked(): void {
-    this.indeterminate = false;
-    if (this.allChecked) {
-      this.checkOptionsOne = this.checkOptionsOne.map(item => ({
-        ...item,
-        checked: true
-      }));
-    } else {
-      this.checkOptionsOne = this.checkOptionsOne.map(item => ({
-        ...item,
-        checked: false
-      }));
+    if (!this.isAllCheckedFirstChange) {
+      this.value = this.allChecked ? this.options.map(item => item.value) : [];
     }
+    this.isAllCheckedFirstChange = false;
   }
 
   updateSingleChecked(): void {
-    if (this.checkOptionsOne.every(item => !item.checked)) {
-      this.allChecked = false;
-      this.indeterminate = false;
-    } else if (this.checkOptionsOne.every(item => item.checked)) {
-      this.allChecked = true;
-      this.indeterminate = false;
-    } else {
-      this.indeterminate = true;
-    }
+    this.allChecked = this.value.length === this.options.length;
   }
 }

--- a/components/checkbox/demo/controller.ts
+++ b/components/checkbox/demo/controller.ts
@@ -12,6 +12,7 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
       {{ isCheckedButton ? 'Checked' : 'Unchecked' }} - {{ isDisabledButton ? 'Disabled' : 'Enabled' }}
     </label>
     <br />
+    <br />
     <button nz-button [nzType]="'primary'" (click)="checkButton()" [nzSize]="'small'">
       {{ !isCheckedButton ? 'Checked' : 'Unchecked' }}
     </button>

--- a/components/checkbox/demo/group.ts
+++ b/components/checkbox/demo/group.ts
@@ -1,39 +1,41 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
+import { NzCheckboxModule, NzCheckboxOption } from 'ng-zorro-antd/checkbox';
 
 @Component({
   selector: 'nz-demo-checkbox-group',
   imports: [FormsModule, NzCheckboxModule],
   template: `
-    <nz-checkbox-group [(ngModel)]="checkOptionsOne" (ngModelChange)="log(checkOptionsOne)"></nz-checkbox-group>
+    <nz-checkbox-group [nzOptions]="options1" [(ngModel)]="value" (ngModelChange)="log($event)" />
     <br />
     <br />
-    <nz-checkbox-group [(ngModel)]="checkOptionsTwo" (ngModelChange)="log(checkOptionsTwo)"></nz-checkbox-group>
+    <nz-checkbox-group [nzOptions]="options2" [(ngModel)]="value" (ngModelChange)="log($event)" />
     <br />
     <br />
-    <nz-checkbox-group [(ngModel)]="checkOptionsThree" (ngModelChange)="log(checkOptionsThree)"></nz-checkbox-group>
+    <nz-checkbox-group nzDisabled [nzOptions]="options3" [(ngModel)]="value" (ngModelChange)="log($event)" />
   `
 })
 export class NzDemoCheckboxGroupComponent {
-  checkOptionsOne = [
-    { label: 'Apple', value: 'Apple', checked: true },
+  options1: NzCheckboxOption[] = [
+    { label: 'Apple', value: 'Apple' },
     { label: 'Pear', value: 'Pear' },
     { label: 'Orange', value: 'Orange' }
   ];
-  checkOptionsTwo = [
+  options2: NzCheckboxOption[] = [
     { label: 'Apple', value: 'Apple' },
-    { label: 'Pear', value: 'Pear', checked: true },
-    { label: 'Orange', value: 'Orange' }
+    { label: 'Pear', value: 'Pear' },
+    { label: 'Orange', value: 'Orange', disabled: true }
   ];
-  checkOptionsThree = [
-    { label: 'Apple', value: 'Apple', disabled: true, checked: true },
-    { label: 'Pear', value: 'Pear', disabled: true },
+  options3: NzCheckboxOption[] = [
+    { label: 'Apple', value: 'Apple' },
+    { label: 'Pear', value: 'Pear' },
     { label: 'Orange', value: 'Orange' }
   ];
 
-  log(value: object[]): void {
+  value = ['Apple'];
+
+  log(value: string[]): void {
     console.log(value);
   }
 }

--- a/components/checkbox/demo/layout-legacy.md
+++ b/components/checkbox/demo/layout-legacy.md
@@ -1,0 +1,18 @@
+---
+order: 6
+title:
+  zh-CN: 布局（弃用）
+  en-US: Use with Grid (Deprecated)
+---
+
+## zh-CN
+
+`nz-checkbox-wrapper` 内嵌 `nz-checkbox` 并与 Grid 组件一起使用，可以实现灵活的布局。
+
+> ⚠️ `nz-checkbox-wrapper` 已被弃用，推荐使用 `nz-checkbox-group`。
+
+## en-US
+
+We can use `nz-checkbox` and Grid in `nz-checkbox-wrapper`, to implement complex layout.
+
+> ⚠️ `nz-checkbox-wrapper` is deprecated, we recommend using `nz-checkbox-group`.

--- a/components/checkbox/demo/layout-legacy.ts
+++ b/components/checkbox/demo/layout-legacy.ts
@@ -5,13 +5,13 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 
 @Component({
-  selector: 'nz-demo-checkbox-layout',
+  selector: 'nz-demo-checkbox-layout-legacy',
   imports: [FormsModule, NzCheckboxModule, NzGridModule],
   template: `
-    <nz-checkbox-group [(ngModel)]="value" [style.width.%]="100" (ngModelChange)="log($event)">
+    <nz-checkbox-wrapper style="width: 100%;" (nzOnChange)="log($event)">
       <nz-row>
         <nz-col nzSpan="8">
-          <label nz-checkbox nzValue="A">A</label>
+          <label nz-checkbox nzValue="A" [ngModel]="true">A</label>
         </nz-col>
         <nz-col nzSpan="8">
           <label nz-checkbox nzValue="B">B</label>
@@ -26,10 +26,10 @@ import { NzGridModule } from 'ng-zorro-antd/grid';
           <label nz-checkbox nzValue="E">E</label>
         </nz-col>
       </nz-row>
-    </nz-checkbox-group>
+    </nz-checkbox-wrapper>
   `
 })
-export class NzDemoCheckboxLayoutComponent {
+export class NzDemoCheckboxLayoutLegacyComponent {
   value = ['A'];
 
   log(value: string[]): void {

--- a/components/checkbox/demo/layout.md
+++ b/components/checkbox/demo/layout.md
@@ -7,8 +7,8 @@ title:
 
 ## zh-CN
 
-`nz-checkbox-wrapper` 内嵌 `nz-checkbox` 并与 Grid 组件一起使用，可以实现灵活的布局。
+`nz-checkbox-group` 内嵌 `nz-checkbox` 并与 Grid 组件一起使用，可以实现灵活的布局。
 
 ## en-US
 
-We can use `nz-checkbox` and Grid in `nz-checkbox-wrapper`, to implement complex layout.
+We can use `nz-checkbox` and Grid in `nz-checkbox-group`, to implement complex layout.

--- a/components/checkbox/doc/index.en-US.md
+++ b/components/checkbox/doc/index.en-US.md
@@ -23,6 +23,7 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 | Property            | Description                                                     | Type                    | Default |
 | ------------------- | --------------------------------------------------------------- | ----------------------- | ------- |
 | `[nzId]`            | input id attribute inside the component                         | `string`                | -       |
+| `[nzName]`          | input name attribute inside the component                       | `string`                | -       |
 | `[nzAutoFocus]`     | get focus when component mounted                                | `boolean`               | `false` |
 | `[nzDisabled]`      | Disable checkbox                                                | `boolean`               | `false` |
 | `[ngModel]`         | Specifies whether the checkbox is selected, double binding      | `boolean`               | `false` |
@@ -35,6 +36,8 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 | Property          | Description                                                     | Type                                                                        | Default |
 | ----------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------- | ------- |
 | `[ngModel]`       | Specifies options, double binding                               | `Array<{ label: string; value: string; checked?: boolean; }>`               | `[]`    |
+| `[nzName]`        | The `name` property of all input children                       | `string`                                                                    | -       |
+| `[nzOptions]`     | Specifies options                                               | `string[] \| number[] \| NzCheckboxOption[]`                                | `[]`    |
 | `[nzDisabled]`    | Disable all checkboxes                                          | `boolean`                                                                   | `false` |
 | `(ngModelChange)` | The callback function that is triggered when the state changes. | `EventEmitter<Array<{ label: string; value: string; checked?: boolean; }>>` | -       |
 
@@ -52,3 +55,15 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 | ------- | ------------ |
 | focus() | get focus    |
 | blur()  | remove focus |
+
+## Interfaces
+
+### NzCheckboxOption
+
+```ts
+export interface NzCheckboxOption {
+  label: string;
+  value: string | number;
+  disabled?: boolean;
+}
+```

--- a/components/checkbox/doc/index.zh-CN.md
+++ b/components/checkbox/doc/index.zh-CN.md
@@ -23,7 +23,8 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 
 | 参数                | 说明                                          | 类型                    | 默认值  |
 | ------------------- | --------------------------------------------- | ----------------------- | ------- |
-| `[nzId]`            | 组件内部 input 的 id 值                       | `string`                | -       |
+| `[nzId]`            | 组件内部 input 的 `id` 值                     | `string`                | -       |
+| `[nzName]`          | 组件内部 input 的 `name` 值                   | `string`                | -       |
 | `[nzAutoFocus]`     | 自动获取焦点                                  | `boolean`               | `false` |
 | `[nzDisabled]`      | 设定 disable 状态                             | `boolean`               | `false` |
 | `[ngModel]`         | 指定当前是否选中，可双向绑定                  | `boolean`               | `false` |
@@ -33,11 +34,13 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 
 ### nz-checkbox-group
 
-| 参数              | 说明                           | 类型                                                                        | 默认值  |
-| ----------------- | ------------------------------ | --------------------------------------------------------------------------- | ------- |
-| `[ngModel]`       | 指定可选项，可双向绑定         | `Array<{ label: string; value: string; checked?: boolean; }>`               | `[]`    |
-| `[nzDisabled]`    | 设定全部 checkbox disable 状态 | `boolean`                                                                   | `false` |
-| `(ngModelChange)` | 选中数据变化时的回调           | `EventEmitter<Array<{ label: string; value: string; checked?: boolean; }>>` | -       |
+| 参数              | 说明                                      | 类型                                                                   | 默认值  |
+| ----------------- | ----------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| `[ngModel]`       | 指定可选项，可双向绑定                    | `{ label: string; value: string; checked?: boolean; }[]`               | `[]`    |
+| `[nzName]`        | CheckboxGroup 下所有 input 的 `name` 属性 | `string`                                                               | -       |
+| `[nzOptions]`     | 指定可选项                                | `string[] \| number[] \| NzCheckboxOption[]`                           | `[]`    |
+| `[nzDisabled]`    | 设定全部 checkbox disable 状态            | `boolean`                                                              | `false` |
+| `(ngModelChange)` | 选中数据变化时的回调                      | `EventEmitter<{ label: string; value: string; checked?: boolean; }[]>` | -       |
 
 ### nz-checkbox-wrapper
 
@@ -55,3 +58,15 @@ import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
 | ------- | -------- |
 | focus() | 获取焦点 |
 | blur()  | 移除焦点 |
+
+## Interfaces
+
+### NzCheckboxOption
+
+```ts
+export interface NzCheckboxOption {
+  label: string;
+  value: string | number;
+  disabled?: boolean;
+}
+```

--- a/components/checkbox/public-api.ts
+++ b/components/checkbox/public-api.ts
@@ -3,7 +3,8 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-export * from './checkbox.component';
-export * from './checkbox.module';
 export * from './checkbox-group.component';
 export * from './checkbox-wrapper.component';
+export * from './checkbox.component';
+export * from './checkbox.module';
+export * from './tokens';

--- a/components/checkbox/tokens.ts
+++ b/components/checkbox/tokens.ts
@@ -1,0 +1,10 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { InjectionToken } from '@angular/core';
+
+import type { NzCheckboxGroupComponent } from './checkbox-group.component';
+
+export const NZ_CHECKBOX_GROUP = new InjectionToken<NzCheckboxGroupComponent>('NZ_CHECKBOX_GROUP');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4883

- `<nz-checkbox-group>` 的 `ngModel` 的类型为 `NzCheckBoxOptionInterface[]`，与 antd 不一致
- `<nz-checkbox-group>` 无法像 [antd](https://4x-ant-design.antgroup.com/components/checkbox-cn/#components-checkbox-demo-layout) 那样自定义布局，需要借助 `<nz-checkbox-wrapper>` 组件实现自定义布局，但 `<nz-checkbox-wrapper>` 又不是一个控件组件，用途不大。实际上 `<nz-checkbox-wrapper>` 应该被实现为 `<nz-checkbox-group>`。

## What is the new behavior?

- 将 `<nz-checkbox-group>` 的 `ngModel` 的类型修正为 `NzCheckBoxOptionInterface['value'][]`
- `<nz-checkbox-group>` 支持自定义布局
- `<nz-checkbox-group>` 新增 `[nzName]`
- `[nz-checkbox]` 新增 `[nzName]`
- 弃用 `<nz-checkbox-wrapper>`
- 弃用 `NzCheckBoxOptionInterface`，使用 `NzCheckBoxOption` 替代

```html
<nz-checkbox-group [ngModel]="['A', 'B']">
  <nz-row>
    <nz-col nzSpan="8">
      <label nz-checkbox nzValue="A">A</label>
    </nz-col>
    <nz-col nzSpan="8">
      <label nz-checkbox nzValue="B">B</label>
    </nz-col>
    <nz-col nzSpan="8">
      <label nz-checkbox nzValue="C">C</label>
    </nz-col>
    <nz-col nzSpan="8">
      <label nz-checkbox nzValue="D">D</label>
    </nz-col>
    <nz-col nzSpan="8">
      <label nz-checkbox nzValue="E">E</label>
    </nz-col>
  </nz-row>
</nz-checkbox-group>
```

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- `<nz-checkbox-group>` 的 `ngModel` 的类型修改为 `NzCheckBoxOptionInterface['value'][]`
- 移除 `NzCheckBoxOptionInterface['checked']`


## Other information
