### PR TITLE
refactor(module:code-editor): replace `const enum`

### DIFF
--- a/components/code-editor/typings.ts
+++ b/components/code-editor/typings.ts
@@ -20,8 +20,10 @@ export type JoinedEditorOptions = EditorOptions | DiffEditorOptions;
 
 export type NzEditorMode = 'normal' | 'diff';
 
-export const enum NzCodeEditorLoadingStatus {
-  UNLOAD = 'unload',
-  LOADING = 'loading',
-  LOADED = 'LOADED'
-}
+export const NzCodeEditorLoadingStatus = {
+  UNLOAD: 'unload',
+  LOADING: 'loading',
+  LOADED: 'LOADED'
+} as const;
+
+export type NzCodeEditorLoadingStatus = (typeof NzCodeEditorLoadingStatus)[keyof typeof NzCodeEditorLoadingStatus];


### PR DESCRIPTION
Angular has a local compilation mode, intended for use with the TypeScript compiler option `isolatedModules`, which disallows importing `const enum`. In such cases, we replace it with a `const` object.