### PR TITLE
refactor(schematics): use `@schematics/angular/utility` for workspace helpers

### DIFF
--- a/schematics/ng-add/index.spec.ts
+++ b/schematics/ng-add/index.spec.ts
@@ -9,7 +9,7 @@ import { normalize } from '@angular-devkit/core';
 import { Tree } from '@angular-devkit/schematics';
 import { NodePackageName } from '@angular-devkit/schematics/tasks/package-manager/options';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
+import { readWorkspace } from '@schematics/angular/utility';
 
 import { join } from 'path';
 
@@ -72,7 +72,7 @@ describe('ng-add schematic', () => {
     const options = { ...defaultOptions, gestures: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
     const fileContent = getFileContent(tree, normalize(join(project.sourceRoot, 'main.ts')));
 
     expect(fileContent).toContain(`import 'hammerjs';`);
@@ -82,7 +82,7 @@ describe('ng-add schematic', () => {
     const options = { ...defaultOptions };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
 
     expect(getProjectTargetOptions(project, 'build').styles).toContain(
       './node_modules/ng-zorro-antd/ng-zorro-antd.min.css'
@@ -95,7 +95,7 @@ describe('ng-add schematic', () => {
     appTree = await createTestApp(runner, { style: 'less', standalone: false });
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
 
     const customThemePath = normalize(join(project.sourceRoot, 'styles.less'));
     const buffer = tree.read(customThemePath);
@@ -110,7 +110,7 @@ describe('ng-add schematic', () => {
     const options = { ...defaultOptions, theme: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
 
     expect(getProjectTargetOptions(project, 'build').styles).toContain('projects/ng-zorro/src/theme.less');
   });
@@ -119,7 +119,7 @@ describe('ng-add schematic', () => {
     const options = { ...defaultOptions, dynamicIcon: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
     const assets = getProjectTargetOptions(project, 'build').assets;
 
     const assetsString = JSON.stringify(assets);

--- a/schematics/ng-add/index.spec.ts
+++ b/schematics/ng-add/index.spec.ts
@@ -6,11 +6,10 @@
 import { getProjectFromWorkspace, getProjectTargetOptions } from '@angular/cdk/schematics';
 
 import { normalize } from '@angular-devkit/core';
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import { Tree } from '@angular-devkit/schematics';
 import { NodePackageName } from '@angular-devkit/schematics/tasks/package-manager/options';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
 
 import { join } from 'path';
 
@@ -72,7 +71,7 @@ describe('ng-add schematic', () => {
   it('should add hammerjs import to project main file', async () => {
     const options = { ...defaultOptions, gestures: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
     const fileContent = getFileContent(tree, normalize(join(project.sourceRoot, 'main.ts')));
 
@@ -82,7 +81,7 @@ describe('ng-add schematic', () => {
   it('should add default theme', async () => {
     const options = { ...defaultOptions };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
 
     expect(getProjectTargetOptions(project, 'build').styles).toContain(
@@ -95,7 +94,7 @@ describe('ng-add schematic', () => {
 
     appTree = await createTestApp(runner, { style: 'less', standalone: false });
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
 
     const customThemePath = normalize(join(project.sourceRoot, 'styles.less'));
@@ -110,7 +109,7 @@ describe('ng-add schematic', () => {
   it('should add custom theme file when no LESS file in project', async () => {
     const options = { ...defaultOptions, theme: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
 
     expect(getProjectTargetOptions(project, 'build').styles).toContain('projects/ng-zorro/src/theme.less');
@@ -119,7 +118,7 @@ describe('ng-add schematic', () => {
   it('should add icon assets', async () => {
     const options = { ...defaultOptions, dynamicIcon: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
     const assets = getProjectTargetOptions(project, 'build').assets;
 

--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -16,7 +16,7 @@ import { getProjectStyle } from '../utils/project-style';
 // @ts-ignore
 import { hammerjsVersion, zorroVersion } from '../utils/version-names';
 
-export default function (options: Schema): Rule {
+export default function(options: Schema): Rule {
   return chain([
     (host: Tree, context: SchematicContext) => {
       // The CLI inserts `ng-zorro-antd` into the `package.json` before this schematic runs.
@@ -38,7 +38,7 @@ export default function (options: Schema): Rule {
         context.addTask(new RunSchematicTask('ng-add-setup-project', options), [installTaskId]);
       }
     },
-    options.template ? applyTemplate(options) : noop(),
+    options.template ? applyTemplate(options) : noop()
   ]);
 }
 
@@ -48,6 +48,6 @@ function applyTemplate(options: Schema): Rule {
     const project = getProjectFromWorkspace(workspace, options.project);
     const style = getProjectStyle(project);
 
-    return schematic(options.template, {...options, style});
-  }
+    return schematic(options.template, { ...options, style });
+  };
 }

--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -7,7 +7,7 @@ import { getProjectFromWorkspace } from '@angular/cdk/schematics';
 
 import { chain, noop, Rule, schematic, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schematics/tasks';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { readWorkspace } from '@schematics/angular/utility';
 
 import { Schema } from './schema';
 import { addPackageToPackageJson } from '../utils/package-config';
@@ -44,7 +44,7 @@ export default function (options: Schema): Rule {
 
 function applyTemplate(options: Schema): Rule {
   return async (host: Tree) => {
-    const workspace = await getWorkspace(host);
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
     const style = getProjectStyle(project);
 

--- a/schematics/ng-add/schema.ts
+++ b/schematics/ng-add/schema.ts
@@ -42,10 +42,10 @@ export type Locale =
   | 'zh_TW';
 
 export enum ProjectTemplate {
-  Blank    = 'blank',
+  Blank = 'blank',
   Sidemenu = 'sidemenu',
-  Topnav   = 'topnav',
-  None     = 'none'
+  Topnav = 'topnav',
+  None = 'none'
 }
 
 export interface Schema {

--- a/schematics/ng-add/setup-project/add-required-providers.ts
+++ b/schematics/ng-add/setup-project/add-required-providers.ts
@@ -19,7 +19,7 @@ function addAnimations(options: Schema): Rule {
   return addRootProvider(options.project, ({ code, external }) => {
     return code`${external(
       'provideAnimationsAsync',
-      '@angular/platform-browser/animations/async',
+      '@angular/platform-browser/animations/async'
     )}(${options.animations ? '' : `'noop'`})`;
   });
 }
@@ -28,7 +28,7 @@ function addHttpClient(options: Schema): Rule {
   return addRootProvider(options.project, ({ code, external }) => {
     return code`${external(
       'provideHttpClient',
-      '@angular/common/http',
+      '@angular/common/http'
     )}()`;
   });
 }

--- a/schematics/ng-add/setup-project/hammerjs-import.ts
+++ b/schematics/ng-add/setup-project/hammerjs-import.ts
@@ -6,7 +6,7 @@
 import { getProjectFromWorkspace, getProjectMainFile } from '@angular/cdk/schematics';
 
 import { Rule, Tree } from '@angular-devkit/schematics';
-import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
+import { readWorkspace } from '@schematics/angular/utility';
 import { blue, red } from 'chalk';
 
 import { Schema } from '../schema';
@@ -17,7 +17,7 @@ const hammerjsImportStatement = `import 'hammerjs';`;
 export function hammerjsImport(options: Schema): Rule {
   return async (host: Tree) => {
     const workspace = await readWorkspace(host);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, options.project);
+    const project = getProjectFromWorkspace(workspace, options.project);
     const mainFile = getProjectMainFile(project);
 
     const recorder = host.beginUpdate(mainFile);

--- a/schematics/ng-add/setup-project/hammerjs-import.ts
+++ b/schematics/ng-add/setup-project/hammerjs-import.ts
@@ -5,9 +5,8 @@
 
 import { getProjectFromWorkspace, getProjectMainFile } from '@angular/cdk/schematics';
 
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import { Rule, Tree } from '@angular-devkit/schematics';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
 import { blue, red } from 'chalk';
 
 import { Schema } from '../schema';
@@ -17,7 +16,7 @@ const hammerjsImportStatement = `import 'hammerjs';`;
 /** Adds HammerJS to the main file of the specified Angular CLI project. */
 export function hammerjsImport(options: Schema): Rule {
   return async (host: Tree) => {
-    const workspace = await getWorkspace(host);
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, options.project);
     const mainFile = getProjectMainFile(project);
 

--- a/schematics/ng-add/setup-project/index.ts
+++ b/schematics/ng-add/setup-project/index.ts
@@ -13,7 +13,7 @@ import { hammerjsImport } from './hammerjs-import';
 import { registerLocale } from './register-locale';
 import { addThemeToAppStyles } from './theming';
 
-export default function (options: Schema): Rule {
+export default function(options: Schema): Rule {
   return chain([
     registerLocale(options),
     addRequiredModules(options),

--- a/schematics/ng-add/setup-project/register-locale.ts
+++ b/schematics/ng-add/setup-project/register-locale.ts
@@ -17,11 +17,10 @@ import {
 } from '@angular/cdk/schematics';
 
 import { chain, Rule, Tree } from '@angular-devkit/schematics';
-import { addRootProvider } from '@schematics/angular/utility';
+import { addRootProvider , readWorkspace } from '@schematics/angular/utility';
 import { Change, InsertChange, NoopChange } from '@schematics/angular/utility/change';
 import { findAppConfig } from '@schematics/angular/utility/standalone/app_config';
 import { findBootstrapApplicationCall } from '@schematics/angular/utility/standalone/util';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
 import { blue, cyan, yellow } from 'chalk';
 import * as ts from 'typescript';
 
@@ -30,7 +29,7 @@ import { Schema } from '../schema';
 
 export function registerLocale(options: Schema): Rule {
   return async (host: Tree) => {
-    const workspace = await getWorkspace(host);
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
     const mainFile = getProjectMainFile(project);
     if (isStandaloneApp(host, mainFile)) {

--- a/schematics/ng-add/setup-project/register-locale.ts
+++ b/schematics/ng-add/setup-project/register-locale.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/cdk/schematics';
 
 import { chain, Rule, Tree } from '@angular-devkit/schematics';
-import { addRootProvider , readWorkspace } from '@schematics/angular/utility';
+import { addRootProvider, readWorkspace } from '@schematics/angular/utility';
 import { Change, InsertChange, NoopChange } from '@schematics/angular/utility/change';
 import { findAppConfig } from '@schematics/angular/utility/standalone/app_config';
 import { findBootstrapApplicationCall } from '@schematics/angular/utility/standalone/util';
@@ -60,7 +60,7 @@ function safeInsertImport(moduleSource: ts.SourceFile | undefined, filePath: str
 
   const importExists = allImports.some(node => {
     // Make sure it's an import declaration
-    if (!ts.isImportDeclaration(node)){
+    if (!ts.isImportDeclaration(node)) {
       return false;
     }
 
@@ -82,7 +82,7 @@ function safeInsertImport(moduleSource: ts.SourceFile | undefined, filePath: str
       return false;
     }
     const namedBindings = node.importClause.namedBindings;
-    if (!namedBindings){
+    if (!namedBindings) {
       return false;
     }
 
@@ -195,7 +195,7 @@ function registerLocaleData(moduleSource: ts.SourceFile, modulePath: string, loc
   const registerLocaleDataFun = allFun.filter(node => {
     if (!node) return false;
     const children = node.getChildren();
-    if (!children || children.length === 0){
+    if (!children || children.length === 0) {
       return false;
     }
     const firstChild = children[0];
@@ -238,12 +238,12 @@ function insertI18nTokenProvide(moduleSource: ts.SourceFile, modulePath: string,
   }
 
   const addProvide = addSymbolToNgModuleMetadata(
-      moduleSource,
-      modulePath,
-      'providers',
-      `provideNzI18n(${locale})`,
-      null
-    );
+    moduleSource,
+    modulePath,
+    'providers',
+    `provideNzI18n(${locale})`,
+    null
+  );
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const node: any = nodes[0];
 

--- a/schematics/ng-add/setup-project/theming.ts
+++ b/schematics/ng-add/setup-project/theming.ts
@@ -6,10 +6,9 @@
 import { getProjectFromWorkspace, getProjectStyleFile, getProjectTargetOptions } from '@angular/cdk/schematics';
 
 import { logging, normalize } from '@angular-devkit/core';
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
 import { chain, noop, Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
+import { ProjectDefinition, readWorkspace, updateWorkspace } from '@schematics/angular/utility';
 import { InsertChange } from '@schematics/angular/utility/change';
-import { getWorkspace, updateWorkspace } from '@schematics/angular/utility/workspace';
 
 import { join } from 'path';
 
@@ -44,7 +43,7 @@ export function addThemeToAppStyles(options: Schema): Rule {
  * Scss file for the custom theme will be created.
  */
 async function insertCustomTheme(projectName: string, host: Tree, logger: logging.LoggerApi): Promise<Rule> {
-  const workspace = await getWorkspace(host);
+  const workspace = await readWorkspace(host);
   const project = getProjectFromWorkspace(workspace, projectName);
   const stylesPath = getProjectStyleFile(project, 'less');
   const themeContent = createCustomTheme();

--- a/schematics/ng-add/setup-project/theming.ts
+++ b/schematics/ng-add/setup-project/theming.ts
@@ -22,7 +22,7 @@ const defaultCustomThemeFilename = 'theme.less';
 /** Object that maps a CLI target to its default builder name. */
 const defaultTargetBuilders = {
   build: [
-    '@angular/build:application',
+    '@angular/build:application'
   ],
   test: ['@angular/build:karma']
 };
@@ -52,7 +52,7 @@ async function insertCustomTheme(projectName: string, host: Tree, logger: loggin
     if (!project.sourceRoot) {
       throw new SchematicsException(
         `Could not find source root for project: "${projectName}". ` +
-          `Please make sure that the "sourceRoot" property is set in the workspace config.`
+        `Please make sure that the "sourceRoot" property is set in the workspace config.`
       );
     }
 
@@ -119,7 +119,7 @@ function addThemeStyleToTarget(
         if (stylePath.includes(defaultCustomThemeFilename)) {
           logger.error(
             `Could not style file to the CLI project configuration ` +
-              `because there is already a custom theme file referenced.`
+            `because there is already a custom theme file referenced.`
           );
           logger.info(`Please manually add the following style file to your configuration:`);
           logger.info(`${assetPath}`);
@@ -130,7 +130,7 @@ function addThemeStyleToTarget(
       }
     }
     styles.unshift(assetPath);
-  }) as unknown as Rule;
+  });
 }
 
 /**
@@ -150,13 +150,13 @@ function validateDefaultTargetBuilder(
   if (!isDefaultBuilder && targetName === 'build') {
     throw new SchematicsException(
       `Your project is not using the default builders for ` +
-        `"${targetName}". The NG-ZORRO schematics cannot add a theme to the workspace ` +
-        `configuration if the builder has been changed.`
+      `"${targetName}". The NG-ZORRO schematics cannot add a theme to the workspace ` +
+      `configuration if the builder has been changed.`
     );
   } else if (!isDefaultBuilder) {
     logger.warn(
       `Your project is not using the default builders for "${targetName}". This ` +
-        `means that we cannot add the configured theme to the "${targetName}" target.`
+      `means that we cannot add the configured theme to the "${targetName}" target.`
     );
   }
 

--- a/schematics/ng-add/standalone.spec.ts
+++ b/schematics/ng-add/standalone.spec.ts
@@ -9,7 +9,7 @@ import { normalize } from '@angular-devkit/core';
 import { Tree } from '@angular-devkit/schematics';
 import { NodePackageName } from '@angular-devkit/schematics/tasks/package-manager/options';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
+import { readWorkspace } from '@schematics/angular/utility';
 
 import { join } from 'path';
 
@@ -73,7 +73,7 @@ describe('[standalone] ng-add schematic', () => {
     const options = { ...defaultOptions, gestures: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace , defaultOptions.project);
     const fileContent = getFileContent(tree, normalize(join(project.sourceRoot, 'main.ts')));
 
     expect(fileContent).toContain(`import 'hammerjs';`);
@@ -83,7 +83,7 @@ describe('[standalone] ng-add schematic', () => {
     const options = { ...defaultOptions };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
 
     expect(getProjectTargetOptions(project, 'build').styles).toContain(
       './node_modules/ng-zorro-antd/ng-zorro-antd.min.css'
@@ -96,7 +96,7 @@ describe('[standalone] ng-add schematic', () => {
     appTree = await createTestApp(runner, { style: 'less' });
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
 
     const customThemePath = normalize(join(project.sourceRoot, 'styles.less'));
     const buffer = tree.read(customThemePath);
@@ -111,7 +111,7 @@ describe('[standalone] ng-add schematic', () => {
     const options = { ...defaultOptions, theme: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
 
     expect(getProjectTargetOptions(project, 'build').styles).toContain('projects/ng-zorro/src/theme.less');
   });
@@ -120,7 +120,7 @@ describe('[standalone] ng-add schematic', () => {
     const options = { ...defaultOptions, dynamicIcon: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
     const assets = getProjectTargetOptions(project, 'build').assets;
 
     const assetsString = JSON.stringify(assets);

--- a/schematics/ng-add/standalone.spec.ts
+++ b/schematics/ng-add/standalone.spec.ts
@@ -6,11 +6,10 @@
 import { getProjectFromWorkspace, getProjectTargetOptions } from '@angular/cdk/schematics';
 
 import { normalize } from '@angular-devkit/core';
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import { Tree } from '@angular-devkit/schematics';
 import { NodePackageName } from '@angular-devkit/schematics/tasks/package-manager/options';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
 
 import { join } from 'path';
 
@@ -73,7 +72,7 @@ describe('[standalone] ng-add schematic', () => {
   it('should add hammerjs import to project main file', async () => {
     const options = { ...defaultOptions, gestures: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
     const fileContent = getFileContent(tree, normalize(join(project.sourceRoot, 'main.ts')));
 
@@ -83,7 +82,7 @@ describe('[standalone] ng-add schematic', () => {
   it('should add default theme', async () => {
     const options = { ...defaultOptions };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
 
     expect(getProjectTargetOptions(project, 'build').styles).toContain(
@@ -96,7 +95,7 @@ describe('[standalone] ng-add schematic', () => {
 
     appTree = await createTestApp(runner, { style: 'less' });
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
 
     const customThemePath = normalize(join(project.sourceRoot, 'styles.less'));
@@ -111,7 +110,7 @@ describe('[standalone] ng-add schematic', () => {
   it('should add custom theme file when no LESS file in project', async () => {
     const options = { ...defaultOptions, theme: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
 
     expect(getProjectTargetOptions(project, 'build').styles).toContain('projects/ng-zorro/src/theme.less');
@@ -120,7 +119,7 @@ describe('[standalone] ng-add schematic', () => {
   it('should add icon assets', async () => {
     const options = { ...defaultOptions, dynamicIcon: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
-    const workspace = await getWorkspace(tree);
+    const workspace = await readWorkspace(tree);
     const project = getProjectFromWorkspace(workspace as unknown as WorkspaceDefinition, defaultOptions.project);
     const assets = getProjectTargetOptions(project, 'build').assets;
 

--- a/schematics/ng-add/standalone.spec.ts
+++ b/schematics/ng-add/standalone.spec.ts
@@ -73,7 +73,7 @@ describe('[standalone] ng-add schematic', () => {
     const options = { ...defaultOptions, gestures: true };
     const tree = await runner.runSchematic('ng-add-setup-project', options, appTree);
     const workspace = await readWorkspace(tree);
-    const project = getProjectFromWorkspace(workspace , defaultOptions.project);
+    const project = getProjectFromWorkspace(workspace, defaultOptions.project);
     const fileContent = getFileContent(tree, normalize(join(project.sourceRoot, 'main.ts')));
 
     expect(fileContent).toContain(`import 'hammerjs';`);

--- a/schematics/ng-component/index.spec.ts
+++ b/schematics/ng-component/index.spec.ts
@@ -28,8 +28,19 @@ const defaultOptions = {
   skipTests: false,
   module: undefined,
   export: false,
-    project: 'ng-zorro'
+  project: 'ng-zorro'
 };
+
+function generateModuleContent(moduleName: string): string {
+  return `
+import { NgModule } from '@angular/core';
+@NgModule({
+  imports: [],
+  declarations: []
+})
+export class ${moduleName} {}
+`;
+}
 
 describe('ng-component schematic', () => {
   let runner: SchematicTestRunner;
@@ -56,7 +67,7 @@ describe('ng-component schematic', () => {
   });
 
   describe('style', () => {
-    it('should create specified style',  async() => {
+    it('should create specified style', async () => {
       const options = { ...defaultOptions, style: Style.Sass };
       const tree = await runner.runSchematic('component', options, appTree);
       const files = tree.files.filter(file => file.startsWith('/projects/ng-zorro/src/app/test/'));
@@ -71,7 +82,7 @@ describe('ng-component schematic', () => {
       );
     });
 
-    it('should not create style file when inlineStyle is true',  async() => {
+    it('should not create style file when inlineStyle is true', async () => {
       const options = { ...defaultOptions, inlineStyle: true };
       const tree = await runner.runSchematic('component', options, appTree);
       const files = tree.files.filter(file => file.startsWith('/projects/ng-zorro/src/app/test/'));
@@ -86,7 +97,7 @@ describe('ng-component schematic', () => {
       );
     });
 
-    it('should not create style file when style is none',  async() => {
+    it('should not create style file when style is none', async () => {
       const options = { ...defaultOptions, style: Style.None };
       const tree = await runner.runSchematic('component', options, appTree);
       const files = tree.files.filter(file => file.startsWith('/projects/ng-zorro/src/app/test/'));
@@ -144,14 +155,7 @@ describe('ng-component schematic', () => {
 
       appTree.create(
         closestModule,
-        `
-        import { NgModule } from '@angular/core';
-        @NgModule({
-          imports: [],
-          declarations: []
-        })
-        export class ClosestModule { }
-      `
+        generateModuleContent('ClosestModule')
       );
       const tree = await runner.runSchematic('component', options, appTree);
       const fooModuleContent = tree.readContent(closestModule);
@@ -165,14 +169,7 @@ describe('ng-component schematic', () => {
 
       appTree.create(
         testModule,
-        `
-        import { NgModule } from '@angular/core';
-        @NgModule({
-          imports: [],
-          declarations: []
-        })
-        export class TestModule { }
-      `
+        generateModuleContent('TestModule')
       );
 
       const tree = await runner.runSchematic('component', options, appTree);

--- a/schematics/ng-component/index.ts
+++ b/schematics/ng-component/index.ts
@@ -3,18 +3,13 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  chain,
-  Rule
-} from '@angular-devkit/schematics';
+import { chain, Rule } from '@angular-devkit/schematics';
 
 import { Schema } from './schema';
 import { buildComponent } from '../utils/build-component';
 
 export default function(options: Schema): Rule {
   return chain([
-    buildComponent(
-      { ...options }
-    )
+    buildComponent({ ...options })
   ]);
 }

--- a/schematics/ng-generate/blank/index.ts
+++ b/schematics/ng-generate/blank/index.ts
@@ -7,7 +7,7 @@ import { getProjectFromWorkspace } from '@angular/cdk/schematics';
 
 
 import { noop, Rule, Tree } from '@angular-devkit/schematics';
-import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
+import { readWorkspace } from '@schematics/angular/utility';
 
 import { existsSync, statSync as fsStatSync } from 'fs';
 
@@ -20,7 +20,7 @@ const bootPageHTML = `<!-- NG-ZORRO -->
 
 export default function(options: Schema): Rule {
   return async (host: Tree, context) => {
-    const workspace = await readWorkspace(host) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
     const appHTMLFile = `${project.sourceRoot}/app/app.html`;
     const buffer = host.read(appHTMLFile);

--- a/schematics/ng-generate/blank/index.ts
+++ b/schematics/ng-generate/blank/index.ts
@@ -27,7 +27,7 @@ export default function(options: Schema): Rule {
 
     if (!buffer) {
       context.logger.error(
-       `Could not find the project ${appHTMLFile} file inside of the ` + `workspace config`
+        `Could not find the project ${appHTMLFile} file inside of the ` + `workspace config`
       );
       return noop();
     }

--- a/schematics/ng-generate/blank/index.ts
+++ b/schematics/ng-generate/blank/index.ts
@@ -6,9 +6,8 @@
 import { getProjectFromWorkspace } from '@angular/cdk/schematics';
 
 
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import { noop, Rule, Tree } from '@angular-devkit/schematics';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
 
 import { existsSync, statSync as fsStatSync } from 'fs';
 
@@ -21,7 +20,7 @@ const bootPageHTML = `<!-- NG-ZORRO -->
 
 export default function(options: Schema): Rule {
   return async (host: Tree, context) => {
-    const workspace = await getWorkspace(host) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host) as unknown as WorkspaceDefinition;
     const project = getProjectFromWorkspace(workspace, options.project);
     const appHTMLFile = `${project.sourceRoot}/app/app.html`;
     const buffer = host.read(appHTMLFile);

--- a/schematics/ng-generate/side-menu/files/src/app/app-routing.module.ts.template
+++ b/schematics/ng-generate/side-menu/files/src/app/app-routing.module.ts.template
@@ -10,4 +10,4 @@ const routes: Routes = [
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/schematics/ng-generate/side-menu/files/src/app/pages/welcome/welcome-routing.module.ts.template
+++ b/schematics/ng-generate/side-menu/files/src/app/pages/welcome/welcome-routing.module.ts.template
@@ -10,4 +10,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class WelcomeRoutingModule { }
+export class WelcomeRoutingModule {}

--- a/schematics/ng-generate/side-menu/files/src/app/pages/welcome/welcome.component.ts.template
+++ b/schematics/ng-generate/side-menu/files/src/app/pages/welcome/welcome.component.ts.template
@@ -6,6 +6,4 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './welcome.component.html',
   styleUrl: './welcome.component.<%= style %>'
 })
-export class WelcomeComponent {
-  constructor() {}
-}
+export class WelcomeComponent {}

--- a/schematics/ng-generate/side-menu/files/src/app/pages/welcome/welcome.module.ts.template
+++ b/schematics/ng-generate/side-menu/files/src/app/pages/welcome/welcome.module.ts.template
@@ -10,4 +10,4 @@ import { WelcomeComponent } from './welcome.component';
   declarations: [WelcomeComponent],
   exports: [WelcomeComponent]
 })
-export class WelcomeModule { }
+export class WelcomeModule {}

--- a/schematics/ng-generate/side-menu/index.ts
+++ b/schematics/ng-generate/side-menu/index.ts
@@ -11,8 +11,6 @@ import {
   parseSourceFile
 } from '@angular/cdk/schematics';
 
-import { strings } from '@angular-devkit/core';
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import {
   apply,
   applyTemplates,
@@ -23,13 +21,13 @@ import {
   mergeWith,
   move,
   Rule,
+  strings,
   Tree,
   url
 } from '@angular-devkit/schematics';
-import { addRootProvider } from '@schematics/angular/utility';
+import { addRootProvider , readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
 import { findAppConfig } from '@schematics/angular/utility/standalone/app_config';
 import { findBootstrapApplicationCall } from '@schematics/angular/utility/standalone/util';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
 
 import { Schema } from './schema';
 import { applyChangesToFile } from '../../utils/apply-changes';
@@ -37,7 +35,7 @@ import { addModule } from '../../utils/root-module';
 
 export default function (options: Schema): Rule {
   return async (host: Tree) => {
-    const workspace = (await getWorkspace(host)) as unknown as WorkspaceDefinition;
+    const workspace = (await readWorkspace(host)) as unknown as WorkspaceDefinition;
     const project = getProjectFromWorkspace(workspace, options.project);
     const mainFile = getProjectMainFile(project);
     const prefix = options.prefix || project.prefix;

--- a/schematics/ng-generate/side-menu/index.ts
+++ b/schematics/ng-generate/side-menu/index.ts
@@ -25,7 +25,7 @@ import {
   Tree,
   url
 } from '@angular-devkit/schematics';
-import { addRootProvider , readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
+import { addRootProvider , readWorkspace } from '@schematics/angular/utility';
 import { findAppConfig } from '@schematics/angular/utility/standalone/app_config';
 import { findBootstrapApplicationCall } from '@schematics/angular/utility/standalone/util';
 
@@ -35,7 +35,7 @@ import { addModule } from '../../utils/root-module';
 
 export default function (options: Schema): Rule {
   return async (host: Tree) => {
-    const workspace = (await readWorkspace(host)) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
     const mainFile = getProjectMainFile(project);
     const prefix = options.prefix || project.prefix;

--- a/schematics/ng-generate/side-menu/index.ts
+++ b/schematics/ng-generate/side-menu/index.ts
@@ -25,7 +25,7 @@ import {
   Tree,
   url
 } from '@angular-devkit/schematics';
-import { addRootProvider , readWorkspace } from '@schematics/angular/utility';
+import { addRootProvider, readWorkspace } from '@schematics/angular/utility';
 import { findAppConfig } from '@schematics/angular/utility/standalone/app_config';
 import { findBootstrapApplicationCall } from '@schematics/angular/utility/standalone/util';
 
@@ -33,7 +33,7 @@ import { Schema } from './schema';
 import { applyChangesToFile } from '../../utils/apply-changes';
 import { addModule } from '../../utils/root-module';
 
-export default function (options: Schema): Rule {
+export default function(options: Schema): Rule {
   return async (host: Tree) => {
     const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
@@ -93,5 +93,5 @@ function importIconDefinitions(mainFile: string): Rule {
     applyChangesToFile(host, appConfigFile, [
       insertImport(appConfigSource, appConfigFile, 'icons', './icons-provider')
     ]);
-  }
+  };
 }

--- a/schematics/ng-generate/side-menu/schema.ts
+++ b/schematics/ng-generate/side-menu/schema.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Style, Schema as ComponentSchema } from '@schematics/angular/application/schema';
+import { Schema as ComponentSchema, Style } from '@schematics/angular/application/schema';
 
 export interface Schema extends ComponentSchema {
   project: string;

--- a/schematics/ng-generate/side-menu/standalone/src/app/pages/welcome/welcome.component.ts.template
+++ b/schematics/ng-generate/side-menu/standalone/src/app/pages/welcome/welcome.component.ts.template
@@ -5,6 +5,4 @@ import { Component } from '@angular/core';
   templateUrl: './welcome.component.html',
   styleUrl: './welcome.component.<%= style %>'
 })
-export class WelcomeComponent {
-  constructor() {}
-}
+export class WelcomeComponent {}

--- a/schematics/ng-generate/topnav/files/src/app/app-routing.module.ts.template
+++ b/schematics/ng-generate/topnav/files/src/app/app-routing.module.ts.template
@@ -10,4 +10,4 @@ const routes: Routes = [
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/schematics/ng-generate/topnav/files/src/app/pages/welcome/welcome-routing.module.ts.template
+++ b/schematics/ng-generate/topnav/files/src/app/pages/welcome/welcome-routing.module.ts.template
@@ -10,4 +10,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class WelcomeRoutingModule { }
+export class WelcomeRoutingModule {}

--- a/schematics/ng-generate/topnav/files/src/app/pages/welcome/welcome.component.ts.template
+++ b/schematics/ng-generate/topnav/files/src/app/pages/welcome/welcome.component.ts.template
@@ -6,6 +6,4 @@ import { Component } from '@angular/core';
   templateUrl: './welcome.component.html',
   styleUrl: './welcome.component.<%= style %>'
 })
-export class WelcomeComponent {
-  constructor() {}
-}
+export class WelcomeComponent {}

--- a/schematics/ng-generate/topnav/files/src/app/pages/welcome/welcome.module.ts.template
+++ b/schematics/ng-generate/topnav/files/src/app/pages/welcome/welcome.module.ts.template
@@ -10,4 +10,4 @@ import { WelcomeComponent } from './welcome.component';
   declarations: [WelcomeComponent],
   exports: [WelcomeComponent]
 })
-export class WelcomeModule { }
+export class WelcomeModule {}

--- a/schematics/ng-generate/topnav/index.ts
+++ b/schematics/ng-generate/topnav/index.ts
@@ -5,8 +5,6 @@
 
 import { getProjectFromWorkspace, getProjectMainFile, isStandaloneApp } from '@angular/cdk/schematics';
 
-import { strings } from '@angular-devkit/core';
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import {
   apply,
   applyTemplates,
@@ -17,18 +15,19 @@ import {
   mergeWith,
   move,
   Rule,
+  strings,
   Tree,
   url
 } from '@angular-devkit/schematics';
 import { Style } from '@schematics/angular/application/schema';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
 
 import { Schema } from './schema';
 import { addModule } from '../../utils/root-module';
 
 export default function(options: Schema): Rule {
   return async (host: Tree) => {
-    const workspace = await getWorkspace(host) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host) as unknown as WorkspaceDefinition;
     const project = getProjectFromWorkspace(workspace, options.project);
     const mainFile = getProjectMainFile(project);
     const prefix = options.prefix || project.prefix;

--- a/schematics/ng-generate/topnav/index.ts
+++ b/schematics/ng-generate/topnav/index.ts
@@ -20,14 +20,14 @@ import {
   url
 } from '@angular-devkit/schematics';
 import { Style } from '@schematics/angular/application/schema';
-import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
+import { readWorkspace } from '@schematics/angular/utility';
 
 import { Schema } from './schema';
 import { addModule } from '../../utils/root-module';
 
 export default function(options: Schema): Rule {
   return async (host: Tree) => {
-    const workspace = await readWorkspace(host) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
     const mainFile = getProjectMainFile(project);
     const prefix = options.prefix || project.prefix;

--- a/schematics/ng-generate/topnav/standalone.spec.ts
+++ b/schematics/ng-generate/topnav/standalone.spec.ts
@@ -14,18 +14,18 @@ import { getFileContent } from '../../utils/get-file-content';
 
 describe('[standalone] top-nav schematic', () => {
   const defaultOptions: NzOptions = {
-    project: 'ng-zorro-top-nav',
+    project: 'ng-zorro-top-nav'
   };
   let runner: SchematicTestRunner;
   let appTree: Tree;
 
   beforeEach(async () => {
     runner = new SchematicTestRunner('schematics', require.resolve('../../collection.json'));
-    appTree = await createTestApp(runner, {name: 'ng-zorro-top-nav'});
+    appTree = await createTestApp(runner, { name: 'ng-zorro-top-nav' });
   });
 
   it('should create top-nav files', async () => {
-    const options = {...defaultOptions};
+    const options = { ...defaultOptions };
 
     const tree = await runner.runSchematic('topnav', options, appTree);
     const files = tree.files;
@@ -44,7 +44,7 @@ describe('[standalone] top-nav schematic', () => {
   });
 
   it('should fall back to the @schematics/angular:component option value', async () => {
-    const options = {...defaultOptions};
+    const options = { ...defaultOptions };
     const tree = await runner.runSchematic('topnav', options, appTree);
     const appContent = getFileContent(tree, '/projects/ng-zorro-top-nav/src/app/app.component.ts');
 
@@ -56,7 +56,7 @@ describe('[standalone] top-nav schematic', () => {
   });
 
   it('should set the style preprocessor correctly', async () => {
-    const options = {...defaultOptions, style: Style.Less};
+    const options = { ...defaultOptions, style: Style.Less };
 
     const tree = await runner.runSchematic('topnav', options, appTree);
     const files = tree.files;
@@ -75,7 +75,7 @@ describe('[standalone] top-nav schematic', () => {
   });
 
   it('should set the prefix correctly', async () => {
-    const options = {...defaultOptions, prefix: 'nz'};
+    const options = { ...defaultOptions, prefix: 'nz' };
     const tree = await runner.runSchematic('topnav', options, appTree);
     const appContent = getFileContent(tree, '/projects/ng-zorro-top-nav/src/app/app.component.ts');
     const welcomeContent = getFileContent(tree, '/projects/ng-zorro-top-nav/src/app/pages/welcome/welcome.component.ts');

--- a/schematics/ng-generate/topnav/standalone/src/app/pages/welcome/welcome.component.ts.template
+++ b/schematics/ng-generate/topnav/standalone/src/app/pages/welcome/welcome.component.ts.template
@@ -5,6 +5,4 @@ import { Component } from '@angular/core';
   templateUrl: './welcome.component.html',
   styleUrl: './welcome.component.<%= style %>'
 })
-export class WelcomeComponent {
-  constructor() {}
-}
+export class WelcomeComponent {}

--- a/schematics/utils/build-component.ts
+++ b/schematics/utils/build-component.ts
@@ -5,8 +5,7 @@
 
 import { getDefaultComponentOptions, getProjectFromWorkspace, isStandaloneSchematic } from '@angular/cdk/schematics';
 
-import { strings, template as interpolateTemplate } from '@angular-devkit/core';
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
+import { template as interpolateTemplate } from '@angular-devkit/core';
 import {
   apply,
   applyTemplates,
@@ -18,18 +17,19 @@ import {
   noop,
   Rule,
   SchematicsException,
+  strings,
   Tree,
   url
 } from '@angular-devkit/schematics';
 import { FileSystemSchematicContext } from '@angular-devkit/schematics/tools';
 import { Schema as ComponentOptions, Style } from '@schematics/angular/component/schema';
 import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { ProjectDefinition, readWorkspace } from '@schematics/angular/utility';
 import { addDeclarationToModule, addExportToModule, getDecoratorMetadata } from '@schematics/angular/utility/ast-utils';
 import { InsertChange } from '@schematics/angular/utility/change';
 import { buildRelativePath, findModuleFromOptions } from '@schematics/angular/utility/find-module';
 import { parseName } from '@schematics/angular/utility/parse-name';
 import { validateHtmlSelector } from '@schematics/angular/utility/validation';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
 import { ProjectType } from '@schematics/angular/utility/workspace-models';
 
 import { readFileSync, statSync } from 'fs';
@@ -196,7 +196,7 @@ function indentTextContent(text: string, numSpaces: number): string {
  */
 export function buildComponent(options: ZorroComponentOptions, additionalFiles: Record<string, string> = {}): Rule {
   return async (host: Tree, context: FileSystemSchematicContext) => {
-    const workspace = await getWorkspace(host);
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, options.project);
     const defaultZorroComponentOptions = getDefaultComponentOptions(project);
     let modulePrefix = '';

--- a/schematics/utils/build-component.ts
+++ b/schematics/utils/build-component.ts
@@ -84,8 +84,7 @@ function buildDefaultPath(project: ProjectDefinition): string {
  */
 const supportedCssExtensions = ['css', 'scss', 'sass', 'less', 'none'];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function readIntoSourceFile(host: Tree, modulePath: string): any {
+function readIntoSourceFile(host: Tree, modulePath: string): ts.SourceFile {
   const text = host.read(modulePath);
   if (text === null) {
     throw new SchematicsException(`File ${modulePath} does not exist.`);
@@ -94,8 +93,7 @@ function readIntoSourceFile(host: Tree, modulePath: string): any {
   return ts.createSourceFile(modulePath, text.toString('utf-8'), ts.ScriptTarget.Latest, true);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getModuleClassnamePrefix(source: any): string {
+function getModuleClassnamePrefix(source: ts.SourceFile): string {
   const className = getFirstNgModuleName(source);
   if (className) {
     const execArray = /(\w+)Module/gi.exec(className);
@@ -279,12 +277,10 @@ export function buildComponent(options: ZorroComponentOptions, additionalFiles: 
       options.inlineTemplate ? filter(path => !path.endsWith('.html.template')) : noop(),
       // Treat the template options as any, because the type definition for the template options
       // is made unnecessarily explicit. Every type of object can be used in the EJS template.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      applyTemplates({ indentTextContent, resolvedFiles, ...baseTemplateContext } as any),
+      applyTemplates({ indentTextContent, resolvedFiles, ...baseTemplateContext }),
       // TODO(devversion): figure out why we cannot just remove the first parameter
       // See for example: angular-cli#schematics/angular/component/index.ts#L160
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      move(null as any, parsedPath.path)
+      move(null, parsedPath.path)
     ]);
 
     return () =>

--- a/schematics/utils/create-custom-theme.ts
+++ b/schematics/utils/create-custom-theme.ts
@@ -13,5 +13,5 @@ export function createCustomTheme(): string {
 // View all variables: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/components/style/themes/default.less
 
 // @primary-color: #1890ff;
-`
+`;
 }

--- a/schematics/utils/ng-update/module-specifiers.ts
+++ b/schematics/utils/ng-update/module-specifiers.ts
@@ -17,11 +17,11 @@ export function isNgZorroExportDeclaration(node: ts.Node): boolean {
   return isNgZorroDeclaration(getExportDeclaration(node));
 }
 
-function isNgZorroDeclaration(declaration: ts.ImportDeclaration|ts.ExportDeclaration): boolean {
+function isNgZorroDeclaration(declaration: ts.ImportDeclaration | ts.ExportDeclaration): boolean {
   if (!declaration.moduleSpecifier) {
     return false;
   }
 
   const moduleSpecifier = declaration.moduleSpecifier.getText();
-  return moduleSpecifier.indexOf(ngZorroModuleSpecifier) !== -1
+  return moduleSpecifier.indexOf(ngZorroModuleSpecifier) !== -1;
 }

--- a/schematics/utils/project-style.ts
+++ b/schematics/utils/project-style.ts
@@ -5,8 +5,8 @@
 
 import { getProjectStyleFile } from '@angular/cdk/schematics';
 
-import { ProjectDefinition } from '@angular-devkit/core/src/workspace';
 import { Style } from '@schematics/angular/application/schema';
+import { ProjectDefinition } from '@schematics/angular/utility'
 
 export function getProjectStyle(project: ProjectDefinition): Style {
   const stylesPath = getProjectStyleFile(project);

--- a/schematics/utils/project-style.ts
+++ b/schematics/utils/project-style.ts
@@ -6,10 +6,10 @@
 import { getProjectStyleFile } from '@angular/cdk/schematics';
 
 import { Style } from '@schematics/angular/application/schema';
-import { ProjectDefinition } from '@schematics/angular/utility'
+import { ProjectDefinition } from '@schematics/angular/utility';
 
 export function getProjectStyle(project: ProjectDefinition): Style {
   const stylesPath = getProjectStyleFile(project);
-  const style = stylesPath ? stylesPath.split('.').pop() :  Style.Css;
+  const style = stylesPath ? stylesPath.split('.').pop() : Style.Css;
   return style as Style;
 }

--- a/schematics/utils/root-module.ts
+++ b/schematics/utils/root-module.ts
@@ -5,12 +5,11 @@
 
 import { addDeclarationToModule, addModuleImportToRootModule, getProjectFromWorkspace, getProjectMainFile } from '@angular/cdk/schematics';
 
-import { WorkspaceDefinition } from '@angular-devkit/core/src/workspace';
 import { noop, Rule, SchematicsException, Tree } from '@angular-devkit/schematics';
+import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
 import { InsertChange } from '@schematics/angular/utility/change';
 import { buildRelativePath } from '@schematics/angular/utility/find-module';
 import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
-import { getWorkspace } from '@schematics/angular/utility/workspace';
 import * as ts from 'typescript';
 
 function readIntoSourceFile(host: Tree, modulePath: string): ts.SourceFile {
@@ -25,7 +24,7 @@ function readIntoSourceFile(host: Tree, modulePath: string): ts.SourceFile {
 
 export function addModule(moduleName: string, modulePath: string, projectName: string): Rule {
   return async (host: Tree) => {
-    const workspace = await getWorkspace(host) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host) as unknown as WorkspaceDefinition;
     const project = getProjectFromWorkspace(workspace, projectName);
     addModuleImportToRootModule(host, moduleName, modulePath, project);
     return noop();
@@ -34,7 +33,7 @@ export function addModule(moduleName: string, modulePath: string, projectName: s
 
 export function addDeclaration(componentName: string, componentPath: string, projectName: string): Rule {
   return async (host: Tree) => {
-    const workspace = await getWorkspace(host) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host) as unknown as WorkspaceDefinition;
     const project = getProjectFromWorkspace(workspace, projectName);
     const appModulePath = getAppModulePath(host, getProjectMainFile(project));
     const source = readIntoSourceFile(host, appModulePath);

--- a/schematics/utils/root-module.ts
+++ b/schematics/utils/root-module.ts
@@ -3,7 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { addDeclarationToModule, addModuleImportToRootModule, getProjectFromWorkspace, getProjectMainFile } from '@angular/cdk/schematics';
+import {
+  addDeclarationToModule,
+  addModuleImportToRootModule,
+  getProjectFromWorkspace,
+  getProjectMainFile
+} from '@angular/cdk/schematics';
 
 import { noop, Rule, SchematicsException, Tree } from '@angular-devkit/schematics';
 import { readWorkspace } from '@schematics/angular/utility';
@@ -24,16 +29,16 @@ function readIntoSourceFile(host: Tree, modulePath: string): ts.SourceFile {
 
 export function addModule(moduleName: string, modulePath: string, projectName: string): Rule {
   return async (host: Tree) => {
-    const workspace = await readWorkspace(host) ;
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, projectName);
     addModuleImportToRootModule(host, moduleName, modulePath, project);
     return noop();
-  }
+  };
 }
 
 export function addDeclaration(componentName: string, componentPath: string, projectName: string): Rule {
   return async (host: Tree) => {
-    const workspace = await readWorkspace(host) ;
+    const workspace = await readWorkspace(host);
     const project = getProjectFromWorkspace(workspace, projectName);
     const appModulePath = getAppModulePath(host, getProjectMainFile(project));
     const source = readIntoSourceFile(host, appModulePath);
@@ -48,5 +53,5 @@ export function addDeclaration(componentName: string, componentPath: string, pro
     host.commitUpdate(declarationRecorder);
 
     return noop();
-  }
+  };
 }

--- a/schematics/utils/root-module.ts
+++ b/schematics/utils/root-module.ts
@@ -6,7 +6,7 @@
 import { addDeclarationToModule, addModuleImportToRootModule, getProjectFromWorkspace, getProjectMainFile } from '@angular/cdk/schematics';
 
 import { noop, Rule, SchematicsException, Tree } from '@angular-devkit/schematics';
-import { readWorkspace, WorkspaceDefinition } from '@schematics/angular/utility';
+import { readWorkspace } from '@schematics/angular/utility';
 import { InsertChange } from '@schematics/angular/utility/change';
 import { buildRelativePath } from '@schematics/angular/utility/find-module';
 import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
@@ -24,7 +24,7 @@ function readIntoSourceFile(host: Tree, modulePath: string): ts.SourceFile {
 
 export function addModule(moduleName: string, modulePath: string, projectName: string): Rule {
   return async (host: Tree) => {
-    const workspace = await readWorkspace(host) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host) ;
     const project = getProjectFromWorkspace(workspace, projectName);
     addModuleImportToRootModule(host, moduleName, modulePath, project);
     return noop();
@@ -33,7 +33,7 @@ export function addModule(moduleName: string, modulePath: string, projectName: s
 
 export function addDeclaration(componentName: string, componentPath: string, projectName: string): Rule {
   return async (host: Tree) => {
-    const workspace = await readWorkspace(host) as unknown as WorkspaceDefinition;
+    const workspace = await readWorkspace(host) ;
     const project = getProjectFromWorkspace(workspace, projectName);
     const appModulePath = getAppModulePath(host, getProjectMainFile(project));
     const source = readIntoSourceFile(host, appModulePath);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The `@schematics/angular` package's `utility` entry point provides access
to several Angular workspace helper functions and types. Usage of this
avoids deep importing into this package for the equivalent functionality
as well as removing the need in several cases of importing from `@angular-devkit/core`.

Sess https://github.com/angular/components/pull/30951

## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
