### PR TITLE
fix(module:i18n): add missing translations to `he_IL`

### DIFF
--- a/components/i18n/languages/he_IL.ts
+++ b/components/i18n/languages/he_IL.ts
@@ -21,7 +21,15 @@ export default {
   DatePicker: {
     lang: {
       placeholder: 'בחר תאריך',
+      yearPlaceholder: 'בחר שנה',
+      quarterPlaceholder: 'בחר רבעון',
+      monthPlaceholder: 'בחר חודש',
+      weekPlaceholder: 'בחר שבוע',
       rangePlaceholder: ['תאריך התחלה', 'תאריך סיום'],
+      rangeYearPlaceholder: ['שנת התחלה', 'שנת סיום'],
+      rangeQuarterPlaceholder: ['רבעון התחלה', 'רבעון סיום'],
+      rangeMonthPlaceholder: ['חודש התחלה', 'חודש סיום'],
+      rangeWeekPlaceholder: ['שבוע התחלה', 'שבוע סיום'],
       locale: 'he_IL',
       today: 'היום',
       now: 'עכשיו',
@@ -51,16 +59,25 @@ export default {
       nextCentury: 'המאה הבאה'
     },
     timePickerLocale: {
-      placeholder: 'בחר שעה'
+      placeholder: 'בחר שעה',
+      rangePlaceholder: ['שעת התחלה', 'שעת סיום']
     }
   },
   TimePicker: {
-    placeholder: 'בחר שעה'
+    placeholder: 'בחר שעה',
+    rangePlaceholder: ['שעת התחלה', 'שעת סיום']
   },
   Calendar: {
     lang: {
       placeholder: 'בחר תאריך',
+      yearPlaceholder: 'בחר שנה',
+      quarterPlaceholder: 'בחר רבעון',
+      monthPlaceholder: 'בחר חודש',
+      weekPlaceholder: 'בחר שבוע',
       rangePlaceholder: ['תאריך התחלה', 'תאריך סיום'],
+      rangeYearPlaceholder: ['שנת התחלה', 'שנת סיום'],
+      rangeMonthPlaceholder: ['חודש התחלה', 'חודש סיום'],
+      rangeWeekPlaceholder: ['שבוע התחלה', 'שבוע סיום'],
       locale: 'he_IL',
       today: 'היום',
       now: 'עכשיו',
@@ -90,7 +107,8 @@ export default {
       nextCentury: 'המאה הבאה'
     },
     timePickerLocale: {
-      placeholder: 'בחר שעה'
+      placeholder: 'בחר שעה',
+      rangePlaceholder: ['שעת התחלה', 'שעת סיום']
     }
   },
   global: {
@@ -105,7 +123,7 @@ export default {
     selectionAll: 'בחר את כל הנתונים',
     sortTitle: 'מיון',
     expand: 'הרחב שורה',
-    collapse: 'צמצם שורהw',
+    collapse: 'צמצם שורה',
     triggerDesc: 'לחץ על מיון לפי סדר יורד',
     triggerAsc: 'לחץ על מיון לפי סדר עולה',
     cancelSort: 'לחץ כדי לבטל את המיון'


### PR DESCRIPTION

This pull request enhances the Hebrew (`he_IL`) localization for date and time pickers by adding more granular placeholder translations and correcting a minor typo. These changes improve the user experience for Hebrew-speaking users by providing clearer prompts and fixing a text error.

Localization improvements for date and time pickers:

* Added specific placeholders for year, quarter, month, and week selections, as well as their corresponding range placeholders, to both the `DatePicker` and `Calendar` components (`components/i18n/languages/he_IL.ts`). [[1]](diffhunk://#diff-b8c5ffae33958f7d3ca46ede8fb87eed359728fd7b266137486c0c48415c43dfR24-R32) [[2]](diffhunk://#diff-b8c5ffae33958f7d3ca46ede8fb87eed359728fd7b266137486c0c48415c43dfL54-R80)
* Added `rangePlaceholder` to `timePickerLocale` and `TimePicker` for selecting time ranges (`components/i18n/languages/he_IL.ts`). [[1]](diffhunk://#diff-b8c5ffae33958f7d3ca46ede8fb87eed359728fd7b266137486c0c48415c43dfL54-R80) [[2]](diffhunk://#diff-b8c5ffae33958f7d3ca46ede8fb87eed359728fd7b266137486c0c48415c43dfL93-R111)

Minor correction:

* Fixed a typo in the `collapse` translation in the table section (`components/i18n/languages/he_IL.ts`).