### PR TITLE
feat(module:pageheader): disable back button if no history

### DIFF
--- a/components/page-header/page-header.component.ts
+++ b/components/page-header/page-header.component.ts
@@ -13,21 +13,23 @@ import {
   ContentChild,
   ElementRef,
   EventEmitter,
+  inject,
   Input,
   OnDestroy,
   OnInit,
   Output,
   TemplateRef,
-  ViewEncapsulation,
-  inject
+  ViewEncapsulation
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 
+import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
 import { PREFIX } from 'ng-zorro-antd/core/logger';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
+import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import { NzPageHeaderBreadcrumbDirective, NzPageHeaderFooterDirective } from './page-header-cells';
@@ -45,11 +47,18 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'pageHeader';
         <!--back-->
         @if (nzBackIcon !== null) {
           <div (click)="onBack()" class="ant-page-header-back">
-            <div role="button" tabindex="0" class="ant-page-header-back-button">
+            <button
+              nz-button
+              role="button"
+              tabindex="0"
+              class="ant-page-header-back-button"
+              nzType="text"
+              [disabled]="!enableBackButton"
+            >
               <ng-container *nzStringTemplateOutlet="nzBackIcon; let backIcon">
                 <nz-icon [nzType]="backIcon || getBackIcon()" nzTheme="outline" />
               </ng-container>
-            </div>
+            </button>
           </div>
         }
 
@@ -91,9 +100,10 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'pageHeader';
     '[class.ant-page-header-compact]': 'compact',
     '[class.ant-page-header-rtl]': `dir === 'rtl'`
   },
-  imports: [NzOutletModule, NzIconModule]
+  imports: [NzOutletModule, NzIconModule, NzButtonModule]
 })
 export class NzPageHeaderComponent implements AfterViewInit, OnDestroy, OnInit {
+  private location = inject(Location, { optional: true });
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 
   @Input() nzBackIcon: string | TemplateRef<void> | null = null;
@@ -110,8 +120,7 @@ export class NzPageHeaderComponent implements AfterViewInit, OnDestroy, OnInit {
   compact = false;
   destroy$ = new Subject<void>();
   dir: Direction = 'ltr';
-
-  private location = inject(Location, { optional: true });
+  enableBackButton = true;
 
   constructor(
     public nzConfigService: NzConfigService,
@@ -126,11 +135,18 @@ export class NzPageHeaderComponent implements AfterViewInit, OnDestroy, OnInit {
       this.dir = direction;
       this.cdr.detectChanges();
     });
-
     this.dir = this.directionality.value;
   }
 
   ngAfterViewInit(): void {
+    if (!this.nzBack.observed && this.location) {
+      this.enableBackButton = (this.location.getState() as NzSafeAny)?.navigationId > 1;
+      this.location.subscribe(() => {
+        this.enableBackButton = (this.location?.getState() as NzSafeAny)?.navigationId > 1;
+        this.cdr.detectChanges();
+      });
+    }
+
     this.nzResizeObserver
       .observe(this.elementRef)
       .pipe(

--- a/components/page-header/page-header.spec.ts
+++ b/components/page-header/page-header.spec.ts
@@ -6,7 +6,7 @@
 import { BidiModule, Dir, Direction } from '@angular/cdk/bidi';
 import { Location } from '@angular/common';
 import { Component, DebugElement, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -39,6 +39,14 @@ describe('NzPageHeaderComponent', () => {
     expect(pageHeader.nativeElement.querySelector('.ant-page-header-heading-sub-title')).toBeTruthy();
   });
 
+  it('should enable the back button if nzBack has observer', () => {
+    const fixture = TestBed.createComponent(NzDemoPageHeaderBasicComponent);
+    const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
+    fixture.detectChanges();
+    const back = pageHeader.nativeElement.querySelector('.ant-page-header-back-button');
+    expect((back as HTMLButtonElement).disabled).toBeFalsy();
+  });
+
   it('should ghost work', () => {
     const fixture = TestBed.createComponent(NzDemoPageHeaderGhostComponent);
     const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
@@ -66,6 +74,30 @@ describe('NzPageHeaderComponent', () => {
     fixture.detectChanges();
     expect(location.back).toHaveBeenCalled();
   });
+
+  it('should set the property disabled on back button if there is no history of navigation', fakeAsync(async () => {
+    const fixture = TestBed.createComponent(NzDemoPageHeaderResponsiveComponent);
+    const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
+    spyOn(location, 'getState').and.returnValue({ navigationId: 1 });
+    fixture.detectChanges();
+    pageHeader.componentInstance.ngAfterViewInit();
+    tick();
+    fixture.detectChanges();
+    const back = pageHeader.nativeElement.querySelector('.ant-page-header-back-button');
+    expect((back as HTMLButtonElement).disabled).toBeTruthy();
+  }));
+
+  it('should not set the property disabled on back button if there is no history of navigation', fakeAsync(async () => {
+    const fixture = TestBed.createComponent(NzDemoPageHeaderResponsiveComponent);
+    const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
+    spyOn(location, 'getState').and.returnValue({ navigationId: 2 });
+    fixture.detectChanges();
+    pageHeader.componentInstance.ngAfterViewInit();
+    tick();
+    fixture.detectChanges();
+    const back = pageHeader.nativeElement.querySelector('.ant-page-header-back-button');
+    expect((back as HTMLButtonElement).disabled).toBeFalsy();
+  }));
 
   it('should content work', () => {
     const fixture = TestBed.createComponent(NzDemoPageHeaderContentComponent);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently back button in Page Header component is never disabled even if there is no history entry

Issue Number: N/A


## What is the new behavior?

Back button is disabled is there is no entry in the history navigation


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
