### PR TITLE
fix(module:input-number): consider input value ends with 0 as incomplete

### DIFF
--- a/components/input-number/input-number.component.spec.ts
+++ b/components/input-number/input-number.component.spec.ts
@@ -8,6 +8,7 @@ import { Component, ElementRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
+import { dispatchKeyboardEvent } from 'ng-zorro-antd/core/testing';
 import { NzSizeLDSType, NzStatus } from 'ng-zorro-antd/core/types';
 import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 
@@ -373,6 +374,19 @@ describe('Input number', () => {
     expect(hostElement.querySelector('.ant-input-number-handler-wrap')).toBeNull();
   });
 
+  it('should not format input value if incomplete', () => {
+    fixture.detectChanges();
+
+    input('1.0');
+    expect(component.displayValue).toBe('1.0');
+
+    input('1.00'); // 2 consecutive zeros
+    expect(component.displayValue).toBe('1.00');
+
+    input('1.10'); // zero is not preceded by a `.`
+    expect(component.displayValue).toBe('1.10');
+  });
+
   function upStepByHandler(eventInit?: MouseEventInit): void {
     const handler = hostElement.querySelector('.ant-input-number-handler-up')!;
     handler.dispatchEvent(new MouseEvent('mousedown', eventInit));
@@ -385,13 +399,13 @@ describe('Input number', () => {
   }
 
   function upStepByKeyboard(): void {
-    hostElement.dispatchEvent(new KeyboardEvent('keydown', { keyCode: UP_ARROW }));
+    dispatchKeyboardEvent(hostElement, 'keydown', UP_ARROW);
   }
   function downStepByKeyboard(): void {
-    hostElement.dispatchEvent(new KeyboardEvent('keydown', { keyCode: DOWN_ARROW }));
+    dispatchKeyboardEvent(hostElement, 'keydown', DOWN_ARROW);
   }
   function enter(): void {
-    hostElement.dispatchEvent(new KeyboardEvent('keydown', { keyCode: ENTER }));
+    dispatchKeyboardEvent(hostElement, 'keydown', ENTER);
   }
 
   function getInputElement(): HTMLInputElement {
@@ -496,6 +510,10 @@ class InputNumberTestComponent {
   value: number | null = null;
   controlDisabled = false;
   inputNumber = viewChild.required(NzInputNumberComponent);
+
+  get displayValue(): string {
+    return this.inputNumber()['displayValue']();
+  }
 }
 
 @Component({

--- a/components/input-number/input-number.component.ts
+++ b/components/input-number/input-number.component.ts
@@ -557,5 +557,5 @@ function getDecimalPlaces(num: number): number {
 }
 
 function isNotCompleteNumber(value: string | number): boolean {
-  return /[.。]$/.test(value.toString());
+  return /[.。](\d*0)?$/.test(value.toString());
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

input value like `/[.。]$/` is considered as not completed, resulting in `3.0` being considered as completed number and being format to 3.

Issue Number: close #9049

## What is the new behavior?

1. typing 0

| typing | display (before) | display (now) |
| - | - | -|
| 3.**0** | 3.0 | 3 |
| 3.1**0** | 3.10 | 3.1 |
| 3.0**0** | 3.00 | 3 |

2. backspace the last character

| backspace | display (before) | display (now) |
| - | - | -|
| 3.0~1~ | 3.0 | 3 |
| 3.10~1~ | 3.10 | 3.1 |
| 3.00~1~ | 3.00 | 3 |


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
