### PR TITLE
fix(module:date-picker): update input value when nzFormat changed

### DIFF
--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -374,6 +374,23 @@ describe('NzDatePickerComponent', () => {
       expect(input.value).toBe('24.02.2020');
     }));
 
+    it('should rerender input value when nzFormat changed', fakeAsync(() => {
+      fixtureInstance.nzFormat = 'dd.MM.yyyy';
+      fixtureInstance.nzValue = new Date('2025-05-23');
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      const input = getPickerInput(fixture.debugElement);
+      expect(input.value).toBe('23.05.2025');
+      const nzOnChange = spyOn(fixtureInstance, 'nzOnChange');
+      fixtureInstance.nzFormat = 'dd/MM/yyyy';
+      fixture.detectChanges();
+      flush();
+      fixture.detectChanges();
+      expect(input.value).toBe('23/05/2025');
+      expect(nzOnChange).not.toHaveBeenCalled();
+    }));
+
     it('should support nzDisabledDate', fakeAsync(() => {
       fixture.detectChanges();
       const compareDate = new Date('2018-11-15 00:00:00');

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -745,6 +745,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, AfterViewInit, 
 
     if (nzFormat?.currentValue) {
       this.isCustomFormat = true;
+      this.updateInputValue();
     }
 
     if (nzLocale) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: close #7783 


## What is the new behavior?

when the `nzFormat` changed, the input value will rerender.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
