### PR TITLE
fix(module:select): bugfix for changing ngModel value of mutilple select with nzMaxMultipleCount

### DIFF
--- a/components/select/option-container.component.ts
+++ b/components/select/option-container.component.ts
@@ -70,7 +70,9 @@ import { NzSelectItemInterface, NzSelectModeType } from './select.types';
                 [customContent]="item.nzCustomContent"
                 [template]="item.template ?? null"
                 [grouped]="!!item.groupLabel"
-                [disabled]="item.nzDisabled || (isMaxLimitReached && !listOfSelectedValue.includes(item['nzValue']))"
+                [disabled]="
+                  item.nzDisabled || (isMaxMultipleCountReached && !listOfSelectedValue.includes(item['nzValue']))
+                "
                 [showState]="mode === 'tags' || mode === 'multiple'"
                 [title]="item.nzTitle"
                 [label]="item.nzLabel"
@@ -109,7 +111,7 @@ export class NzOptionContainerComponent implements OnChanges, AfterViewInit {
   @Input() matchWidth = true;
   @Input() itemSize = 32;
   @Input() maxItemLength = 8;
-  @Input() isMaxLimitReached = false;
+  @Input() isMaxMultipleCountReached = false;
   @Input() listOfContainerItem: NzSelectItemInterface[] = [];
   @Output() readonly itemClick = new EventEmitter<NzSafeAny>();
   @Output() readonly scrollToBottom = new EventEmitter<void>();

--- a/components/select/select-arrow.component.ts
+++ b/components/select/select-arrow.component.ts
@@ -21,7 +21,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    @if (isMaxTagCountSet) {
+    @if (isMaxMultipleCountSet) {
       <span>{{ listOfValue.length }} / {{ nzMaxMultipleCount }}</span>
     }
     @if (loading) {
@@ -54,7 +54,7 @@ export class NzSelectArrowComponent {
   @Input() loading = false;
   @Input() search = false;
   @Input() showArrow = false;
-  @Input() isMaxTagCountSet = false;
+  @Input() isMaxMultipleCountSet = false;
   @Input() suffixIcon: TemplateRef<NzSafeAny> | string | null = null;
   @Input() feedbackIcon: TemplateRef<NzSafeAny> | string | null = null;
   @Input({ transform: numberAttribute }) nzMaxMultipleCount: number = Infinity;

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -128,7 +128,7 @@ export type NzSelectSizeType = NzSizeLDSType;
       (deleteItem)="onItemDelete($event)"
       (keydown)="onKeyDown($event)"
     ></nz-select-top-control>
-    @if (nzShowArrow || (hasFeedback && !!status) || isMaxTagCountSet) {
+    @if (nzShowArrow || (hasFeedback && !!status) || isMaxMultipleCountSet) {
       <nz-select-arrow
         [showArrow]="nzShowArrow"
         [loading]="nzLoading"
@@ -137,7 +137,7 @@ export type NzSelectSizeType = NzSizeLDSType;
         [feedbackIcon]="feedbackIconTpl"
         [nzMaxMultipleCount]="nzMaxMultipleCount"
         [listOfValue]="listOfValue"
-        [isMaxTagCountSet]="isMaxTagCountSet"
+        [isMaxMultipleCountSet]="isMaxMultipleCountSet"
       >
         <ng-template #feedbackIconTpl>
           @if (hasFeedback && !!status) {
@@ -185,7 +185,7 @@ export type NzSelectSizeType = NzSizeLDSType;
         [dropdownRender]="nzDropdownRender"
         [compareWith]="compareWith"
         [mode]="nzMode"
-        [isMaxLimitReached]="isMaxLimitReached"
+        [isMaxMultipleCountReached]="isMaxMultipleCountReached"
         (keydown)="onKeyDown($event)"
         (itemClick)="onItemClick($event)"
         (scrollToBottom)="nzScrollToBottom.emit()"
@@ -271,8 +271,12 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
     return this._nzShowArrow === undefined ? this.nzMode === 'default' : this._nzShowArrow;
   }
 
-  get isMaxTagCountSet(): boolean {
+  get isMaxMultipleCountSet(): boolean {
     return this.nzMaxMultipleCount !== Infinity;
+  }
+
+  get isMaxMultipleCountReached(): boolean {
+    return this.nzMaxMultipleCount !== Infinity && this.listOfValue.length === this.nzMaxMultipleCount;
   }
 
   @Output() readonly nzOnSearch = new EventEmitter<string>();
@@ -320,7 +324,6 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   focused = false;
   dir: Direction = 'ltr';
   positions: ConnectionPositionPair[] = [];
-  isMaxLimitReached = false;
 
   // status
   prefixCls: string = 'ant-select';
@@ -434,9 +437,6 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
       this.value = model;
       this.onChange(this.value);
     }
-
-    this.isMaxLimitReached =
-      this.nzMaxMultipleCount !== Infinity && this.listOfValue.length === this.nzMaxMultipleCount;
   }
 
   onTokenSeparate(listOfLabel: string[]): void {

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -1162,6 +1162,7 @@ describe('select', () => {
   describe('multiple reactive mode', () => {
     let component: TestSelectReactiveMultipleComponent;
     let fixture: ComponentFixture<TestSelectReactiveMultipleComponent>;
+    let selectComponent: NzSelectComponent;
     let selectElement!: HTMLElement;
     let overlayContainerElement: HTMLElement;
 
@@ -1169,6 +1170,7 @@ describe('select', () => {
       fixture = TestBed.createComponent(TestSelectReactiveMultipleComponent);
       component = fixture.componentInstance;
       fixture.detectChanges();
+      selectComponent = fixture.debugElement.query(By.directive(NzSelectComponent)).componentInstance;
       selectElement = fixture.debugElement.query(By.directive(NzSelectComponent)).nativeElement;
       overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
     });
@@ -1332,6 +1334,65 @@ describe('select', () => {
       expect(listOfContainerItem[1]).toHaveClass('ant-select-item-option-disabled');
     }));
 
+    it('should isMaxMultipleCountSet work correct', () => {
+      component.nzMaxMultipleCount = Infinity;
+      fixture.detectChanges();
+      expect(selectComponent.isMaxMultipleCountSet).toBeFalsy();
+
+      component.nzMaxMultipleCount = 1;
+      fixture.detectChanges();
+      expect(selectComponent.isMaxMultipleCountSet).toBeTruthy();
+    });
+
+    it('should isMaxMultipleCountReached be set correctly when click options', fakeAsync(() => {
+      const flushRefresh = (): void => {
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
+      };
+      component.nzOpen = true;
+      component.listOfOption = [
+        { value: 'test_01', label: 'test_01' },
+        { value: 'test_02', label: 'test_02' }
+      ];
+      component.value = [];
+      component.nzMaxMultipleCount = 1;
+      flushRefresh();
+      expect(selectComponent.isMaxMultipleCountReached).toBeFalsy();
+      const listOfContainerItem = document.querySelectorAll('nz-option-item');
+      dispatchMouseEvent(listOfContainerItem[0], 'click');
+      flushRefresh();
+      expect(selectComponent.isMaxMultipleCountReached).toBeTruthy();
+    }));
+
+    it('should isMaxMultipleCountReached be set correctly when change the ng model value', fakeAsync(() => {
+      const options = [
+        { value: 'test_01', label: 'test_01' },
+        { value: 'test_02', label: 'test_02' }
+      ];
+      const flushRefresh = (): void => {
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
+      };
+      component.nzOpen = true;
+      component.listOfOption = options;
+      component.value = [];
+      component.nzMaxMultipleCount = 1;
+      flushRefresh();
+      const listOfContainerItem = document.querySelectorAll('nz-option-item');
+      expect(selectComponent.isMaxMultipleCountReached).toBeFalsy();
+      selectComponent.writeValue([options[0]]);
+      flushRefresh();
+      expect(selectComponent.isMaxMultipleCountReached).toBeTruthy();
+      expect(listOfContainerItem[1]).toHaveClass('ant-select-item-option-disabled');
+      selectComponent.writeValue([]);
+      flushRefresh();
+      expect(selectComponent.isMaxMultipleCountReached).toBeFalsy();
+      expect(listOfContainerItem[0]).not.toHaveClass('ant-select-item-option-disabled');
+      expect(listOfContainerItem[1]).not.toHaveClass('ant-select-item-option-disabled');
+    }));
+
     it('should show nzShowArrow component when having nzMaxMultipleCount', () => {
       component.nzMaxMultipleCount = 0;
       expect(selectElement.querySelector('nz-select-arrow')).toBeFalsy();
@@ -1492,33 +1553,6 @@ describe('select', () => {
       expect(detectChangesSpy).toHaveBeenCalledTimes(1);
       // expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2);
     }));
-
-    it('should isMaxTagCountSet work correct', () => {
-      component.nzMaxMultipleCount = Infinity;
-      fixture.detectChanges();
-      let isMaxTagCountSet;
-      isMaxTagCountSet = selectComponent['isMaxTagCountSet'];
-      expect(isMaxTagCountSet).toBeFalsy();
-
-      component.nzMaxMultipleCount = 1;
-      fixture.detectChanges();
-      isMaxTagCountSet = selectComponent['isMaxTagCountSet'];
-      expect(isMaxTagCountSet).toBeTruthy();
-    });
-
-    it('should isMaxLimitReached be set correctly', () => {
-      selectComponent.nzMaxMultipleCount = 2;
-      selectComponent.listOfValue = ['a', 'b'];
-      fixture.detectChanges();
-      selectComponent.updateListOfValue(['a', 'b']);
-      expect(selectComponent.isMaxLimitReached).toBeTruthy();
-
-      selectComponent.nzMaxMultipleCount = 20;
-      selectComponent.listOfValue = ['a', 'b'];
-      fixture.detectChanges();
-      selectComponent.updateListOfValue(['a', 'b']);
-      expect(selectComponent.isMaxLimitReached).toBeFalsy();
-    });
 
     it('should not run change detection when `nz-select-top-control` is clicked and should focus the `nz-select-search`', () => {
       const appRef = TestBed.inject(ApplicationRef);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: close #9055 


## What is the new behavior?
when change ngModel value of the select component, the disabled status of options will match expectation

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
