### PR TITLE
Export css in package json

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -74,6 +74,9 @@
     "./*.less": {
       "less": "./*.less"
     },
+    "./*.css": {
+      "style": "./*.css"
+    },
     "./affix/style/*": {
       "less": "./affix/style/*.less",
       "style": "./affix/style/index.min.css"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
#7928 add support for style exports in the package.json. But the index.min.css file is not exported.
<img width="578" alt="Scherm­afbeelding 2025-06-06 om 14 54 54" src="https://github.com/user-attachments/assets/5460b98f-69a5-45f9-a898-ed14dc3b4f1d" />

Issue Number: N/A


## What is the new behavior?
Add the index.min.css file as exported in the same way as the index.less

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No