### PR TITLE
feat(module:i18n): enhance provideNzI18n to support factory function

### DIFF
--- a/components/i18n/nz-i18n.service.spec.ts
+++ b/components/i18n/nz-i18n.service.spec.ts
@@ -4,15 +4,12 @@
  */
 
 import { Component, inject, OnDestroy } from '@angular/core';
-import { ComponentFixture, TestBed, inject as testingInject } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subscription } from 'rxjs';
 
 import { NZ_I18N, provideNzI18n } from 'ng-zorro-antd/i18n/nz-i18n.token';
 
-import cs_CZ from './languages/cs_CZ';
-import de_DE from './languages/de_DE';
 import en_US from './languages/en_US';
-import ka_GE from './languages/ka_GE';
 import zh_CN from './languages/zh_CN';
 import { NzI18nInterface } from './nz-i18n.interface';
 import { NzI18nService } from './nz-i18n.service';
@@ -23,30 +20,15 @@ describe('i18n service', () => {
   let testComponent: NzI18nTestComponent;
   const DEFAULT_LAN = zh_CN;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideNzI18n(DEFAULT_LAN)]
-    });
-  });
-
   describe('#setLocale', () => {
     beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideNzI18n(DEFAULT_LAN)]
+      });
+
       fixture = TestBed.createComponent(NzI18nTestComponent);
       testComponent = fixture.debugElement.componentInstance;
-    });
-
-    beforeEach(
-      testingInject([NzI18nService], (s: NzI18nService) => {
-        srv = s;
-      })
-    );
-
-    it('should interface be right', () => {
-      const i18nEN: NzI18nInterface = en_US;
-      const i18nDE: NzI18nInterface = de_DE;
-      const i18nCS: NzI18nInterface = cs_CZ;
-      const i18nKA: NzI18nInterface = ka_GE;
-      console.log(i18nEN, i18nDE, i18nCS, i18nKA);
+      srv = TestBed.inject(NzI18nService);
     });
 
     it('should be provide interface be right', () => {
@@ -83,6 +65,22 @@ You can use "NzI18nService.setLocale" as a temporary fix.
 Welcome to submit a pull request to help us optimize the translations!
 https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md`
       );
+    });
+  });
+
+  describe('provideNzI18n', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideNzI18n(() => en_US)]
+      });
+
+      fixture = TestBed.createComponent(NzI18nTestComponent);
+      testComponent = fixture.debugElement.componentInstance;
+      srv = TestBed.inject(NzI18nService);
+    });
+
+    it('should factory work', () => {
+      expect(testComponent.locale.locale).toBe(en_US.locale);
     });
   });
 });

--- a/components/i18n/nz-i18n.token.ts
+++ b/components/i18n/nz-i18n.token.ts
@@ -9,8 +9,17 @@ import { DateLocale, NzI18nInterface } from './nz-i18n.interface';
 
 export const NZ_I18N = new InjectionToken<NzI18nInterface>('nz-i18n');
 
-export function provideNzI18n(config: NzI18nInterface): EnvironmentProviders {
-  return makeEnvironmentProviders([{ provide: NZ_I18N, useValue: config }]);
+type FactoryLike<T> = T | (() => T);
+
+/**
+ * Set the locale globally.
+ */
+export function provideNzI18n(config: NzI18nInterface): EnvironmentProviders;
+export function provideNzI18n(factory: () => NzI18nInterface): EnvironmentProviders;
+export function provideNzI18n(config: FactoryLike<NzI18nInterface>): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    typeof config === 'function' ? { provide: NZ_I18N, useFactory: config } : { provide: NZ_I18N, useValue: config }
+  ]);
 }
 
 /** Locale for date operations, should import from date-fns, see example: https://github.com/date-fns/date-fns/blob/v1.30.1/src/locale/zh_cn/index.js */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The previous `provideNzI18n` API only supported passing a static locale object, which was not friendly for multilingual projects, which need to determine the locale dynamically, such as based on `LOCALE_ID`. This limitation made it difficult to implement flexible i18n strategies and dynamic language switching.

The developers have to fall back to the original Angular provider syntax:

```ts
// app.config.ts

// you cannot do tihs
provideNzIcon(inject(LOCALE_ID) === 'en' ? en_US : zh_CN);

// fallback to
{
    provide: NZ_I18N,
    useFactory: () => {
      const localeId = inject(LOCALE_ID);
      switch (localeId) {
        case 'en':
          return en_US;
        case 'zh':
          return zh_CN;
        default:
          return en_US;
      }
    }
}
```

## What is the new behavior?

This PR enhances `provideNzI18n` to support both static locale objects and factory functions. Developers can now provide a factory function to resolve the locale based on injection context.

```typescript
provideNzI18n(() => {
  const localeId = inject(LOCALE_ID);
  switch (localeId) {
    case 'en':
      return en_US;
    case 'zh':
      return zh_CN;
    default:
      return en_US;
  }
})
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
