### PR TITLE
feat(module:popconfirm): add nzDanger support to cancel button

### DIFF
--- a/components/popconfirm/popconfirm.spec.ts
+++ b/components/popconfirm/popconfirm.spec.ts
@@ -114,6 +114,15 @@ describe('NzPopconfirm', () => {
     expect(getTooltipTrigger(0).disabled).toBeTrue();
   });
 
+  it('should support nzCancelButtonProps and support danger on close button', () => {
+    fixture.detectChanges();
+    const triggerElement = component.stringTemplate.nativeElement;
+    dispatchMouseEvent(triggerElement, 'click');
+    component.nzCancelButtonProps.update(props => ({ ...props, nzDanger: true }));
+    fixture.detectChanges();
+    expect(getTooltipTrigger(0).classList).toContain('ant-btn-dangerous');
+  });
+
   it('should cancel work', fakeAsync(() => {
     const triggerElement = component.stringTemplate.nativeElement;
 

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -201,6 +201,7 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
                     nz-button
                     #cancelBtn
                     [nzSize]="'small'"
+                    [nzDanger]="nzCancelButtonProps()?.nzDanger"
                     (click)="onCancel()"
                     [disabled]="nzCancelButtonProps()?.nzDisabled"
                     [attr.cdkFocusInitial]="nzAutoFocus === 'cancel' || null"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

the close button for the pop confirm component does not support nzDanger



## What is the new behavior?

the close button for the pop confirm component now support nzDanger


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
