### PR TITLE
fix(schematics): ng add failed when call twice

### DIFF
--- a/schematics/ng-add/index.spec.ts
+++ b/schematics/ng-add/index.spec.ts
@@ -173,18 +173,14 @@ describe('ng-add schematic', () => {
     expect(fileContent).toContain('registerLocaleData(zh)');
   });
 
-  /**
-   * Test skip because it seems that it's not possible anymore to call the runSchematics method twice in the same test.
-   * error: getStart of undefined
-   */
-  xit('should not add locale id if locale id is set up', async () => {
+  it('should not add locale id if locale id is set up', async () => {
     const options = { ...defaultOptions, i18n: 'zh_CN' };
     await runner.runSchematic('ng-add-setup-project', { ...defaultOptions }, appTree);
 
     spyOn(console, 'log');
 
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const fileContent = getFileContent(tree, '/projects/ng-zorro/src/app/app.module.ts');
+    const fileContent = getFileContent(tree, '/projects/ng-zorro/src/app/app-module.ts');
 
     expect(fileContent).toContain('provideNzI18n(en_US)');
     expect(fileContent).toContain('registerLocaleData(en)');

--- a/schematics/ng-add/standalone.spec.ts
+++ b/schematics/ng-add/standalone.spec.ts
@@ -173,11 +173,7 @@ describe('[standalone] ng-add schematic', () => {
     expect(fileContent).toContain('registerLocaleData(zh)');
   });
 
-  /**
-   * Test skip because it seems that it's not possible anymore to call the runSchematics method twice in the same test.
-   * error: getStart of undefined
-   */
-  xit('should not add locale id if locale id is set up', async () => {
+  it('should not add locale id if locale id is set up', async () => {
     const options = { ...defaultOptions, i18n: 'zh_CN' };
     await runner.runSchematic('ng-add-setup-project', { ...defaultOptions }, appTree);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

If you run the schematics twice, one time after another one the second time the schematics fails with getText of undefined.

Issue Number: N/A


## What is the new behavior?

It not failed anymore


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
