### PR TITLE
fix(module:tree): read initial state of nzNodes

### DIFF
--- a/components/core/tree/nz-tree-base.service.ts
+++ b/components/core/tree/nz-tree-base.service.ts
@@ -37,11 +37,11 @@ export class NzTreeBaseService {
    */
   initTree(nzNodes: NzTreeNode[]): void {
     this.rootNodes = nzNodes;
-    this.expandedNodeList = [];
-    this.selectedNodeList = [];
-    this.halfCheckedNodeList = [];
-    this.checkedNodeList = [];
-    this.matchedNodeList = [];
+    this.expandedNodeList = nzNodes == null ? [] : nzNodes.filter(n => n.isExpanded);
+    this.selectedNodeList = nzNodes == null ? [] : nzNodes.filter(n => n.isSelected);
+    this.halfCheckedNodeList = nzNodes == null ? [] : nzNodes.filter(n => n.isHalfChecked);
+    this.checkedNodeList = nzNodes == null ? [] : nzNodes.filter(n => n.isChecked);
+    this.matchedNodeList = nzNodes == null ? [] : nzNodes.filter(n => n.isMatched);
   }
 
   flattenTreeData(nzNodes: NzTreeNode[], expandedKeys: NzTreeNodeKey[] | true = []): void {

--- a/components/core/tree/nz-tree-base.service.ts
+++ b/components/core/tree/nz-tree-base.service.ts
@@ -43,9 +43,10 @@ export class NzTreeBaseService {
     this.rootNodes = nzNodes;
     this.expandedNodeList = this.filterNodesRecursively(nzNodes, 'isExpanded');
     this.selectedNodeList = this.filterNodesRecursively(nzNodes, 'isSelected');
-    this.halfCheckedNodeList = this.filterNodesRecursively(nzNodes, 'isHalfChecked');
     this.checkedNodeList = this.filterNodesRecursively(nzNodes, 'isChecked');
-    this.matchedNodeList = this.filterNodesRecursively(nzNodes, 'isMatched');
+    this.halfCheckedNodeList = [];
+    this.refreshCheckState(this.isCheckStrictly); // set halfCheckedNodeList
+    this.matchedNodeList = [];
   }
 
   flattenTreeData(nzNodes: NzTreeNode[], expandedKeys: NzTreeNodeKey[] | true = []): void {

--- a/components/tree/tree.spec.ts
+++ b/components/tree/tree.spec.ts
@@ -61,6 +61,19 @@ describe('tree', () => {
         expect(component.treeComponent.getExpandedNodeList().length).toEqual(1);
       }));
 
+      it('should expand the specified node based on "expanded" property', fakeAsync(() => {
+        const nodes: NzTreeNodeOptions[] = structuredClone(component.nodes);
+        nodes.find(n => n.key === '0-1')!.expanded = true;
+        component.nodes = nodes;
+        fixture.detectChanges();
+        const shownNodes = nativeElement.querySelectorAll('nz-tree-node[builtin]');
+        expect(shownNodes.length).toEqual(4);
+        tick(300);
+        fixture.detectChanges();
+        // leaf node should not be included
+        expect(component.treeComponent.getExpandedNodeList().length).toEqual(1);
+      }));
+
       it('should expand all nodes while setting nzExpandAll', fakeAsync(() => {
         component.expandAll = true;
         fixture.detectChanges();
@@ -75,6 +88,25 @@ describe('tree', () => {
       it('should render checkbox state of nodes based on nzCheckedKeys', fakeAsync(() => {
         component.expandAll = true; // Just for testing the selected state
         component.defaultCheckedKeys = ['0-0-0', '0-0-1'];
+        fixture.detectChanges();
+        const checkedNodes = nativeElement.querySelectorAll('.ant-tree-checkbox-checked');
+        const halfCheckedNodes = nativeElement.querySelectorAll('.ant-tree-checkbox-indeterminate');
+        expect(checkedNodes.length).toEqual(2);
+        expect(halfCheckedNodes.length).toEqual(1);
+        tick(300);
+        fixture.detectChanges();
+        expect(component.treeComponent.getCheckedNodeList().length).toEqual(2);
+        expect(component.treeComponent.getHalfCheckedNodeList().length).toEqual(1);
+      }));
+
+      it('should render checkbox state of nodes based on "checked" property', fakeAsync(() => {
+        component.expandAll = true; // Just for testing the selected state
+        const nodes: NzTreeNodeOptions[] = structuredClone(component.nodes);
+        nodes
+          .find(n => n.key === '0-0')!
+          .children!.filter(n => ['0-0-0', '0-0-1'].includes(n.key))
+          .forEach(n => (n.checked = true));
+        component.nodes = nodes;
         fixture.detectChanges();
         const checkedNodes = nativeElement.querySelectorAll('.ant-tree-checkbox-checked');
         const halfCheckedNodes = nativeElement.querySelectorAll('.ant-tree-checkbox-indeterminate');
@@ -101,8 +133,41 @@ describe('tree', () => {
         expect(component.treeComponent.getHalfCheckedNodeList().length).toEqual(0);
       }));
 
+      it('node check should not affect other nodes based on nzCheckStrictly (using "checked" property)', fakeAsync(() => {
+        component.expandAll = true;
+        component.checkStrictly = true;
+        const nodes: NzTreeNodeOptions[] = structuredClone(component.nodes);
+        nodes
+          .find(n => n.key === '0-0')!
+          .children!.filter(n => ['0-0-0', '0-0-1'].includes(n.key))
+          .forEach(n => (n.checked = true));
+        component.nodes = nodes;
+        fixture.detectChanges();
+        const checkedNodes = nativeElement.querySelectorAll('.ant-tree-checkbox-checked');
+        const halfCheckedNodes = nativeElement.querySelectorAll('.ant-tree-checkbox-indeterminate');
+        expect(checkedNodes.length).toEqual(2);
+        expect(halfCheckedNodes.length).toEqual(0);
+        tick(300);
+        fixture.detectChanges();
+        expect(component.treeComponent.getCheckedNodeList().length).toEqual(2);
+        expect(component.treeComponent.getHalfCheckedNodeList().length).toEqual(0);
+      }));
+
       it('should select nodes based on nzSelectedKeys', fakeAsync(() => {
         component.defaultSelectedKeys = ['0-0', '0-1'];
+        fixture.detectChanges();
+        // nzMultiple is true
+        const selectedNodes = nativeElement.querySelectorAll('.ant-tree-node-selected');
+        expect(selectedNodes.length).toEqual(2);
+        tick(300);
+        fixture.detectChanges();
+        expect(component.treeComponent.getSelectedNodeList().length).toEqual(2);
+      }));
+
+      it('should select nodes based on "selected" property', fakeAsync(() => {
+        const nodes: NzTreeNodeOptions[] = structuredClone(component.nodes);
+        nodes.filter(n => ['0-0', '0-1'].includes(n.key)).forEach(n => (n.selected = true));
+        component.nodes = nodes;
         fixture.detectChanges();
         // nzMultiple is true
         const selectedNodes = nativeElement.querySelectorAll('.ant-tree-node-selected');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Node state (`isExpanded`, `isSelected`, `isChecked`, `isHalfChecked`, `isMatched`) is ignored when updating nodes/loading children

Issue Number: N/A

## What is the new behavior?
Node state is correctly set and thus represented on the UI

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
