### PR TITLE
revert(module:pagination): rollback validatePageIndex to old version

### DIFF
--- a/components/pagination/pagination.component.ts
+++ b/components/pagination/pagination.component.ts
@@ -119,7 +119,13 @@ export class NzPaginationComponent implements OnInit, OnChanges {
   private total$ = new ReplaySubject<number>(1);
 
   validatePageIndex(value: number, lastIndex: number): number {
-    return Math.min(Math.max(value, 1), lastIndex);
+    if (value > lastIndex) {
+      return lastIndex;
+    } else if (value < 1) {
+      return 1;
+    } else {
+      return value;
+    }
   }
 
   onPageIndexChange(index: number): void {


### PR DESCRIPTION
The new validatePageIndex funciton "Math.min(Math.max(value, 1), lastIndex)" will return 0 when lastIndex is 0. This will result in the pageIndexChange being triggered incorrectly when nzTotal changes from 0 to a value greater than 0. So, back to the old version

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
