### PR TITLE
refactor(module:tooltip): deprecate cdkConnectedOverlayPush input

### DIFF
--- a/components/tooltip/base.ts
+++ b/components/tooltip/base.ts
@@ -10,6 +10,7 @@ import { isPlatformBrowser } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectorRef,
+  DestroyRef,
   Directive,
   ElementRef,
   EventEmitter,
@@ -22,8 +23,7 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
-  inject,
-  DestroyRef
+  inject
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, asapScheduler } from 'rxjs';
@@ -35,9 +35,9 @@ import {
   DEFAULT_TOOLTIP_POSITIONS,
   POSITION_MAP,
   POSITION_TYPE,
+  TOOLTIP_OFFSET_MAP,
   getPlacementName,
-  setConnectedPositionOffset,
-  TOOLTIP_OFFSET_MAP
+  setConnectedPositionOffset
 } from 'ng-zorro-antd/core/overlay';
 import { NgClassInterface, NgStyleInterface, NzSafeAny, NzTSType } from 'ng-zorro-antd/core/types';
 import { isNotNil, toBoolean } from 'ng-zorro-antd/core/util';
@@ -65,7 +65,8 @@ export abstract class NzTooltipBaseDirective implements AfterViewInit, OnChanges
   abstract overlayClassName?: string;
   abstract overlayStyle?: NgStyleInterface;
   abstract overlayClickable?: boolean;
-  cdkConnectedOverlayPush?: boolean;
+  /** @deprecated Default is false, and customization is no longer supported. This will be removed in v22.0.0. */
+  cdkConnectedOverlayPush?: boolean = false;
   visibleChange = new EventEmitter<boolean>();
 
   /**
@@ -359,7 +360,8 @@ export abstract class NzTooltipBaseComponent implements OnInit {
   nzBackdrop = false;
   nzMouseEnterDelay?: number;
   nzMouseLeaveDelay?: number;
-  cdkConnectedOverlayPush?: boolean = true;
+  /** @deprecated Default is false, and customization is no longer supported. This will be removed in v22.0.0. */
+  cdkConnectedOverlayPush?: boolean = false;
 
   nzVisibleChange = new Subject<boolean>();
 

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -52,7 +52,8 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
   @Input('nzTooltipOverlayClassName') override overlayClassName?: string;
   @Input('nzTooltipOverlayStyle') override overlayStyle?: NgStyleInterface;
   @Input({ alias: 'nzTooltipArrowPointAtCenter', transform: booleanAttribute }) override arrowPointAtCenter?: boolean;
-  @Input({ transform: booleanAttribute }) override cdkConnectedOverlayPush?: boolean = true;
+  /** @deprecated Default is false, and customization is no longer supported. This will be removed in v22.0.0. */
+  @Input({ transform: booleanAttribute }) override cdkConnectedOverlayPush?: boolean = false;
   @Input() nzTooltipColor?: string;
 
   override directiveContent?: NzTSType | null = null;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

<img width="340" height="316" alt="image" src="https://github.com/user-attachments/assets/68eb7685-aeae-4c58-a934-9cdf0e266f0c" />

即便 trigger 已经在视口之外，overlay 仍然卡在视口边缘，此行为与 antd 不符

## What is the new behavior?

据我观察，antd 的 popover/popconfirm/tooltip overlay 的行为都是 `cdkConnectedOverlayPush=false`，此 PR 将 cdkConnectedOverlayPush 默认值设置为 false，并弃用这个 input（该 input 从未在文档上公开）

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
