### PR TITLE
refactor(module:core): deprecate `NzHighlightModule`

### DIFF
--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -21,7 +21,7 @@ import {
   ChangeDetectorRef
 } from '@angular/core';
 
-import { NzHighlightModule } from 'ng-zorro-antd/core/highlight';
+import { NzHighlightPipe } from 'ng-zorro-antd/core/highlight';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzTreeNode } from 'ng-zorro-antd/core/tree';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -31,7 +31,7 @@ import { NzCascaderOption } from './typings';
 @Component({
   selector: '[nz-cascader-option]',
   exportAs: 'nzCascaderOption',
-  imports: [NgTemplateOutlet, NzHighlightModule, NzIconModule, NzOutletModule],
+  imports: [NgTemplateOutlet, NzHighlightPipe, NzIconModule, NzOutletModule],
   template: `
     @if (checkable) {
       <span

--- a/components/core/highlight/highlight.module.ts
+++ b/components/core/highlight/highlight.module.ts
@@ -7,6 +7,9 @@ import { NgModule } from '@angular/core';
 
 import { NzHighlightPipe } from './highlight.pipe';
 
+/**
+ * @deprecated Will be removed in v21, use `NzHighlightPipe` directly instead.
+ */
 @NgModule({
   imports: [NzHighlightPipe],
   exports: [NzHighlightPipe]

--- a/components/core/highlight/highlight.pipe.ts
+++ b/components/core/highlight/highlight.pipe.ts
@@ -5,32 +5,10 @@
 
 import { Pipe, PipeTransform } from '@angular/core';
 
-// Regular Expressions for parsing tags and attributes
-const SURROGATE_PAIR_REGEXP = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
-// ! to ~ is the ASCII range.
-const NON_ALPHANUMERIC_REGEXP = /([^#-~ |!])/g;
-
-/**
- * Escapes all potentially dangerous characters, so that the
- * resulting string can be safely inserted into attribute or
- * element text.
- */
-function encodeEntities(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(SURROGATE_PAIR_REGEXP, (match: string) => {
-      const hi = match.charCodeAt(0);
-      const low = match.charCodeAt(1);
-      return `&#${(hi - 0xd800) * 0x400 + (low - 0xdc00) + 0x10000};`;
-    })
-    .replace(NON_ALPHANUMERIC_REGEXP, (match: string) => `&#${match.charCodeAt(0)};`)
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
+import { encodeEntities } from 'ng-zorro-antd/core/util';
 
 @Pipe({
-  name: 'nzHighlight',
-  pure: true
+  name: 'nzHighlight'
 })
 export class NzHighlightPipe implements PipeTransform {
   private UNIQUE_WRAPPERS: [string, string] = ['##==-open_tag-==##', '##==-close_tag-==##'];

--- a/components/core/pipe/time-range.pipe.ts
+++ b/components/core/pipe/time-range.pipe.ts
@@ -9,8 +9,7 @@ import { timeUnits } from 'ng-zorro-antd/core/time';
 import { padStart } from 'ng-zorro-antd/core/util';
 
 @Pipe({
-  name: 'nzTimeRange',
-  pure: true
+  name: 'nzTimeRange'
 })
 export class NzTimeRangePipe implements PipeTransform {
   transform(value: string | number, format: string = 'HH:mm:ss'): string {

--- a/components/core/util/encode-entities.ts
+++ b/components/core/util/encode-entities.ts
@@ -1,0 +1,26 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+const SURROGATE_PAIR_REGEXP = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
+// ! to ~ is the ASCII range.
+const NON_ALPHANUMERIC_REGEXP = /([^#-~ |!])/g;
+
+/**
+ * Escapes all potentially dangerous characters, so that the
+ * resulting string can be safely inserted into attribute or
+ * element text.
+ */
+export function encodeEntities(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(SURROGATE_PAIR_REGEXP, (match: string) => {
+      const hi = match.charCodeAt(0);
+      const low = match.charCodeAt(1);
+      return `&#${(hi - 0xd800) * 0x400 + (low - 0xdc00) + 0x10000};`;
+    })
+    .replace(NON_ALPHANUMERIC_REGEXP, (match: string) => `&#${match.charCodeAt(0)};`)
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/components/core/util/public-api.ts
+++ b/components/core/util/public-api.ts
@@ -24,3 +24,4 @@ export * from './dynamic-css';
 export * from './status-util';
 export * from './from-event-outside-angular';
 export * from './variant-utils';
+export * from './encode-entities';

--- a/components/tree/tree-node-title.component.ts
+++ b/components/tree/tree-node-title.component.ts
@@ -16,7 +16,7 @@ import {
   inject
 } from '@angular/core';
 
-import { NzHighlightModule } from 'ng-zorro-antd/core/highlight';
+import { NzHighlightPipe } from 'ng-zorro-antd/core/highlight';
 import { NzTreeNode, NzTreeNodeOptions } from 'ng-zorro-antd/core/tree';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
@@ -69,7 +69,7 @@ import { NzTreeDropIndicatorComponent } from './tree-drop-indicator.component';
     '[class.ant-tree-node-content-wrapper-close]': `!selectMode && isSwitcherClose`,
     '[class.ant-tree-node-selected]': `!selectMode && isSelected`
   },
-  imports: [NgTemplateOutlet, NzIconModule, NzHighlightModule, NzTreeDropIndicatorComponent]
+  imports: [NgTemplateOutlet, NzIconModule, NzHighlightPipe, NzTreeDropIndicatorComponent]
 })
 export class NzTreeNodeTitleComponent implements OnChanges {
   private cdr = inject(ChangeDetectorRef);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

- Mark `NzHighlightModule` as deprecated, use `NzHighlightPipe` directly instead
- Remove redundant `pure: true` because it is the default value

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
