### PR TITLE
feat(module:core): support `withConfigFactory` for `input` properties

### DIFF
--- a/components/core/config/config.spec.ts
+++ b/components/core/config/config.spec.ts
@@ -3,114 +3,206 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Component, DebugElement, inject } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
+import { Component, ElementRef, inject, input, Input, inputBinding, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 
-import { NzButtonComponent, NzButtonModule, NzButtonSize } from 'ng-zorro-antd/button';
+import { NzButtonSize } from 'ng-zorro-antd/button';
 
-import { provideNzConfig } from './config';
-import { NzConfigService } from './config.service';
+import { NzConfigKey, provideNzConfig } from './config';
+import { NzConfigService, withConfigFactory, WithConfig } from './config.service';
+
+const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'button';
+const withConfig = withConfigFactory(NZ_CONFIG_MODULE_NAME);
 
 @Component({
-  imports: [NzButtonModule],
-  template: `<button nz-button nzType="primary" [nzSize]="size">Global Config</button>`
+  selector: 'nz-with-config',
+  template: ``
 })
-export class NzGlobalConfigTestBasicComponent {
-  public nzConfigService = inject(NzConfigService);
-  size!: NzButtonSize;
+class NzWithConfigTestComponent {
+  readonly elementRef = inject(ElementRef);
+  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+
+  @Input() @WithConfig() nzSize: NzButtonSize = 'default';
+}
+
+@Component({
+  selector: 'nz-with-config-signal',
+  template: ``
+})
+class NzWithConfigSignalTestComponent {
+  readonly elementRef = inject(ElementRef);
+
+  readonly nzSize = input<NzButtonSize>('default');
+  readonly innerSize = withConfig('nzSize', this.nzSize);
 }
 
 describe('nz global config', () => {
-  let fixture: ComponentFixture<NzGlobalConfigTestBasicComponent>;
-  let testComponent: NzGlobalConfigTestBasicComponent;
-  let button: DebugElement;
-  let buttonEl: HTMLButtonElement;
+  const size = signal<NzButtonSize | undefined>(undefined);
 
-  describe('without config', () => {
-    beforeEach(() => {
-      fixture = TestBed.createComponent(NzGlobalConfigTestBasicComponent);
-      testComponent = fixture.debugElement.componentInstance;
-      button = fixture.debugElement.query(By.directive(NzButtonComponent));
-      buttonEl = button.nativeElement;
+  // resign to unassigned value
+  afterEach(() => {
+    size.set(undefined);
+  });
+
+  describe('@WithConfig', () => {
+    it('should render with in-component props', async () => {
+      const fixture = TestBed.createComponent(NzWithConfigTestComponent, {
+        bindings: [inputBinding('nzSize', size)]
+      });
+      const component = fixture.debugElement.componentInstance as NzWithConfigTestComponent;
+      await fixture.whenStable();
+
+      fixture.detectChanges();
+      expect(component.nzSize).toBe('default');
+
+      size.set('large');
+      fixture.detectChanges();
+      expect(component.nzSize).toBe('large');
     });
 
-    it('should render with in-component props', () => {
-      fixture.detectChanges();
-      expect(buttonEl.className).toContain('ant-btn ant-btn-primary');
+    describe('with config', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          providers: [
+            provideNzConfig({
+              button: {
+                nzSize: 'large'
+              }
+            })
+          ]
+        });
+      });
 
-      testComponent.size = 'large';
-      fixture.detectChanges();
-      expect(buttonEl.classList).toContain('ant-btn-lg');
+      it('should static config work', async () => {
+        const fixture = TestBed.createComponent(NzWithConfigTestComponent, {
+          bindings: [inputBinding('nzSize', size)]
+        });
+        const component = fixture.debugElement.componentInstance as NzWithConfigTestComponent;
+        await fixture.whenStable();
+
+        fixture.detectChanges();
+        expect(component.nzSize).toBe('large');
+
+        size.set('default');
+        fixture.detectChanges();
+        expect(component.nzSize).toBe('default');
+      });
+
+      it('should dynamic config work', async () => {
+        const fixture = TestBed.createComponent(NzWithConfigTestComponent, {
+          bindings: [inputBinding('nzSize', size)]
+        });
+        const component = fixture.debugElement.componentInstance as NzWithConfigTestComponent;
+        const nzConfigService = TestBed.inject(NzConfigService);
+        await fixture.whenStable();
+
+        fixture.detectChanges();
+        expect(component.nzSize).toBe('large');
+
+        nzConfigService.set('button', { nzSize: 'small' });
+        fixture.detectChanges();
+        expect(component.nzSize).toBe('small');
+
+        size.set('default');
+        fixture.detectChanges();
+        expect(component.nzSize).toBe('default');
+      });
     });
   });
 
-  describe('with config', () => {
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          provideNzConfig({
-            button: {
-              nzSize: 'large'
-            }
-          })
-        ]
+  describe('withConfig signal', () => {
+    it('should render with in-component props', async () => {
+      const fixture = TestBed.createComponent(NzWithConfigSignalTestComponent, {
+        bindings: [inputBinding('nzSize', size)]
       });
-    }));
+      const component = fixture.debugElement.componentInstance as NzWithConfigSignalTestComponent;
+      await fixture.whenStable();
+
+      fixture.detectChanges();
+      expect(component.nzSize()).toBeUndefined();
+      expect(component.innerSize()).toBe('default');
+
+      size.set('large');
+      fixture.detectChanges();
+      expect(component.nzSize()).toBe('large');
+      expect(component.innerSize()).toBe('large');
+    });
+
+    describe('with config', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          providers: [
+            provideNzConfig({
+              button: {
+                nzSize: 'large'
+              }
+            })
+          ]
+        });
+      });
+
+      it('should static config work', async () => {
+        const fixture = TestBed.createComponent(NzWithConfigSignalTestComponent, {
+          bindings: [inputBinding('nzSize', size)]
+        });
+        const component = fixture.debugElement.componentInstance as NzWithConfigSignalTestComponent;
+        await fixture.whenStable();
+
+        fixture.detectChanges();
+        expect(component.nzSize()).toBeUndefined();
+        expect(component.innerSize()).toBe('large');
+
+        size.set('default');
+        fixture.detectChanges();
+        expect(component.nzSize()).toBe('default');
+        expect(component.innerSize()).toBe('default');
+      });
+
+      it('should dynamic config work', async () => {
+        const fixture = TestBed.createComponent(NzWithConfigSignalTestComponent, {
+          bindings: [inputBinding('nzSize', size)]
+        });
+        const component = fixture.debugElement.componentInstance as NzWithConfigSignalTestComponent;
+        const nzConfigService = TestBed.inject(NzConfigService);
+        await fixture.whenStable();
+
+        fixture.detectChanges();
+        expect(component.nzSize()).toBeUndefined();
+        expect(component.innerSize()).toBe('large');
+
+        nzConfigService.set('button', { nzSize: 'small' });
+        fixture.detectChanges();
+        expect(component.nzSize()).toBeUndefined();
+        expect(component.innerSize()).toBe('small');
+
+        size.set('default');
+        fixture.detectChanges();
+        expect(component.nzSize()).toBe('default');
+        expect(component.innerSize()).toBe('default');
+      });
+    });
+  });
+
+  describe('theme config', () => {
+    let nzConfigService: NzConfigService;
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(NzGlobalConfigTestBasicComponent);
-      testComponent = fixture.debugElement.componentInstance;
-      button = fixture.debugElement.query(By.directive(NzButtonComponent));
-      buttonEl = button.nativeElement;
+      nzConfigService = TestBed.inject(NzConfigService);
     });
 
-    it('should static config work', () => {
-      fixture.detectChanges();
-      expect(buttonEl.classList).toContain('ant-btn-lg');
-
-      testComponent.size = 'default';
-      fixture.detectChanges();
-      expect(buttonEl.classList).not.toContain('ant-btn-lg');
-    });
-
-    it('should dynamic config work', () => {
-      fixture.detectChanges();
-      expect(buttonEl.classList).toContain('ant-btn-lg');
-
-      testComponent.nzConfigService.set('button', { nzSize: 'small' });
-      fixture.detectChanges();
-      expect(buttonEl.classList).toContain('ant-btn-sm');
-
-      testComponent.size = 'default';
-      fixture.detectChanges();
-      expect(buttonEl.classList).not.toContain('ant-btn-lg');
-      expect(buttonEl.classList).not.toContain('ant-btn-sm');
-    });
+    function getComputedStylePropertyValue(property: string): string {
+      return getComputedStyle(document.documentElement).getPropertyValue(property).trim();
+    }
 
     it('should dynamic theme colors config work', () => {
-      fixture.detectChanges();
-      testComponent.nzConfigService.set('theme', { primaryColor: '#0000FF' });
-      fixture.detectChanges();
-      expect(getComputedStyle(document.documentElement).getPropertyValue('--ant-primary-color').trim()).toEqual(
-        'rgb(0, 0, 255)'
-      );
+      nzConfigService.set('theme', { primaryColor: '#0000FF' });
+      expect(getComputedStylePropertyValue('--ant-primary-color')).toEqual('rgb(0, 0, 255)');
     });
 
     it('should dynamic theme colors config with custom prefix work', () => {
-      fixture.detectChanges();
-      testComponent.nzConfigService.set('prefixCls', { prefixCls: 'custom-variable' });
-      testComponent.nzConfigService.set('theme', { primaryColor: '#0000FF' });
-      fixture.detectChanges();
-      expect(
-        getComputedStyle(document.documentElement).getPropertyValue('--custom-variable-primary-color').trim()
-      ).toEqual('rgb(0, 0, 255)');
+      nzConfigService.set('prefixCls', { prefixCls: 'custom-variable' });
+      nzConfigService.set('theme', { primaryColor: '#0000FF' });
+      expect(getComputedStylePropertyValue('--custom-variable-primary-color')).toEqual('rgb(0, 0, 255)');
     });
-
-    // It would fail silently. User cannot input a component name wrong - TypeScript comes to help!
-    // it('should raise error when the component with given name is not defined', () => {
-    //   expect(() => {
-    //   }).toThrowError();
-    // });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

`@WithConfig` have been widely used to decorate on `@Input` properties, but it is not compatible with the `input` properties.

In this PR, we introduce a new `withConfigFactory` function, which can be used to generate a `withConfig` function, and its logic is same with `@WithConfig`.

### Usage Example

Firstly you should create a `withConfig` function with the factory and specific a `_nzModuleName`.

Then, add `input` property (or transform from the previous `@Input` property).

The last step is to declare a inner (**private** or **protected**) state with the `withConfig` function.

```ts
const withConfig = withConfigFactory('button');

class ExampleComponent {
  readonly nzSize = input<NzButtonSize>('default');
  protected readonly size = withConfig('nzSize', this.nzSize);
}
```

**The `size` property carries the latest value merged from the user inputs and the global config, we should use it instead of `nzSize` in the component logic.**
 If the `nzSize` property is not assigned by user, it will try to load the latest global config and apply to `size`. If the `nzSize` is assigned or changed by user, it wll also apply to `size`. 


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
