### PR TITLE
refactor(showcase): wrap iframe demo with simulated iframe by default

### DIFF
--- a/scripts/site/_site/doc/app/codebox/codebox.component.html
+++ b/scripts/site/_site/doc/app/codebox/codebox.component.html
@@ -1,11 +1,12 @@
 <section class="code-box" [class.expand]="nzExpanded" [attr.id]="nzId">
   <section class="code-box-demo">
-    @if (!showIframe) {
+    @if (!nzIframe || !iframe) {
+      @let simulateIframe = nzIframe && !iframe;
       <div
-        [class.simulate-iframe]="simulateIFrame"
-        [class.browser-mockup]="simulateIFrame"
-        [class.with-url]="simulateIFrame"
-        [style.height.px]="simulateIFrame && nzIframeHeight"
+        [class.simulate-iframe]="simulateIframe"
+        [class.browser-mockup]="simulateIframe"
+        [class.with-url]="simulateIframe"
+        [style.height.px]="simulateIframe && nzIframeHeight"
       >
         <ng-content select="[demo]"></ng-content>
       </div>
@@ -26,7 +27,8 @@
       <ng-content select="[intro]"></ng-content>
     </div>
     <div class="code-box-actions">
-      <nz-icon
+      <span
+        nz-icon
         [nzTooltipTitle]="
           !onlineIDELoading
             ? language === 'zh'
@@ -41,8 +43,9 @@
         nzTheme="fill"
         class="code-box-code-copy"
         (click)="openOnlineIDE()"
-      />
-      <nz-icon
+      ></span>
+      <span
+        nz-icon
         [nzTooltipTitle]="
           !copyLoading ? (language === 'zh' ? '复制代码' : 'Copy Code') : language === 'zh' ? '加载中...' : 'Loading...'
         "
@@ -51,16 +54,17 @@
         class="code-box-code-copy"
         [class.ant-tooltip-open]="copied"
         (click)="copyCode()"
-      />
+      ></span>
       @if (nzGenerateCommand) {
-        <nz-icon
+        <span
+          nz-icon
           [nzTooltipTitle]="language === 'zh' ? '复制生成代码命令' : 'Copy Generate Command'"
           nz-tooltip
           [nzType]="commandCopied ? 'check' : 'code'"
           class="code-box-code-copy"
           [class.ant-tooltip-open]="commandCopied"
           (click)="copyGenerateCommand(nzGenerateCommand)"
-        />
+        ></span>
       }
       <span
         class="code-expand-icon"

--- a/scripts/site/template/code-box.template.html
+++ b/scripts/site/template/code-box.template.html
@@ -5,6 +5,7 @@
   [nzLink]="'components-{{component}}-demo-{{key}}'"
   nzGenerateCommand="{{nzGenerateCommand}}"
   nzComponentName="{{componentName}}"
+  [nzIframe]="{{iframe}}"
   nzIframeSource="{{iframeSource}}"
   [nzIframeHeight]="{{iframeHeight}}"
   [nzHref]="'https://github.com/NG-ZORRO/ng-zorro-antd/edit/master/components/{{component}}/demo/{{key}}.md'">

--- a/scripts/site/utils/generate-code-box.js
+++ b/scripts/site/utils/generate-code-box.js
@@ -10,21 +10,9 @@ module.exports = function generateCodeBox(component, demoName, key, title, doc, 
   output = output.replace(/{{componentName}}/g, demoName);
   output = output.replace(/{{key}}/g, key);
   output = output.replace(/{{doc}}/g, doc);
-  if (iframe) {
-    if (iframe.source) {
-      output = output.replace(/{{iframeSource}}/g, iframe.source);
-    } else {
-      output = output.replace(/{{iframeSource}}/g, `/iframe/#/${component}-${key}`);
-    }
-    if (iframe.height) {
-      output = output.replace(/{{iframeHeight}}/g, iframe.height);
-    } else {
-      output = output.replace(/{{iframeHeight}}/g, null);
-    }
-  } else {
-    output = output.replace(/{{iframeSource}}/g, null);
-    output = output.replace(/{{iframeHeight}}/g, null);
-  }
+  output = output.replace(/{{iframe}}/g,  iframe ? 'true' : 'false');
+  output = output.replace(/{{iframeSource}}/g, iframe?.source ?? null);
+  output = output.replace(/{{iframeHeight}}/g, iframe?.height ?? null);
   output = output.replace(/{{code}}/g, camelCase(key));
   output = output.replace(/{{rawCode}}/g, `${camelCase(key)}Raw`);
   output = output.replace(/{{nzGenerateCommand}}/g, `ng g ng-zorro-antd:${component}-${key} <name>`);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

https://ng.ant.design/components/layout/zh#components-layout-demo-side

iframe 中嵌入 src 地址为官网地址的（主要是 Layout 组件下的），未正确加载相应内容

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/960d0177-5144-49ee-b57a-9f533101b051" />



## What is the new behavior?

除外部 iframe src （主要是 stackblitz）外，官网下的 iframe src 统一使用模拟的 iframe 容器组件实现，能够正常渲染相应内容。

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/4a349aee-93a0-4894-96d4-9837ebb36860" />



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
