### PR TITLE
refactor(module:avatar): expose `NzAvatarProps` interface

### DIFF
--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -3,7 +3,6 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { PlatformModule } from '@angular/cdk/platform';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -20,8 +19,9 @@ import {
   numberAttribute
 } from '@angular/core';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzShapeSCType, NzSizeLDSType } from 'ng-zorro-antd/core/types';
+import { toCssPixel } from 'ng-zorro-antd/core/util';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
@@ -29,7 +29,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
 @Component({
   selector: 'nz-avatar',
   exportAs: 'nzAvatar',
-  imports: [NzIconModule, PlatformModule],
+  imports: [NzIconModule],
   template: `
     @if (nzIcon && hasIcon) {
       <nz-icon [nzType]="nzIcon" />
@@ -77,17 +77,15 @@ export class NzAvatarComponent implements OnChanges {
   @ViewChild('textEl', { static: false }) textEl?: ElementRef<HTMLSpanElement>;
 
   private el: HTMLElement = inject(ElementRef).nativeElement;
+  private cdr = inject(ChangeDetectorRef);
 
-  constructor(
-    public nzConfigService: NzConfigService,
-    private cdr: ChangeDetectorRef
-  ) {
+  constructor() {
     afterRender(() => this.calcStringSize());
   }
 
-  imgError($event: Event): void {
-    this.nzError.emit($event);
-    if (!$event.defaultPrevented) {
+  imgError(event: Event): void {
+    this.nzError.emit(event);
+    if (!event.defaultPrevented) {
       this.hasSrc = false;
       this.hasIcon = false;
       this.hasText = false;
@@ -128,7 +126,7 @@ export class NzAvatarComponent implements OnChanges {
 
   private setSizeStyle(): void {
     if (typeof this.nzSize === 'number') {
-      this.customSize = `${this.nzSize}px`;
+      this.customSize = toCssPixel(this.nzSize);
     } else {
       this.customSize = null;
     }

--- a/components/avatar/demo/badge.ts
+++ b/components/avatar/demo/badge.ts
@@ -7,11 +7,11 @@ import { NzBadgeModule } from 'ng-zorro-antd/badge';
   selector: 'nz-demo-avatar-badge',
   imports: [NzBadgeModule, NzAvatarModule],
   template: `
-    <nz-badge [nzCount]="5" style="margin-right: 24px;">
-      <nz-avatar nzIcon="user" [nzShape]="'square'"></nz-avatar>
+    <nz-badge [nzCount]="5" style="margin-right: 24px">
+      <nz-avatar nzIcon="user" nzShape="square"></nz-avatar>
     </nz-badge>
     <nz-badge nzDot>
-      <nz-avatar nzIcon="user" [nzShape]="'square'"></nz-avatar>
+      <nz-avatar nzIcon="user" nzShape="square"></nz-avatar>
     </nz-badge>
   `
 })

--- a/components/avatar/demo/basic.ts
+++ b/components/avatar/demo/basic.ts
@@ -13,10 +13,10 @@ import { NzAvatarModule } from 'ng-zorro-antd/avatar';
       <nz-avatar nzSize="small" nzIcon="user"></nz-avatar>
     </div>
     <div>
-      <nz-avatar [nzShape]="'square'" [nzSize]="64" [nzIcon]="'user'"></nz-avatar>
-      <nz-avatar [nzShape]="'square'" [nzSize]="'large'" [nzIcon]="'user'"></nz-avatar>
-      <nz-avatar [nzShape]="'square'" [nzIcon]="'user'"></nz-avatar>
-      <nz-avatar [nzShape]="'square'" [nzSize]="'small'" [nzIcon]="'user'"></nz-avatar>
+      <nz-avatar nzShape="square" [nzSize]="64" nzIcon="user"></nz-avatar>
+      <nz-avatar nzShape="square" nzSize="large" nzIcon="user"></nz-avatar>
+      <nz-avatar nzShape="square" nzIcon="user"></nz-avatar>
+      <nz-avatar nzShape="square" nzSize="small" nzIcon="user"></nz-avatar>
     </div>
   `,
   styles: [

--- a/components/avatar/demo/dynamic.ts
+++ b/components/avatar/demo/dynamic.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, computed, model, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
@@ -13,22 +13,12 @@ const colorList = ['#f56a00', '#7265e6', '#ffbf00', '#00a2ae'];
   imports: [FormsModule, NzAvatarModule, NzButtonModule, NzInputNumberModule],
   template: `
     <div>
-      <label>
-        Gap:
-        <nz-input-number [nzMin]="0" [nzMax]="16" [nzStep]="1" [(ngModel)]="gap"></nz-input-number>
-      </label>
-      <button nz-button (click)="change()">
-        <span>Change Text</span>
-      </button>
+      <label>Gap: </label>
+      <nz-input-number [nzMin]="0" [nzMax]="16" [nzStep]="1" [(ngModel)]="gap"></nz-input-number>
+      <button nz-button (click)="change()">Change Text</button>
     </div>
 
-    <nz-avatar
-      [nzGap]="gap"
-      [style]="{ 'background-color': color }"
-      [nzText]="text"
-      nzSize="large"
-      style="vertical-align: middle;"
-    ></nz-avatar>
+    <nz-avatar [nzGap]="gap()" [nzText]="text()" nzSize="large" [style.background-color]="color()"></nz-avatar>
   `,
   styles: [
     `
@@ -42,16 +32,11 @@ const colorList = ['#f56a00', '#7265e6', '#ffbf00', '#00a2ae'];
   ]
 })
 export class NzDemoAvatarDynamicComponent {
-  text: string = userList[3];
-  color: string = colorList[3];
-  gap = 4;
+  index = signal(3);
+  text = computed(() => userList[this.index()]);
+  color = computed(() => colorList[this.index()]);
+  gap = model(4);
   change(): void {
-    let idx = userList.indexOf(this.text);
-    ++idx;
-    if (idx === userList.length) {
-      idx = 0;
-    }
-    this.text = userList[idx];
-    this.color = colorList[idx];
+    this.index.update(idx => (idx + 1) % userList.length);
   }
 }

--- a/components/avatar/doc/index.en-US.md
+++ b/components/avatar/doc/index.en-US.md
@@ -16,7 +16,7 @@ import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 ### nz-avatar
 
 | Property     | Description                                                                                        | Type                                        | Default     | Global Config |
-| ------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------- | ------------- |
+|--------------|----------------------------------------------------------------------------------------------------|---------------------------------------------|-------------|---------------|
 | `[nzIcon]`   | The `Icon` type for an icon avatar, see `Icon`                                                     | `string`                                    | -           |
 | `[nzShape]`  | The shape of avatar                                                                                | `'circle' \| 'square'`                      | `'circle'`  | ✅             |
 | `[nzSize]`   | The size of the avatar                                                                             | `'large' \| 'small' \| 'default' \| number` | `'default'` | ✅             |
@@ -30,8 +30,8 @@ import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 ### nz-avatar-group
 
 ```html
- <nz-avatar-group>
+<nz-avatar-group>
   <nz-avatar nzIcon="user"></nz-avatar>
-  ...
+  <!--  ...  -->
 </nz-avatar-group>
 ```

--- a/components/avatar/doc/index.zh-CN.md
+++ b/components/avatar/doc/index.zh-CN.md
@@ -16,23 +16,23 @@ import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 
 ### nz-avatar
 
-| 参数         | 说明                                                                         | 类型                                        | 默认值      | 全局配置 |
-| ------------ | ---------------------------------------------------------------------------- | ------------------------------------------- | ----------- | -------- |
-| `[nzIcon]`   | 设置头像的图标类型，参考 `Icon`                                              | `string`                                    | -           |
-| `[nzShape]`  | 指定头像的形状                                                               | `'circle' \| 'square'`                      | `'circle'`  | ✅        |
-| `[nzSize]`   | 设置头像的大小                                                               | `'large' \| 'small' \| 'default' \| number` | `'default'` | ✅        |
-| `[nzGap]`    | 字符类型距离左右两侧边界单位像素                                             | `number`                                    | `4`         | ✅        |
-| `[nzSrc]`    | 图片类头像的资源地址                                                         | `string`                                    | -           |
-| `[nzSrcSet]` | 设置图片类头像响应式资源地址                                                 | string                                      | -           |
-| `[nzAlt]`    | 图像无法显示时的替代文本                                                     | string                                      | -           |
-| `[nzText]`   | 文本类头像                                                                   | `string`                                    | -           |
+| 参数           | 说明                                                   | 类型                                          | 默认值         | 全局配置 |
+|--------------|------------------------------------------------------|---------------------------------------------|-------------|------|
+| `[nzIcon]`   | 设置头像的图标类型，参考 `Icon`                                  | `string`                                    | -           |
+| `[nzShape]`  | 指定头像的形状                                              | `'circle' \| 'square'`                      | `'circle'`  | ✅    |
+| `[nzSize]`   | 设置头像的大小                                              | `'large' \| 'small' \| 'default' \| number` | `'default'` | ✅    |
+| `[nzGap]`    | 字符类型距离左右两侧边界单位像素                                     | `number`                                    | `4`         | ✅    |
+| `[nzSrc]`    | 图片类头像的资源地址                                           | `string`                                    | -           |
+| `[nzSrcSet]` | 设置图片类头像响应式资源地址                                       | string                                      | -           |
+| `[nzAlt]`    | 图像无法显示时的替代文本                                         | string                                      | -           |
+| `[nzText]`   | 文本类头像                                                | `string`                                    | -           |
 | `(nzError)`  | 图片加载失败的事件，调用 `preventDefault` 方法会阻止组件默认的 fallback 行为 | `EventEmitter<Event>`                       | -           |
 
 ### nz-avatar-group
 
 ```html
- <nz-avatar-group>
+<nz-avatar-group>
   <nz-avatar nzIcon="user"></nz-avatar>
-  ...
+  <!--  ...  -->
 </nz-avatar-group>
 ```

--- a/components/avatar/public-api.ts
+++ b/components/avatar/public-api.ts
@@ -6,3 +6,4 @@
 export * from './avatar.component';
 export * from './avatar-group.component';
 export * from './avatar.module';
+export * from './types';

--- a/components/avatar/types.ts
+++ b/components/avatar/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { NzShapeSCType, NzSizeLDSType } from 'ng-zorro-antd/core/types';
+
+export interface NzAvatarProps {
+  shape?: NzShapeSCType;
+  size?: NzSizeLDSType | number;
+  gap?: number;
+  src?: string;
+  srcSet?: string;
+  alt?: string;
+  icon?: string;
+  text?: string;
+  error?: (event: Event) => void;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

像 nz-comment 这类内部包含头像的组件，在使用时只能通过 ng-content，使用灵活度受限。

此 PR 将 avatar props 提取出 interface 导出，后续将考虑通过 input 方式为 nz-comment 指定 avatar 参数，如

```html
<!-- Old -->
<nz-comment>
	<nz-avatar nz-comment-avatar nzIcon="user"></nz-avatar>
</nz-comment>

<!-- New -->
<nz-comment [nzAvatar]="{ icon: 'user' }"></nz-comment>
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
