### PR TITLE
refactor(module:affix): use inject instead constructor

### DIFF
--- a/components/affix/affix.spec.ts
+++ b/components/affix/affix.spec.ts
@@ -650,9 +650,7 @@ describe('NzAffixComponent', () => {
 
   it('should remove listeners on destroy', () => {
     spyOn(component as NzSafeAny, 'removeListeners').and.callThrough();
-
-    component.ngOnDestroy();
-
+    fixture.destroy();
     expect(component['removeListeners']).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Affix component still use contructor to inject token

Issue Number: N/A


## What is the new behavior?

Affix component use the inject function to inject token.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
