### PR TITLE
feat(module:cascader): switch checked status of option by ENTER key

### DIFF
--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -1022,9 +1022,11 @@ export class NzCascaderComponent
     const columnIndex = Math.max(this.cascaderService.activatedNodes.length - 1, 0);
     const node = this.cascaderService.activatedNodes[columnIndex];
     if (node && !node.isDisabled) {
-      this.inSearchingMode
-        ? this.cascaderService.setSearchOptionSelected(node)
-        : this.cascaderService.setNodeActivated(node, columnIndex, true);
+      this.nzMultiple
+        ? this.onOptionCheck(node, columnIndex, true)
+        : this.inSearchingMode
+          ? this.cascaderService.setSearchOptionSelected(node)
+          : this.cascaderService.setNodeActivated(node, columnIndex, true);
     }
   }
 
@@ -1047,7 +1049,7 @@ export class NzCascaderComponent
         break;
       }
       const nextOption = options[nextIndex];
-      if (!nextOption || nextOption.isDisabled) {
+      if (!nextOption || nextOption.isDisabled || nextOption.isDisableCheckbox) {
         continue;
       }
       this.cascaderService.setNodeActivated(nextOption, columnIndex);
@@ -1069,7 +1071,7 @@ export class NzCascaderComponent
     const length = this.cascaderService.activatedNodes.length;
     const options = this.cascaderService.columns[length];
     if (options && options.length) {
-      const nextOpt = options.find(o => !o.isDisabled);
+      const nextOpt = options.find(o => !o.isDisabled && !o.isDisableCheckbox);
       if (nextOpt) {
         this.cascaderService.setNodeActivated(nextOpt, length);
       }

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -2034,6 +2034,71 @@ describe('cascader', () => {
       expect(testComponent.onChanges).toHaveBeenCalledWith([['light']]);
     }));
 
+    it('should support ENTER key to toggle option checked state in multiple mode', fakeAsync(() => {
+      cascader.componentInstance.setMenuVisible(true);
+      fixture.detectChanges();
+      tick(600);
+      fixture.detectChanges();
+      getItemAtColumnAndRow(1, 1)!.click();
+      fixture.detectChanges();
+      const optionEl = getItemAtColumnAndRow(2, 1)!;
+      const checkboxEl = getCheckboxAtColumnAndRow(2, 1)!;
+      // Initially, the option should not be checked
+      expect(checkboxEl.classList).not.toContain('ant-cascader-checkbox-checked');
+      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+      expect(optionEl.classList).toContain('ant-cascader-menu-item-active');
+      // Press ENTER to toggle the option checked state
+      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
+      fixture.detectChanges();
+      // The option should now be checked
+      expect(checkboxEl.classList).toContain('ant-cascader-checkbox-checked');
+      // Press ENTER again to toggle the option unchecked state
+      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
+      fixture.detectChanges();
+      // The option should now be unchecked
+      expect(checkboxEl.classList).not.toContain('ant-cascader-checkbox-checked');
+    }));
+
+    it('should not activate option with isDisableCheckbox by pressing RIGHT ARROW key', fakeAsync(() => {
+      cascader.componentInstance.setMenuVisible(true);
+      fixture.detectChanges();
+      tick(600);
+      fixture.detectChanges();
+      getItemAtColumnAndRow(1, 2)!.click();
+      fixture.detectChanges();
+      getItemAtColumnAndRow(2, 1)!.click();
+      fixture.detectChanges();
+      // Try to navigate to a disabled checkbox option using keyboard
+      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+      // The option with disableCheckbox should not be activatable via keyboard
+      expect(getItemAtColumnAndRow(3, 1)!.classList).not.toContain('ant-cascader-menu-item-active');
+      expect(getCheckboxAtColumnAndRow(3, 1)!.classList).toContain('ant-cascader-checkbox-disabled');
+      // activate item (3, 2)
+      expect(getItemAtColumnAndRow(3, 2)!.classList).toContain('ant-cascader-menu-item-active');
+      expect(getCheckboxAtColumnAndRow(3, 2)!.classList).not.toContain('ant-cascader-checkbox-disabled');
+    }));
+
+    it('should not activate option with isDisableCheckbox in moveUpOrDown method', fakeAsync(() => {
+      cascader.componentInstance.setMenuVisible(true);
+      fixture.detectChanges();
+      tick(600);
+      fixture.detectChanges();
+      getItemAtColumnAndRow(1, 2)!.click();
+      fixture.detectChanges();
+      getItemAtColumnAndRow(2, 1)!.click();
+      fixture.detectChanges();
+      getItemAtColumnAndRow(3, 2)!.click();
+      fixture.detectChanges();
+      expect(getItemAtColumnAndRow(3, 2)!.classList).toContain('ant-cascader-menu-item-active');
+      // Up key
+      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
+      // The option with disableCheckbox should not be activatable via keyboard
+      expect(getItemAtColumnAndRow(3, 1)!.classList).not.toContain('ant-cascader-menu-item-active');
+      expect(getItemAtColumnAndRow(3, 2)!.classList).toContain('ant-cascader-menu-item-active');
+    }));
+
     describe('should cascade work when the value of ngModel includes nodes that are not existed in options', () => {
       it('should remove item work', fakeAsync(() => {
         setValues(2);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

1、https://github.com/NG-ZORRO/ng-zorro-antd/pull/9448#discussion_r2403591550
2、If the current option is disabled, it should not support activating it through the Up, Down, Left, Right key.
<img width="459" height="272" alt="截屏2025-10-13 11 23 04" src="https://github.com/user-attachments/assets/0d12f141-c2f7-41f6-b6a2-c0f87190d533" />

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No