### PR TITLE
refactor(module:*): remove redundant preserveWhitespaces

### DIFF
--- a/components/alert/alert.component.ts
+++ b/components/alert/alert.component.ts
@@ -98,8 +98,7 @@ export type NzAlertType = 'success' | 'info' | 'warning' | 'error';
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false
+  encapsulation: ViewEncapsulation.None
 })
 export class NzAlertComponent implements OnChanges, OnInit {
   public nzConfigService = inject(NzConfigService);

--- a/components/alert/demo/basic.ts
+++ b/components/alert/demo/basic.ts
@@ -5,6 +5,6 @@ import { NzAlertModule } from 'ng-zorro-antd/alert';
 @Component({
   selector: 'nz-demo-alert-basic',
   imports: [NzAlertModule],
-  template: ` <nz-alert nzType="success" nzMessage="Success Text"></nz-alert> `
+  template: `<nz-alert nzType="success" nzMessage="Success Text"></nz-alert>`
 })
 export class NzDemoAlertBasicComponent {}

--- a/components/alert/demo/close-text.ts
+++ b/components/alert/demo/close-text.ts
@@ -5,6 +5,6 @@ import { NzAlertModule } from 'ng-zorro-antd/alert';
 @Component({
   selector: 'nz-demo-alert-close-text',
   imports: [NzAlertModule],
-  template: ` <nz-alert nzType="info" nzMessage="Info Text" nzCloseText="Close Now"></nz-alert> `
+  template: `<nz-alert nzType="info" nzMessage="Info Text" nzCloseText="Close Now"></nz-alert>`
 })
 export class NzDemoAlertCloseTextComponent {}

--- a/components/anchor/anchor-link.component.ts
+++ b/components/anchor/anchor-link.component.ts
@@ -26,7 +26,6 @@ import { NzAnchorComponent } from './anchor.component';
 @Component({
   selector: 'nz-link',
   exportAs: 'nzLink',
-  preserveWhitespaces: false,
   imports: [NgTemplateOutlet],
   template: `
     <a

--- a/components/anchor/anchor.component.ts
+++ b/components/anchor/anchor.component.ts
@@ -51,7 +51,6 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
 @Component({
   selector: 'nz-anchor',
   exportAs: 'nzAnchor',
-  preserveWhitespaces: false,
   imports: [NgTemplateOutlet, NzAffixModule],
   template: `
     @if (nzAffix) {

--- a/components/auto-complete/autocomplete-optgroup.component.ts
+++ b/components/auto-complete/autocomplete-optgroup.component.ts
@@ -10,7 +10,6 @@ import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 @Component({
   selector: 'nz-auto-optgroup',
   exportAs: 'nzAutoOptgroup',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [NzOutletModule],

--- a/components/auto-complete/autocomplete-option.component.ts
+++ b/components/auto-complete/autocomplete-option.component.ts
@@ -36,7 +36,6 @@ export class NzOptionSelectionChange {
 @Component({
   selector: 'nz-auto-option',
   exportAs: 'nzAutoOption',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/auto-complete/autocomplete.component.ts
+++ b/components/auto-complete/autocomplete.component.ts
@@ -63,7 +63,6 @@ function normalizeDataSource(value: AutocompleteDataSource): AutocompleteDataSou
 @Component({
   selector: 'nz-autocomplete',
   exportAs: 'nzAutocomplete',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [NgTemplateOutlet, NzAutocompleteOptionComponent, NzNoAnimationDirective],

--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -54,7 +54,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'avatar';
     // nzSize type is number when customSize is true
     '[style.font-size.px]': '(hasIcon && customSize) ? $any(nzSize) / 2 : null'
   },
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })

--- a/components/back-top/back-top.component.ts
+++ b/components/back-top/back-top.component.ts
@@ -63,7 +63,6 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   providers: [NzDestroyService]
 })
 export class NzBackTopComponent implements OnInit, OnDestroy, OnChanges {

--- a/components/badge/badge-sup.component.ts
+++ b/components/badge/badge-sup.component.ts
@@ -22,7 +22,6 @@ import { NzSafeAny, NzSizeDSType } from 'ng-zorro-antd/core/types';
 @Component({
   selector: 'nz-badge-sup',
   exportAs: 'nzBadgeSup',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [zoomBadgeMotion],

--- a/components/badge/badge.component.ts
+++ b/components/badge/badge.component.ts
@@ -37,7 +37,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'badge';
 @Component({
   selector: 'nz-badge',
   exportAs: 'nzBadge',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [zoomBadgeMotion],

--- a/components/badge/ribbon.component.ts
+++ b/components/badge/ribbon.component.ts
@@ -20,7 +20,6 @@ import { badgePresetColors } from './preset-colors';
 @Component({
   selector: 'nz-ribbon',
   exportAs: 'nzRibbon',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzOutletModule],

--- a/components/breadcrumb/breadcrumb-item.component.ts
+++ b/components/breadcrumb/breadcrumb-item.component.ts
@@ -18,7 +18,6 @@ import { NzBreadCrumbSeparatorComponent } from './breadcrumb-separator.component
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-breadcrumb-item',
   exportAs: 'nzBreadcrumbItem',
-  preserveWhitespaces: false,
   imports: [NgTemplateOutlet, NzBreadCrumbSeparatorComponent, NzDropDownModule, NzIconModule, NzOutletModule],
   template: `
     @if (!!nzOverlay) {

--- a/components/breadcrumb/breadcrumb.component.ts
+++ b/components/breadcrumb/breadcrumb.component.ts
@@ -40,7 +40,6 @@ export interface BreadcrumbOption {
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-breadcrumb',
   exportAs: 'nzBreadcrumb',
-  preserveWhitespaces: false,
   providers: [{ provide: NzBreadcrumb, useExisting: forwardRef(() => NzBreadCrumbComponent) }],
   imports: [NzBreadCrumbItemComponent],
   template: `

--- a/components/button/button.component.ts
+++ b/components/button/button.component.ts
@@ -45,7 +45,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'button';
   selector: 'button[nz-button], a[nz-button]',
   exportAs: 'nzButton',
   imports: [NzIconModule],
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/calendar/demo/basic.ts
+++ b/components/calendar/demo/basic.ts
@@ -6,7 +6,7 @@ import { NzCalendarMode, NzCalendarModule } from 'ng-zorro-antd/calendar';
 @Component({
   selector: 'nz-demo-calendar-basic',
   imports: [FormsModule, NzCalendarModule],
-  template: ` <nz-calendar [(ngModel)]="date" [(nzMode)]="mode" (nzPanelChange)="panelChange($event)"></nz-calendar> `
+  template: `<nz-calendar [(ngModel)]="date" [(nzMode)]="mode" (nzPanelChange)="panelChange($event)"></nz-calendar>`
 })
 export class NzDemoCalendarBasicComponent {
   date = new Date(2012, 11, 21);

--- a/components/card/card-meta.component.ts
+++ b/components/card/card-meta.component.ts
@@ -11,7 +11,6 @@ import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 @Component({
   selector: 'nz-card-meta',
   exportAs: 'nzCardMeta',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/card/card.component.ts
+++ b/components/card/card.component.ts
@@ -35,7 +35,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'card';
 @Component({
   selector: 'nz-card',
   exportAs: 'nzCard',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -60,7 +60,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'carousel';
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-carousel',
   exportAs: 'nzCarousel',
-  preserveWhitespaces: false,
   template: `
     <div
       class="slick-initialized slick-slider"

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -99,7 +99,6 @@ const defaultDisplayRender = (labels: string[]): string => labels.join(' / ');
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-cascader, [nz-cascader]',
   exportAs: 'nzCascader',
-  preserveWhitespaces: false,
   template: `
     @if (nzShowInput) {
       <div #selectContainer class="ant-select-selector">

--- a/components/cdk/overflow/overflow-container.component.ts
+++ b/components/cdk/overflow/overflow-container.component.ts
@@ -27,9 +27,11 @@ import { NzOverflowSuffixDirective } from './overflow-suffix.directive';
 
 @Component({
   selector: 'nz-overflow-container',
-  template: ` <ng-content></ng-content>
+  template: `
+    <ng-content></ng-content>
     <ng-content select="[appOverflowRest]"></ng-content>
-    <ng-content select="[appOverflowSuffix]"></ng-content>`,
+    <ng-content select="[appOverflowSuffix]"></ng-content>
+  `,
   providers: [NzResizeObserver],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/components/cdk/resize-observer/resize-observer.spec.ts
+++ b/components/cdk/resize-observer/resize-observer.spec.ts
@@ -96,7 +96,7 @@ describe('resize observer', () => {
 });
 
 @Component({
-  template: ` <div nzResizeObserver></div>`,
+  template: `<div nzResizeObserver></div>`,
   imports: [NzResizeObserverDirective]
 })
 class TestHostComponent {}

--- a/components/checkbox/checkbox-wrapper.component.ts
+++ b/components/checkbox/checkbox-wrapper.component.ts
@@ -16,7 +16,6 @@ import { NzCheckboxComponent } from './checkbox.component';
   selector: 'nz-checkbox-wrapper',
   exportAs: 'nzCheckboxWrapper',
   template: `<ng-content></ng-content>`,
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {

--- a/components/checkbox/checkbox.component.ts
+++ b/components/checkbox/checkbox.component.ts
@@ -38,7 +38,6 @@ import { NZ_CHECKBOX_GROUP } from './tokens';
 @Component({
   selector: '[nz-checkbox]',
   exportAs: 'nzCheckbox',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/collapse/collapse.component.ts
+++ b/components/collapse/collapse.component.ts
@@ -27,7 +27,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapse';
   exportAs: 'nzCollapse',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  template: ` <ng-content></ng-content> `,
+  template: `<ng-content></ng-content>`,
   host: {
     class: 'ant-collapse',
     '[class.ant-collapse-icon-position-start]': `nzExpandIconPosition === 'start'`,

--- a/components/color-picker/color-block.component.ts
+++ b/components/color-picker/color-block.component.ts
@@ -15,7 +15,7 @@ import { defaultColor } from './src/util/util';
   exportAs: 'NzColorBlock',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgAntdColorPickerModule],
-  template: ` <ng-antd-color-block [color]="nzColor" (nzOnClick)="nzOnClick.emit($event)"></ng-antd-color-block> `,
+  template: `<ng-antd-color-block [color]="nzColor" (nzOnClick)="nzOnClick.emit($event)"></ng-antd-color-block>`,
   host: {
     class: 'ant-color-picker-inline',
     '[class.ant-color-picker-inline-sm]': `nzSize === 'small'`,

--- a/components/core/form/nz-form-item-feedback-icon.component.ts
+++ b/components/core/form/nz-form-item-feedback-icon.component.ts
@@ -27,7 +27,6 @@ const iconTypeMap = {
   selector: 'nz-form-item-feedback-icon',
   exportAs: 'nzFormFeedbackIcon',
   imports: [NzIconModule],
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/cron-expression/cron-expression-preview.component.ts
+++ b/components/cron-expression/cron-expression-preview.component.ts
@@ -24,39 +24,41 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-cron-expression-preview',
   exportAs: 'nzCronExpressionPreview',
-  template: ` <div class="ant-collapse ant-collapse-borderless ant-cron-expression-preview">
-    <div class="ant-cron-expression-preview-dateTime" [class.ant-cron-expression-preview-dateTime-center]="!isExpand">
-      @if (visible) {
-        @if (!nzSemantic) {
-          {{ TimeList[0] | date: 'yyyy-MM-dd HH:mm:ss' }}
-        } @else {
-          <ng-template [ngTemplateOutlet]="nzSemantic" />
-        }
-      } @else {
-        {{ locale.cronError }}
-      }
-    </div>
-    @if (visible && !isExpand) {
-      <div class="ant-cron-expression-preview-content">
-        <ul class="ant-cron-expression-preview-list">
-          @for (item of TimeList; track item) {
-            <li>
-              {{ item | date: 'yyyy-MM-dd HH:mm:ss' }}
-            </li>
+  template: `
+    <div class="ant-collapse ant-collapse-borderless ant-cron-expression-preview">
+      <div class="ant-cron-expression-preview-dateTime" [class.ant-cron-expression-preview-dateTime-center]="!isExpand">
+        @if (visible) {
+          @if (!nzSemantic) {
+            {{ TimeList[0] | date: 'yyyy-MM-dd HH:mm:ss' }}
+          } @else {
+            <ng-template [ngTemplateOutlet]="nzSemantic" />
           }
-          <li><a (click)="loadMorePreview.emit()">···</a></li>
-        </ul>
+        } @else {
+          {{ locale.cronError }}
+        }
       </div>
-    }
-
-    <ul class="ant-cron-expression-preview-icon">
-      @if (isExpand) {
-        <li><nz-icon nzType="down" nzTheme="outline" (click)="setExpand()" /></li>
-      } @else {
-        <li><nz-icon nzType="up" nzTheme="outline" (click)="setExpand()" /></li>
+      @if (visible && !isExpand) {
+        <div class="ant-cron-expression-preview-content">
+          <ul class="ant-cron-expression-preview-list">
+            @for (item of TimeList; track item) {
+              <li>
+                {{ item | date: 'yyyy-MM-dd HH:mm:ss' }}
+              </li>
+            }
+            <li><a (click)="loadMorePreview.emit()">···</a></li>
+          </ul>
+        </div>
       }
-    </ul>
-  </div>`,
+
+      <ul class="ant-cron-expression-preview-icon">
+        @if (isExpand) {
+          <li><nz-icon nzType="down" nzTheme="outline" (click)="setExpand()" /></li>
+        } @else {
+          <li><nz-icon nzType="up" nzTheme="outline" (click)="setExpand()" /></li>
+        }
+      </ul>
+    </div>
+  `,
   imports: [NgTemplateOutlet, DatePipe, NzIconModule]
 })
 export class NzCronExpressionPreviewComponent {

--- a/components/cron-expression/demo/borderless.ts
+++ b/components/cron-expression/demo/borderless.ts
@@ -5,6 +5,6 @@ import { NzCronExpressionModule } from 'ng-zorro-antd/cron-expression';
 @Component({
   selector: 'nz-demo-cron-expression-borderless',
   imports: [NzCronExpressionModule],
-  template: ` <nz-cron-expression nzBorderless></nz-cron-expression> `
+  template: `<nz-cron-expression nzBorderless></nz-cron-expression>`
 })
 export class NzDemoCronExpressionBorderlessComponent {}

--- a/components/cron-expression/demo/collapse.ts
+++ b/components/cron-expression/demo/collapse.ts
@@ -5,6 +5,6 @@ import { NzCronExpressionModule } from 'ng-zorro-antd/cron-expression';
 @Component({
   selector: 'nz-demo-cron-expression-collapse',
   imports: [NzCronExpressionModule],
-  template: ` <nz-cron-expression [nzCollapseDisable]="true"></nz-cron-expression> `
+  template: `<nz-cron-expression [nzCollapseDisable]="true"></nz-cron-expression>`
 })
 export class NzDemoCronExpressionCollapseComponent {}

--- a/components/descriptions/descriptions-item.component.ts
+++ b/components/descriptions/descriptions-item.component.ts
@@ -25,8 +25,7 @@ import { Subject } from 'rxjs';
       <ng-content></ng-content>
     </ng-template>
   `,
-  exportAs: 'nzDescriptionsItem',
-  preserveWhitespaces: false
+  exportAs: 'nzDescriptionsItem'
 })
 export class NzDescriptionsItemComponent implements OnChanges, OnDestroy {
   @ViewChild(TemplateRef, { static: true }) content!: TemplateRef<void>;

--- a/components/descriptions/descriptions.component.ts
+++ b/components/descriptions/descriptions.component.ts
@@ -47,7 +47,6 @@ const defaultColumnMap: Record<NzBreakpointEnum, number> = {
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-descriptions',
   exportAs: 'nzDescriptions',
-  preserveWhitespaces: false,
   template: `
     @if (nzTitle || nzExtra) {
       <div class="ant-descriptions-header">

--- a/components/divider/divider.component.ts
+++ b/components/divider/divider.component.ts
@@ -17,7 +17,6 @@ import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 @Component({
   selector: 'nz-divider',
   exportAs: 'nzDivider',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -138,7 +138,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
       </div>
     </ng-template>
   `,
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [drawerMaskMotion],
   imports: [NzNoAnimationDirective, NzOutletModule, NzIconModule, PortalModule, NgTemplateOutlet, CdkScrollable]

--- a/components/dropdown/dropdown-menu.component.ts
+++ b/components/dropdown/dropdown-menu.component.ts
@@ -61,7 +61,6 @@ export type NzPlacementType = 'bottomLeft' | 'bottomCenter' | 'bottomRight' | 't
       </div>
     </ng-template>
   `,
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzNoAnimationDirective]

--- a/components/experimental/image/image.component.ts
+++ b/components/experimental/image/image.component.ts
@@ -50,7 +50,6 @@ const sizeBreakpoints = [16, 32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080,
       [attr.alt]="nzAlt || null"
     />
   `,
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [NzImageDirective]

--- a/components/float-button/float-button-top.component.ts
+++ b/components/float-button/float-button-top.component.ts
@@ -68,7 +68,6 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   providers: [NzDestroyService]
 })
 export class NzFloatButtonTopComponent implements OnInit, OnDestroy, OnChanges {

--- a/components/form/form-control.component.ts
+++ b/components/form/form-control.component.ts
@@ -36,7 +36,6 @@ import { NzFormDirective } from './form.directive';
 @Component({
   selector: 'nz-form-control',
   exportAs: 'nzFormControl',
-  preserveWhitespaces: false,
   animations: [helpMotion],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/components/form/form-item.component.ts
+++ b/components/form/form-item.component.ts
@@ -12,7 +12,6 @@ export type NzFormControlStatusType = 'success' | 'error' | 'warning' | 'validat
 @Component({
   selector: 'nz-form-item',
   exportAs: 'nzFormItem',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {

--- a/components/form/form-label.component.ts
+++ b/components/form/form-label.component.ts
@@ -38,7 +38,6 @@ function toTooltipIcon(value: string | NzFormTooltipIcon): Required<NzFormToolti
 @Component({
   selector: 'nz-form-label',
   exportAs: 'nzFormLabel',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/form/form-split.component.ts
+++ b/components/form/form-split.component.ts
@@ -8,7 +8,6 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 @Component({
   selector: 'nz-form-split',
   exportAs: 'nzFormSplit',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: ` <ng-content></ng-content> `,

--- a/components/form/form-split.component.ts
+++ b/components/form/form-split.component.ts
@@ -10,7 +10,7 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
   exportAs: 'nzFormSplit',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: ` <ng-content></ng-content> `,
+  template: `<ng-content></ng-content>`,
   host: {
     class: 'ant-form-split'
   }

--- a/components/form/form-text.component.ts
+++ b/components/form/form-text.component.ts
@@ -8,10 +8,9 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 @Component({
   selector: 'nz-form-text',
   exportAs: 'nzFormText',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  template: ` <ng-content></ng-content> `,
+  template: `<ng-content></ng-content>`,
   host: {
     class: 'ant-form-text'
   }

--- a/components/image/demo/fallback.ts
+++ b/components/image/demo/fallback.ts
@@ -5,7 +5,7 @@ import { NzImageModule } from 'ng-zorro-antd/image';
 @Component({
   selector: 'nz-demo-image-fallback',
   imports: [NzImageModule],
-  template: ` <img nz-image width="200px" height="200px" nzSrc="error" [nzFallback]="fallback" alt="" /> `
+  template: `<img nz-image width="200px" height="200px" nzSrc="error" [nzFallback]="fallback" alt="" />`
 })
 export class NzDemoImageFallbackComponent {
   fallback =

--- a/components/image/image-group.component.ts
+++ b/components/image/image-group.component.ts
@@ -11,7 +11,6 @@ import { NzImageDirective } from './image.directive';
   selector: 'nz-image-group',
   exportAs: 'nzImageGroup',
   template: '<ng-content></ng-content>',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })

--- a/components/image/image-preview.component.ts
+++ b/components/image/image-preview.component.ts
@@ -137,7 +137,6 @@ const NZ_DEFAULT_ROTATE = 0;
       </div>
     </div>
   `,
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {

--- a/components/image/image.spec.ts
+++ b/components/image/image.spec.ts
@@ -699,7 +699,7 @@ describe('Preview', () => {
 
 @Component({
   imports: [NzImageModule],
-  template: ` <img nz-image [nzSrc]="src" [nzPlaceholder]="placeholder" /> `
+  template: `<img nz-image [nzSrc]="src" [nzPlaceholder]="placeholder" />`
 })
 export class TestImageBasicsComponent {
   @ViewChild(NzImageDirective) nzImage!: NzImageDirective;
@@ -709,7 +709,7 @@ export class TestImageBasicsComponent {
 
 @Component({
   imports: [NzImageModule],
-  template: ` <img nz-image [nzSrc]="src" [nzPlaceholder]="placeholder" [nzDisablePreview]="disablePreview" /> `
+  template: `<img nz-image [nzSrc]="src" [nzPlaceholder]="placeholder" [nzDisablePreview]="disablePreview" />`
 })
 export class TestImagePlaceholderComponent {
   @ViewChild(NzImageDirective) nzImage!: NzImageDirective;

--- a/components/input-number-legacy/input-number-group-slot.component.ts
+++ b/components/input-number-legacy/input-number-group-slot.component.ts
@@ -13,7 +13,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
  */
 @Component({
   selector: '[nz-input-number-group-slot]',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/input-number/demo/digit.ts
+++ b/components/input-number/demo/digit.ts
@@ -6,7 +6,7 @@ import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 @Component({
   selector: 'nz-demo-input-number-digit',
   imports: [FormsModule, NzInputNumberModule],
-  template: ` <nz-input-number [(ngModel)]="value" nzMin="0" nzMax="10" nzStep="0.1" nzPlaceHolder="Digital" /> `
+  template: `<nz-input-number [(ngModel)]="value" nzMin="0" nzMax="10" nzStep="0.1" nzPlaceHolder="Digital" />`
 })
 export class NzDemoInputNumberDigitComponent {
   value = 0.1;

--- a/components/input/input-group-slot.component.ts
+++ b/components/input/input-group-slot.component.ts
@@ -10,7 +10,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: '[nz-input-group-slot]',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/input/input-otp.component.ts
+++ b/components/input/input-otp.component.ts
@@ -37,7 +37,6 @@ import { NzInputDirective } from './input.directive';
 @Component({
   selector: 'nz-input-otp',
   exportAs: 'nzInputOtp',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/input/textarea-count.component.ts
+++ b/components/input/textarea-count.component.ts
@@ -24,7 +24,7 @@ import { NzInputDirective } from './input.directive';
 
 @Component({
   selector: 'nz-textarea-count',
-  template: ` <ng-content select="textarea[nz-input]"></ng-content> `,
+  template: `<ng-content select="textarea[nz-input]"></ng-content>`,
   host: {
     class: 'ant-input-textarea-show-count'
   },

--- a/components/layout/content.component.ts
+++ b/components/layout/content.component.ts
@@ -9,7 +9,6 @@ import { ChangeDetectionStrategy, Component, ElementRef, Renderer2, ViewEncapsul
   selector: 'nz-content',
   exportAs: 'nzContent',
   template: `<ng-content></ng-content>`,
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })

--- a/components/layout/footer.component.ts
+++ b/components/layout/footer.component.ts
@@ -9,7 +9,6 @@ import { ChangeDetectionStrategy, Component, ElementRef, Renderer2, ViewEncapsul
   selector: 'nz-footer',
   exportAs: 'nzFooter',
   template: `<ng-content></ng-content>`,
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/components/layout/header.component.ts
+++ b/components/layout/header.component.ts
@@ -10,8 +10,7 @@ import { ChangeDetectionStrategy, Component, ElementRef, Renderer2, ViewEncapsul
   exportAs: 'nzHeader',
   template: `<ng-content></ng-content>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false
+  encapsulation: ViewEncapsulation.None
 })
 export class NzHeaderComponent {
   constructor(

--- a/components/layout/layout.component.ts
+++ b/components/layout/layout.component.ts
@@ -24,7 +24,6 @@ import { NzSiderComponent } from './sider.component';
   template: `<ng-content></ng-content>`,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   host: {
     class: 'ant-layout',
     '[class.ant-layout-rtl]': `dir === 'rtl'`,

--- a/components/layout/sider-trigger.component.ts
+++ b/components/layout/sider-trigger.component.ts
@@ -20,7 +20,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 @Component({
   selector: '[nz-sider-trigger]',
   exportAs: 'nzSiderTrigger',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/layout/sider.component.ts
+++ b/components/layout/sider.component.ts
@@ -33,7 +33,6 @@ import { NzSiderTriggerComponent } from './sider-trigger.component';
 @Component({
   selector: 'nz-sider',
   exportAs: 'nzSider',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/list/list-item-meta.component.ts
+++ b/components/list/list-item-meta.component.ts
@@ -65,7 +65,6 @@ import {
       </div>
     }
   `,
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {

--- a/components/list/list-item.component.ts
+++ b/components/list/list-item.component.ts
@@ -64,7 +64,6 @@ import { NzListComponent } from './list.component';
       <ng-template [ngTemplateOutlet]="actionsTpl" />
     }
   `,
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {

--- a/components/list/list.component.ts
+++ b/components/list/list.component.ts
@@ -112,7 +112,6 @@ import {
 
     <ng-content select="nz-list-pagination, [nz-list-pagination]" />
   `,
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {

--- a/components/mention/mention.component.ts
+++ b/components/mention/mention.component.ts
@@ -118,7 +118,6 @@ export type MentionPlacement = 'top' | 'bottom';
       <nz-form-item-feedback-icon class="ant-mentions-suffix" [status]="status" />
     }
   `,
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [NzMentionService, NzDestroyService],
   host: {

--- a/components/menu/menu-group.component.ts
+++ b/components/menu/menu-group.component.ts
@@ -49,7 +49,6 @@ export function MenuGroupFactory(): boolean {
     </div>
     <ng-content></ng-content>
   `,
-  preserveWhitespaces: false,
   imports: [NzOutletModule]
 })
 export class NzMenuGroupComponent implements AfterViewInit {

--- a/components/menu/menu-item.component.ts
+++ b/components/menu/menu-item.component.ts
@@ -35,7 +35,6 @@ import { NzSubmenuService } from './submenu.service';
   exportAs: 'nzMenuItem',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   template: `
     <span class="ant-menu-title-content">
       <ng-content></ng-content>

--- a/components/menu/submenu-inline-child.component.ts
+++ b/components/menu/submenu-inline-child.component.ts
@@ -32,7 +32,7 @@ import { NzMenuModeType } from './menu.types';
   exportAs: 'nzSubmenuInlineChild',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: ` <ng-template [ngTemplateOutlet]="templateOutlet"></ng-template> `,
+  template: `<ng-template [ngTemplateOutlet]="templateOutlet"></ng-template>`,
   host: {
     class: 'ant-menu ant-menu-inline ant-menu-sub',
     '[class.ant-menu-rtl]': `dir === 'rtl'`,

--- a/components/menu/submenu.component.ts
+++ b/components/menu/submenu.component.ts
@@ -64,7 +64,6 @@ const listOfHorizontalPositions = [
   providers: [NzSubmenuService],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   template: `
     <div
       nz-submenu-title

--- a/components/message/message-container.component.ts
+++ b/components/message/message-container.component.ts
@@ -29,7 +29,6 @@ const NZ_MESSAGE_DEFAULT_CONFIG: Required<MessageConfig> = {
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-message-container',
   exportAs: 'nzMessageContainer',
-  preserveWhitespaces: false,
   template: `
     <div class="ant-message" [class.ant-message-rtl]="dir === 'rtl'" [style.top]="top">
       @for (instance of instances; track instance) {

--- a/components/message/message.component.ts
+++ b/components/message/message.component.ts
@@ -26,7 +26,6 @@ import { NzMessageData } from './typings';
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-message',
   exportAs: 'nzMessage',
-  preserveWhitespaces: false,
   animations: [moveUpMotion],
   template: `
     <div

--- a/components/message/message.spec.ts
+++ b/components/message/message.spec.ts
@@ -211,7 +211,7 @@ describe('message', () => {
 });
 
 @Component({
-  template: ` <ng-template #contentTemplate let-data="data">Content in template{{ data }}</ng-template>`
+  template: `<ng-template #contentTemplate let-data="data">Content in template{{ data }}</ng-template>`
 })
 export class NzTestMessageComponent {
   @ViewChild('contentTemplate', { static: true }) template!: TemplateRef<{

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -1766,7 +1766,7 @@ class TestWithViewContainerDirective {
 
 @Component({
   imports: [TestWithViewContainerDirective],
-  template: ` <test-with-view-container></test-with-view-container> `
+  template: `<test-with-view-container></test-with-view-container>`
 })
 class TestWithChildViewContainerComponent {
   @ViewChild(TestWithViewContainerDirective) childWithViewContainer!: TestWithViewContainerDirective;

--- a/components/notification/demo/update.ts
+++ b/components/notification/demo/update.ts
@@ -6,7 +6,7 @@ import { NzNotificationService } from 'ng-zorro-antd/notification';
 @Component({
   selector: 'nz-demo-notification-update',
   imports: [NzButtonModule],
-  template: ` <button nz-button nzType="primary" (click)="createNotification()"> Open the notification box </button> `
+  template: `<button nz-button nzType="primary" (click)="createNotification()"> Open the notification box </button>`
 })
 export class NzDemoNotificationUpdateComponent {
   constructor(private notification: NzNotificationService) {}

--- a/components/notification/notification-container.component.ts
+++ b/components/notification/notification-container.component.ts
@@ -33,7 +33,6 @@ const NZ_NOTIFICATION_DEFAULT_CONFIG: Required<NotificationConfig> = {
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-notification-container',
   exportAs: 'nzNotificationContainer',
-  preserveWhitespaces: false,
   template: `
     <div
       class="ant-notification ant-notification-topLeft"

--- a/components/notification/notification.component.ts
+++ b/components/notification/notification.component.ts
@@ -17,7 +17,6 @@ import { NzNotificationData } from './typings';
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-notification',
   exportAs: 'nzNotification',
-  preserveWhitespaces: false,
   animations: [notificationMotion],
   template: `
     <div

--- a/components/pagination/pagination-default.component.ts
+++ b/components/pagination/pagination-default.component.ts
@@ -34,7 +34,6 @@ import { PaginationItemRenderContext } from './pagination.types';
 
 @Component({
   selector: 'nz-pagination-default',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/pagination/pagination-item.component.ts
+++ b/components/pagination/pagination-item.component.ts
@@ -23,7 +23,6 @@ import { PaginationItemRenderContext, PaginationItemType } from './pagination.ty
 
 @Component({
   selector: 'li[nz-pagination-item]',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/pagination/pagination-options.component.ts
+++ b/components/pagination/pagination-options.component.ts
@@ -21,7 +21,6 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 
 @Component({
   selector: 'li[nz-pagination-options]',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/pagination/pagination-simple.component.ts
+++ b/components/pagination/pagination-simple.component.ts
@@ -33,7 +33,6 @@ import { PaginationItemRenderContext } from './pagination.types';
 
 @Component({
   selector: 'nz-pagination-simple',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/pagination/pagination.component.ts
+++ b/components/pagination/pagination.component.ts
@@ -37,7 +37,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'pagination';
 @Component({
   selector: 'nz-pagination',
   exportAs: 'nzPagination',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -127,7 +127,6 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-popconfirm',
   exportAs: 'nzPopconfirmComponent',
-  preserveWhitespaces: false,
   animations: [zoomBigMotion],
   template: `
     <ng-template

--- a/components/popover/popover.ts
+++ b/components/popover/popover.ts
@@ -81,7 +81,6 @@ export class NzPopoverDirective extends NzTooltipBaseDirective {
   animations: [zoomBigMotion],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   template: `
     <ng-template
       #overlay="cdkConnectedOverlay"

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -59,7 +59,6 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-progress',
   exportAs: 'nzProgress',
-  preserveWhitespaces: false,
   imports: [NzIconModule, NzOutletModule, NgTemplateOutlet],
   template: `
     <ng-template #progressInfoTemplate>

--- a/components/progress/progress.spec.ts
+++ b/components/progress/progress.spec.ts
@@ -505,7 +505,7 @@ export class NzTestProgressCircleComponent {
 
 @Component({
   imports: [NzProgressModule],
-  template: ` <nz-progress nzType="circle" [nzPercent]="75" [nzSuccessPercent]="60"></nz-progress>`
+  template: `<nz-progress nzType="circle" [nzPercent]="75" [nzSuccessPercent]="60"></nz-progress>`
 })
 export class NzTestProgressCircleSuccessComponent {}
 

--- a/components/radio/radio-group.component.ts
+++ b/components/radio/radio-group.component.ts
@@ -30,7 +30,7 @@ export type NzRadioButtonStyle = 'outline' | 'solid';
 @Component({
   selector: 'nz-radio-group',
   exportAs: 'nzRadioGroup',
-  template: ` <ng-content></ng-content> `,
+  template: `<ng-content></ng-content>`,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [

--- a/components/radio/radio-group.component.ts
+++ b/components/radio/radio-group.component.ts
@@ -30,7 +30,6 @@ export type NzRadioButtonStyle = 'outline' | 'solid';
 @Component({
   selector: 'nz-radio-group',
   exportAs: 'nzRadioGroup',
-  preserveWhitespaces: false,
   template: ` <ng-content></ng-content> `,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/components/radio/radio.component.ts
+++ b/components/radio/radio.component.ts
@@ -34,7 +34,6 @@ import { NzRadioService } from './radio.service';
 @Component({
   selector: '[nz-radio],[nz-radio-button]',
   exportAs: 'nzRadio',
-  preserveWhitespaces: false,
   template: `
     <span
       [class.ant-radio]="!isRadioButton"

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -43,7 +43,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'rate';
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-rate',
   exportAs: 'nzRate',
-  preserveWhitespaces: false,
   template: `
     <ul
       #ulElement

--- a/components/resizable/resize-handle.component.ts
+++ b/components/resizable/resize-handle.component.ts
@@ -47,7 +47,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
 @Component({
   selector: 'nz-resize-handle, [nz-resize-handle]',
   exportAs: 'nzResizeHandle',
-  template: ` <ng-content></ng-content> `,
+  template: `<ng-content></ng-content>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'nz-resizable-handle',

--- a/components/segmented/segmented.spec.ts
+++ b/components/segmented/segmented.spec.ts
@@ -244,7 +244,7 @@ export class NzSegmentedTestComponent {
 
 @Component({
   imports: [FormsModule, NzSegmentedModule],
-  template: ` <nz-segmented [nzOptions]="options" [(ngModel)]="value" (ngModelChange)="handleValueChange($event)" /> `
+  template: `<nz-segmented [nzOptions]="options" [(ngModel)]="value" (ngModelChange)="handleValueChange($event)" />`
 })
 export class NzSegmentedNgModelTestComponent {
   options: NzSegmentedOptions = [1, 2, 3];

--- a/components/select/option-container.component.ts
+++ b/components/select/option-container.component.ts
@@ -36,7 +36,6 @@ import { NzSelectItemInterface, NzSelectModeType } from './select.types';
   exportAs: 'nzOptionContainer',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   template: `
     <div>
       @if (listOfContainerItem.length === 0) {

--- a/components/select/option-item-group.component.ts
+++ b/components/select/option-item-group.component.ts
@@ -10,7 +10,7 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 @Component({
   selector: 'nz-option-item-group',
-  template: ` <ng-container *nzStringTemplateOutlet="nzLabel">{{ nzLabel }}</ng-container> `,
+  template: `<ng-container *nzStringTemplateOutlet="nzLabel">{{ nzLabel }}</ng-container>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {

--- a/components/select/select-top-control.component.ts
+++ b/components/select/select-top-control.component.ts
@@ -36,7 +36,6 @@ import { NzSelectItemInterface, NzSelectModeType, NzSelectTopControlItemType } f
 @Component({
   selector: 'nz-select-top-control',
   exportAs: 'nzSelectTopControl',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -96,7 +96,6 @@ export type NzSelectSizeType = NzSizeLDSType;
 @Component({
   selector: 'nz-select',
   exportAs: 'nzSelect',
-  preserveWhitespaces: false,
   providers: [
     NzDestroyService,
     {

--- a/components/slider/handle.component.ts
+++ b/components/slider/handle.component.ts
@@ -30,7 +30,6 @@ import { NzSliderShowTooltip } from './typings';
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-slider-handle',
   exportAs: 'nzSliderHandle',
-  preserveWhitespaces: false,
   template: `
     <div
       #handle

--- a/components/slider/marks.component.ts
+++ b/components/slider/marks.component.ts
@@ -21,7 +21,6 @@ import { NzDisplayedMark, NzExtendedMark, NzMark, NzMarkObj } from './typings';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   selector: 'nz-slider-marks',
   exportAs: 'nzSliderMarks',
   template: `

--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -55,7 +55,6 @@ import { NzExtendedMark, NzMarks, NzSliderHandler, NzSliderShowTooltip, NzSlider
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-slider',
   exportAs: 'nzSlider',
-  preserveWhitespaces: false,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/components/slider/step.component.ts
+++ b/components/slider/step.component.ts
@@ -21,7 +21,6 @@ import { NzDisplayedStep, NzExtendedMark } from './typings';
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-slider-step',
   exportAs: 'nzSliderStep',
-  preserveWhitespaces: false,
   template: `
     @for (step of steps; track step.value) {
       <span class="ant-slider-dot" [class.ant-slider-dot-active]="step.active" [style]="step.style!"></span>

--- a/components/slider/track.component.ts
+++ b/components/slider/track.component.ts
@@ -27,7 +27,6 @@ export interface NzSliderTrackStyle {
   selector: 'nz-slider-track',
   exportAs: 'nzSliderTrack',
   template: `<div class="ant-slider-track" [style]="style"></div>`,
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/components/spin/spin.component.ts
+++ b/components/spin/spin.component.ts
@@ -29,7 +29,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'spin';
 @Component({
   selector: 'nz-spin',
   exportAs: 'nzSpin',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   template: `
     <ng-template #defaultTemplate>

--- a/components/statistic/statistic-number.component.ts
+++ b/components/statistic/statistic-number.component.ts
@@ -20,7 +20,6 @@ import { NzStatisticValueType } from './typings';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   selector: 'nz-statistic-number',
   exportAs: 'nzStatisticNumber',
   template: `

--- a/components/steps/step.component.ts
+++ b/components/steps/step.component.ts
@@ -31,7 +31,6 @@ import { NzProgressFormatter, NzProgressModule } from 'ng-zorro-antd/progress';
   encapsulation: ViewEncapsulation.None,
   selector: 'nz-step',
   exportAs: 'nzStep',
-  preserveWhitespaces: false,
   template: `
     <div
       #itemContainer

--- a/components/steps/steps.component.ts
+++ b/components/steps/steps.component.ts
@@ -37,7 +37,6 @@ export type NzProgressDotTemplate = TemplateRef<{ $implicit: TemplateRef<void>; 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   selector: 'nz-steps',
   exportAs: 'nzSteps',
   template: `<ng-content></ng-content>`,

--- a/components/switch/switch.component.ts
+++ b/components/switch/switch.component.ts
@@ -38,7 +38,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'switch';
 @Component({
   selector: 'nz-switch',
   exportAs: 'nzSwitch',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   providers: [

--- a/components/table/src/addon/filter-trigger.component.ts
+++ b/components/table/src/addon/filter-trigger.component.ts
@@ -29,7 +29,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'filterTrigger';
   selector: 'nz-filter-trigger',
   exportAs: `nzFilterTrigger`,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   template: `
     <span

--- a/components/table/src/addon/filter.component.ts
+++ b/components/table/src/addon/filter.component.ts
@@ -42,7 +42,6 @@ interface NzThItemInterface {
 
 @Component({
   selector: 'nz-table-filter',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/table/src/addon/selection.component.ts
+++ b/components/table/src/addon/selection.component.ts
@@ -13,7 +13,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'nz-table-selection',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/table/src/addon/sorters.component.ts
+++ b/components/table/src/addon/sorters.component.ts
@@ -21,7 +21,6 @@ import { NzTableSortOrder } from '../table.types';
 
 @Component({
   selector: 'nz-table-sorters',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
@@ -37,7 +36,9 @@ import { NzTableSortOrder } from '../table.types';
       </span>
     </span>
   `,
-  host: { class: 'ant-table-column-sorters' },
+  host: {
+    class: 'ant-table-column-sorters'
+  },
   imports: [NzIconModule, NgTemplateOutlet]
 })
 export class NzTableSortersComponent implements OnChanges {

--- a/components/table/src/cell/td-addon.component.ts
+++ b/components/table/src/cell/td-addon.component.ts
@@ -29,7 +29,6 @@ import { NzRowIndentDirective } from '../addon/row-indent.directive';
   selector:
     'td[nzChecked], td[nzDisabled], td[nzIndeterminate], td[nzIndentSize], td[nzExpand], td[nzShowExpand], td[nzShowCheckbox]',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzShowExpand || nzIndentSize > 0) {

--- a/components/table/src/cell/th-addon.component.ts
+++ b/components/table/src/cell/th-addon.component.ts
@@ -43,7 +43,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
 @Component({
   selector:
     'th[nzColumnKey], th[nzSortFn], th[nzSortOrder], th[nzFilters], th[nzShowSort], th[nzShowFilter], th[nzCustomFilter]',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/table/src/cell/th-selection.component.ts
+++ b/components/table/src/cell/th-selection.component.ts
@@ -23,7 +23,6 @@ import { NzTableSelectionComponent } from '../addon/selection.component';
 
 @Component({
   selector: 'th[nzSelections],th[nzChecked],th[nzShowCheckbox],th[nzShowRowSelection]',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -58,7 +58,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
   selector: 'nz-table',
   exportAs: 'nzTable',
   providers: [NzTableStyleService, NzTableDataService],
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/table/src/table/tbody.component.ts
+++ b/components/table/src/table/tbody.component.ts
@@ -19,7 +19,6 @@ import { NzTrMeasureComponent } from './tr-measure.component';
 
 @Component({
   selector: 'tbody',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/table/src/table/tr-measure.component.ts
+++ b/components/table/src/table/tr-measure.component.ts
@@ -24,7 +24,6 @@ import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
 
 @Component({
   selector: 'tr[nz-table-measure-row]',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
@@ -32,7 +31,9 @@ import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
       <td #tdElement class="nz-disable-td" style="padding: 0; border: 0; height: 0;"></td>
     }
   `,
-  host: { class: 'ant-table-measure-now' }
+  host: {
+    class: 'ant-table-measure-now'
+  }
 })
 export class NzTrMeasureComponent implements AfterViewInit, OnDestroy {
   @Input() listOfMeasureColumn: readonly string[] = [];

--- a/components/tabs/tab-body.component.ts
+++ b/components/tabs/tab-body.component.ts
@@ -13,7 +13,7 @@ import { tabSwitchMotion } from 'ng-zorro-antd/core/animation';
   exportAs: 'nzTabBody',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: ` <ng-template [ngTemplateOutlet]="content"></ng-template> `,
+  template: `<ng-template [ngTemplateOutlet]="content"></ng-template>`,
   host: {
     class: 'ant-tabs-tabpane',
     '[class.ant-tabs-tabpane-active]': 'active',

--- a/components/tabs/tab-body.component.ts
+++ b/components/tabs/tab-body.component.ts
@@ -11,7 +11,6 @@ import { tabSwitchMotion } from 'ng-zorro-antd/core/animation';
 @Component({
   selector: '[nz-tab-body]',
   exportAs: 'nzTabBody',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: ` <ng-template [ngTemplateOutlet]="content"></ng-template> `,

--- a/components/tabs/tab-nav-bar.component.ts
+++ b/components/tabs/tab-nav-bar.component.ts
@@ -53,7 +53,6 @@ const CSS_TRANSFORM_TIME = 150;
 @Component({
   selector: 'nz-tabs-nav',
   exportAs: 'nzTabsNav',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/tabs/tab-nav-operation.component.ts
+++ b/components/tabs/tab-nav-operation.component.ts
@@ -29,7 +29,6 @@ import { NzTabNavItemDirective } from './tab-nav-item.directive';
 @Component({
   selector: 'nz-tab-nav-operation',
   exportAs: 'nzTabNavOperation',
-  preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `

--- a/components/tabs/tab.component.ts
+++ b/components/tabs/tab.component.ts
@@ -36,7 +36,6 @@ export const NZ_TAB_SET = new InjectionToken<NzSafeAny>('NZ_TAB_SET');
 @Component({
   selector: 'nz-tab',
   exportAs: 'nzTab',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/tabs/tabset.component.ts
+++ b/components/tabs/tabset.component.ts
@@ -65,7 +65,6 @@ let nextId = 0;
 @Component({
   selector: 'nz-tabset',
   exportAs: 'nzTabset',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.Default,
   providers: [

--- a/components/tag/tag.component.ts
+++ b/components/tag/tag.component.ts
@@ -36,7 +36,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 @Component({
   selector: 'nz-tag',
   exportAs: 'nzTag',
-  preserveWhitespaces: false,
   template: `
     <ng-content></ng-content>
     @if (nzMode === 'closeable') {

--- a/components/timeline/timeline-item.component.ts
+++ b/components/timeline/timeline-item.component.ts
@@ -27,7 +27,6 @@ function isDefaultColor(color?: string): boolean {
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   selector: 'nz-timeline-item, [nz-timeline-item]',
   exportAs: 'nzTimelineItem',
   template: `

--- a/components/timeline/timeline.component.ts
+++ b/components/timeline/timeline.component.ts
@@ -35,7 +35,6 @@ import { NzTimelineMode, NzTimelinePosition } from './typings';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   selector: 'nz-timeline',
   providers: [TimelineService],
   exportAs: 'nzTimeline',

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -114,7 +114,6 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
       </div>
     </ng-template>
   `,
-  preserveWhitespaces: false,
   imports: [OverlayModule, NzNoAnimationDirective, NzOutletModule, NzOverlayModule]
 })
 export class NzToolTipComponent extends NzTooltipBaseComponent {

--- a/components/transfer/transfer-list.component.ts
+++ b/components/transfer/transfer-list.component.ts
@@ -35,7 +35,6 @@ import { NzTransferSearchComponent } from './transfer-search.component';
 @Component({
   selector: 'nz-transfer-list',
   exportAs: 'nzTransferList',
-  preserveWhitespaces: false,
   template: `
     <div class="ant-transfer-list-header">
       @if (showSelectAll && !oneWay) {

--- a/components/transfer/transfer-search.component.ts
+++ b/components/transfer/transfer-search.component.ts
@@ -21,7 +21,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 @Component({
   selector: '[nz-transfer-search]',
   exportAs: 'nzTransferSearch',
-  preserveWhitespaces: false,
   template: `
     <span class="ant-input-prefix">
       <nz-icon nzType="search" />

--- a/components/transfer/transfer.component.ts
+++ b/components/transfer/transfer.component.ts
@@ -48,7 +48,6 @@ import { NzTransferListComponent } from './transfer-list.component';
 @Component({
   selector: 'nz-transfer',
   exportAs: 'nzTransfer',
-  preserveWhitespaces: false,
   template: `
     <nz-transfer-list
       class="ant-transfer-list"

--- a/components/tree-view/checkbox.ts
+++ b/components/tree-view/checkbox.ts
@@ -24,7 +24,6 @@ import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
   selector: 'nz-tree-node-checkbox:not([builtin])',
   template: ` <span class="ant-tree-checkbox-inner"></span> `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   host: {
     class: 'ant-tree-checkbox',
     '[class.ant-tree-checkbox-checked]': `nzChecked`,

--- a/components/tree-view/checkbox.ts
+++ b/components/tree-view/checkbox.ts
@@ -22,7 +22,7 @@ import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 
 @Component({
   selector: 'nz-tree-node-checkbox:not([builtin])',
-  template: ` <span class="ant-tree-checkbox-inner"></span> `,
+  template: `<span class="ant-tree-checkbox-inner"></span>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-tree-checkbox',

--- a/components/tree-view/option.ts
+++ b/components/tree-view/option.ts
@@ -25,7 +25,7 @@ import { NzTreeNodeComponent } from './node';
 
 @Component({
   selector: 'nz-tree-node-option',
-  template: ` <span class="ant-tree-title"><ng-content></ng-content></span> `,
+  template: `<span class="ant-tree-title"><ng-content></ng-content></span>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-tree-node-content-wrapper',

--- a/components/tree/tree-drop-indicator.component.ts
+++ b/components/tree/tree-drop-indicator.component.ts
@@ -20,7 +20,6 @@ import { NgStyleInterface } from 'ng-zorro-antd/core/types';
   exportAs: 'NzTreeDropIndicator',
   template: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   host: {
     '[class.ant-tree-drop-indicator]': 'true',
     '[style]': 'style'

--- a/components/tree/tree-indent.component.ts
+++ b/components/tree/tree-indent.component.ts
@@ -21,7 +21,6 @@ import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } f
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   host: {
     '[attr.aria-hidden]': 'true',
     '[class.ant-tree-indent]': '!nzSelectMode',

--- a/components/tree/tree-node-checkbox.component.ts
+++ b/components/tree/tree-node-checkbox.component.ts
@@ -11,7 +11,6 @@ import { ChangeDetectionStrategy, Component, Input, booleanAttribute } from '@an
     <span [class.ant-tree-checkbox-inner]="!nzSelectMode" [class.ant-select-tree-checkbox-inner]="nzSelectMode"></span>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   host: {
     '[class.ant-select-tree-checkbox]': `nzSelectMode`,
     '[class.ant-select-tree-checkbox-checked]': `nzSelectMode && isChecked`,

--- a/components/tree/tree-node-switcher.component.ts
+++ b/components/tree/tree-node-switcher.component.ts
@@ -40,7 +40,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   host: {
     '[class.ant-select-tree-switcher]': 'nzSelectMode',
     '[class.ant-select-tree-switcher-noop]': 'nzSelectMode && isLeaf',

--- a/components/tree/tree-node-title.component.ts
+++ b/components/tree/tree-node-title.component.ts
@@ -54,7 +54,6 @@ import { NzTreeDropIndicatorComponent } from './tree-drop-indicator.component';
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   host: {
     '[attr.title]': 'title',
     '[attr.draggable]': 'canDraggable',

--- a/components/tree/tree-node.component.ts
+++ b/components/tree/tree-node.component.ts
@@ -96,7 +96,6 @@ import { NzTreeNodeTitleComponent } from './tree-node-title.component';
     ></nz-tree-node-title>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  preserveWhitespaces: false,
   host: {
     '[class.ant-select-tree-treenode]': `nzSelectMode`,
     '[class.ant-select-tree-treenode-disabled]': `nzSelectMode && isDisabled`,

--- a/components/typography/text-copy.component.ts
+++ b/components/typography/text-copy.component.ts
@@ -49,7 +49,6 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   imports: [NzToolTipModule, NzTransButtonModule, NzIconModule, NzOutletModule]
 })
 export class NzTextCopyComponent implements OnInit, OnDestroy, OnChanges {

--- a/components/typography/text-edit.component.ts
+++ b/components/typography/text-edit.component.ts
@@ -58,7 +58,6 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   providers: [NzDestroyService],
   imports: [NzInputModule, NzTransButtonModule, NzIconModule, NzToolTipModule, NzOutletModule]
 })

--- a/components/typography/typography.component.ts
+++ b/components/typography/typography.component.ts
@@ -113,7 +113,6 @@ const EXPAND_ELEMENT_CLASSNAME = 'ant-typography-expand';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  preserveWhitespaces: false,
   host: {
     '[class.ant-typography]': '!editing',
     '[class.ant-typography-rtl]': 'dir === "rtl"',

--- a/components/upload/upload-btn.component.ts
+++ b/components/upload/upload-btn.component.ts
@@ -27,7 +27,6 @@ import { NzUploadFile, NzUploadXHRArgs, ZipButtonOptions } from './interface';
     '(drop)': 'onFileDrop($event)',
     '(dragover)': 'onFileDrop($event)'
   },
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None
 })
 export class NzUploadBtnComponent implements OnInit, OnDestroy {

--- a/components/upload/upload-list.component.ts
+++ b/components/upload/upload-list.component.ts
@@ -63,7 +63,6 @@ interface UploadListFile extends NzUploadFile {
     '[class.ant-upload-list-picture]': `listType === 'picture'`,
     '[class.ant-upload-list-picture-card]': `listType === 'picture-card'`
   },
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzToolTipModule, NgTemplateOutlet, NzIconModule, NzButtonModule, NzProgressModule]

--- a/components/upload/upload.component.ts
+++ b/components/upload/upload.component.ts
@@ -51,7 +51,6 @@ import { NzUploadListComponent } from './upload-list.component';
   selector: 'nz-upload',
   exportAs: 'nzUpload',
   templateUrl: './upload.component.html',
-  preserveWhitespaces: false,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {

--- a/components/water-mark/water-mark.component.ts
+++ b/components/water-mark/water-mark.component.ts
@@ -33,7 +33,7 @@ const FontGap = 3;
   selector: 'nz-water-mark',
   exportAs: 'NzWaterMark',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: ` <ng-content></ng-content> `,
+  template: `<ng-content></ng-content>`,
   host: {
     class: 'ant-water-mark'
   }

--- a/scripts/site/template/demo-component.standalone.template.ts
+++ b/scripts/site/template/demo-component.standalone.template.ts
@@ -11,7 +11,6 @@ import { ShareModule } from '../share/share.module';
     ShareModule,
 {{declarations}}
   ],
-  preserveWhitespaces: false,
   templateUrl  : './{{language}}.html'
 })
 export class {{componentName}} {

--- a/scripts/site/template/demo-component.template.ts
+++ b/scripts/site/template/demo-component.template.ts
@@ -3,7 +3,6 @@ import { NzCodeBoxComponent } from '../codebox/codebox.component';
 
 @Component({
   selector     : 'nz-demo-{{component}}',
-  preserveWhitespaces: false,
   templateUrl  : './{{language}}.html'
 })
 export class {{componentName}} {

--- a/scripts/site/template/doc-component.template.ts
+++ b/scripts/site/template/doc-component.template.ts
@@ -5,8 +5,7 @@ import { ShareModule } from '../share/share.module';
   selector     : 'nz-doc-{{component}}-{{language}}',
   standalone   : true,
   imports      : [ShareModule],
-  templateUrl  : './{{component}}-{{language}}.html',
-  preserveWhitespaces: false
+  templateUrl  : './{{component}}-{{language}}.html'
 })
 export class NzDoc{{componentName}}Component {
   goLink(link: string) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Remove redundant `preserveWhitespaces` because they equal to the default value.

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
