### PR TITLE
refactor: no explicit FocusMonitor#stopMonitor invocation

### DIFF
--- a/components/checkbox/checkbox-group.component.ts
+++ b/components/checkbox/checkbox-group.component.ts
@@ -100,10 +100,6 @@ export class NzCheckboxGroupComponent implements ControlValueAccessor {
             this.onTouched();
           }
         });
-
-      destroyRef.onDestroy(() => {
-        focusMonitor.stopMonitoring(elementRef);
-      });
     });
   }
 

--- a/components/checkbox/checkbox.component.ts
+++ b/components/checkbox/checkbox.component.ts
@@ -145,7 +145,6 @@ export class NzCheckboxComponent implements OnInit, ControlValueAccessor, AfterV
 
   constructor() {
     this.destroyRef.onDestroy(() => {
-      this.focusMonitor.stopMonitoring(this.elementRef);
       this.nzCheckboxWrapperComponent?.removeCheckbox(this);
     });
     if (this.checkboxGroupComponent) {

--- a/components/input-number/input-number.component.ts
+++ b/components/input-number/input-number.component.ts
@@ -322,10 +322,6 @@ export class NzInputNumberComponent implements OnInit, ControlValueAccessor {
             this.nzBlur.emit();
           }
         });
-
-      destroyRef.onDestroy(() => {
-        this.focusMonitor.stopMonitoring(element);
-      });
     });
 
     this.nzFormStatusService?.formStatusChanges.pipe(takeUntilDestroyed()).subscribe(({ status, hasFeedback }) => {

--- a/components/input/input-group.component.ts
+++ b/components/input/input-group.component.ts
@@ -171,10 +171,6 @@ export class NzInputGroupComponent implements AfterContentInit, OnChanges, OnIni
   status: NzValidateStatus = '';
   hasFeedback: boolean = false;
 
-  constructor() {
-    this.destroyRef.onDestroy(() => this.focusMonitor.stopMonitoring(this.elementRef));
-  }
-
   updateChildrenInputSize(): void {
     if (this.listOfNzInputDirective) {
       this.listOfNzInputDirective.forEach(item => item['size'].set(this.nzSize));

--- a/components/radio/radio.component.ts
+++ b/components/radio/radio.component.ts
@@ -109,12 +109,6 @@ export class NzRadioComponent implements ControlValueAccessor, AfterViewInit, On
     this.inputElement!.nativeElement.blur();
   }
 
-  constructor() {
-    this.destroyRef.onDestroy(() => {
-      this.focusMonitor.stopMonitoring(this.elementRef);
-    });
-  }
-
   setDisabledState(disabled: boolean): void {
     this.nzDisabled = (this.isNzDisableFirstChange && this.nzDisabled) || disabled;
     this.isNzDisableFirstChange = false;

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -632,10 +632,7 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
   private nzFormNoStatusService = inject(NzFormNoStatusService, { optional: true });
 
   constructor() {
-    this.destroyRef.onDestroy(() => {
-      cancelAnimationFrame(this.requestId);
-      this.focusMonitor.stopMonitoring(this.host);
-    });
+    this.destroyRef.onDestroy(() => cancelAnimationFrame(this.requestId));
 
     onConfigChangeEventForComponent(NZ_CONFIG_MODULE_NAME, () => {
       this.size.set(this.nzSize);

--- a/components/switch/switch.component.ts
+++ b/components/switch/switch.component.ts
@@ -121,12 +121,6 @@ export class NzSwitchComponent implements ControlValueAccessor, AfterViewInit, O
     this.switchElement.nativeElement.blur();
   }
 
-  constructor() {
-    this.destroyRef.onDestroy(() => {
-      this.focusMonitor.stopMonitoring(this.switchElement!.nativeElement);
-    });
-  }
-
   ngOnInit(): void {
     this.directionality.change.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(direction => {
       this.dir = direction;


### PR DESCRIPTION
FocusMonitor does `stopMonitor` in its onDestroy callback (https://github.com/angular/components/blob/464adf010ca94f504e2f5c920c1cc2b5c6495826/src/cdk/a11y/focus-monitor/focus-monitor.ts#L303), so we need not to invoke `stopMonitor` explicitly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
