### PR TITLE
fix(module:select): limit number of pasted item to nzMaxMultipleCount

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -449,11 +449,10 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   }
 
   onTokenSeparate(listOfLabel: string[]): void {
-    const listOfMatchedValue = this.listOfTagAndTemplateItem.filter(
-      item =>
-        listOfLabel.findIndex(label => label === item.nzLabel) !== -1 &&
-        this.listOfValue.findIndex(value => this.compareWith(value, item.nzValue)) === -1
-    );
+    const listOfMatchedValue = this.listOfTagAndTemplateItem
+      .filter(item => listOfLabel.findIndex(label => label === item.nzLabel) !== -1)
+      .map(item => item.nzValue)
+      .filter(item => this.listOfValue.findIndex(v => this.compareWith(v, item)) === -1);
     /**
      * Limit the number of selected item to nzMaxMultipleCount
      */

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -449,17 +449,26 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   }
 
   onTokenSeparate(listOfLabel: string[]): void {
-    const listOfMatchedValue = this.listOfTagAndTemplateItem
-      .filter(item => listOfLabel.findIndex(label => label === item.nzLabel) !== -1)
-      .map(item => item.nzValue)
-      .filter(item => this.listOfValue.findIndex(v => this.compareWith(v, item)) === -1);
+    const listOfMatchedValue = this.listOfTagAndTemplateItem.filter(
+      item =>
+        listOfLabel.findIndex(label => label === item.nzLabel) !== -1 &&
+        this.listOfValue.findIndex(value => this.compareWith(value, item.nzValue)) === -1
+    );
+    /**
+     * Limit the number of selected item to nzMaxMultipleCount
+     */
+    const limitWithinMaxCount = <T>(value: T[]): T[] =>
+      this.isMaxMultipleCountSet ? value.slice(0, this.nzMaxMultipleCount) : value;
+
     if (this.nzMode === 'multiple') {
-      this.updateListOfValue([...this.listOfValue, ...listOfMatchedValue]);
+      const updateValue = limitWithinMaxCount([...this.listOfValue, ...listOfMatchedValue]);
+      this.updateListOfValue(updateValue);
     } else if (this.nzMode === 'tags') {
       const listOfUnMatchedLabel = listOfLabel.filter(
         label => this.listOfTagAndTemplateItem.findIndex(item => item.nzLabel === label) === -1
       );
-      this.updateListOfValue([...this.listOfValue, ...listOfMatchedValue, ...listOfUnMatchedLabel]);
+      const updateValue = limitWithinMaxCount([...this.listOfValue, ...listOfMatchedValue, ...listOfUnMatchedLabel]);
+      this.updateListOfValue(updateValue);
     }
     this.clearInput();
   }

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -1322,7 +1322,7 @@ describe('select', () => {
       flush();
       fixture.detectChanges();
       const inputElement = selectElement.querySelector('input')!;
-      inputElement.value = 'test_01,test_02';
+      inputElement.value = 'label_01,label_02';
       dispatchFakeEvent(inputElement, 'input');
       fixture.detectChanges();
       flush();
@@ -1516,6 +1516,27 @@ describe('select', () => {
       expect(component.value.length).toBe(2);
       expect(component.value[0]).toBe('test_01');
       expect(component.value[1]).toBe('test_02');
+    }));
+
+    it('should nzTokenSeparators + nzMaxMultipleCount work', fakeAsync(() => {
+      component.nzMaxMultipleCount = 1;
+      component.listOfOption = [
+        { value: 'test_01', label: 'label_01' },
+        { value: 'test_02', label: 'label_02' }
+      ];
+      component.value = [];
+      component.nzTokenSeparators = [','];
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const inputElement = selectElement.querySelector('input')!;
+      inputElement.value = 'label_01,label_02';
+      dispatchFakeEvent(inputElement, 'input');
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(component.value.length).toBe(1);
+      expect(component.value[0]).toBe('test_01');
     }));
 
     it('should nzMaxTagCount works', fakeAsync(() => {
@@ -2042,6 +2063,7 @@ export class TestSelectReactiveMultipleComponent {
       [nzOptions]="listOfOption"
       [nzSize]="nzSize"
       [nzMaxTagCount]="nzMaxTagCount"
+      [nzMaxMultipleCount]="nzMaxMultipleCount"
       [nzTokenSeparators]="nzTokenSeparators"
       [nzMaxTagPlaceholder]="nzMaxTagPlaceholder ?? null"
       (ngModelChange)="valueChange($event)"
@@ -2058,6 +2080,7 @@ export class TestSelectReactiveTagsComponent {
   valueChange = jasmine.createSpy('valueChange');
   nzTokenSeparators: string[] = [];
   nzMaxTagPlaceholder?: TemplateRef<NzSafeAny>;
+  nzMaxMultipleCount?: number;
 }
 
 @Component({

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -1310,6 +1310,27 @@ describe('select', () => {
       expect(component.value[0]).toBe('test_01');
     }));
 
+    it('should nzTokenSeparators + nzMaxMultipleCount work', fakeAsync(() => {
+      component.nzMaxMultipleCount = 1;
+      component.listOfOption = [
+        { value: 'test_01', label: 'label_01' },
+        { value: 'test_02', label: 'label_02' }
+      ];
+      component.value = [];
+      component.nzTokenSeparators = [','];
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const inputElement = selectElement.querySelector('input')!;
+      inputElement.value = 'test_01,test_02';
+      dispatchFakeEvent(inputElement, 'input');
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(component.value.length).toBe(1);
+      expect(component.value[0]).toBe('test_01');
+    }));
+
     it('should nzMaxMultipleCount work', fakeAsync(() => {
       const flushRefresh = (): void => {
         fixture.detectChanges();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fix #9078 


## What is the new behavior?

多选模式下，设置了 `nzMaxMultipleCount` 以及 `nzTokenSeparators` 时，粘贴的选项受到最大数量的限制


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
