### PR TITLE
docs: fix input borderless style for website in non-dafult theme

### DIFF
--- a/scripts/site/_site/doc/app/components-overview/components-overview.component.less
+++ b/scripts/site/_site/doc/app/components-overview/components-overview.component.less
@@ -21,7 +21,7 @@
   }
 }
 
-.components-overview-search {
+nz-input-group.components-overview-search {
   width: 100%;
   padding: 0;
   font-size: 20px;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<img width="1115" alt="截屏2025-04-15 16 15 46" src="https://github.com/user-attachments/assets/888aeb75-7c2e-4043-bfee-6009744cdc58" />
<img width="1004" alt="截屏2025-04-15 16 26 44" src="https://github.com/user-attachments/assets/6cd0b6b5-36be-447e-9e0a-f3d3e1198b2d" />
<img width="1029" alt="截屏2025-04-15 16 27 07" src="https://github.com/user-attachments/assets/02fef70c-c6f2-44b1-9cf2-7566828ae12f" />
<img width="896" alt="截屏2025-04-15 16 27 33" src="https://github.com/user-attachments/assets/362f29f6-785e-484c-b2ee-546bed8fa6d4" />


Issue Number: N/A


## What is the new behavior?
Consistent with the default theme, no borders
<img width="698" alt="截屏2025-04-15 16 30 10" src="https://github.com/user-attachments/assets/e8eceb95-c8c7-43be-bb37-06660778341e" />
<img width="826" alt="截屏2025-04-15 16 30 21" src="https://github.com/user-attachments/assets/2aa4a7e9-9652-4766-a31f-ec78495e7941" />
<img width="831" alt="截屏2025-04-15 16 30 40" src="https://github.com/user-attachments/assets/debacaca-b5be-41d5-b593-147882908640" />



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
