### PR TITLE
fix(module:input-number): ngModel value can be undefined

### DIFF
--- a/components/input-number/input-number.component.ts
+++ b/components/input-number/input-number.component.ts
@@ -410,7 +410,7 @@ export class NzInputNumberComponent implements OnInit, ControlValueAccessor {
       value &&= +value.toFixed(precision);
     }
 
-    const formatedValue = value === null ? '' : formatter(value);
+    const formatedValue = value === null || typeof value === 'undefined' ? '' : formatter(value);
     this.displayValue.set(formatedValue);
     this.updateValue(value);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Binding of the `undefined` field cause the error in the log:

`core.mjs:6537 ERROR TypeError: Cannot read properties of undefined (reading 'toString') at defaultFormater (ng-zorro-antd-input-number.mjs:313:18) at _NzInputNumberComponent.setValue (ng-zorro-antd-input-number.mjs:468:49) at ng-zorro-antd-input-number.mjs:418:12 at untracked (untracked-BKcld_ew.mjs:573:12) at untracked2 (core.mjs:38350:10) at _NzInputNumberComponent.writeValue (ng-zorro-antd-input-number.mjs:416:5) at onChange (forms.mjs:3476:23) at forms.mjs:3992:42 at Array.forEach (<anonymous>) at FormControl2.setValue (forms.mjs:3992:22)` 

Issue Number: N/A


## What is the new behavior?

No error message.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Just bug has been fixed.
The discussion has been created early https://github.com/NG-ZORRO/ng-zorro-antd/discussions/9121
I am not sure that `number | null` is a proper type for `value` of this component.
