### PR TITLE
fix(module:color-picker): fix NG01350 error

### DIFF
--- a/components/color-picker/color-format.component.ts
+++ b/components/color-picker/color-format.component.ts
@@ -41,9 +41,9 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [ReactiveFormsModule, NzSelectModule, NzInputModule, NzInputNumberModule],
   template: `
-    <div [formGroup]="validateForm" class="ant-color-picker-input-container">
+    <div class="ant-color-picker-input-container">
       <div class="ant-color-picker-format-select">
-        <nz-select formControlName="isFormat" nzBorderless nzSize="small">
+        <nz-select [formControl]="validateForm.controls.isFormat" nzBorderless nzSize="small">
           <nz-option nzValue="hex" nzLabel="HEX" />
           <nz-option nzValue="hsb" nzLabel="HSB" />
           <nz-option nzValue="rgb" nzLabel="RGB" />
@@ -55,7 +55,7 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
           @case ('hex') {
             <div class="ant-color-picker-hex-input">
               <nz-input-wrapper nzPrefix="#">
-                <input nz-input nzSize="small" formControlName="hex" />
+                <input nz-input nzSize="small" [formControl]="validateForm.controls.hex" />
               </nz-input-wrapper>
             </div>
           }
@@ -63,7 +63,7 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
             <div class="ant-color-picker-hsb-input">
               <div class="ant-color-picker-steppers ant-color-picker-hsb-input">
                 <nz-input-number
-                  formControlName="hsbH"
+                  [formControl]="validateForm.controls.hsbH"
                   [nzMin]="0"
                   [nzMax]="360"
                   [nzStep]="1"
@@ -73,7 +73,7 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
               </div>
               <div class="ant-color-picker-steppers ant-color-picker-hsb-input">
                 <nz-input-number
-                  formControlName="hsbS"
+                  [formControl]="validateForm.controls.hsbS"
                   [nzMin]="0"
                   [nzMax]="100"
                   [nzStep]="1"
@@ -84,7 +84,7 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
               </div>
               <div class="ant-color-picker-steppers ant-color-picker-hsb-input">
                 <nz-input-number
-                  formControlName="hsbB"
+                  [formControl]="validateForm.controls.hsbB"
                   [nzMin]="0"
                   [nzMax]="100"
                   [nzStep]="1"
@@ -98,13 +98,31 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
           @default {
             <div class="ant-color-picker-rgb-input">
               <div class="ant-color-picker-steppers ant-color-picker-rgb-input">
-                <nz-input-number formControlName="rgbR" [nzMin]="0" [nzMax]="255" [nzStep]="1" nzSize="small" />
+                <nz-input-number
+                  [formControl]="validateForm.controls.rgbR"
+                  [nzMin]="0"
+                  [nzMax]="255"
+                  [nzStep]="1"
+                  nzSize="small"
+                />
               </div>
               <div class="ant-color-picker-steppers ant-color-picker-rgb-input">
-                <nz-input-number formControlName="rgbG" [nzMin]="0" [nzMax]="255" [nzStep]="1" nzSize="small" />
+                <nz-input-number
+                  [formControl]="validateForm.controls.rgbG"
+                  [nzMin]="0"
+                  [nzMax]="255"
+                  [nzStep]="1"
+                  nzSize="small"
+                />
               </div>
               <div class="ant-color-picker-steppers ant-color-picker-rgb-input">
-                <nz-input-number formControlName="rgbB" [nzMin]="0" [nzMax]="255" [nzStep]="1" nzSize="small" />
+                <nz-input-number
+                  [formControl]="validateForm.controls.rgbB"
+                  [nzMin]="0"
+                  [nzMax]="255"
+                  [nzStep]="1"
+                  nzSize="small"
+                />
               </div>
             </div>
           }
@@ -114,7 +132,7 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
       @if (!nzDisabledAlpha) {
         <div class="ant-color-picker-steppers ant-color-picker-alpha-input">
           <nz-input-number
-            formControlName="roundA"
+            [formControl]="validateForm.controls.roundA"
             [nzMin]="0"
             [nzMax]="100"
             [nzStep]="1"
@@ -137,18 +155,6 @@ export class NzColorFormatComponent implements OnChanges, OnInit {
   @Output() readonly formatChange = new EventEmitter<{ color: string; format: NzColorPickerFormatType }>();
   @Output() readonly nzOnFormatChange = new EventEmitter<NzColorPickerFormatType>();
 
-  validatorFn(): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
-      const REGEXP = /^[0-9a-fA-F]{6}$/;
-      if (!control.value) {
-        return { error: true };
-      } else if (!REGEXP.test(control.value)) {
-        return { error: true };
-      }
-      return null;
-    };
-  }
-
   validateForm: FormGroup<{
     isFormat: FormControl<NzColorPickerFormatType | null>;
     hex: FormControl<string | null>;
@@ -161,7 +167,7 @@ export class NzColorFormatComponent implements OnChanges, OnInit {
     roundA: FormControl<number>;
   }> = this.formBuilder.nonNullable.group({
     isFormat: this.formBuilder.control<NzColorPickerFormatType>('hex'),
-    hex: this.formBuilder.control<string>('1677FF', this.validatorFn()),
+    hex: this.formBuilder.control<string>('1677FF', hexValidator),
     hsbH: 215,
     hsbS: 91,
     hsbB: 100,
@@ -251,3 +257,13 @@ export class NzColorFormatComponent implements OnChanges, OnInit {
     }
   }
 }
+
+const hexValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+  const REGEXP = /^[0-9a-fA-F]{6}$/;
+  if (!control.value) {
+    return { error: true };
+  } else if (!REGEXP.test(control.value)) {
+    return { error: true };
+  }
+  return null;
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

https://stackblitz.com/edit/lsu41tha?file=src%2Fapp%2Fapp.ts

color-picker 在 ng-template 中使用 ngTemplateOutletInjector 时，会报错：

```
ERROR RuntimeError: NG01350: 
    ngModel cannot be used to register form controls with a parent formGroup directive.  Try using
    formGroup's partner directive "formControlName" instead.  Example:

    
  <div [formGroup]="myGroup">
    <input formControlName="firstName">
  </div>

  In your class:

  this.myGroup = new FormGroup({
      firstName: new FormControl()
  });

    Or, if you'd like to avoid registering this form control, indicate that it's standalone in ngModelOptions:

    Example:

    
  <div [formGroup]="myGroup">
      <input formControlName="firstName">
      <input [(ngModel)]="showMoreControls" [ngModelOptions]="{standalone: true}">
  </div>
``` 

## What is the new behavior?

通过使用 formControl 而不是 formGroup + formControlName，明确指定 control 实例，避免自定义 injector 扰乱 formControlName 向上寻找 找不到 formGroup 的问题


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
