### PR TITLE
refactor(module:*): update exportAs to follow naming conventions and remove exportAs in internal components

### DIFF
--- a/components/color-picker/color-block.component.ts
+++ b/components/color-picker/color-block.component.ts
@@ -12,7 +12,7 @@ import { defaultColor } from './src/util/util';
 
 @Component({
   selector: 'nz-color-block',
-  exportAs: 'NzColorBlock',
+  exportAs: 'nzColorBlock',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgAntdColorPickerModule],
   template: `<ng-antd-color-block [color]="nzColor" (nzOnClick)="nzOnClick.emit($event)"></ng-antd-color-block>`,

--- a/components/color-picker/color-format.component.ts
+++ b/components/color-picker/color-format.component.ts
@@ -37,7 +37,7 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
 
 @Component({
   selector: 'nz-color-format',
-  exportAs: 'NzColorFormat',
+  exportAs: 'nzColorFormat',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [ReactiveFormsModule, NzSelectModule, NzInputDirective, NzInputGroupComponent, NzInputNumberComponent],
   template: `

--- a/components/color-picker/color-picker.component.ts
+++ b/components/color-picker/color-picker.component.ts
@@ -35,7 +35,7 @@ import { NzColor, NzColorPickerFormatType, NzColorPickerTriggerType } from './ty
 
 @Component({
   selector: 'nz-color-picker',
-  exportAs: 'NzColorPicker',
+  exportAs: 'nzColorPicker',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgAntdColorPickerModule,

--- a/components/date-picker/calendar-footer.component.ts
+++ b/components/date-picker/calendar-footer.component.ts
@@ -30,7 +30,7 @@ import { PREFIX_CLASS } from './util';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'calendar-footer',
-  exportAs: 'calendarFooter',
+  exportAs: 'nzCalendarFooter',
   imports: [NgTemplateOutlet, NzButtonModule, NzStringTemplateOutletDirective],
   template: `
     <div class="{{ prefixCls }}-footer">

--- a/components/date-picker/calendar-footer.component.ts
+++ b/components/date-picker/calendar-footer.component.ts
@@ -30,7 +30,6 @@ import { PREFIX_CLASS } from './util';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'calendar-footer',
-  exportAs: 'nzCalendarFooter',
   imports: [NgTemplateOutlet, NzButtonModule, NzStringTemplateOutletDirective],
   template: `
     <div class="{{ prefixCls }}-footer">

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -58,7 +58,7 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'date-range-popup',
-  exportAs: 'dateRangePopup',
+  exportAs: 'nzDateRangePopup',
   template: `
     @if (isRange) {
       <div class="{{ prefixCls }}-range-wrapper {{ prefixCls }}-date-range-wrapper">

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -58,7 +58,6 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'date-range-popup',
-  exportAs: 'nzDateRangePopup',
   template: `
     @if (isRange) {
       <div class="{{ prefixCls }}-range-wrapper {{ prefixCls }}-date-range-wrapper">

--- a/components/date-picker/inner-popup.component.ts
+++ b/components/date-picker/inner-popup.component.ts
@@ -29,7 +29,6 @@ import { PREFIX_CLASS } from './util';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'inner-popup',
-  exportAs: 'innerPopup',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `

--- a/components/date-picker/lib/date-header.component.ts
+++ b/components/date-picker/lib/date-header.component.ts
@@ -16,7 +16,6 @@ import { transCompatFormat } from './util';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'date-header', // eslint-disable-line @angular-eslint/component-selector
-  exportAs: 'dateHeader',
   templateUrl: './abstract-panel-header.html'
 })
 export class DateHeaderComponent extends AbstractPanelHeader {

--- a/components/date-picker/lib/date-table.component.ts
+++ b/components/date-picker/lib/date-table.component.ts
@@ -19,7 +19,6 @@ import { transCompatFormat } from './util';
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'date-table',
-  exportAs: 'dateTable',
   templateUrl: './abstract-table.html',
   imports: [NzStringTemplateOutletDirective]
 })

--- a/components/date-picker/lib/decade-header.component.ts
+++ b/components/date-picker/lib/decade-header.component.ts
@@ -13,7 +13,6 @@ import { PanelSelector } from './interface';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'decade-header', // eslint-disable-line @angular-eslint/component-selector
-  exportAs: 'decadeHeader',
   templateUrl: './abstract-panel-header.html'
 })
 export class DecadeHeaderComponent extends AbstractPanelHeader {

--- a/components/date-picker/lib/decade-table.component.ts
+++ b/components/date-picker/lib/decade-table.component.ts
@@ -18,7 +18,6 @@ const MAX_COL = 3;
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'decade-table',
-  exportAs: 'decadeTable',
   templateUrl: 'abstract-table.html',
   imports: [NzStringTemplateOutletDirective]
 })

--- a/components/date-picker/lib/month-header.component.ts
+++ b/components/date-picker/lib/month-header.component.ts
@@ -16,7 +16,6 @@ import { transCompatFormat } from './util';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'month-header', // eslint-disable-line @angular-eslint/component-selector
-  exportAs: 'monthHeader',
   templateUrl: './abstract-panel-header.html'
 })
 export class MonthHeaderComponent extends AbstractPanelHeader {

--- a/components/date-picker/lib/month-table.component.ts
+++ b/components/date-picker/lib/month-table.component.ts
@@ -18,7 +18,6 @@ import { DateBodyRow, DateCell } from './interface';
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'month-table',
-  exportAs: 'monthTable',
   templateUrl: 'abstract-table.html',
   imports: [NzStringTemplateOutletDirective]
 })

--- a/components/date-picker/lib/quarter-header.component.ts
+++ b/components/date-picker/lib/quarter-header.component.ts
@@ -16,7 +16,6 @@ import { transCompatFormat } from './util';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'quarter-header', // eslint-disable-line @angular-eslint/component-selector
-  exportAs: 'quarterHeader',
   templateUrl: './abstract-panel-header.html'
 })
 export class QuarterHeaderComponent extends AbstractPanelHeader {

--- a/components/date-picker/lib/quarter-table.component.ts
+++ b/components/date-picker/lib/quarter-table.component.ts
@@ -20,7 +20,6 @@ import { DateBodyRow, DateCell } from './interface';
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'quarter-table',
-  exportAs: 'quarterTable',
   templateUrl: 'abstract-table.html',
   imports: [NzStringTemplateOutletDirective]
 })

--- a/components/date-picker/lib/year-header.component.ts
+++ b/components/date-picker/lib/year-header.component.ts
@@ -13,7 +13,6 @@ import { PanelSelector } from './interface';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'year-header', // eslint-disable-line @angular-eslint/component-selector
-  exportAs: 'yearHeader',
   templateUrl: './abstract-panel-header.html'
 })
 export class YearHeaderComponent extends AbstractPanelHeader {

--- a/components/date-picker/lib/year-table.component.ts
+++ b/components/date-picker/lib/year-table.component.ts
@@ -18,7 +18,6 @@ import { DateBodyRow, DateCell, YearCell } from './interface';
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'year-table',
-  exportAs: 'nzYearTable',
   templateUrl: 'abstract-table.html',
   imports: [NzStringTemplateOutletDirective]
 })

--- a/components/date-picker/lib/year-table.component.ts
+++ b/components/date-picker/lib/year-table.component.ts
@@ -18,7 +18,7 @@ import { DateBodyRow, DateCell, YearCell } from './interface';
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'year-table',
-  exportAs: 'yearTable',
+  exportAs: 'nzYearTable',
   templateUrl: 'abstract-table.html',
   imports: [NzStringTemplateOutletDirective]
 })

--- a/components/modal/modal-close.component.ts
+++ b/components/modal/modal-close.component.ts
@@ -12,7 +12,7 @@ import { ModalOptions } from './modal-types';
 
 @Component({
   selector: 'button[nz-modal-close]',
-  exportAs: 'NzModalCloseBuiltin',
+  exportAs: 'nzModalCloseBuiltin',
   template: `
     <span class="ant-modal-close-x">
       <ng-container *nzStringTemplateOutlet="config.nzCloseIcon; let closeIcon">

--- a/components/modal/modal-footer.component.ts
+++ b/components/modal/modal-footer.component.ts
@@ -16,7 +16,7 @@ import { ModalButtonOptions, ModalOptions } from './modal-types';
 
 @Component({
   selector: 'div[nz-modal-footer]',
-  exportAs: 'NzModalFooterBuiltin',
+  exportAs: 'nzModalFooterBuiltin',
   template: `
     @if (config.nzFooter) {
       <ng-container

--- a/components/modal/modal-title.component.ts
+++ b/components/modal/modal-title.component.ts
@@ -11,7 +11,7 @@ import { ModalOptions } from './modal-types';
 
 @Component({
   selector: 'div[nz-modal-title]',
-  exportAs: 'NzModalTitleBuiltin',
+  exportAs: 'nzModalTitleBuiltin',
   template: `
     <div class="ant-modal-title">
       <ng-container *nzStringTemplateOutlet="config.nzTitle">

--- a/components/tree/tree-drop-indicator.component.ts
+++ b/components/tree/tree-drop-indicator.component.ts
@@ -18,11 +18,11 @@ import { NgStyleInterface } from 'ng-zorro-antd/core/types';
 
 @Component({
   selector: 'nz-tree-drop-indicator',
-  exportAs: 'NzTreeDropIndicator',
+  exportAs: 'nzTreeDropIndicator',
   template: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    '[class.ant-tree-drop-indicator]': 'true',
+    class: 'ant-tree-drop-indicator',
     '[style]': 'style'
   }
 })

--- a/components/water-mark/water-mark.component.ts
+++ b/components/water-mark/water-mark.component.ts
@@ -31,7 +31,7 @@ const FontGap = 3;
 
 @Component({
   selector: 'nz-water-mark',
-  exportAs: 'NzWaterMark',
+  exportAs: 'nzWaterMark',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content></ng-content>`,
   host: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

- all the `exportAs` of components follow name convention:
  - starts with `nz`
  - camel case
- remove `exportAs` internal component because they are basically not used by users

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

| Component | Original | Current |
|-|-|-|
|`nz-color-block`|`NzColorBlock`|`nzColorBlock`|
|`nz-color-format`|`NzColorFormat`|`nzColorFormat`|
|`nz-color-picker`|`NzColorPicker`|`nzColorPicker`|
|`calendar-footer`|`calendarFooter`|-|
|`date-helper`|`dateHelper`|-|
|`date-range-popup`|`dateRangePopup`|-|
|`date-table`|`dateTable`|-|
|`decade-helper`|`decadeHelper`|-|
|`decade-table`|`decadeTable`|-|
|`month-helper`|`monthHelper`|-|
|`month-table`|`monthTable`|-|
|`quarter-helper`|`quarterHelper`|-|
|`quarter-table`|`quarterTable`|-|
|`year-helper`|`yearHelper`|-|
|`year-table`|`yearTable`|-|
|`inner-popup`|`innerPopup`|-|
|`nz-model-close`|`NzModalCloseBuiltin`|`nzModalCloseBuiltin`|
|`nz-model-footer`|`NzModalFooterBuiltin`|`nzModalFooterBuiltin`|
|`nz-model-title`|`NzModalTitleBuiltin`|`nzModalTitleBuiltin`|
|`nz-tree-drop-indicator`|`NzTreeDropIndicator`|`nzTreeDropIndicator`|
|`nz-water-mark`|`NzWaterMark`|`nzWaterMark`|


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
