### PR TITLE
feat(module:transfer): support multiple row selection with Shift key

### DIFF
--- a/components/transfer/transfer.spec.ts
+++ b/components/transfer/transfer.spec.ts
@@ -39,9 +39,7 @@ describe('transfer', () => {
   let pageObject: TransferPageObject<AbstractTestTransferComponent>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideNzIconsTesting(), provideNoopAnimations()]
-    });
+    TestBed.configureTestingModule({ providers: [provideNzIconsTesting(), provideNoopAnimations()] });
     fixture = TestBed.createComponent(TestTransferComponent);
     debugElement = fixture.debugElement;
     instance = debugElement.componentInstance;
@@ -208,6 +206,22 @@ describe('transfer', () => {
       expect(instance.comp.rightDataSource.filter(w => w.checked).length).toBe(COUNT - LEFTCOUNT - DISABLED);
       btn.click();
       expect(instance.comp.rightDataSource.filter(w => w.checked).length).toBe(0);
+    });
+
+    it('should be checkboxes are toggle select via shift key', () => {
+      expect(instance.comp.rightDataSource.filter(w => w.checked).length).toBe(0);
+      pageObject.checkItem('right', 0);
+      expect(instance.comp.rightDataSource.filter(w => w.checked).length).toBe(1);
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }));
+      expect(instance.comp.isShiftPressed).toBeTrue();
+      fixture.detectChanges();
+      const multiSelectEndIndex = 9;
+      pageObject.checkItem('right', multiSelectEndIndex);
+      expect(instance.comp.rightDataSource.filter(w => w.checked).length).toBe(
+        COUNT - LEFTCOUNT - DISABLED - multiSelectEndIndex + 1
+      );
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Shift' }));
+      expect(instance.comp.isShiftPressed).toBeFalse();
     });
 
     describe('#notFoundContent', () => {
@@ -680,22 +694,12 @@ class TestTransferComponent implements OnInit, AbstractTestTransferComponent {
 })
 class TestTransferCustomRenderComponent implements OnInit, AbstractTestTransferComponent {
   @ViewChild('comp', { static: false }) comp!: NzTransferComponent;
-  nzDataSource: Array<{
-    key: string;
-    title: string;
-    description: string;
-    direction: TransferDirection;
-    icon: string;
-  }> = [];
+  nzDataSource: Array<{ key: string; title: string; description: string; direction: TransferDirection; icon: string }> =
+    [];
 
   ngOnInit(): void {
-    const ret: Array<{
-      key: string;
-      title: string;
-      description: string;
-      direction: TransferDirection;
-      icon: string;
-    }> = [];
+    const ret: Array<{ key: string; title: string; description: string; direction: TransferDirection; icon: string }> =
+      [];
     for (let i = 0; i < COUNT; i++) {
       ret.push({
         key: i.toString(),
@@ -710,21 +714,14 @@ class TestTransferCustomRenderComponent implements OnInit, AbstractTestTransferC
 }
 
 // https://github.com/NG-ZORRO/ng-zorro-antd/issues/996
-@Component({
-  imports: [NzTransferModule],
-  template: `<nz-transfer [nzDataSource]="list"></nz-transfer>`
-})
+@Component({ imports: [NzTransferModule], template: `<nz-transfer [nzDataSource]="list"></nz-transfer>` })
 class Test996Component implements OnInit {
   @ViewChild(NzTransferComponent, { static: true }) comp!: NzTransferComponent;
   list: NzSafeAny[] = [];
 
   ngOnInit(): void {
     for (let i = 0; i < 2; i++) {
-      this.list.push({
-        key: i.toString(),
-        title: `content${i + 1}`,
-        disabled: i % 3 < 1
-      });
+      this.list.push({ key: i.toString(), title: `content${i + 1}`, disabled: i % 3 < 1 });
     }
 
     [0, 1].forEach(idx => (this.list[idx].direction = 'right'));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It is not possible to select multiple row by using keyboard key SHIFT

Issue Number: N/A


## What is the new behavior?
The new behavior allow to select multiple row by using the keyboard key SHIFT

## Does this PR introduce a breaking change?
- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

![transfer_multiple_selection_demo](https://github.com/user-attachments/assets/8ee274f1-72d8-4a7d-9579-d9715967c996)

ANT DESIGN support this feature in their React component: https://ant.design/components/transfer