### PR TITLE
refactor(module:*): enhance popup arrow positioning and styles

### DIFF
--- a/components/core/overlay/overlay-position.ts
+++ b/components/core/overlay/overlay-position.ts
@@ -42,7 +42,36 @@ export type POSITION_TYPE_HORIZONTAL = Extract<
   'bottomLeft' | 'bottomCenter' | 'bottomRight' | 'topLeft' | 'topCenter' | 'topRight'
 >;
 
-export const DEFAULT_TOOLTIP_POSITIONS = [POSITION_MAP.top, POSITION_MAP.right, POSITION_MAP.bottom, POSITION_MAP.left];
+/**
+ * @internal
+ * @param offset offset in pixels which should not be less than 0.
+ * The default value is `12`, which means `(arrow-size / 2) + 4`
+ */
+const positionOffsetMapFactory = (offset: number = 12): Record<string, [number, number]> => ({
+  top: [0, -offset],
+  topCenter: [0, -offset],
+  topLeft: [0, -offset],
+  topRight: [0, -offset],
+  right: [offset, 0],
+  rightTop: [offset, 0],
+  rightBottom: [offset, 0],
+  bottom: [0, offset],
+  bottomCenter: [0, offset],
+  bottomLeft: [0, offset],
+  bottomRight: [0, offset],
+  left: [-offset, 0],
+  leftTop: [-offset, 0],
+  leftBottom: [-offset, 0]
+});
+
+export const TOOLTIP_OFFSET_MAP = positionOffsetMapFactory();
+
+export const DEFAULT_TOOLTIP_POSITIONS = [
+  setConnectedPositionOffset(POSITION_MAP.top, TOOLTIP_OFFSET_MAP.top),
+  setConnectedPositionOffset(POSITION_MAP.right, TOOLTIP_OFFSET_MAP.right),
+  setConnectedPositionOffset(POSITION_MAP.bottom, TOOLTIP_OFFSET_MAP.bottom),
+  setConnectedPositionOffset(POSITION_MAP.left, TOOLTIP_OFFSET_MAP.left)
+];
 
 export const DEFAULT_CASCADER_POSITIONS = [
   POSITION_MAP.bottomLeft,
@@ -108,3 +137,20 @@ export const DEFAULT_DATE_PICKER_POSITIONS = [
   DATE_PICKER_POSITION_MAP.bottomRight,
   DATE_PICKER_POSITION_MAP.topRight
 ];
+
+export function normalizeConnectedPositionOffset(offset: number | [number, number]): [number, number] {
+  return Array.isArray(offset) ? offset : [offset, offset];
+}
+
+export function setConnectedPositionOffset(
+  position: ConnectionPositionPair,
+  offset: number | [number, number]
+): ConnectionPositionPair {
+  const [offsetX, offsetY] = normalizeConnectedPositionOffset(offset);
+  // return new object
+  return {
+    ...position,
+    offsetX: offsetX,
+    offsetY: offsetY
+  };
+}

--- a/components/date-picker/style/index.less
+++ b/components/date-picker/style/index.less
@@ -257,6 +257,9 @@
   // ======================= Dropdown =======================
   &-dropdown {
     .reset-component();
+
+    --antd-arrow-background-color: @calendar-bg;
+
     position: absolute;
     // Fix incorrect position of picker popup
     // https://github.com/ant-design/ant-design/issues/35590
@@ -268,19 +271,19 @@
       display: none;
     }
 
-    &-placement-bottomLeft {
+    &-placement-bottomLeft, &-placement-bottomRight {
       .@{picker-prefix-cls}-range-arrow {
-        top: (@arrow-size / 2) - (@arrow-size / 3) + 0.7px;
+        top: 0;
         display: block;
-        transform: rotate(-135deg) translateY(1px);
+        transform: translateY(-100%);
       }
     }
 
-    &-placement-topLeft {
+    &-placement-topLeft, &-placement-topRight {
       .@{picker-prefix-cls}-range-arrow {
-        bottom: (@arrow-size / 2) - (@arrow-size / 3) + 0.7px;
+        bottom: 0;
         display: block;
-        transform: rotate(45deg);
+        transform: translateY(100%) rotate(180deg);
       }
     }
 
@@ -310,7 +313,7 @@
   }
 
   &-dropdown-range {
-    padding: (@arrow-size * 2 / 3) 0;
+    margin-block: (@arrow-size * 2 / 3);
 
     &-hidden {
       display: none;
@@ -356,12 +359,10 @@
   &-range-arrow {
     position: absolute;
     z-index: 1;
-    width: @arrow-size;
-    height: @arrow-size;
+    box-sizing: content-box;
     margin-left: @input-padding-horizontal-base * 1.5;
-    box-shadow: 2px 2px 6px -2px fade(@black, 10%); // use spread radius to hide shadow over popover
     transition: left @animation-duration-slow ease-out;
-    .roundedArrow(@arrow-size, 5px, @calendar-bg);
+    .roundedArrow(@arrow-size, 4px, @arrow-border-radius, var(--antd-arrow-background-color), @popover-arrow-box-shadow);
   }
 
   &-panel-container {
@@ -381,16 +382,12 @@
     .@{picker-prefix-cls}-panel {
       vertical-align: top;
       background: transparent;
-      border-width: 0 0 @border-width-base;
+      border: none;
       border-radius: 0;
 
       .@{picker-prefix-cls}-content,
       table {
         text-align: center;
-      }
-
-      &-focused {
-        border-color: @border-color-split;
       }
     }
   }

--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -27,19 +27,20 @@ import { BehaviorSubject, EMPTY, Subject, combineLatest, fromEvent, merge } from
 import { auditTime, distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
 
 import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
-import { POSITION_MAP, getPlacementName } from 'ng-zorro-antd/core/overlay';
+import {
+  POSITION_MAP,
+  getPlacementName,
+  POSITION_TYPE,
+  setConnectedPositionOffset,
+  TOOLTIP_OFFSET_MAP
+} from 'ng-zorro-antd/core/overlay';
 import { IndexableObject } from 'ng-zorro-antd/core/types';
 
 import { NzDropdownMenuComponent, NzPlacementType } from './dropdown-menu.component';
 
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'dropDown';
 
-const listOfPositions = [
-  POSITION_MAP.bottomLeft,
-  POSITION_MAP.bottomRight,
-  POSITION_MAP.topRight,
-  POSITION_MAP.topLeft
-];
+const listOfPositions: POSITION_TYPE[] = ['bottomLeft', 'bottomRight', 'topRight', 'topLeft'];
 
 const normalizePlacementForClass = (p: NzPlacementType): NzDropdownMenuComponent['placement'] => {
   // Map center placements to generic top/bottom classes for styling
@@ -191,7 +192,12 @@ export class NzDropDownDirective implements AfterViewInit, OnChanges {
               overlayConfig.minWidth = triggerWidth;
             }
             /** open dropdown with animation **/
-            this.positionStrategy.withPositions([POSITION_MAP[this.nzPlacement], ...listOfPositions]);
+            const positions = [this.nzPlacement, ...listOfPositions].map(position => {
+              return this.nzArrow
+                ? setConnectedPositionOffset(POSITION_MAP[position], TOOLTIP_OFFSET_MAP[position])
+                : POSITION_MAP[position];
+            });
+            this.positionStrategy.withPositions(positions);
             /** reset portal if needed **/
             if (!this.portal || this.portal.templateRef !== this.nzDropdownMenu!.templateRef) {
               this.portal = new TemplatePortal(this.nzDropdownMenu!.templateRef, this.viewContainerRef);

--- a/components/dropdown/style/index.less
+++ b/components/dropdown/style/index.less
@@ -7,6 +7,8 @@
 .@{dropdown-prefix-cls} {
   .reset-component();
 
+  --antd-arrow-background-color: @dropdown-menu-bg;
+
   position: absolute;
   top: -9999px;
   left: -9999px;
@@ -15,13 +17,10 @@
 
   &::before {
     position: absolute;
-    top: -@popover-distance + @popover-arrow-width;
-    right: 0;
-    bottom: -@popover-distance + @popover-arrow-width;
-    left: -7px;
+    inset-block: calc(@popover-arrow-width / 2 - @popover-distance);
     z-index: -9999;
     opacity: 0.0001;
-    content: ' ';
+    content: '';
   }
 
   &-wrap {
@@ -48,72 +47,8 @@
     display: none;
   }
 
-  // Offset the popover to account for the dropdown arrow
-  &-show-arrow&-placement-topLeft,
-  &-show-arrow&-placement-top,
-  &-show-arrow&-placement-topRight {
-    padding-bottom: @popover-distance;
-  }
-
-  &-show-arrow&-placement-bottomLeft,
-  &-show-arrow&-placement-bottom,
-  &-show-arrow&-placement-bottomRight {
-    padding-top: @popover-distance;
-  }
-
-  // Arrows
-  // .popover-arrow is outer, .popover-arrow:after is inner
-
-  &-arrow {
-    position: absolute;
-    z-index: 1; // lift it up so the menu wouldn't cask shadow on it
-    display: block;
-    width: @popover-arrow-width;
-    height: @popover-arrow-width;
-    .roundedArrow(@popover-arrow-width, 5px, @popover-bg);
-  }
-
-  &-placement-top > &-arrow,
-  &-placement-topLeft > &-arrow,
-  &-placement-topRight > &-arrow {
-    bottom: @popover-arrow-width * sqrt((1 / 2)) + 2px;
-    box-shadow: 3px 3px 7px -3px fade(@black, 10%);
-    transform: rotate(45deg);
-  }
-
-  &-placement-top > &-arrow {
-    left: 50%;
-    transform: translateX(-50%) rotate(45deg);
-  }
-
-  &-placement-topLeft > &-arrow {
-    left: 16px;
-  }
-
-  &-placement-topRight > &-arrow {
-    right: 16px;
-  }
-
-  &-placement-bottom > &-arrow,
-  &-placement-bottomLeft > &-arrow,
-  &-placement-bottomRight > &-arrow {
-    top: (@popover-arrow-width + 2px) * sqrt((1 / 2));
-    box-shadow: 2px 2px 5px -2px fade(@black, 10%);
-    transform: rotate(-135deg) translateY(-0.5px);
-  }
-
-  &-placement-bottom > &-arrow {
-    left: 50%;
-    transform: translateX(-50%) rotate(-135deg) translateY(-0.5px);
-  }
-
-  &-placement-bottomLeft > &-arrow {
-    left: 16px;
-  }
-
-  &-placement-bottomRight > &-arrow {
-    right: 16px;
-  }
+  // Arrow Style
+  .placementArrow(@popover-arrow-width, 5px, @arrow-border-radius, var(--antd-arrow-background-color), @popover-arrow-box-shadow);
 
   &-menu {
     position: relative;

--- a/components/dropdown/style/patch.less
+++ b/components/dropdown/style/patch.less
@@ -8,11 +8,7 @@
 
 .ant-dropdown {
   position: relative;
-  top: 0;
-  left: 0;
-  width: 100%;
-  margin-top: 6px;
-  margin-bottom: 6px;
+  inset: 0;
 }
 
 .@{dropdown-prefix-cls} {

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -177,12 +177,10 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         [@zoomBigMotion]="'active'"
       >
+        @if (nzPopconfirmShowArrow) {
+          <div class="ant-popover-arrow"></div>
+        }
         <div class="ant-popover-content">
-          @if (nzPopconfirmShowArrow) {
-            <div class="ant-popover-arrow">
-              <span class="ant-popover-arrow-content"></span>
-            </div>
-          }
           <div class="ant-popover-inner">
             <div>
               <div class="ant-popover-inner-content">

--- a/components/popover/popover.ts
+++ b/components/popover/popover.ts
@@ -109,10 +109,8 @@ export class NzPopoverDirective extends NzTooltipBaseDirective {
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         [@zoomBigMotion]="'active'"
       >
+        <div class="ant-popover-arrow"></div>
         <div class="ant-popover-content">
-          <div class="ant-popover-arrow">
-            <span class="ant-popover-arrow-content"></span>
-          </div>
           <div class="ant-popover-inner" role="tooltip">
             <div>
               @if (nzTitle) {

--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -36,31 +36,6 @@
     display: none;
   }
 
-  // Offset the popover to account for the popover arrow
-  &-placement-top,
-  &-placement-topLeft,
-  &-placement-topRight {
-    padding-bottom: @popover-distance;
-  }
-
-  &-placement-right,
-  &-placement-rightTop,
-  &-placement-rightBottom {
-    padding-left: @popover-distance;
-  }
-
-  &-placement-bottom,
-  &-placement-bottomLeft,
-  &-placement-bottomRight {
-    padding-top: @popover-distance;
-  }
-
-  &-placement-left,
-  &-placement-leftTop,
-  &-placement-leftBottom {
-    padding-right: @popover-distance;
-  }
-
   &-inner {
     background-color: @popover-bg;
     background-clip: padding-box;
@@ -115,149 +90,26 @@
     }
   }
 
-  // Arrows
-  &-arrow {
-    position: absolute;
-    display: block;
-    width: @popover-arrow-rotate-width;
-    height: @popover-arrow-rotate-width;
-    overflow: hidden;
-    background: transparent;
-    pointer-events: none;
-
-    &-content {
-      --antd-arrow-background-color: @popover-bg;
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      display: block;
-      width: @popover-arrow-width;
-      height: @popover-arrow-width;
-      margin: auto;
-      content: '';
-      pointer-events: auto;
-      .roundedArrow(@popover-arrow-width, 5px);
-    }
-  }
-
-  &-placement-top &-arrow,
-  &-placement-topLeft &-arrow,
-  &-placement-topRight &-arrow {
-    bottom: 0;
-    transform: translateY(100%);
-
-    &-content {
-      box-shadow: 3px 3px 7px fade(@black, 7%);
-      transform: translateY((-@popover-arrow-rotate-width / 2)) rotate(45deg);
-    }
-  }
-
-  &-placement-top &-arrow {
-    left: 50%;
-    transform: translateY(100%) translateX(-50%);
-  }
-
-  &-placement-topLeft &-arrow {
-    left: @popover-arrow-offset-horizontal;
-  }
-
-  &-placement-topRight &-arrow {
-    right: @popover-arrow-offset-horizontal;
-  }
-
-  &-placement-right &-arrow,
-  &-placement-rightTop &-arrow,
-  &-placement-rightBottom &-arrow {
-    left: 0;
-    transform: translateX(-100%);
-
-    &-content {
-      box-shadow: 3px 3px 7px fade(@black, 7%);
-      transform: translateX((@popover-arrow-rotate-width / 2)) rotate(135deg);
-    }
-  }
-
-  &-placement-right &-arrow {
-    top: 50%;
-    transform: translateX(-100%) translateY(-50%);
-  }
-
-  &-placement-rightTop &-arrow {
-    top: @popover-arrow-offset-vertical;
-  }
-
-  &-placement-rightBottom &-arrow {
-    bottom: @popover-arrow-offset-vertical;
-  }
-
-  &-placement-bottom &-arrow,
-  &-placement-bottomLeft &-arrow,
-  &-placement-bottomRight &-arrow {
-    top: 0;
-    transform: translateY(-100%);
-
-    &-content {
-      box-shadow: 2px 2px 5px fade(@black, 6%);
-      transform: translateY((@popover-arrow-rotate-width / 2)) rotate(-135deg);
-    }
-  }
-
-  &-placement-bottom &-arrow {
-    left: 50%;
-    transform: translateY(-100%) translateX(-50%);
-  }
-
-  &-placement-bottomLeft &-arrow {
-    left: @popover-arrow-offset-horizontal;
-  }
-
-  &-placement-bottomRight &-arrow {
-    right: @popover-arrow-offset-horizontal;
-  }
-
-  &-placement-left &-arrow,
-  &-placement-leftTop &-arrow,
-  &-placement-leftBottom &-arrow {
-    right: 0;
-    transform: translateX(100%);
-
-    &-content {
-      box-shadow: 3px 3px 7px fade(@black, 7%);
-      transform: translateX((-@popover-arrow-rotate-width / 2)) rotate(-45deg);
-    }
-  }
-
-  &-placement-left &-arrow {
-    top: 50%;
-    transform: translateX(100%) translateY(-50%);
-  }
-
-  &-placement-leftTop &-arrow {
-    top: @popover-arrow-offset-vertical;
-  }
-
-  &-placement-leftBottom &-arrow {
-    bottom: @popover-arrow-offset-vertical;
-  }
+  // Arrow Style
+  .placementArrow(@popover-arrow-width, 4px, @arrow-border-radius, @popover-bg, @popover-arrow-box-shadow);
 }
 
 .generator-popover-preset-color(@i: length(@preset-colors)) when (@i > 0) {
   .generator-popover-preset-color(@i - 1);
   @color: extract(@preset-colors, @i);
   @lightColor: '@{color}-6';
+
   .@{popover-prefix-cls}-@{color} {
     .@{popover-prefix-cls}-inner {
       background-color: @@lightColor;
     }
+
     .@{popover-prefix-cls}-arrow {
-      &-content {
-        background-color: @@lightColor;
-      }
+      background-color: @@lightColor;
     }
   }
 }
+
 .generator-popover-preset-color();
 
 @import './rtl';

--- a/components/style/mixins/index.less
+++ b/components/style/mixins/index.less
@@ -12,5 +12,6 @@
 @import 'reset';
 @import 'operation-unit';
 @import 'rounded-arrow';
+@import 'placement-arrow';
 @import 'compact-item';
 @import 'compact-item-vertical';

--- a/components/style/mixins/placement-arrow.less
+++ b/components/style/mixins/placement-arrow.less
@@ -1,0 +1,110 @@
+.placementArrow(
+  @arrow-size,
+  @border-radius-outer,
+  @border-radius-inner,
+  @bg-color: var(--antd-arrow-background-color),
+  @box-shadow: none
+) {
+  // internal variables
+  @arrow-distance: 0px;
+  @arrow-offset-horizontal: 16px;
+
+  // ============================ Basic ============================
+  &-arrow {
+    position: absolute;
+    z-index: 1; // lift it up so the menu wouldn't cask shadow on it
+    display: block;
+
+    .roundedArrow(@arrow-size, @border-radius-outer, @border-radius-inner, @bg-color, @box-shadow);
+
+    &::before {
+      background: @bg-color;
+    }
+  }
+
+  // ========================== Placement ==========================
+  // Here handle the arrow position and rotate stuff
+  // >>>>> Top
+  &-placement-top > &-arrow,
+  &-placement-topLeft > &-arrow,
+  &-placement-topRight > &-arrow {
+    bottom: @arrow-distance;
+    transform: translateY(100%) rotate(180deg);
+  }
+
+  &-placement-top > &-arrow {
+    left: 50%;
+    transform: translateX(-50%) translateY(100%) rotate(180deg);
+  }
+
+  &-placement-topLeft > &-arrow {
+    left: @arrow-offset-horizontal;
+  }
+
+  &-placement-topRight > &-arrow {
+    right: @arrow-offset-horizontal;
+  }
+
+  // >>>>> Bottom
+  &-placement-bottom > &-arrow,
+  &-placement-bottomLeft > &-arrow,
+  &-placement-bottomRight > &-arrow {
+    top: @arrow-distance;
+    transform: translateY(-100%);
+  }
+
+  &-placement-bottom > &-arrow {
+    left: 50%;
+    transform: translateX(-50%) translateY(-100%);
+  }
+
+  &-placement-bottomLeft > &-arrow {
+    left: @arrow-offset-horizontal;
+  }
+
+  &-placement-bottomRight > &-arrow {
+    right: @arrow-offset-horizontal;
+  }
+
+  // >>>>> Left
+  &-placement-left > &-arrow,
+  &-placement-leftTop > &-arrow,
+  &-placement-leftBottom > &-arrow {
+    right: @arrow-distance;
+    transform: translateX(100%) rotate(90deg);
+  }
+
+  &-placement-left > &-arrow {
+    top: 50%;
+    transform: translateY(-50%) translateX(100%) rotate(90deg);
+  }
+
+  &-placement-leftTop > &-arrow {
+    top: @arrow-offset-horizontal;
+  }
+
+  &-placement-leftBottom > &-arrow {
+    bottom: @arrow-offset-horizontal;
+  }
+
+  // >>>>> Right
+  &-placement-right > &-arrow,
+  &-placement-rightTop > &-arrow,
+  &-placement-rightBottom > &-arrow {
+    left: @arrow-distance;
+    transform: translateX(-100%) rotate(-90deg);
+  }
+
+  &-placement-right > &-arrow {
+    top: 50%;
+    transform: translateY(-50%) translateX(-100%) rotate(-90deg);
+  }
+
+  &-placement-rightTop > &-arrow {
+    top: @arrow-offset-horizontal;
+  }
+
+  &-placement-rightBottom > &-arrow {
+    bottom: @arrow-offset-horizontal;
+  }
+}

--- a/components/style/mixins/rounded-arrow.less
+++ b/components/style/mixins/rounded-arrow.less
@@ -1,44 +1,64 @@
-.roundedArrow(@width, @outer-radius, @bg-color: var(--antd-arrow-background-color)) {
-  @corner-height: unit(((@outer-radius) * (1 - 1 / sqrt(2))));
+.roundedArrow(
+  @arrow-size,
+  @border-radius-outer,
+  @border-radius-inner,
+  @bg-color: var(--antd-arrow-background-color),
+  @box-shadow: none
+) {
+  @unit-width: (unit(@arrow-size) / 2);
+  @border-radius-outer-without-unit: unit(@border-radius-outer);
+  @border-radius-inner-without-unit: unit(@border-radius-inner);
 
-  @width-without-unit: unit(@width);
-  @outer-radius-without-unit: unit(@outer-radius);
-  @inner-radius-without-unit: unit(@arrow-border-radius);
+  @a-x: 0;
+  @a-y: @unit-width;
+  @b-x: ((@border-radius-outer-without-unit * 1) / sqrt(2));
+  @b-y: (@unit-width - @border-radius-outer-without-unit * (1 - 1 / sqrt(2)));
+  @c-x: (@unit-width - @border-radius-inner-without-unit * (1 / sqrt(2)));
+  @c-y: (@border-radius-outer-without-unit * (sqrt(2) - 1) + @border-radius-inner-without-unit * (1 / sqrt(2)));
+  @d-x: 2 * @unit-width - @c-x;
+  @d-y: @c-y;
+  @e-x: 2 * @unit-width - @b-x;
+  @e-y: @b-y;
+  @f-x: 2 * @unit-width - @a-x;
+  @f-y: @a-y;
 
-  @a-x: @width-without-unit - @corner-height;
-  @a-y: 2 * @width-without-unit + @corner-height;
-  @b-x: @a-x + @outer-radius-without-unit * (1 / sqrt(2));
-  @b-y: 2 * @width-without-unit;
-  @c-x: 2 * @width-without-unit - @inner-radius-without-unit;
-  @c-y: 2 * @width-without-unit;
-  @d-x: 2 * @width-without-unit;
-  @d-y: 2 * @width-without-unit - @inner-radius-without-unit;
-  @e-x: 2 * @width-without-unit;
-  @e-y: @f-y + @outer-radius-without-unit * (1 / sqrt(2));
-  @f-x: 2 * @width-without-unit + @corner-height;
-  @f-y: @width-without-unit - @corner-height;
-  @g-x: @f-x - 1;
-  @g-y: @f-y;
-  @h-x: @a-x;
-  @h-y: @a-y - 1;
+  @arrow-shadow-width: @unit-width * sqrt(2) + @border-radius-outer * (sqrt(2) - 2);
 
-  border-radius: 0 0 @arrow-border-radius;
+  // polygon offset
+  @polygon-offset: @border-radius-outer * (sqrt(2) - 1);
+  @polygon-right: @arrow-size - @polygon-offset;
+  @arrow-polygon: polygon(@polygon-offset 100%, 50% @polygon-offset, @polygon-right 100%, @polygon-offset 100%);
+  @arrow-path: path('M @{a-x} @{a-y} A @{border-radius-outer-without-unit} @{border-radius-outer-without-unit} 0 0 0 @{b-x} @{b-y} L @{c-x} @{c-y} A @{border-radius-inner-without-unit} @{border-radius-inner-without-unit} 0 0 1 @{d-x} @{d-y} L @{e-x} @{e-y} A @{border-radius-outer-without-unit} @{border-radius-outer-without-unit} 0 0 0 @{f-x} @{f-y} Z');
+
+  width: @arrow-size;
+  height: @arrow-size;
+  overflow: hidden;
   pointer-events: none;
 
   &::before {
     position: absolute;
-    top: -@width;
-    left: -@width;
-    width: @width * 3;
-    height: @width * 3;
+    bottom: 0;
+    width: @arrow-size;
+    height: calc(@arrow-size / 2);
     background: @bg-color;
-    // Hack firefox: https://github.com/ant-design/ant-design/pull/33710#issuecomment-1015287825
-    background-repeat: no-repeat;
-    background-position: ceil(-@width + 1px) ceil(-@width + 1px);
     content: '';
-    clip-path: inset(33% 33%); // For browsers that do not support path()
-    clip-path: path(
-      'M @{a-x} @{a-y} A @{outer-radius-without-unit} @{outer-radius-without-unit} 0 0 1 @{b-x} @{b-y} L @{c-x} @{c-y} A @{inner-radius-without-unit} @{inner-radius-without-unit} 0 0 0 @{d-x} @{d-y} L @{e-x} @{e-y} A @{outer-radius-without-unit} @{outer-radius-without-unit} 0 0 1 @{f-x} @{f-y} L @{g-x} @{g-y} L @{h-x} @{h-y} Z'
-    );
+    clip-path: @arrow-polygon; // For browser that do not support path()
+    clip-path: @arrow-path;
+    inset-inline-start: 0;
+  }
+
+  &::after {
+    position: absolute;
+    bottom: 0;
+    z-index: 0;
+    width: @arrow-shadow-width;
+    height: @arrow-shadow-width;
+    margin: auto;
+    background: transparent;
+    border-radius: 0 0 @border-radius-inner;
+    box-shadow: @box-shadow;
+    transform: translateY(50%) rotate(-135deg);
+    content: '';
+    inset-inline: 0;
   }
 }

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -553,7 +553,7 @@
 // Popover outer arrow color
 @popover-arrow-outer-color: @popover-bg;
 // Popover distance with trigger
-@popover-distance: @popover-arrow-width + 4px;
+@popover-distance: calc(@popover-arrow-width / 2) + @margin-xss;
 @popover-padding-horizontal: @padding-md;
 
 // Modal

--- a/components/style/themes/variable.less
+++ b/components/style/themes/variable.less
@@ -583,7 +583,7 @@
 // Tooltip background color
 @tooltip-bg: rgba(0, 0, 0, 0.75);
 // Tooltip arrow width
-@tooltip-arrow-width: 8px * sqrt(2);
+@tooltip-arrow-width: 16px;
 // Tooltip distance with trigger
 @tooltip-distance: @tooltip-arrow-width - 1px + 4px;
 // Tooltip arrow color
@@ -603,11 +603,12 @@
 @popover-arrow-width: @tooltip-arrow-width;
 // Popover arrow color
 @popover-arrow-color: @popover-bg;
-// Popover outer arrow width
+// Popover arrow box shadow
+@popover-arrow-box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.05);
 // Popover outer arrow color
 @popover-arrow-outer-color: @popover-bg;
 // Popover distance with trigger
-@popover-distance: @popover-arrow-width + 4px;
+@popover-distance: calc(@popover-arrow-width / 2 + 4px);
 @popover-padding-horizontal: @padding-md;
 
 // Modal

--- a/components/tooltip/base.ts
+++ b/components/tooltip/base.ts
@@ -31,7 +31,14 @@ import { delay, distinctUntilChanged, filter } from 'rxjs/operators';
 
 import { NzConfigService, PopConfirmConfig, PopoverConfig } from 'ng-zorro-antd/core/config';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
-import { DEFAULT_TOOLTIP_POSITIONS, POSITION_MAP, POSITION_TYPE, getPlacementName } from 'ng-zorro-antd/core/overlay';
+import {
+  DEFAULT_TOOLTIP_POSITIONS,
+  POSITION_MAP,
+  POSITION_TYPE,
+  getPlacementName,
+  setConnectedPositionOffset,
+  TOOLTIP_OFFSET_MAP
+} from 'ng-zorro-antd/core/overlay';
 import { NgClassInterface, NgStyleInterface, NzSafeAny, NzTSType } from 'ng-zorro-antd/core/types';
 import { isNotNil, toBoolean } from 'ng-zorro-antd/core/util';
 
@@ -381,7 +388,9 @@ export abstract class NzTooltipBaseComponent implements OnInit {
   protected _trigger: NzTooltipTrigger = 'hover';
 
   set nzPlacement(value: POSITION_TYPE[]) {
-    const preferredPosition = value.map(placement => POSITION_MAP[placement]);
+    const preferredPosition = value.map(placement =>
+      setConnectedPositionOffset(POSITION_MAP[placement], TOOLTIP_OFFSET_MAP[placement])
+    );
     this._positions = [...preferredPosition, ...DEFAULT_TOOLTIP_POSITIONS];
   }
 

--- a/components/tooltip/style/index.less
+++ b/components/tooltip/style/index.less
@@ -3,23 +3,16 @@
 
 @tooltip-prefix-cls: ~'@{ant-prefix}-tooltip';
 
-@tooltip-arrow-shadow-width: 3px;
-
-@tooltip-arrow-rotate-width: sqrt(@tooltip-arrow-width * @tooltip-arrow-width * 2) +
-  @tooltip-arrow-shadow-width * 2;
-
-@tooltip-arrow-offset-vertical: 5px; // 8 - 3px
-@tooltip-arrow-offset-horizontal: 13px; // 16 - 3px
-
 // Base class
 .@{tooltip-prefix-cls} {
   .reset-component();
+
+  --antd-arrow-background-color: @tooltip-bg;
 
   position: absolute;
   z-index: @zindex-tooltip;
   display: block;
   width: max-content;
-  width: intrinsic;
   max-width: @tooltip-max-width;
   visibility: visible;
 
@@ -31,37 +24,13 @@
     display: none;
   }
 
-  &-placement-top,
-  &-placement-topLeft,
-  &-placement-topRight {
-    padding-bottom: @tooltip-distance;
-  }
-
-  &-placement-right,
-  &-placement-rightTop,
-  &-placement-rightBottom {
-    padding-left: @tooltip-distance;
-  }
-
-  &-placement-bottom,
-  &-placement-bottomLeft,
-  &-placement-bottomRight {
-    padding-top: @tooltip-distance;
-  }
-
-  &-placement-left,
-  &-placement-leftTop,
-  &-placement-leftBottom {
-    padding-right: @tooltip-distance;
-  }
-
   // Wrapper for the tooltip content
   &-inner {
     min-width: 30px;
     min-height: 32px;
-    padding: 6px 8px;
+    padding: calc(@padding-sm / 2) @padding-xs;
     color: @tooltip-color;
-    text-align: left;
+    text-align: start;
     text-decoration: none;
     word-wrap: break-word;
     background-color: @tooltip-bg;
@@ -69,156 +38,26 @@
     box-shadow: @box-shadow-base;
   }
 
-  // Arrows
-  &-arrow {
-    position: absolute;
-    z-index: 2;
-    display: block;
-    width: @tooltip-arrow-rotate-width;
-    height: @tooltip-arrow-rotate-width;
-    overflow: hidden;
-    background: transparent;
-    pointer-events: none;
-
-    &-content {
-      // Use linear gradient to mix box shadow of tooltip inner
-      --antd-arrow-background-color: linear-gradient(
-        to right bottom,
-        fadeout(@tooltip-bg, 10%),
-        @tooltip-bg
-      );
-
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      display: block;
-      width: @tooltip-arrow-width;
-      height: @tooltip-arrow-width;
-      margin: auto;
-      content: '';
-      pointer-events: auto;
-      .roundedArrow(@tooltip-arrow-width, 5px);
-    }
-  }
-
-  &-placement-top &-arrow,
-  &-placement-topLeft &-arrow,
-  &-placement-topRight &-arrow {
-    bottom: 0;
-    transform: translateY(100%);
-
-    &-content {
-      box-shadow: @tooltip-arrow-shadow-width @tooltip-arrow-shadow-width 7px fade(@black, 7%);
-      transform: translateY((-@tooltip-arrow-rotate-width / 2)) rotate(45deg);
-    }
-  }
-
-  &-placement-top &-arrow {
-    left: 50%;
-    transform: translateY(100%) translateX(-50%);
-  }
-
-  &-placement-topLeft &-arrow {
-    left: @tooltip-arrow-offset-horizontal;
-  }
-
-  &-placement-topRight &-arrow {
-    right: @tooltip-arrow-offset-horizontal;
-  }
-
-  &-placement-right &-arrow,
-  &-placement-rightTop &-arrow,
-  &-placement-rightBottom &-arrow {
-    left: 0;
-    transform: translateX(-100%);
-
-    &-content {
-      box-shadow: -@tooltip-arrow-shadow-width @tooltip-arrow-shadow-width 7px fade(@black, 7%);
-      transform: translateX((@tooltip-arrow-rotate-width / 2)) rotate(135deg);
-    }
-  }
-
-  &-placement-right &-arrow {
-    top: 50%;
-    transform: translateX(-100%) translateY(-50%);
-  }
-
-  &-placement-rightTop &-arrow {
-    top: @tooltip-arrow-offset-vertical;
-  }
-
-  &-placement-rightBottom &-arrow {
-    bottom: @tooltip-arrow-offset-vertical;
-  }
-
-  &-placement-left &-arrow,
-  &-placement-leftTop &-arrow,
-  &-placement-leftBottom &-arrow {
-    right: 0;
-    transform: translateX(100%);
-
-    &-content {
-      box-shadow: @tooltip-arrow-shadow-width -@tooltip-arrow-shadow-width 7px fade(@black, 7%);
-      transform: translateX((-@tooltip-arrow-rotate-width / 2)) rotate(315deg);
-    }
-  }
-
-  &-placement-left &-arrow {
-    top: 50%;
-    transform: translateX(100%) translateY(-50%);
-  }
-
-  &-placement-leftTop &-arrow {
-    top: @tooltip-arrow-offset-vertical;
-  }
-
-  &-placement-leftBottom &-arrow {
-    bottom: @tooltip-arrow-offset-vertical;
-  }
-
-  &-placement-bottom &-arrow,
-  &-placement-bottomLeft &-arrow,
-  &-placement-bottomRight &-arrow {
-    top: 0;
-    transform: translateY(-100%);
-
-    &-content {
-      box-shadow: -@tooltip-arrow-shadow-width -@tooltip-arrow-shadow-width 7px fade(@black, 7%);
-      transform: translateY((@tooltip-arrow-rotate-width / 2)) rotate(225deg);
-    }
-  }
-
-  &-placement-bottom &-arrow {
-    left: 50%;
-    transform: translateY(-100%) translateX(-50%);
-  }
-
-  &-placement-bottomLeft &-arrow {
-    left: @tooltip-arrow-offset-horizontal;
-  }
-
-  &-placement-bottomRight &-arrow {
-    right: @tooltip-arrow-offset-horizontal;
-  }
+  // Arrow Style
+  .placementArrow(@tooltip-arrow-width, 4px, @arrow-border-radius, var(--antd-arrow-background-color), @popover-arrow-box-shadow);
 }
 
 .generator-tooltip-preset-color(@i: length(@preset-colors)) when (@i > 0) {
   .generator-tooltip-preset-color(@i - 1);
   @color: extract(@preset-colors, @i);
   @lightColor: '@{color}-6';
+
   .@{tooltip-prefix-cls}-@{color} {
     .@{tooltip-prefix-cls}-inner {
       background-color: @@lightColor;
     }
+
     .@{tooltip-prefix-cls}-arrow {
-      &-content::before {
-        background: @@lightColor;
-      }
+      --antd-arrow-background-color: @@lightColor;
     }
   }
 }
+
 .generator-tooltip-preset-color();
 
 @import './rtl';

--- a/components/tooltip/style/rtl.less
+++ b/components/tooltip/style/rtl.less
@@ -5,10 +5,4 @@
   &-rtl {
     direction: rtl;
   }
-  // Wrapper for the tooltip content
-  &-inner {
-    .@{tooltip-prefix-cls}-rtl & {
-      text-align: right;
-    }
-  }
 }

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -79,6 +79,7 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
   exportAs: 'nzTooltipComponent',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
+  // todo: currently the animation will cause small shake for the arrow (< 1px) when the tooltip is shown
   animations: [zoomBigMotion],
   template: `
     <ng-template
@@ -103,10 +104,8 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
         [nzNoAnimation]="noAnimation?.nzNoAnimation"
         [@zoomBigMotion]="'active'"
       >
+        <div class="ant-tooltip-arrow" [style]="_arrowStyleMap"></div>
         <div class="ant-tooltip-content">
-          <div class="ant-tooltip-arrow">
-            <span class="ant-tooltip-arrow-content" [style]="_contentStyleMap"></span>
-          </div>
           <div class="ant-tooltip-inner" [style]="_contentStyleMap">
             <ng-container *nzStringTemplateOutlet="nzTitle; context: nzTitleContext">{{ nzTitle }}</ng-container>
           </div>
@@ -122,7 +121,8 @@ export class NzTooltipComponent extends NzTooltipBaseComponent {
 
   nzColor?: string | NzPresetColor;
 
-  _contentStyleMap: NgStyleInterface = {};
+  protected _arrowStyleMap: NgStyleInterface = {};
+  protected _contentStyleMap: NgStyleInterface = {};
 
   protected isEmpty(): boolean {
     return isTooltipEmpty(this.nzTitle);
@@ -138,8 +138,11 @@ export class NzTooltipComponent extends NzTooltipBaseComponent {
     };
 
     this._contentStyleMap = {
-      backgroundColor: !!this.nzColor && !isColorPreset ? this.nzColor : null,
-      '--antd-arrow-background-color': this.nzColor
+      backgroundColor: !!this.nzColor && !isColorPreset ? this.nzColor : null
+    };
+
+    this._arrowStyleMap = {
+      '--antd-arrow-background-color': !!this.nzColor && !isColorPreset ? this.nzColor : null
     };
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The new arrow works well, take a look on the following screenshots:

### Tooltip

<img width="254" height="95" alt="image" src="https://github.com/user-attachments/assets/5056075c-0eec-4465-8a91-f87cfb872b03" />

<img width="487" height="218" alt="image" src="https://github.com/user-attachments/assets/4dffa0ae-a9fa-450a-b96e-2a4453ebd2f5" />

> By the way, why `RB` but the arrow points to the rightTop, I think this is a bug.

<img width="510" height="310" alt="image" src="https://github.com/user-attachments/assets/897f562f-f809-47ca-84d5-edf6a3c94062" />

### Popover

<img width="538" height="224" alt="image" src="https://github.com/user-attachments/assets/e844826b-c8ab-4057-91a5-2f09e002c2a9" />

### Dropdown

<img width="597" height="324" alt="image" src="https://github.com/user-attachments/assets/ad9a682b-e99b-4f3e-aaa8-5f417095dc7b" />

### DatePicker

![Uploading image.png…]()


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

#9324 depends on this, and this PR can solve the related issue in #9333
