### PR TITLE
fix(module:table): should col be wrapped within colgroup in ssr mode

### DIFF
--- a/components/table/src/table/table-content.component.ts
+++ b/components/table/src/table/table-content.component.ts
@@ -15,8 +15,12 @@ import { NzTableLayout } from '../table.types';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
-    @for (width of listOfColWidth; track $index) {
-      <col [style.width]="width" [style.minWidth]="width" />
+    @if (listOfColWidth.length > 0) {
+      <colgroup>
+        @for (width of listOfColWidth; track $index) {
+          <col [style.width]="width" [style.minWidth]="width" />
+        }
+      </colgroup>
     }
     @if (theadTemplate) {
       <thead class="ant-table-thead">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`nz-table-content` 中的 `col` 没有用 `colgroup` 包起来，与服务端渲染出来的 html 不匹配，导致水合时报错 **NG0502** 

Issue Number: close #8922 


## What is the new behavior?

`nz-table-content` 中的 `col` 使用 `colgroup` 包起来

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
