### PR TITLE
refactor: reduce config service boilerplate

### DIFF
--- a/components/alert/alert.component.ts
+++ b/components/alert/alert.component.ts
@@ -23,7 +23,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { slideAlertMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
@@ -101,7 +101,6 @@ export type NzAlertType = 'success' | 'info' | 'warning' | 'error';
   encapsulation: ViewEncapsulation.None
 })
 export class NzAlertComponent implements OnChanges, OnInit {
-  public nzConfigService = inject(NzConfigService);
   private cdr = inject(ChangeDetectorRef);
   private directionality = inject(Directionality);
   private readonly destroyRef = inject(DestroyRef);
@@ -127,12 +126,7 @@ export class NzAlertComponent implements OnChanges, OnInit {
   private isShowIconSet = false;
 
   constructor() {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed())
-      .subscribe(() => {
-        this.cdr.markForCheck();
-      });
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => this.cdr.markForCheck());
   }
 
   ngOnInit(): void {

--- a/components/button/button.component.ts
+++ b/components/button/button.component.ts
@@ -28,7 +28,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject } from 'rxjs';
 import { filter, startWith } from 'rxjs/operators';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
 import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzIconDirective, NzIconModule } from 'ng-zorro-antd/icon';
@@ -80,7 +80,6 @@ export class NzButtonComponent implements OnChanges, AfterViewInit, AfterContent
   private elementRef = inject(ElementRef);
   private cdr = inject(ChangeDetectorRef);
   private renderer = inject(Renderer2);
-  public nzConfigService = inject(NzConfigService);
   private directionality = inject(Directionality);
   private destroyRef = inject(DestroyRef);
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
@@ -131,15 +130,15 @@ export class NzButtonComponent implements OnChanges, AfterViewInit, AfterContent
     return !!this.nzIconDirectiveElement && noSpan && noText;
   }
 
+  constructor() {
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
+      this.size.set(this.nzSize);
+      this.cdr.markForCheck();
+    });
+  }
+
   ngOnInit(): void {
     this.size.set(this.nzSize);
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.size.set(this.nzSize);
-        this.cdr.markForCheck();
-      });
 
     this.directionality.change?.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((direction: Direction) => {
       this.dir = direction;

--- a/components/card/card.component.ts
+++ b/components/card/card.component.ts
@@ -22,7 +22,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NgStyleInterface, NzSizeDSType } from 'ng-zorro-antd/core/types';
 import { NzSkeletonModule } from 'ng-zorro-antd/skeleton';
@@ -95,7 +95,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'card';
   imports: [NzOutletModule, NgTemplateOutlet, NzSkeletonModule]
 })
 export class NzCardComponent implements OnInit {
-  public nzConfigService = inject(NzConfigService);
   private cdr = inject(ChangeDetectorRef);
   private directionality = inject(Directionality);
   private destroyRef = inject(DestroyRef);
@@ -117,12 +116,7 @@ export class NzCardComponent implements OnInit {
   dir: Direction = 'ltr';
 
   constructor() {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed())
-      .subscribe(() => {
-        this.cdr.markForCheck();
-      });
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => this.cdr.markForCheck());
   }
 
   ngOnInit(): void {

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -46,7 +46,7 @@ import { BehaviorSubject, merge, Observable, of } from 'rxjs';
 import { distinctUntilChanged, map, startWith, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { slideMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzFormItemFeedbackIconComponent, NzFormNoStatusService, NzFormStatusService } from 'ng-zorro-antd/core/form';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import {
@@ -488,7 +488,6 @@ export class NzCascaderComponent
   noAnimation = inject(NzNoAnimationDirective, { host: true, optional: true });
   nzFormStatusService = inject(NzFormStatusService, { optional: true });
   private nzFormNoStatusService = inject(NzFormNoStatusService, { optional: true });
-  private nzConfigService = inject(NzConfigService);
   public cascaderService = inject(NzCascaderService);
 
   constructor() {
@@ -500,6 +499,11 @@ export class NzCascaderComponent
     this.destroyRef.onDestroy(() => {
       this.clearDelayMenuTimer();
       this.clearDelaySelectTimer();
+    });
+
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
+      this.size.set(this.nzSize);
+      this.cdr.markForCheck();
     });
   }
 
@@ -556,13 +560,6 @@ export class NzCascaderComponent
     });
 
     this.size.set(this.nzSize);
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.size.set(this.nzSize);
-        this.cdr.markForCheck();
-      });
 
     this.dir = this.directionality.value;
     this.directionality.change.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {

--- a/components/code-editor/code-editor.service.ts
+++ b/components/code-editor/code-editor.service.ts
@@ -3,11 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { DestroyRef, DOCUMENT, inject, Injectable } from '@angular/core';
+import { DOCUMENT, inject, Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, of, ReplaySubject } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 
-import { CodeEditorConfig, NzConfigService } from 'ng-zorro-antd/core/config';
+import { CodeEditorConfig, NzConfigService, onConfigChangeEventForComponent } from 'ng-zorro-antd/core/config';
 import { PREFIX, warn } from 'ng-zorro-antd/core/logger';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
@@ -56,14 +56,12 @@ export class NzCodeEditorService {
     }
     this.option = this.config.defaultEditorOption || {};
 
-    const subscription = this.nzConfigService.getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME).subscribe(() => {
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
       const newGlobalConfig: NzSafeAny = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME);
       if (newGlobalConfig) {
         this._updateDefaultOption(newGlobalConfig.defaultEditorOption);
       }
     });
-
-    inject(DestroyRef).onDestroy(() => subscription.unsubscribe());
   }
 
   private _updateDefaultOption(option: JoinedEditorOptions): void {

--- a/components/collapse/collapse-panel.component.ts
+++ b/components/collapse/collapse-panel.component.ts
@@ -24,7 +24,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { filter } from 'rxjs/operators';
 
 import { collapseMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
@@ -78,7 +78,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapsePanel';
   imports: [NzOutletModule, NzIconModule]
 })
 export class NzCollapsePanelComponent implements OnInit {
-  public nzConfigService = inject(NzConfigService);
   private ngZone = inject(NgZone);
   private cdr = inject(ChangeDetectorRef);
   private destroyRef = inject(DestroyRef);
@@ -102,12 +101,7 @@ export class NzCollapsePanelComponent implements OnInit {
   }
 
   constructor() {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed())
-      .subscribe(() => {
-        this.cdr.markForCheck();
-      });
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => this.cdr.markForCheck());
 
     this.destroyRef.onDestroy(() => {
       this.nzCollapseComponent.removePanel(this);

--- a/components/collapse/collapse.component.ts
+++ b/components/collapse/collapse.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 
 import { NzCollapsePanelComponent } from './collapse-panel.component';
 
@@ -39,7 +39,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapse';
   }
 })
 export class NzCollapseComponent implements OnInit {
-  public nzConfigService = inject(NzConfigService);
   private cdr = inject(ChangeDetectorRef);
   private directionality = inject(Directionality);
   private destroyRef = inject(DestroyRef);
@@ -56,12 +55,7 @@ export class NzCollapseComponent implements OnInit {
   private listOfNzCollapsePanelComponent: NzCollapsePanelComponent[] = [];
 
   constructor() {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed())
-      .subscribe(() => {
-        this.cdr.markForCheck();
-      });
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => this.cdr.markForCheck());
   }
 
   ngOnInit(): void {

--- a/components/experimental/image/image.component.ts
+++ b/components/experimental/image/image.component.ts
@@ -18,9 +18,8 @@ import {
   inject,
   DestroyRef
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { warn } from 'ng-zorro-antd/core/logger';
 import { ImagePreloadService, PreloadDisposeHandle } from 'ng-zorro-antd/core/services';
 import { NzImageDirective } from 'ng-zorro-antd/image';
@@ -55,7 +54,6 @@ const sizeBreakpoints = [16, 32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080,
   imports: [NzImageDirective]
 })
 export class NzImageViewComponent implements OnInit, OnChanges {
-  private nzConfigService = inject(NzConfigService);
   private cdr = inject(ChangeDetectorRef);
   private imagePreloadService = inject(ImagePreloadService);
   private destroyRef = inject(DestroyRef);
@@ -83,13 +81,10 @@ export class NzImageViewComponent implements OnInit, OnChanges {
   private reloadDisposeHandler: PreloadDisposeHandle = () => void 0;
 
   constructor() {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed())
-      .subscribe(() => {
-        this.composeImageAttrs();
-        this.cdr.markForCheck();
-      });
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
+      this.composeImageAttrs();
+      this.cdr.markForCheck();
+    });
 
     this.destroyRef.onDestroy(() => {
       this.reloadDisposeHandler();

--- a/components/icon/icon.service.ts
+++ b/components/icon/icon.service.ts
@@ -4,13 +4,12 @@
  */
 
 import { Platform } from '@angular/cdk/platform';
-import { DestroyRef, inject, Injectable, InjectionToken } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { IconDefinition, IconService } from '@ant-design/icons-angular';
 
-import { IconConfig, NzConfigService } from 'ng-zorro-antd/core/config';
+import { IconConfig, NzConfigService, onConfigChangeEventForComponent } from 'ng-zorro-antd/core/config';
 import { warn } from 'ng-zorro-antd/core/logger';
 
 import { NZ_ICONS_USED_BY_ZORRO } from './icons';
@@ -31,7 +30,6 @@ export const DEFAULT_TWOTONE_COLOR = '#1890ff';
 })
 export class NzIconService extends IconService {
   protected nzConfigService = inject(NzConfigService);
-  private destroyRef = inject(DestroyRef);
   private platform = inject(Platform);
 
   configUpdated$ = new Subject<void>();
@@ -79,14 +77,11 @@ export class NzIconService extends IconService {
   }
 
   private onConfigChange(): void {
-    this.nzConfigService
-      .getConfigChangeEventForComponent('icon')
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.configDefaultTwotoneColor();
-        this.configDefaultTheme();
-        this.configUpdated$.next();
-      });
+    onConfigChangeEventForComponent('icon', () => {
+      this.configDefaultTwotoneColor();
+      this.configDefaultTheme();
+      this.configUpdated$.next();
+    });
   }
 
   private configDefaultTheme(): void {

--- a/components/message/base.ts
+++ b/components/message/base.ts
@@ -72,8 +72,7 @@ export abstract class NzMNService<T extends NzMNContainerComponent> {
 export abstract class NzMNContainerComponent<
   C extends MessageConfig = MessageConfig,
   D extends NzMessageData = NzMessageData
-> implements OnInit
-{
+> {
   config?: Required<C>;
   instances: Array<Required<D>> = [];
 
@@ -81,11 +80,10 @@ export abstract class NzMNContainerComponent<
 
   readonly afterAllInstancesRemoved = this._afterAllInstancesRemoved.asObservable();
 
-  protected destroyRef = inject(DestroyRef);
   protected cdr = inject(ChangeDetectorRef);
   protected nzConfigService = inject(NzConfigService);
 
-  ngOnInit(): void {
+  constructor() {
     this.subscribeConfigChange();
   }
 

--- a/components/message/message-container.component.ts
+++ b/components/message/message-container.component.ts
@@ -5,9 +5,8 @@
 
 import { Direction } from '@angular/cdk/bidi';
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-import { MessageConfig } from 'ng-zorro-antd/core/config';
+import { MessageConfig, onConfigChangeEventForComponent } from 'ng-zorro-antd/core/config';
 import { toCssPixel } from 'ng-zorro-antd/core/util';
 
 import { NzMNContainerComponent } from './base';
@@ -48,13 +47,10 @@ export class NzMessageContainerComponent extends NzMNContainerComponent {
   }
 
   protected subscribeConfigChange(): void {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.updateConfig();
-        this.dir = this.nzConfigService.getConfigForComponent(NZ_CONFIG_COMPONENT_NAME)?.nzDirection || this.dir;
-      });
+    onConfigChangeEventForComponent(NZ_CONFIG_COMPONENT_NAME, () => {
+      this.updateConfig();
+      this.dir = this.nzConfigService.getConfigForComponent(NZ_CONFIG_COMPONENT_NAME)?.nzDirection || this.dir;
+    });
   }
 
   protected updateConfig(): void {

--- a/components/modal/modal-container.directive.ts
+++ b/components/modal/modal-container.directive.ts
@@ -24,7 +24,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-import { NzConfigService } from 'ng-zorro-antd/core/config';
+import { NzConfigService, onConfigChangeEventForComponent } from 'ng-zorro-antd/core/config';
 import { requestAnimationFrame } from 'ng-zorro-antd/core/polyfill';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { fromEventOutsideAngular, getElementOffset, isNotNil } from 'ng-zorro-antd/core/util';
@@ -85,12 +85,8 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
     super();
     this.dir = this.overlayRef.getDirection();
     this.isStringContent = typeof this.config.nzContent === 'string';
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed())
-      .subscribe(() => {
-        this.updateMaskClassname();
-      });
+
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => this.updateMaskClassname());
 
     this.destroyRef.onDestroy(() => {
       this.setMaskExitAnimationClass(true);

--- a/components/notification/notification-container.component.ts
+++ b/components/notification/notification-container.component.ts
@@ -5,10 +5,9 @@
 
 import { Direction } from '@angular/cdk/bidi';
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject } from 'rxjs';
 
-import { NotificationConfig } from 'ng-zorro-antd/core/config';
+import { NotificationConfig, onConfigChangeEventForComponent } from 'ng-zorro-antd/core/config';
 import { toCssPixel } from 'ng-zorro-antd/core/util';
 import { NzMNContainerComponent } from 'ng-zorro-antd/message';
 
@@ -163,13 +162,10 @@ export class NzNotificationContainerComponent extends NzMNContainerComponent<Not
   }
 
   protected subscribeConfigChange(): void {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.updateConfig();
-        this.dir = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME)?.nzDirection || this.dir;
-      });
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
+      this.updateConfig();
+      this.dir = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME)?.nzDirection || this.dir;
+    });
   }
 
   protected updateConfig(): void {

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -20,7 +20,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NgStyleInterface } from 'ng-zorro-antd/core/types';
 import { isNotNil, numberAttributeWithZeroFallback } from 'ng-zorro-antd/core/util';
@@ -173,7 +173,6 @@ export class NzProgressComponent implements OnChanges, OnInit {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 
   private readonly cdr = inject(ChangeDetectorRef);
-  public readonly nzConfigService = inject(NzConfigService);
   private readonly directionality = inject(Directionality);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -238,6 +237,14 @@ export class NzProgressComponent implements OnChanges, OnInit {
   private cachedStatus: NzProgressStatusType = 'normal';
   private inferredStatus: NzProgressStatusType = 'normal';
 
+  constructor() {
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
+      this.updateIcon();
+      this.setStrokeColor();
+      this.getCirclePaths();
+    });
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     const {
       nzSteps,
@@ -288,15 +295,6 @@ export class NzProgressComponent implements OnChanges, OnInit {
   }
 
   ngOnInit(): void {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.updateIcon();
-        this.setStrokeColor();
-        this.getCirclePaths();
-      });
-
     this.directionality.change?.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(direction => {
       this.dir = direction;
       this.cdr.detectChanges();

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -30,7 +30,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NgClassType, OnChangeType, OnTouchedType } from 'ng-zorro-antd/core/types';
 import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
@@ -86,7 +86,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'rate';
 export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 
-  public readonly nzConfigService = inject(NzConfigService);
   private readonly ngZone = inject(NgZone);
   private readonly renderer = inject(Renderer2);
   private readonly cdr = inject(ChangeDetectorRef);
@@ -132,6 +131,10 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
     this.hoverValue = Math.ceil(input);
   }
 
+  constructor() {
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => this.cdr.markForCheck());
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     const { nzAutoFocus, nzCount, nzValue } = changes;
 
@@ -154,11 +157,6 @@ export class NzRateComponent implements OnInit, ControlValueAccessor, OnChanges 
   }
 
   ngOnInit(): void {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.cdr.markForCheck());
-
     this.directionality.change.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((direction: Direction) => {
       this.dir = direction;
       this.cdr.detectChanges();

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -46,7 +46,7 @@ import { BehaviorSubject, combineLatest, merge, of as observableOf } from 'rxjs'
 import { distinctUntilChanged, map, startWith, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { slideMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzFormItemFeedbackIconComponent, NzFormNoStatusService, NzFormStatusService } from 'ng-zorro-antd/core/form';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { NzOverlayModule, POSITION_MAP, POSITION_TYPE, getPlacementName } from 'ng-zorro-antd/core/overlay';
@@ -232,7 +232,6 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 
   private readonly ngZone = inject(NgZone);
-  public readonly nzConfigService = inject(NzConfigService);
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly host = inject(ElementRef<HTMLElement>);
   private readonly renderer = inject(Renderer2);
@@ -637,6 +636,11 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
       cancelAnimationFrame(this.requestId);
       this.focusMonitor.stopMonitoring(this.host);
     });
+
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
+      this.size.set(this.nzSize);
+      this.cdr.markForCheck();
+    });
   }
 
   writeValue(modelValue: NzSafeAny | NzSafeAny[]): void {
@@ -774,14 +778,6 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
       this.dir = direction;
       this.cdr.detectChanges();
     });
-
-    this.nzConfigService
-      .getConfigChangeEventForComponent('select')
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.size.set(this.nzSize);
-        this.cdr.markForCheck();
-      });
 
     this.dir = this.directionality.value;
 

--- a/components/spin/spin.component.ts
+++ b/components/spin/spin.component.ts
@@ -24,7 +24,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Observable, of, ReplaySubject } from 'rxjs';
 import { distinctUntilChanged, startWith, switchMap } from 'rxjs/operators';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'spin';
@@ -72,7 +72,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'spin';
 export class NzSpinComponent implements OnChanges, OnInit {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 
-  nzConfigService = inject(NzConfigService);
   private cdr = inject(ChangeDetectorRef);
   private directionality = inject(Directionality);
   private destroyRef = inject(DestroyRef);
@@ -89,6 +88,10 @@ export class NzSpinComponent implements OnChanges, OnInit {
   readonly isLoading = signal(false);
 
   dir: Direction = 'ltr';
+
+  constructor() {
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => this.cdr.markForCheck());
+  }
 
   ngOnInit(): void {
     this.delay$
@@ -117,11 +120,6 @@ export class NzSpinComponent implements OnChanges, OnInit {
       .subscribe(isLoading => {
         this.isLoading.set(isLoading);
       });
-
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.cdr.markForCheck());
 
     this.directionality.change?.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(direction => {
       this.dir = direction;

--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -32,7 +32,7 @@ import { BehaviorSubject, combineLatest } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
 import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { measureScrollbar } from 'ng-zorro-antd/core/util';
 import { NzPaginationModule, PaginationItemRenderContext } from 'ng-zorro-antd/pagination';
@@ -163,7 +163,6 @@ export class NzTableComponent<T> implements OnInit, OnChanges, AfterViewInit {
 
   private elementRef = inject(ElementRef);
   private nzResizeObserver = inject(NzResizeObserver);
-  private nzConfigService = inject(NzConfigService);
   private cdr = inject(ChangeDetectorRef);
   private nzTableStyleService = inject(NzTableStyleService);
   private nzTableDataService = inject(NzTableDataService<T>);
@@ -239,10 +238,7 @@ export class NzTableComponent<T> implements OnInit, OnChanges, AfterViewInit {
   }
 
   constructor() {
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed())
-      .subscribe(() => this.cdr.markForCheck());
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => this.cdr.markForCheck());
   }
 
   ngOnInit(): void {

--- a/components/tree-select/tree-select.component.ts
+++ b/components/tree-select/tree-select.component.ts
@@ -42,7 +42,7 @@ import { Subject, combineLatest, merge, of as observableOf } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, tap, withLatestFrom } from 'rxjs/operators';
 
 import { slideMotion } from 'ng-zorro-antd/core/animation';
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import { NzFormItemFeedbackIconComponent, NzFormNoStatusService, NzFormStatusService } from 'ng-zorro-antd/core/form';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { NzOverlayModule, POSITION_MAP } from 'ng-zorro-antd/core/overlay';
@@ -267,7 +267,6 @@ const listOfPositions = [
 export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAccessor, OnInit, OnChanges {
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 
-  nzConfigService = inject(NzConfigService);
   private renderer = inject(Renderer2);
   private cdr = inject(ChangeDetectorRef);
   private elementRef = inject(ElementRef);
@@ -389,17 +388,15 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
     this.destroyRef.onDestroy(() => {
       this.closeDropDown();
     });
+
+    onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
+      this.size.set(this.nzSize);
+      this.cdr.markForCheck();
+    });
   }
 
   ngOnInit(): void {
     this.size.set(this.nzSize);
-    this.nzConfigService
-      .getConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.size.set(this.nzSize);
-        this.cdr.markForCheck();
-      });
 
     this.nzFormStatusService?.formStatusChanges
       .pipe(


### PR DESCRIPTION
In this commit, we introduce the `onConfigChangeEventForComponent` utility to reduce repetitive subscription logic across components that depend on configuration changes from `NzConfigService`.