### PR TITLE
fix(module:badge): hex `nzColor` should work

### DIFF
--- a/components/badge/badge.component.ts
+++ b/components/badge/badge.component.ts
@@ -55,11 +55,11 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'badge';
           [nzOffset]="nzOffset"
           [nzSize]="nzSize"
           [nzTitle]="nzTitle"
-          [nzStyle]="nzStyle"
+          [nzStyle]="mergedStyle"
           [nzDot]="nzDot"
           [nzCount]="nzCount"
           [nzOverflowCount]="nzOverflowCount"
-          [disableAnimation]="!!(nzStandalone || nzStatus || nzColor || noAnimation?.nzNoAnimation)"
+          [disableAnimation]="!!(nzStandalone || nzStatus || presetColor || noAnimation?.nzNoAnimation)"
           [noAnimation]="!!noAnimation?.nzNoAnimation"
         />
       }

--- a/components/badge/badge.spec.ts
+++ b/components/badge/badge.spec.ts
@@ -3,19 +3,20 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { BidiModule, Dir, Direction } from '@angular/cdk/bidi';
-import { Component, DebugElement, ViewChild } from '@angular/core';
+import { BidiModule, Direction } from '@angular/cdk/bidi';
+import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
-import { badgePresetColors } from 'ng-zorro-antd/badge/preset-colors';
-import { NzRibbonComponent } from 'ng-zorro-antd/badge/ribbon.component';
 import { NzNoAnimationDirective } from 'ng-zorro-antd/core/no-animation';
 import { NgStyleInterface, NzSizeDSType } from 'ng-zorro-antd/core/types';
 
 import { NzBadgeComponent } from './badge.component';
 import { NzBadgeModule } from './badge.module';
+import { badgePresetColors } from './preset-colors';
+import { NzRibbonComponent } from './ribbon.component';
+import { NzBadgeStatusType } from './types';
 
 describe('nz-badge', () => {
   beforeEach(() => {
@@ -242,8 +243,22 @@ describe('nz-badge', () => {
       expect(badgeElement.nativeElement.querySelector('.ant-badge-status-text')).toBeNull();
     }));
 
+    it('should hex nzColor work', () => {
+      testComponent.count = 0;
+      testComponent.color = '#f5222d';
+      fixture.detectChanges();
+      expect(badgeElement.nativeElement.querySelector('.ant-badge-status-dot').style.backgroundColor).toBe(
+        'rgb(245, 34, 45)'
+      );
+
+      testComponent.count = 5;
+      fixture.detectChanges();
+      expect(badgeElement.nativeElement.querySelector('nz-badge-sup').style.backgroundColor).toBe('rgb(245, 34, 45)');
+    });
+
     it('should nzStyle work even if nzColor is not provided', () => {
       testComponent.color = undefined;
+      testComponent.status = 'success'; // must set nzStatus to make sure status dot is rendered
       testComponent.style = { backgroundColor: '#52c41a' };
       fixture.detectChanges();
       expect(badgeElement.nativeElement.querySelector('nz-badge-sup').style.backgroundColor).toBe('rgb(82, 196, 26)');
@@ -345,7 +360,7 @@ export class NzTestBadgeBasicComponent {
   standalone = false;
   overflow = 20;
   showZero = false;
-  status!: string;
+  status!: NzBadgeStatusType | string;
   style!: NgStyleInterface;
   text!: string;
   title?: string | null;
@@ -364,7 +379,6 @@ export class NzTestBadgeBasicComponent {
   `
 })
 export class NzTestBadgeRtlComponent {
-  @ViewChild(Dir) dir!: Dir;
   direction: Direction = 'rtl';
   count = 5;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fix #9509

## What is the new behavior?

```html
<nz-badge [nzCount]="5" nzColor="#ccc">
  <a class="head-example"></a>
</nz-badge>
```
<img width="79" height="79" alt="image" src="https://github.com/user-attachments/assets/d4db2b3f-27c8-4d07-b958-efcd663dddcc" />

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
