### PR TITLE
fix(module:input): fix input-group-wrapper-compact styles

### DIFF
--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -20,6 +20,8 @@
       display: inline-block;
       text-align: start;
       vertical-align: top; // https://github.com/ant-design/ant-design/issues/6403
+
+      .input-group-wrapper-compact(~'@{input-number-prefix-cls}');
     }
   }
 

--- a/components/input/style/index.less
+++ b/components/input/style/index.less
@@ -21,6 +21,8 @@
       width: 100%;
       text-align: start;
       vertical-align: top; // https://github.com/ant-design/ant-design/issues/6403
+
+      .input-group-wrapper-compact(~'@{input-prefix-cls}');
     }
   }
 

--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -457,6 +457,51 @@
   }
 }
 
+.input-group-wrapper-compact(@inputClass) {
+  // Fix the issue of using icons in Space Compact mode
+  // https://github.com/ant-design/ant-design/issues/42122
+  &:not(.@{inputClass}-compact-first-item):not(.@{inputClass}-compact-last-item).@{inputClass}-compact-item {
+    .@{inputClass},
+    .@{inputClass}-group-addon {
+      border-radius: 0,
+    }
+  }
+
+  &:not(.@{inputClass}-compact-last-item).@{inputClass}-compact-first-item {
+    .@{inputClass},
+    .@{inputClass}-group-addon {
+      border-start-end-radius: 0;
+      border-end-end-radius: 0;
+    }
+  }
+
+  &:not(.@{inputClass}-compact-first-item).@{inputClass}-compact-last-item {
+    .@{inputClass},
+    .@{inputClass}-group-addon {
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
+    }
+  }
+
+  // Fix the issue of input use show-count param in space compact mode
+  // https://github.com/ant-design/ant-design/issues/46872
+  &:not(.@{inputClass}-compact-last-item).@{inputClass}-compact-item {
+    .@{inputClass}-affix-wrapper {
+      border-start-end-radius: 0;
+      border-end-end-radius: 0;
+    }
+  }
+
+  // Fix the issue of input use `addonAfter` param in space compact mode
+  // https://github.com/ant-design/ant-design/issues/52483
+  &:not(.@{inputClass}-compact-first-item).@{inputClass}-compact-item {
+    .@{inputClass}-affix-wrapper {
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
+    }
+  }
+}
+
 .status-color(
   @prefix-cls: @input-prefix-cls;
   @text-color: @input-color;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

<img width="1218" height="570" alt="image" src="https://github.com/user-attachments/assets/d13df198-15e9-4811-94da-066b6041c638" />



## What is the new behavior?
<img width="1210" height="568" alt="image" src="https://github.com/user-attachments/assets/f7daeb93-f4cf-4d6e-af13-296d385a59e8" />

```html
<nz-space-compact>
  <nz-input-wrapper nzAddonBefore="before">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
  <nz-input-wrapper nzAddonBefore="before">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
  <nz-input-wrapper nzAddonBefore="before">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
</nz-space-compact>
<br />
<br />
<nz-space-compact>
  <nz-input-wrapper nzAddonAfter="after">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
  <nz-input-wrapper nzAddonAfter="after">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
  <nz-input-wrapper nzAddonAfter="after">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
</nz-space-compact>
<br />
<br />
<nz-space-compact>
  <nz-input-wrapper nzAddonBefore="before" nzAddonAfter="after">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
  <nz-input-wrapper nzAddonBefore="before" nzAddonAfter="after">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
  <nz-input-wrapper nzAddonBefore="before" nzAddonAfter="after">
    <input nz-input placeholder="input" />
  </nz-input-wrapper>
</nz-space-compact>
<br />
<br />
<nz-space-compact>
  <nz-input-number nzPlaceHolder="input number" nzAddonBefore="before" />
  <nz-input-number nzPlaceHolder="input number" nzAddonBefore="before" />
  <nz-input-number nzPlaceHolder="input number" nzAddonBefore="before" />
</nz-space-compact>
<br />
<br />
<nz-space-compact>
  <nz-input-number nzPlaceHolder="input number" nzAddonAfter="after" />
  <nz-input-number nzPlaceHolder="input number" nzAddonAfter="after" />
  <nz-input-number nzPlaceHolder="input number" nzAddonAfter="after" />
</nz-space-compact>
<br />
<br />
<nz-space-compact>
  <nz-input-number nzPlaceHolder="input number" nzAddonBefore="before" nzAddonAfter="after" />
  <nz-input-number nzPlaceHolder="input number" nzAddonBefore="before" nzAddonAfter="after" />
  <nz-input-number nzPlaceHolder="input number" nzAddonBefore="before" nzAddonAfter="after" />
</nz-space-compact>

```

Patch style from: https://github.com/ant-design/ant-design/blob/dc179c8985ff905aa659e37ebe947d42de1305c4/components/input/style/index.ts#L612-L650

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
