### PR TITLE
feat(module:message,notification): display nzData when content is a template

### DIFF
--- a/components/message/demo/template.md
+++ b/components/message/demo/template.md
@@ -1,0 +1,16 @@
+---
+order: 5
+title:
+  zh-CN: 自定义模板
+  en-US: Custom Template
+---
+
+## zh-CN
+
+您可以为消息内容创建自定义模板。
+通过 `nzData` 选项，您可以传递一些可选的数据给此自定义模板。
+
+## en-US
+
+You can have a custom template for the message content.
+You would have the possibility to pass some optional data to this custom template thanks to the `nzData` option

--- a/components/message/demo/template.ts
+++ b/components/message/demo/template.ts
@@ -1,0 +1,25 @@
+import { Component, TemplateRef, ViewChild } from '@angular/core';
+
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzMessageComponent, NzMessageService } from 'ng-zorro-antd/message';
+
+@Component({
+  selector: 'nz-demo-message-template',
+  imports: [NzButtonModule],
+  template: `
+    <button nz-button nzType="default" (click)="showMessage()">Display a custom template</button>
+    <ng-template #customTemplate let-data="data">My Favorite Framework is {{ data }}</ng-template>
+  `
+})
+export class NzDemoMessageTemplateComponent {
+  @ViewChild('customTemplate', { static: true }) customTemplate!: TemplateRef<{
+    $implicit: NzMessageComponent;
+    data: string;
+  }>;
+
+  constructor(private message: NzMessageService) {}
+
+  showMessage(): void {
+    this.message.success(this.customTemplate, { nzData: 'Angular' });
+  }
+}

--- a/components/message/doc/index.en-US.md
+++ b/components/message/doc/index.en-US.md
@@ -38,11 +38,12 @@ This components provides some service methods, with usage and arguments as follo
 
 The parameters that are set by the `options` support are as follows:
 
-| Argument       | Description                                                            | Type      |
-| -------------- | ---------------------------------------------------------------------- | --------- |
-| nzDuration     | Duration (milliseconds), does not disappear when set to 0              | `number`  |
-| nzPauseOnHover | Do not remove automatically when mouse is over while setting to `true` | `boolean` |
-| nzAnimate      | Whether to turn on animation                                           | `boolean` |
+| Argument      | Description                                                           | Type        |
+|---------------|-----------------------------------------------------------------------|-------------|
+| nzDuration    | Duration (milliseconds), does not disappear when set to 0             | `number`    |
+| nzPauseOnHover | Do not remove automatically when mouse is over while setting to `true` | `boolean`   |
+| nzAnimate     | Whether to turn on animation                                          | `boolean`   |
+| nzData        | Data to pass to custom template                                       | `NzSafeAny` |
 
 Methods for destruction are also provided:
 

--- a/components/message/doc/index.zh-CN.md
+++ b/components/message/doc/index.zh-CN.md
@@ -44,6 +44,7 @@ private readonly message = inject(NzMessageService);
 | nzDuration     | 持续时间(毫秒)，当设置为0时不消失 | `number`  |
 | nzPauseOnHover | 鼠标移上时禁止自动移除            | `boolean` |
 | nzAnimate      | 开关动画效果                      | `boolean` |
+| nzData        | 传递给自定义模板的数据                                       | `NzSafeAny` |
 
 还提供了全局销毁方法：
 

--- a/components/message/message.component.ts
+++ b/components/message/message.component.ts
@@ -55,7 +55,9 @@ import { NzMessageData } from './typings';
               <nz-icon nzType="loading" />
             }
           }
-          <ng-container *nzStringTemplateOutlet="instance.content">
+          <ng-container
+            *nzStringTemplateOutlet="instance.content; context: { $implicit: this, data: instance.options?.nzData }"
+          >
             <span [innerHTML]="instance.content"></span>
           </ng-container>
         </div>

--- a/components/message/message.service.ts
+++ b/components/message/message.service.ts
@@ -6,11 +6,9 @@
 import { Overlay } from '@angular/cdk/overlay';
 import { Injectable, Injector } from '@angular/core';
 
-import { NzTSType } from 'ng-zorro-antd/core/types';
-
 import { NzMNService } from './base';
 import { NzMessageContainerComponent } from './message-container.component';
-import { NzMessageData, NzMessageDataOptions, NzMessageRef, NzMessageType } from './typings';
+import { NzMessageContentType, NzMessageData, NzMessageDataOptions, NzMessageRef, NzMessageType } from './typings';
 
 @Injectable({
   providedIn: 'root'
@@ -22,27 +20,27 @@ export class NzMessageService extends NzMNService<NzMessageContainerComponent> {
     super(overlay, injector);
   }
 
-  success(content: NzTSType, options?: NzMessageDataOptions): NzMessageRef {
+  success(content: NzMessageContentType, options?: NzMessageDataOptions): NzMessageRef {
     return this.createInstance({ type: 'success', content }, options);
   }
 
-  error(content: NzTSType, options?: NzMessageDataOptions): NzMessageRef {
+  error(content: NzMessageContentType, options?: NzMessageDataOptions): NzMessageRef {
     return this.createInstance({ type: 'error', content }, options);
   }
 
-  info(content: NzTSType, options?: NzMessageDataOptions): NzMessageRef {
+  info(content: NzMessageContentType, options?: NzMessageDataOptions): NzMessageRef {
     return this.createInstance({ type: 'info', content }, options);
   }
 
-  warning(content: NzTSType, options?: NzMessageDataOptions): NzMessageRef {
+  warning(content: NzMessageContentType, options?: NzMessageDataOptions): NzMessageRef {
     return this.createInstance({ type: 'warning', content }, options);
   }
 
-  loading(content: NzTSType, options?: NzMessageDataOptions): NzMessageRef {
+  loading(content: NzMessageContentType, options?: NzMessageDataOptions): NzMessageRef {
     return this.createInstance({ type: 'loading', content }, options);
   }
 
-  create(type: NzMessageType | string, content: NzTSType, options?: NzMessageDataOptions): NzMessageRef {
+  create(type: NzMessageType | string, content: NzMessageContentType, options?: NzMessageDataOptions): NzMessageRef {
     return this.createInstance({ type, content }, options);
   }
 

--- a/components/message/message.spec.ts
+++ b/components/message/message.spec.ts
@@ -11,6 +11,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { NzConfigService, provideNzConfig } from 'ng-zorro-antd/core/config';
 import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
 
+import { NzMessageComponent } from './message.component';
 import { NzMessageService } from './message.service';
 
 describe('message', () => {
@@ -91,11 +92,11 @@ describe('message', () => {
   });
 
   it('should support template', fakeAsync(() => {
-    messageService.info(testComponent.template);
+    messageService.info(testComponent.template, { nzData: 'from template' });
     fixture.detectChanges();
     overlayContainerElement = overlayContainer.getContainerElement();
 
-    expect(overlayContainerElement.textContent).toContain('Content in template');
+    expect(overlayContainerElement.textContent).toContain('Content in templatefrom template');
     tick(10000);
   }));
 
@@ -210,8 +211,11 @@ describe('message', () => {
 });
 
 @Component({
-  template: `<ng-template #contentTemplate>Content in template</ng-template>`
+  template: ` <ng-template #contentTemplate let-data="data">Content in template{{ data }}</ng-template>`
 })
 export class NzTestMessageComponent {
-  @ViewChild('contentTemplate', { static: true }) template!: TemplateRef<void>;
+  @ViewChild('contentTemplate', { static: true }) template!: TemplateRef<{
+    $implicit: NzMessageComponent;
+    data: string;
+  }>;
 }

--- a/components/message/typings.ts
+++ b/components/message/typings.ts
@@ -6,22 +6,28 @@
 import { TemplateRef } from '@angular/core';
 import { Subject } from 'rxjs';
 
+import { NzSafeAny } from 'ng-zorro-antd/core/types';
+
+import { NzMNComponent } from './base';
+
 export type NzMessageType = 'success' | 'info' | 'warning' | 'error' | 'loading';
+
+export type NzMessageContentType = string | TemplateRef<void | { $implicit: NzMNComponent; data: NzSafeAny }>;
 
 export interface NzMessageDataOptions {
   nzDuration?: number;
   nzAnimate?: boolean;
   nzPauseOnHover?: boolean;
+  nzData?: NzSafeAny;
 }
 
 export interface NzMessageData {
   type?: NzMessageType | string;
-  content?: string | TemplateRef<void>;
+  content?: NzMessageContentType;
   messageId?: string;
   createdAt?: Date;
   options?: NzMessageDataOptions;
   state?: 'enter' | 'leave';
-
   onClose?: Subject<boolean>;
 }
 

--- a/components/notification/demo/custom-icon.ts
+++ b/components/notification/demo/custom-icon.ts
@@ -2,7 +2,7 @@ import { Component, TemplateRef } from '@angular/core';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzIconModule } from 'ng-zorro-antd/icon';
-import { NzNotificationService } from 'ng-zorro-antd/notification';
+import { type NzNotificationComponent, NzNotificationService } from 'ng-zorro-antd/notification';
 
 @Component({
   selector: 'nz-demo-notification-custom-icon',
@@ -28,7 +28,7 @@ import { NzNotificationService } from 'ng-zorro-antd/notification';
 export class NzDemoNotificationCustomIconComponent {
   constructor(private notification: NzNotificationService) {}
 
-  createNotification(template: TemplateRef<{}>): void {
+  createNotification(template: TemplateRef<{ $implicit: NzNotificationComponent; data: undefined }>): void {
     this.notification.template(template);
   }
 }

--- a/components/notification/demo/template.ts
+++ b/components/notification/demo/template.ts
@@ -1,7 +1,7 @@
 import { Component, TemplateRef, ViewChild } from '@angular/core';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';
-import { NzNotificationService } from 'ng-zorro-antd/notification';
+import { type NzNotificationComponent, NzNotificationService } from 'ng-zorro-antd/notification';
 import { NzTagModule } from 'ng-zorro-antd/tag';
 
 @Component({
@@ -24,7 +24,10 @@ import { NzTagModule } from 'ng-zorro-antd/tag';
   ]
 })
 export class NzDemoNotificationTemplateComponent {
-  @ViewChild(TemplateRef, { static: false }) template?: TemplateRef<{}>;
+  @ViewChild(TemplateRef, { static: false }) template?: TemplateRef<{
+    $implicit: NzNotificationComponent;
+    data: Array<{ name: string; color: string }>;
+  }>;
 
   constructor(private notificationService: NzNotificationService) {}
 

--- a/components/notification/doc/index.en-US.md
+++ b/components/notification/doc/index.en-US.md
@@ -36,16 +36,16 @@ The component provides a number of service methods using the following methods a
 - `NzNotificationService.info(title, content, [options])`
 - `NzNotificationService.warning(title, content, [options])`
 
-| Argument | Description                                                                          | Type                          | Default |
-| -------- | ------------------------------------------------------------------------------------ | ----------------------------- | ------- |
-| title    | Title                                                                                | `string \| TemplateRef<void>` | -       |
-| content  | Notification content                                                                 | `string \| TemplateRef<void>` | -       |
-| options  | Support setting the parameters for the current notification box, see the table below | `object`                      | -       |
+| Argument | Description                                                                          | Type                                                                              | Default |
+|----------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|---------|
+| title    | Title                                                                                | `string \| TemplateRef<void>`                                                     | -       |
+| content  | Notification content                                                                 | `NzNotificationContentType` | -       |
+| options  | Support setting the parameters for the current notification box, see the table below | `object`                                                                          | -       |
 
 The parameters that are set by the `options` support are as follows:
 
 | Argument       | Description                                                            | Type                                                            |
-| -------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------- |
+|----------------|------------------------------------------------------------------------|-----------------------------------------------------------------|
 | nzKey          | The unique identifier of the Notification                              | `string`                                                        |
 | nzDuration     | Duration (milliseconds), does not disappear when set to 0              | `number`                                                        |
 | nzPauseOnHover | Do not remove automatically when mouse is over while setting to `true` | `boolean`                                                       |
@@ -65,7 +65,7 @@ Methods for destruction are also provided:
 You can use `NzConfigService` to configure this component globally. Please check the [Global Configuration](/docs/global-config/en) chapter for more information.
 
 | Parameter      | Description                                                                             | Type             | Default    |
-| -------------- | --------------------------------------------------------------------------------------- | ---------------- | ---------- |
+|----------------|-----------------------------------------------------------------------------------------|------------------|------------|
 | nzDuration     | Duration (milliseconds), does not disappear when set to 0                               | `number`         | 4500       |
 | nzMaxStack     | The maximum number of notifications that can be displayed at the same time              | `number`         | 8          |
 | nzPauseOnHover | Do not remove automatically when mouse is over while setting to `true`                  | `boolean`        | `true`     |

--- a/components/notification/doc/index.zh-CN.md
+++ b/components/notification/doc/index.zh-CN.md
@@ -35,25 +35,25 @@ private readonly notification = inject(NzNotificationService);
 - `NzNotificationService.info(title, content, [options])`
 - `NzNotificationService.warning(title, content, [options])`
 
-| 参数    | 说明                                     | 类型                          | 默认值 |
-| ------- | ---------------------------------------- | ----------------------------- | ------ |
-| title   | 标题                                     | `string \| TemplateRef<void>` | -      |
-| content | 提示内容                                 | `string \| TemplateRef<void>` | -      |
-| options | 支持设置针对当前提示框的参数，见下方表格 | `object`                      | -      |
+| 参数      | 说明                   | 类型                                                                                | 默认值 |
+|---------|----------------------|-----------------------------------------------------------------------------------|-----|
+| title   | 标题                   | `string \| TemplateRef<void>`                                                     | -   |
+| content | 提示内容                 | `NzNotificationContentType` | -   |
+| options | 支持设置针对当前提示框的参数，见下方表格 | `object`                                                                          | -   |
 
 `options` 支持设置的参数如下：
 
-| 参数           | 说明                                | 类型                                                            |
-| -------------- | ----------------------------------- | --------------------------------------------------------------- |
-| nzKey          | 通知提示的唯一标识符                | `string`                                                        |
+| 参数             | 说明                   | 类型                                                              |
+|----------------|----------------------|-----------------------------------------------------------------|
+| nzKey          | 通知提示的唯一标识符           | `string`                                                        |
 | nzDuration     | 持续时间(毫秒)，当设置为 0 时不消失 | `number`                                                        |
-| nzPauseOnHover | 鼠标移上时禁止自动移除              | `boolean`                                                       |
-| nzAnimate      | 开关动画效果                        | `boolean`                                                       |
-| nzStyle        | 自定义内联样式                      | `object`                                                        |
-| nzClass        | 自定义 CSS class                    | `object`                                                        |
-| nzData         | 任何想要在模板中作为上下文的数据    | `any`                                                           |
-| nzCloseIcon    | 自定义关闭图标                      | `TemplateRef<void> \| string`                                   |
-| nzButton       | 自定义按钮                          | `TemplateRef<{ $implicit: NzNotificationComponent }> \| string` |
+| nzPauseOnHover | 鼠标移上时禁止自动移除          | `boolean`                                                       |
+| nzAnimate      | 开关动画效果               | `boolean`                                                       |
+| nzStyle        | 自定义内联样式              | `object`                                                        |
+| nzClass        | 自定义 CSS class        | `object`                                                        |
+| nzData         | 任何想要在模板中作为上下文的数据     | `any`                                                           |
+| nzCloseIcon    | 自定义关闭图标              | `TemplateRef<void> \| string`                                   |
+| nzButton       | 自定义按钮                | `TemplateRef<{ $implicit: NzNotificationComponent }> \| string` |
 
 还提供了全局销毁方法：
 
@@ -63,14 +63,14 @@ private readonly notification = inject(NzNotificationService);
 
 可以通过 `NzConfigService` 进行全局配置，详情请见文档中 [全局配置项](/docs/global-config/zh) 章节。
 
-| 参数           | 说明                                                                          | 类型             | 默认值     |
-| -------------- | ----------------------------------------------------------------------------- | ---------------- | ---------- |
-| nzDuration     | 持续时间(毫秒)，当设置为0时不消失                                             | `number`         | 4500       |
-| nzMaxStack     | 同一时间可展示的最大提示数量                                                  | `number`         | 8          |
-| nzPauseOnHover | 鼠标移上时禁止自动移除                                                        | `boolean`        | `true`     |
-| nzAnimate      | 开关动画效果                                                                  | `boolean`        | `true`     |
-| nzTop          | 消息从顶部弹出时，距离顶部的位置。                                            | `string`         | 24px       |
-| nzBottom       | 消息从底部弹出时，距离底部的位置。                                            | `string`         | 24px       |
+| 参数             | 说明                                                                     | 类型               | 默认值        |
+|----------------|------------------------------------------------------------------------|------------------|------------|
+| nzDuration     | 持续时间(毫秒)，当设置为0时不消失                                                     | `number`         | 4500       |
+| nzMaxStack     | 同一时间可展示的最大提示数量                                                         | `number`         | 8          |
+| nzPauseOnHover | 鼠标移上时禁止自动移除                                                            | `boolean`        | `true`     |
+| nzAnimate      | 开关动画效果                                                                 | `boolean`        | `true`     |
+| nzTop          | 消息从顶部弹出时，距离顶部的位置。                                                      | `string`         | 24px       |
+| nzBottom       | 消息从底部弹出时，距离底部的位置。                                                      | `string`         | 24px       |
 | nzPlacement    | 弹出位置，可选 `topLeft` `topRight` `bottomLeft` `bottomRight` `top` `bottom` | `string`         | `topRight` |
 | nzDirection    | 通知的文字方向                                                                | `'ltr' \| 'rtl'` | -          |
 

--- a/components/notification/notification.component.ts
+++ b/components/notification/notification.component.ts
@@ -75,7 +75,12 @@ import { NzNotificationData } from './typings';
                 </ng-container>
               </div>
               <div class="ant-notification-notice-description">
-                <ng-container *nzStringTemplateOutlet="instance.content">
+                <ng-container
+                  *nzStringTemplateOutlet="
+                    instance.content;
+                    context: { $implicit: this, data: instance.options?.nzData }
+                  "
+                >
                   <div [innerHTML]="instance.content"></div>
                 </ng-container>
               </div>

--- a/components/notification/notification.service.ts
+++ b/components/notification/notification.service.ts
@@ -6,10 +6,12 @@
 import { Overlay } from '@angular/cdk/overlay';
 import { Injectable, Injector, TemplateRef } from '@angular/core';
 
+import type { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { NzMNService } from 'ng-zorro-antd/message';
 
 import { NzNotificationContainerComponent } from './notification-container.component';
-import { NzNotificationData, NzNotificationDataOptions, NzNotificationRef } from './typings';
+import type { NzNotificationComponent } from './notification.component';
+import { NzNotificationContentType, NzNotificationData, NzNotificationDataOptions, NzNotificationRef } from './typings';
 
 let notificationId = 0;
 
@@ -25,7 +27,7 @@ export class NzNotificationService extends NzMNService<NzNotificationContainerCo
 
   success(
     title: string | TemplateRef<void>,
-    content: string | TemplateRef<void>,
+    content: NzNotificationContentType,
     options?: NzNotificationDataOptions
   ): NzNotificationRef {
     return this.create('success', title, content, options);
@@ -33,7 +35,7 @@ export class NzNotificationService extends NzMNService<NzNotificationContainerCo
 
   error(
     title: string | TemplateRef<void>,
-    content: string | TemplateRef<void>,
+    content: NzNotificationContentType,
     options?: NzNotificationDataOptions
   ): NzNotificationRef {
     return this.create('error', title, content, options);
@@ -41,7 +43,7 @@ export class NzNotificationService extends NzMNService<NzNotificationContainerCo
 
   info(
     title: string | TemplateRef<void>,
-    content: string | TemplateRef<void>,
+    content: NzNotificationContentType,
     options?: NzNotificationDataOptions
   ): NzNotificationRef {
     return this.create('info', title, content, options);
@@ -49,7 +51,7 @@ export class NzNotificationService extends NzMNService<NzNotificationContainerCo
 
   warning(
     title: string | TemplateRef<void>,
-    content: string | TemplateRef<void>,
+    content: NzNotificationContentType,
     options?: NzNotificationDataOptions
   ): NzNotificationRef {
     return this.create('warning', title, content, options);
@@ -57,7 +59,7 @@ export class NzNotificationService extends NzMNService<NzNotificationContainerCo
 
   blank(
     title: string | TemplateRef<void>,
-    content: string | TemplateRef<void>,
+    content: NzNotificationContentType,
     options?: NzNotificationDataOptions
   ): NzNotificationRef {
     return this.create('blank', title, content, options);
@@ -66,13 +68,19 @@ export class NzNotificationService extends NzMNService<NzNotificationContainerCo
   create(
     type: 'success' | 'info' | 'warning' | 'error' | 'blank' | string,
     title: string | TemplateRef<void>,
-    content: string | TemplateRef<void>,
+    content: NzNotificationContentType,
     options?: NzNotificationDataOptions
   ): NzNotificationRef {
     return this.createInstance({ type, title, content }, options);
   }
 
-  template(template: TemplateRef<{}>, options?: NzNotificationDataOptions): NzNotificationRef {
+  template(
+    template: TemplateRef<{
+      $implicit: NzNotificationComponent;
+      data: NzSafeAny;
+    }>,
+    options?: NzNotificationDataOptions
+  ): NzNotificationRef {
     return this.createInstance({ template }, options);
   }
 

--- a/components/notification/notification.spec.ts
+++ b/components/notification/notification.spec.ts
@@ -12,13 +12,17 @@ import { NzConfigService, provideNzConfig } from 'ng-zorro-antd/core/config';
 import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
 import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 
+import { NzNotificationComponent } from './notification.component';
 import { NzNotificationService } from './notification.service';
 
 @Component({
   template: `<ng-template let-data="data">{{ 'test template content' }}{{ data }}</ng-template>`
 })
 export class NzTestNotificationComponent {
-  @ViewChild(TemplateRef, { static: true }) demoTemplateRef!: TemplateRef<{}>;
+  @ViewChild(TemplateRef, { static: true }) demoTemplateRef!: TemplateRef<{
+    $implicit: NzNotificationComponent;
+    data: string;
+  }>;
 }
 
 describe('NzNotification', () => {
@@ -69,8 +73,28 @@ describe('NzNotification', () => {
     expect(overlayContainerElement.querySelector('.ant-notification-notice-icon-success')).not.toBeNull();
   });
 
+  it('should open a message box success with custom template and data', () => {
+    const template = fixture.componentInstance.demoTemplateRef;
+    notificationService.success('test-title', template, { nzData: 'SUCCESS' });
+    fixture.detectChanges();
+
+    overlayContainerElement = overlayContainer.getContainerElement();
+    expect(overlayContainerElement.textContent).toContain('SUCCESS');
+    expect(overlayContainerElement.querySelector('.ant-notification-notice-icon-success')).not.toBeNull();
+  });
+
   it('should open a message box with error', () => {
     notificationService.error('test-title', 'ERROR');
+    fixture.detectChanges();
+
+    overlayContainerElement = overlayContainer.getContainerElement();
+    expect(overlayContainerElement.textContent).toContain('ERROR');
+    expect(overlayContainerElement.querySelector('.ant-notification-notice-icon-error')).not.toBeNull();
+  });
+
+  it('should open a message box error with custom template and data', () => {
+    const template = fixture.componentInstance.demoTemplateRef;
+    notificationService.error('test-title', template, { nzData: 'ERROR' });
     fixture.detectChanges();
 
     overlayContainerElement = overlayContainer.getContainerElement();
@@ -87,6 +111,16 @@ describe('NzNotification', () => {
     expect(overlayContainerElement.querySelector('.ant-notification-notice-icon-warning')).not.toBeNull();
   });
 
+  it('should open a message box warning with custom template and data', () => {
+    const template = fixture.componentInstance.demoTemplateRef;
+    notificationService.warning('test-title', template, { nzData: 'WARNING' });
+    fixture.detectChanges();
+
+    overlayContainerElement = overlayContainer.getContainerElement();
+    expect(overlayContainerElement.textContent).toContain('WARNING');
+    expect(overlayContainerElement.querySelector('.ant-notification-notice-icon-warning')).not.toBeNull();
+  });
+
   it('should open a message box with info', () => {
     notificationService.info('test-title', 'INFO');
     fixture.detectChanges();
@@ -96,8 +130,28 @@ describe('NzNotification', () => {
     expect(overlayContainerElement.querySelector('.ant-notification-notice-icon-info')).not.toBeNull();
   });
 
+  it('should open a message box info with custom template and data', () => {
+    const template = fixture.componentInstance.demoTemplateRef;
+    notificationService.info('test-title', template, { nzData: 'INFO' });
+    fixture.detectChanges();
+
+    overlayContainerElement = overlayContainer.getContainerElement();
+    expect(overlayContainerElement.textContent).toContain('INFO');
+    expect(overlayContainerElement.querySelector('.ant-notification-notice-icon-info')).not.toBeNull();
+  });
+
   it('should open a message box with blank', () => {
     notificationService.blank('test-title', 'BLANK');
+    fixture.detectChanges();
+
+    overlayContainerElement = overlayContainer.getContainerElement();
+    expect(overlayContainerElement.textContent).toContain('BLANK');
+    expect(overlayContainerElement.querySelector('.ant-notification-notice-icon')).toBeNull();
+  });
+
+  it('should open a message box blank with custom template and data', () => {
+    const template = fixture.componentInstance.demoTemplateRef;
+    notificationService.blank('test-title', template, { nzData: 'BLANK' });
     fixture.detectChanges();
 
     overlayContainerElement = overlayContainer.getContainerElement();

--- a/components/notification/typings.ts
+++ b/components/notification/typings.ts
@@ -6,11 +6,18 @@
 import { TemplateRef } from '@angular/core';
 import { Subject } from 'rxjs';
 
-import { NgClassInterface, NgStyleInterface } from 'ng-zorro-antd/core/types';
+import { NgClassInterface, NgStyleInterface, NzSafeAny } from 'ng-zorro-antd/core/types';
 
 import type { NzNotificationComponent } from './notification.component';
 
 export type NzNotificationPlacement = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight' | 'top' | 'bottom';
+
+export type NzNotificationContentType =
+  | string
+  | TemplateRef<void | {
+      $implicit: NzNotificationComponent;
+      data: NzSafeAny;
+    }>;
 
 export interface NzNotificationDataOptions<T = {}> {
   nzKey?: string;
@@ -27,7 +34,7 @@ export interface NzNotificationDataOptions<T = {}> {
 
 export interface NzNotificationData {
   title?: string | TemplateRef<void>;
-  content?: string | TemplateRef<void>;
+  content?: NzNotificationContentType;
   createdAt?: Date;
   messageId?: string;
   options?: NzNotificationDataOptions;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

nzData are not passed when content is custom template

Issue Number: 8997


## What is the new behavior?

nzData are  passed when content is custom template


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No




## Other information
