### PR TITLE
feat(module:float-button): `nzIcon` support string type

### DIFF
--- a/components/float-button/demo/description.ts
+++ b/components/float-button/demo/description.ts
@@ -1,26 +1,15 @@
 import { Component } from '@angular/core';
 
 import { NzFloatButtonModule } from 'ng-zorro-antd/float-button';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'nz-demo-float-button-description',
-  imports: [NzFloatButtonModule, NzIconModule],
+  imports: [NzFloatButtonModule],
   template: `
     <div class="description">
-      <nz-float-button
-        [nzIcon]="icon"
-        [nzDescription]="description"
-        nzShape="square"
-        style="right: 24px"
-      ></nz-float-button>
-      <nz-float-button [nzDescription]="description" nzShape="square" style="right: 94px"></nz-float-button>
+      <nz-float-button nzIcon="file-text" nzDescription="HELP" nzShape="square" style="right: 24px"></nz-float-button>
+      <nz-float-button nzDescription="HELP" nzShape="square" style="right: 94px"></nz-float-button>
     </div>
-    <ng-template #description>HELP</ng-template>
-
-    <ng-template #icon>
-      <nz-icon nzType="file-text" nzTheme="outline"></nz-icon>
-    </ng-template>
   `,
   styles: [
     `

--- a/components/float-button/demo/group-menu.ts
+++ b/components/float-button/demo/group-menu.ts
@@ -1,40 +1,33 @@
 import { Component } from '@angular/core';
 
 import { NzFloatButtonModule } from 'ng-zorro-antd/float-button';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'nz-demo-float-button-group-menu',
-  imports: [NzFloatButtonModule, NzIconModule],
+  imports: [NzFloatButtonModule],
   template: `
     <div class="menu">
       <nz-float-button-group
-        [nzIcon]="icon"
+        nzIcon="customer-service"
         nzType="primary"
         nzTrigger="click"
         style="right: 24px"
         (nzOnOpenChange)="openChange($event)"
       >
         <nz-float-button></nz-float-button>
-        <nz-float-button [nzIcon]="inner"></nz-float-button>
+        <nz-float-button nzIcon="comment"></nz-float-button>
       </nz-float-button-group>
       <nz-float-button-group
-        [nzIcon]="icon"
+        nzIcon="customer-service"
         nzType="primary"
         nzTrigger="hover"
         style="right: 94px"
         (nzOnOpenChange)="openChange($event)"
       >
         <nz-float-button></nz-float-button>
-        <nz-float-button [nzIcon]="inner"></nz-float-button>
+        <nz-float-button nzIcon="comment"></nz-float-button>
       </nz-float-button-group>
     </div>
-    <ng-template #icon>
-      <nz-icon nzType="customer-service" nzTheme="outline"></nz-icon>
-    </ng-template>
-    <ng-template #inner>
-      <nz-icon nzType="comment" nzTheme="outline"></nz-icon>
-    </ng-template>
   `,
   styles: [
     `

--- a/components/float-button/demo/group-placement.ts
+++ b/components/float-button/demo/group-placement.ts
@@ -1,74 +1,58 @@
 import { Component } from '@angular/core';
 
 import { NzFloatButtonModule } from 'ng-zorro-antd/float-button';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'nz-demo-float-button-group-placement',
-  imports: [NzFloatButtonModule, NzIconModule],
+  imports: [NzFloatButtonModule],
   template: `
     <div class="container">
       <div class="anchor">
         <nz-float-button-group
           class="up"
-          [nzIcon]="up"
+          nzIcon="up"
           nzType="primary"
           nzTrigger="click"
           (nzOnOpenChange)="openChange($event)"
           nzPlacement="top"
         >
           <nz-float-button></nz-float-button>
-          <nz-float-button [nzIcon]="inner"></nz-float-button>
+          <nz-float-button nzIcon="comment"></nz-float-button>
         </nz-float-button-group>
         <nz-float-button-group
           class="down"
-          [nzIcon]="down"
+          nzIcon="down"
           nzType="primary"
           nzTrigger="click"
           (nzOnOpenChange)="openChange($event)"
           nzPlacement="bottom"
         >
           <nz-float-button></nz-float-button>
-          <nz-float-button [nzIcon]="inner"></nz-float-button>
+          <nz-float-button nzIcon="comment"></nz-float-button>
         </nz-float-button-group>
         <nz-float-button-group
           class="left"
-          [nzIcon]="left"
+          nzIcon="left"
           nzType="primary"
           nzTrigger="click"
           (nzOnOpenChange)="openChange($event)"
           nzPlacement="left"
         >
           <nz-float-button></nz-float-button>
-          <nz-float-button [nzIcon]="inner"></nz-float-button>
+          <nz-float-button nzIcon="comment"></nz-float-button>
         </nz-float-button-group>
         <nz-float-button-group
           class="right"
-          [nzIcon]="right"
+          nzIcon="right"
           nzType="primary"
           nzTrigger="click"
           (nzOnOpenChange)="openChange($event)"
           nzPlacement="right"
         >
           <nz-float-button></nz-float-button>
-          <nz-float-button [nzIcon]="inner"></nz-float-button>
+          <nz-float-button nzIcon="comment"></nz-float-button>
         </nz-float-button-group>
       </div>
-      <ng-template #inner>
-        <nz-icon nzType="comment" nzTheme="outline"></nz-icon>
-      </ng-template>
-      <ng-template #up>
-        <nz-icon nzType="up" nzTheme="outline" />
-      </ng-template>
-      <ng-template #down>
-        <nz-icon nzType="down" nzTheme="outline" />
-      </ng-template>
-      <ng-template #left>
-        <nz-icon nzType="left" nzTheme="outline" />
-      </ng-template>
-      <ng-template #right>
-        <nz-icon nzType="right" nzTheme="outline" />
-      </ng-template>
     </div>
   `,
   styles: [

--- a/components/float-button/demo/group.ts
+++ b/components/float-button/demo/group.ts
@@ -1,32 +1,25 @@
 import { Component } from '@angular/core';
 
 import { NzFloatButtonModule } from 'ng-zorro-antd/float-button';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'nz-demo-float-button-group',
-  imports: [NzFloatButtonModule, NzIconModule],
+  imports: [NzFloatButtonModule],
   template: `
     <div class="group">
       <nz-float-button-group nzShape="circle" style="right: 24px">
-        <nz-float-button [nzIcon]="icon"></nz-float-button>
+        <nz-float-button nzIcon="question-circle"></nz-float-button>
         <nz-float-button></nz-float-button>
         <nz-float-button-top [nzVisibilityHeight]="600"></nz-float-button-top>
-        <nz-float-button [nzIcon]="customer"></nz-float-button>
+        <nz-float-button nzIcon="customer-service"></nz-float-button>
       </nz-float-button-group>
       <nz-float-button-group nzShape="square" style="right: 94px">
-        <nz-float-button [nzIcon]="icon"></nz-float-button>
+        <nz-float-button nzIcon="question-circle"></nz-float-button>
         <nz-float-button></nz-float-button>
         <nz-float-button-top [nzVisibilityHeight]="600"></nz-float-button-top>
-        <nz-float-button [nzIcon]="customer"></nz-float-button>
+        <nz-float-button nzIcon="customer-service"></nz-float-button>
       </nz-float-button-group>
     </div>
-    <ng-template #icon>
-      <nz-icon nzType="question-circle" nzTheme="outline"></nz-icon>
-    </ng-template>
-    <ng-template #customer>
-      <nz-icon nzType="customer-service" nzTheme="outline"></nz-icon>
-    </ng-template>
   `,
   styles: [
     `

--- a/components/float-button/demo/open.ts
+++ b/components/float-button/demo/open.ts
@@ -2,25 +2,24 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NzFloatButtonModule } from 'ng-zorro-antd/float-button';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzSwitchModule } from 'ng-zorro-antd/switch';
 
 @Component({
   selector: 'nz-demo-float-button-open',
-  imports: [FormsModule, NzFloatButtonModule, NzIconModule, NzSwitchModule],
+  imports: [FormsModule, NzFloatButtonModule, NzSwitchModule],
   template: `
     <div class="open">
-      <nz-float-button-group [nzIcon]="icon" [nzOpen]="isOpen" nzType="primary" nzTrigger="hover" style="right: 24px">
+      <nz-float-button-group
+        nzIcon="customer-service"
+        [nzOpen]="isOpen"
+        nzType="primary"
+        nzTrigger="hover"
+        style="right: 24px"
+      >
         <nz-float-button></nz-float-button>
-        <nz-float-button [nzIcon]="inner"></nz-float-button>
+        <nz-float-button nzIcon="comment"></nz-float-button>
       </nz-float-button-group>
       <nz-switch [(ngModel)]="isOpen"></nz-switch>
-      <ng-template #icon>
-        <nz-icon nzType="customer-service" nzTheme="outline"></nz-icon>
-      </ng-template>
-      <ng-template #inner>
-        <nz-icon nzType="comment" nzTheme="outline"></nz-icon>
-      </ng-template>
     </div>
   `,
   styles: [

--- a/components/float-button/demo/shape.ts
+++ b/components/float-button/demo/shape.ts
@@ -1,18 +1,20 @@
 import { Component } from '@angular/core';
 
 import { NzFloatButtonModule } from 'ng-zorro-antd/float-button';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'nz-demo-float-button-shape',
-  imports: [NzFloatButtonModule, NzIconModule],
+  imports: [NzFloatButtonModule],
   template: `
     <div class="shape">
-      <nz-float-button nzShape="circle" style="right: 94px" nzType="primary" [nzIcon]="icon"> </nz-float-button>
-      <nz-float-button nzShape="square" style="right: 24px" nzType="primary" [nzIcon]="icon"></nz-float-button>
-      <ng-template #icon>
-        <nz-icon nzType="customer-service" nzTheme="outline"></nz-icon>
-      </ng-template>
+      <nz-float-button nzShape="circle" style="right: 94px" nzType="primary" nzIcon="customer-service">
+      </nz-float-button>
+      <nz-float-button
+        nzShape="square"
+        style="right: 24px"
+        nzType="primary"
+        nzIcon="customer-service"
+      ></nz-float-button>
     </div>
   `,
   styles: [

--- a/components/float-button/demo/type.ts
+++ b/components/float-button/demo/type.ts
@@ -1,19 +1,15 @@
 import { Component } from '@angular/core';
 
 import { NzFloatButtonModule } from 'ng-zorro-antd/float-button';
-import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'nz-demo-float-button-type',
-  imports: [NzFloatButtonModule, NzIconModule],
+  imports: [NzFloatButtonModule],
   template: `
     <div class="type">
-      <nz-float-button nzType="primary" style="right: 24px" [nzIcon]="icon"></nz-float-button>
-      <nz-float-button nzType="default" style="right: 94px" [nzIcon]="icon"></nz-float-button>
+      <nz-float-button nzType="primary" style="right: 24px" nzIcon="question-circle"></nz-float-button>
+      <nz-float-button nzType="default" style="right: 94px" nzIcon="question-circle"></nz-float-button>
     </div>
-    <ng-template #icon>
-      <nz-icon nzType="question-circle" nzTheme="outline"></nz-icon>
-    </ng-template>
   `,
   styles: [
     `

--- a/components/float-button/doc/index.en-US.md
+++ b/components/float-button/doc/index.en-US.md
@@ -19,7 +19,7 @@ description: A button that floats at the top of the page.
 
 | Property          | Description                               | Type                          | Default     |
 |-------------------|-------------------------------------------|-------------------------------|-------------|
-| `[nzIcon]`        | Set the icon component of button          | `TemplateRef<void>`           | -           |
+| `[nzIcon]`        | Set the icon component of button          | `string \| TemplateRef<void>` | -           |
 | `[nzDescription]` | Text and other                            | `TemplateRef<void> \| string` | -           |
 | `[nzType]`        | Setting button type                       | `'default' \| 'primary'`      | `'default'` |
 | `[nzShape]`       | Setting button shape                      | `'circle' \| 'square'`        | `'circle'`  |

--- a/components/float-button/doc/index.zh-CN.md
+++ b/components/float-button/doc/index.zh-CN.md
@@ -20,7 +20,7 @@ description: 悬浮于页面上方的按钮。
 
 | 参数                | 说明                               | 类型                            | 默认值         |
 |-------------------|----------------------------------|-------------------------------|-------------|
-| `[nzIcon]`        | 自定义图标                            | `TemplateRef<void>`           | -           |
+| `[nzIcon]`        | 自定义图标                            | `string \| TemplateRef<void>` | -           |
 | `[nzDescription]` | 文字及其它内容                          | `TemplateRef<void> \| string` | -           |
 | `[nzType]`        | 设置按钮类型                           | `'default' \| 'primary'`      | `'default'` |
 | `[nzShape]`       | 设置按钮形状                           | `'circle' \| 'square'`        | `'circle'`  |

--- a/components/float-button/float-button-content.component.ts
+++ b/components/float-button/float-button-content.component.ts
@@ -7,6 +7,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, TemplateRef } from '@angular/core';
 
 import { NzStringTemplateOutletDirective } from 'ng-zorro-antd/core/outlet';
+import { isTemplateRef } from 'ng-zorro-antd/core/util';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
@@ -20,7 +21,11 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
         @if (nzDescription || nzIcon) {
           @if (nzIcon) {
             <div class="ant-float-btn-icon">
-              <ng-template [ngTemplateOutlet]="nzIcon"></ng-template>
+              @if (isTemplateRef(nzIcon)) {
+                <ng-template [ngTemplateOutlet]="nzIcon"></ng-template>
+              } @else {
+                <nz-icon [nzType]="nzIcon" nzTheme="outline" />
+              }
             </div>
           }
           @if (nzDescription && nzShape === 'square') {
@@ -40,7 +45,9 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   `
 })
 export class NzFloatButtonContentComponent {
-  @Input() nzIcon: TemplateRef<void> | null = null;
+  @Input() nzIcon: string | TemplateRef<void> | null = null;
   @Input() nzDescription: string | TemplateRef<void> | null = null;
   @Input() nzShape: 'circle' | 'square' = 'circle';
+
+  protected readonly isTemplateRef = isTemplateRef;
 }

--- a/components/float-button/float-button-group.component.spec.ts
+++ b/components/float-button/float-button-group.component.spec.ts
@@ -3,8 +3,8 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { BidiModule, Dir, Direction } from '@angular/cdk/bidi';
-import { Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
+import { BidiModule, Direction } from '@angular/cdk/bidi';
+import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -55,7 +55,6 @@ describe('nz-float-button-group', () => {
     });
 
     it('nzTrigger hover', () => {
-      testComponent.nzIcon = testComponent.icon;
       testComponent.nzTrigger = 'hover';
       fixture.detectChanges();
       resultEl.nativeElement.getElementsByClassName('ant-float-btn')[0].dispatchEvent(new MouseEvent('mouseover'));
@@ -71,7 +70,6 @@ describe('nz-float-button-group', () => {
     });
 
     it('nzTrigger click', () => {
-      testComponent.nzIcon = testComponent.icon;
       testComponent.nzTrigger = 'click';
       fixture.detectChanges();
       resultEl.nativeElement.getElementsByClassName('ant-btn')[0].dispatchEvent(new MouseEvent('click'));
@@ -87,7 +85,6 @@ describe('nz-float-button-group', () => {
     });
 
     it('nzOpen true', () => {
-      testComponent.nzIcon = testComponent.icon;
       testComponent.nzOpen = true;
       testComponent.nzTrigger = 'click';
       fixture.detectChanges();
@@ -97,7 +94,6 @@ describe('nz-float-button-group', () => {
     });
 
     it('nzOpen false', () => {
-      testComponent.nzIcon = testComponent.icon;
       testComponent.nzOpen = false;
       testComponent.nzTrigger = 'click';
       fixture.detectChanges();
@@ -183,7 +179,7 @@ describe('nz-float-button-group RTL', () => {
   imports: [NzFloatButtonModule, NzIconModule],
   template: `
     <nz-float-button-group
-      [nzIcon]="nzIcon"
+      nzIcon="question-circle"
       [nzShape]="nzShape"
       [nzTrigger]="nzTrigger"
       [nzOpen]="nzOpen"
@@ -191,18 +187,13 @@ describe('nz-float-button-group RTL', () => {
       (nzOnOpenChange)="onClick($event)"
     >
     </nz-float-button-group>
-    <ng-template #icon>
-      <nz-icon nzType="question-circle" nzTheme="outline" />
-    </ng-template>
   `
 })
 export class NzTestFloatButtonGroupBasicComponent {
   nzShape: 'circle' | 'square' = 'circle';
   nzTrigger: 'click' | 'hover' | null = null;
   nzOpen: boolean | null = null;
-  nzIcon: TemplateRef<void> | null = null;
   nzPlacement: 'top' | 'right' | 'bottom' | 'left' = 'top';
-  @ViewChild('icon', { static: false }) icon!: TemplateRef<void>;
 
   isClick: boolean = false;
 
@@ -220,6 +211,5 @@ export class NzTestFloatButtonGroupBasicComponent {
   `
 })
 export class NzTestFloatButtonRtlComponent {
-  @ViewChild(Dir) dir!: Dir;
   direction: Direction = 'rtl';
 }

--- a/components/float-button/float-button-group.component.ts
+++ b/components/float-button/float-button-group.component.ts
@@ -64,7 +64,7 @@ export class NzFloatButtonGroupComponent {
   readonly nzHref = input<string | null>(null);
   readonly nzTarget = input<string | null>(null);
   readonly nzType = input<'default' | 'primary'>('default');
-  readonly nzIcon = input<TemplateRef<void> | null>(null);
+  readonly nzIcon = input<string | TemplateRef<void> | null>(null);
   readonly nzDescription = input<TemplateRef<void> | null>(null);
   readonly nzShape = input<'circle' | 'square'>('circle');
   readonly nzTrigger = input<'click' | 'hover' | null>(null);

--- a/components/float-button/float-button-top.component.ts
+++ b/components/float-button/float-button-top.component.ts
@@ -90,7 +90,7 @@ export class NzFloatButtonTopComponent implements OnInit, OnChanges {
   @Input() nzHref: string | null = null;
   @Input() nzType: 'default' | 'primary' = 'default';
   @Input() nzShape: 'circle' | 'square' = 'circle';
-  @Input() nzIcon: TemplateRef<void> | null = null;
+  @Input() nzIcon: string | TemplateRef<void> | null = null;
   @Input() nzDescription: TemplateRef<void> | null = null;
 
   @Input() nzTemplate?: TemplateRef<void>;

--- a/components/float-button/float-button.component.spec.ts
+++ b/components/float-button/float-button.component.spec.ts
@@ -62,6 +62,13 @@ describe('nz-float-button', () => {
       expect(view.getAttribute('nztype') === 'question-circle').toBe(true);
     });
 
+    it('should nzIcon support passing nzType string only', () => {
+      testComponent.nzIcon = 'file-search';
+      fixture.detectChanges();
+      const view = resultEl.nativeElement.getElementsByClassName('anticon-question-circle')[0];
+      expect(view.getAttribute('nztype') === 'file-search').toBe(true);
+    });
+
     it('nzOnClick', () => {
       resultEl.nativeElement.getElementsByClassName('ant-btn')[0].dispatchEvent(new MouseEvent('click'));
       fixture.detectChanges();
@@ -112,7 +119,7 @@ export class NzTestFloatButtonBasicComponent {
   nzTarget: string | null = null;
   nzType: 'default' | 'primary' = 'default';
   nzShape: 'circle' | 'square' = 'circle';
-  nzIcon: TemplateRef<void> | null = null;
+  nzIcon: string | TemplateRef<void> | null = null;
   nzDescription: TemplateRef<void> | null = null;
 
   @ViewChild('icon', { static: false }) icon!: TemplateRef<void>;

--- a/components/float-button/float-button.component.ts
+++ b/components/float-button/float-button.component.ts
@@ -76,14 +76,10 @@ export class NzFloatButtonComponent implements OnInit {
   @Input() nzTarget: string | null = null;
   @Input() nzType: 'default' | 'primary' = 'default';
   @Input() nzShape: 'circle' | 'square' = 'circle';
-  @Input() nzIcon: TemplateRef<void> | null = null;
+  @Input() nzIcon: string | TemplateRef<void> | null = null;
   @Input() nzDescription: TemplateRef<void> | string | null = null;
   @Output() readonly nzOnClick = new EventEmitter<boolean>();
   dir: Direction = 'ltr';
-
-  constructor() {
-    this.dir = this.directionality.value;
-  }
 
   ngOnInit(): void {
     this.directionality.change?.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(direction => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

`nzIcon` of nz-float-button supports `string` type

```diff
- @Input() nzIcon: TemplateRef<void> | null = null;
+ @Input() nzIcon: string | TemplateRef<void> | null = null;
```

In the past, you have to define a template to specify the icon of the float-button, now just passing a string which is `nzType` of nz-icon.

```html
<!-- before -->
<nz-float-button [nzIcon]="icon"></nz-float-button>
<ng-template #icon>
  <nz-icon nzType="question-circle" nzTheme="outline" />
</ng-template>

<!-- now -->
<nz-float-button nzIcon="question-circle"></nz-float-button>
```

Note that the `nzTheme` of the icon is `outline`, which is the default value. If you wanna customize it, please use the old TemplateRef API

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
