### PR TITLE
feat(module:segmented): add default name if `nzName` is not provided

### DIFF
--- a/components/segmented/segmented.component.ts
+++ b/components/segmented/segmented.component.ts
@@ -108,9 +108,9 @@ export class NzSegmentedComponent implements OnChanges, ControlValueAccessor {
   @Input() nzShape: 'default' | 'round' = 'default';
   @Input() @WithConfig() nzSize: NzSizeLDSType = 'default';
 
-  // todo: add a method to generate hash id for the segmented instance as default value of `nzName`
   /**
    * @description set the `name` attribute of the segmented item native `input[type="radio"]`
+   * @since 20.3.0
    */
   @Input() nzName?: string;
 
@@ -199,7 +199,7 @@ export class NzSegmentedComponent implements OnChanges, ControlValueAccessor {
   ngOnChanges(changes: SimpleChanges): void {
     const { nzName, nzOptions, nzDisabled } = changes;
     if (nzName) {
-      this.service.name.set(this.nzName || null);
+      this.service.setName(this.nzName);
     }
     if (nzOptions) {
       this.normalizedOptions = normalizeOptions(nzOptions.currentValue);

--- a/components/segmented/segmented.service.ts
+++ b/components/segmented/segmented.service.ts
@@ -4,18 +4,25 @@
  */
 
 import { AnimationEvent } from '@angular/animations';
-import { Injectable, OnDestroy, signal } from '@angular/core';
+import { _IdGenerator } from '@angular/cdk/a11y';
+import { inject, Injectable, OnDestroy, signal } from '@angular/core';
 import { ReplaySubject, Subject } from 'rxjs';
 
 @Injectable()
 export class NzSegmentedService implements OnDestroy {
-  readonly name = signal<string | null>(null);
+  private readonly defaultName = inject(_IdGenerator).getId('segmented_');
+
+  readonly name = signal<string | null>(this.defaultName);
   readonly selected$ = new ReplaySubject<string | number>(1);
   readonly activated$ = new ReplaySubject<HTMLElement>(1);
   readonly change$ = new Subject<string | number>();
   readonly disabled$ = new ReplaySubject<boolean>(1);
   readonly animationDone$ = new Subject<AnimationEvent>();
   readonly keydown$ = new Subject<KeyboardEvent>();
+
+  setName(name: string | null | undefined): void {
+    this.name.set(typeof name === 'undefined' ? this.defaultName : name);
+  }
 
   ngOnDestroy(): void {
     this.selected$.complete();

--- a/components/segmented/segmented.spec.ts
+++ b/components/segmented/segmented.spec.ts
@@ -590,6 +590,35 @@ describe('nz-segmented', () => {
       }));
     });
   });
+
+  describe('a11y', () => {
+    let fixture: ComponentFixture<NzSegmentedTestComponent>;
+    let component: NzSegmentedTestComponent;
+    let segmentedComponent: DebugElement;
+
+    function getSegmentedOptionByIndex(index: number): HTMLElement {
+      return segmentedComponent.nativeElement.querySelectorAll('.ant-segmented-item')[index];
+    }
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzSegmentedTestComponent);
+      component = fixture.componentInstance;
+      segmentedComponent = fixture.debugElement.query(By.directive(NzSegmentedComponent));
+      fixture.detectChanges();
+    });
+
+    it('should have default radio group name', () => {
+      const theFirstElement = getSegmentedOptionByIndex(0);
+      expect(theFirstElement.querySelector('input')?.getAttribute('name')?.startsWith('segmented_')).toBe(true);
+    });
+
+    it('should support custom radio group name', () => {
+      component.name = 'custom_name';
+      fixture.detectChanges();
+      const theFirstElement = getSegmentedOptionByIndex(0);
+      expect(theFirstElement.querySelector('input')?.getAttribute('name')).toBe('custom_name');
+    });
+  });
 });
 
 @Component({
@@ -602,6 +631,7 @@ describe('nz-segmented', () => {
       [nzBlock]="block"
       [nzVertical]="vertical"
       [nzShape]="shape"
+      [nzName]="name"
       (nzValueChange)="handleValueChange($event)"
     />
   `
@@ -613,6 +643,7 @@ export class NzSegmentedTestComponent {
   disabled = false;
   vertical = false;
   shape: 'default' | 'round' = 'default';
+  name?: string;
 
   handleValueChange(_e: string | number): void {
     // empty
@@ -655,7 +686,7 @@ export class NzSegmentedInReactiveFormTestComponent {
 
 @Component({
   imports: [FormsModule, NzSegmentedModule],
-  template: `<nz-segmented [nzOptions]="options" nzVertical (nzValueChange)="handleValueChange($event)" /> `
+  template: `<nz-segmented [nzOptions]="options" nzVertical (nzValueChange)="handleValueChange($event)" />`
 })
 export class NzSegmentedVerticalTestComponent {
   options: NzSegmentedOptions = [1, 2, 3];
@@ -667,7 +698,7 @@ export class NzSegmentedVerticalTestComponent {
 
 @Component({
   imports: [BidiModule, NzSegmentedModule],
-  template: `<nz-segmented [nzOptions]="options" dir="rtl" /> `
+  template: `<nz-segmented [nzOptions]="options" dir="rtl" />`
 })
 export class NzSegmentedRtlTestComponent {
   options: NzSegmentedOptions = [1, 2, 3];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Add default name to make sure that the radio group a11y works well even if `nzName` is not provided, which aligns with antd.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
