### PR TITLE
fix(module:tabs): prevent incorrect scroll offset on tab focus

### DIFF
--- a/components/tabs/tab-nav-item.directive.ts
+++ b/components/tabs/tab-nav-item.directive.ts
@@ -24,7 +24,7 @@ export class NzTabNavItemDirective implements FocusableOption {
   }
 
   focus(): void {
-    this.el.focus();
+    this.el.focus({ preventScroll: true });
   }
 
   get width(): number {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/NG-ZORRO/ng-zorro-antd/issues/9054


## What is the new behavior?
Modify NzTabNavItemDirective's focus function to prevent the auto-scroll that makes the incorrect offset of **NzTabNavBarComponent**

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
