### PR TITLE
feat(module:progress): add indeterminate state

### DIFF
--- a/components/progress/demo/indeterminate.md
+++ b/components/progress/demo/indeterminate.md
@@ -1,0 +1,14 @@
+---
+order: 11
+title:
+  zh-CN: 不确定进度
+  en-US: Indeterminate
+---
+
+## zh-CN
+
+当无法确定任务的具体进度时，可以使用不确定状态的进度条，展示持续加载动画。
+
+## en-US
+
+When the exact progress of a task is unknown, use an indeterminate progress bar to show continuous loading animation.

--- a/components/progress/demo/indeterminate.ts
+++ b/components/progress/demo/indeterminate.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+import { NzFlexModule } from 'ng-zorro-antd/flex';
+import { NzProgressModule } from 'ng-zorro-antd/progress';
+
+@Component({
+  selector: 'nz-demo-progress-indeterminate',
+  imports: [NzFlexModule, NzProgressModule],
+  template: `
+    <div nz-flex nzVertical nzGap="small">
+      <nz-progress [nzIndeterminate]="true"></nz-progress>
+      <nz-progress [nzIndeterminate]="true" nzStatus="exception"></nz-progress>
+      <nz-progress [nzIndeterminate]="true" nzStatus="success"></nz-progress>
+      <nz-progress [nzIndeterminate]="true" [nzShowInfo]="false"></nz-progress>
+    </div>
+  `
+})
+export class NzDemoProgressIndeterminateComponent {}

--- a/components/progress/doc/index.en-US.md
+++ b/components/progress/doc/index.en-US.md
@@ -17,16 +17,17 @@ If it will take a long time to complete an operation, you can use `Progress` to 
 
 ### nz-progress
 
-| Property             | Description                                                          | Type                                                                                   | Default                    | Global Config |
-| -------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------- | ------------- |
-| `[nzType]`           | to set the type                                                      | `'line' \| 'circle' \| 'dashboard'`                                                    | `'line'`                   |               |
-| `[nzFormat]`         | template function of the content                                     | `(percent: number) => string \| TemplateRef<{ $implicit: number }>`                    | `percent => percent + '%'` |               |
-| `[nzPercent]`        | to set the completion percentage                                     | `number`                                                                               | `0`                        |               |
-| `[nzShowInfo]`       | whether to display the progress value and the status icon            | `boolean`                                                                              | `true`                     | ✅            |
-| `[nzStatus]`         | to set the status of the Progress                                    | `'success' \| 'exception' \| 'active' \| 'normal'`                                     | -                          |               |
-| `[nzStrokeLinecap]`  | to set the style of the progress linecap                             | `'round' \| 'square'`                                                                  | `'round'`                  | ✅            |
-| `[nzStrokeColor]`    | color of progress bar, render linear-gradient when passing an object | `string \| { from: string; to: string: direction: string; [percent: string]: string }` | -                          | ✅            |
-| `[nzSuccessPercent]` | segmented success percent                                            | `number`                                                                               | 0                          |               |
+| Property             | Description                                                                                           | Type                                                                                   | Default                    | Global Config |
+| -------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------- | ------------- |
+| `[nzType]`           | to set the type                                                                                       | `'line' \| 'circle' \| 'dashboard'`                                                    | `'line'`                   |               |
+| `[nzFormat]`         | template function of the content                                                                      | `(percent: number) => string \| TemplateRef<{ $implicit: number }>`                    | `percent => percent + '%'` |               |
+| `[nzPercent]`        | to set the completion percentage                                                                      | `number`                                                                               | `0`                        |               |
+| `[nzShowInfo]`       | whether to display the progress value and the status icon                                             | `boolean`                                                                              | `true`                     | ✅            |
+| `[nzStatus]`         | to set the status of the Progress                                                                     | `'success' \| 'exception' \| 'active' \| 'normal'`                                     | -                          |               |
+| `[nzStrokeLinecap]`  | to set the style of the progress linecap                                                              | `'round' \| 'square'`                                                                  | `'round'`                  | ✅            |
+| `[nzStrokeColor]`    | color of progress bar, render linear-gradient when passing an object                                  | `string \| { from: string; to: string: direction: string; [percent: string]: string }` | -                          | ✅            |
+| `[nzSuccessPercent]` | segmented success percent                                                                             | `number`                                                                               | 0                          |               |
+| `[nzIndeterminate]`  | whether to show indeterminate progress with continuous animation (only available for `nzType="line"`) | `boolean`                                                                              | `false`                    |               |
 
 ### `nzType="line"`
 

--- a/components/progress/doc/index.zh-CN.md
+++ b/components/progress/doc/index.zh-CN.md
@@ -20,16 +20,17 @@ description: 展示操作的当前进度。
 
 各类型通用的属性。
 
-| 属性                 | 说明                         | 类型                                                                                   | 默认值                     | 全局配置 |
-| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | -------------------------- | -------- |
-| `[nzType]`           | 类型                         | `'line' \| 'circle' \| 'dashboard'`                                                    | `'line'`                   |          |
-| `[nzFormat]`         | 内容的模板函数               | `(percent: number) => string \| TemplateRef<{ $implicit: number }>`                    | `percent => percent + '%'` |
-| `[nzPercent]`        | 百分比                       | `number`                                                                               | `0`                        |          |
-| `[nzShowInfo]`       | 是否显示进度数值或状态图标   | `boolean`                                                                              | `true`                     | ✅       |
-| `[nzStatus]`         | 状态                         | `'success' \| 'exception' \| 'active' \| 'normal'`                                     | -                          |          |
-| `[nzStrokeLinecap]`  | 进度条端点形状               | `'round' \| 'square'`                                                                  | `'round'`                  | ✅       |
-| `[nzStrokeColor]`    | 进度条颜色，传入对象时为渐变 | `string \| { from: string; to: string: direction: string; [percent: string]: string }` | -                          | ✅       |
-| `[nzSuccessPercent]` | 已完成的分段百分比           | `number`                                                                               | 0                          |          |
+| 属性                 | 说明                                                         | 类型                                                                                   | 默认值                     | 全局配置 |
+| -------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------- | -------------------------- | -------- |
+| `[nzType]`           | 类型                                                         | `'line' \| 'circle' \| 'dashboard'`                                                    | `'line'`                   |          |
+| `[nzFormat]`         | 内容的模板函数                                               | `(percent: number) => string \| TemplateRef<{ $implicit: number }>`                    | `percent => percent + '%'` |
+| `[nzPercent]`        | 百分比                                                       | `number`                                                                               | `0`                        |          |
+| `[nzShowInfo]`       | 是否显示进度数值或状态图标                                   | `boolean`                                                                              | `true`                     | ✅       |
+| `[nzStatus]`         | 状态                                                         | `'success' \| 'exception' \| 'active' \| 'normal'`                                     | -                          |          |
+| `[nzStrokeLinecap]`  | 进度条端点形状                                               | `'round' \| 'square'`                                                                  | `'round'`                  | ✅       |
+| `[nzStrokeColor]`    | 进度条颜色，传入对象时为渐变                                 | `string \| { from: string; to: string: direction: string; [percent: string]: string }` | -                          | ✅       |
+| `[nzSuccessPercent]` | 已完成的分段百分比                                           | `number`                                                                               | 0                          |          |
+| `[nzIndeterminate]`  | 是否显示不确定状态的持续加载动画（仅适用于 `nzType="line"`） | `boolean`                                                                              | `false`                    |          |
 
 ### `nzType="line"`
 

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -15,6 +15,7 @@ import {
   SimpleChanges,
   ViewEncapsulation,
   numberAttribute,
+  booleanAttribute,
   inject,
   DestroyRef
 } from '@angular/core';
@@ -192,7 +193,7 @@ export class NzProgressComponent implements OnChanges, OnInit {
   @Input() @WithConfig() nzStrokeLinecap: NzProgressStrokeLinecapType = 'round';
 
   @Input({ transform: numberAttribute }) nzSteps: number = 0;
-  @Input() nzIndeterminate: boolean = false;
+  @Input({ transform: booleanAttribute }) nzIndeterminate: boolean = false;
 
   steps: NzProgressStepItem[] = [];
 

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -84,6 +84,7 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
       [class.ant-progress-circle]="isCircleStyle"
       [class.ant-progress-steps]="isSteps"
       [class.ant-progress-rtl]="dir === 'rtl'"
+      [class.ant-progress-indeterminate]="nzIndeterminate && nzType === 'line'"
     >
       @if (nzType === 'line') {
         <div>
@@ -100,7 +101,7 @@ const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
               <div class="ant-progress-inner">
                 <div
                   class="ant-progress-bg"
-                  [style.width.%]="nzPercent"
+                  [style.width.%]="nzIndeterminate ? 100 : nzPercent"
                   [style.border-radius]="nzStrokeLinecap === 'round' ? '100px' : '0'"
                   [style.background]="!isGradient ? nzStrokeColor : null"
                   [style.background-image]="isGradient ? lineGradient : null"
@@ -191,6 +192,7 @@ export class NzProgressComponent implements OnChanges, OnInit {
   @Input() @WithConfig() nzStrokeLinecap: NzProgressStrokeLinecapType = 'round';
 
   @Input({ transform: numberAttribute }) nzSteps: number = 0;
+  @Input() nzIndeterminate: boolean = false;
 
   steps: NzProgressStepItem[] = [];
 

--- a/components/progress/progress.spec.ts
+++ b/components/progress/progress.spec.ts
@@ -180,6 +180,19 @@ describe('progress', () => {
       );
     });
 
+    it('should indeterminate work', () => {
+      fixture.detectChanges();
+      expect(progress.nativeElement.firstElementChild!.classList).not.toContain('ant-progress-indeterminate');
+
+      testComponent.indeterminate = true;
+      fixture.detectChanges();
+      expect(progress.nativeElement.firstElementChild!.classList).toContain('ant-progress-indeterminate');
+
+      // Should only work with line type
+      const progressBar = progress.nativeElement.querySelector('.ant-progress-bg');
+      expect(progressBar).toBeTruthy();
+    });
+
     it('should support steps mode', () => {
       testComponent.steps = 5;
       testComponent.percent = 50;
@@ -447,6 +460,7 @@ describe('progress', () => {
       [nzStrokeColor]="strokeColor"
       [nzStrokeLinecap]="strokeLinecap"
       [nzSteps]="steps"
+      [nzIndeterminate]="indeterminate"
     ></nz-progress>
     <ng-template #formatterTemplate let-percent>{{ percent }} / 100</ng-template>
   `
@@ -463,6 +477,7 @@ export class NzTestProgressLineComponent {
   strokeLinecap: NzProgressStrokeLinecapType = 'round';
   steps?: number;
   strokeColor?: NzProgressStrokeColorType;
+  indeterminate = false;
 }
 
 @Component({

--- a/components/progress/style/index.less
+++ b/components/progress/style/index.less
@@ -122,6 +122,31 @@
     }
   }
 
+  &-indeterminate&-line {
+    .@{progress-prefix-cls}-bg {
+      position: relative;
+      width: 100% !important;
+      overflow: hidden;
+
+      &::before {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 200%;
+        background-image: repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 8px,
+          rgba(255, 255, 255, 0.25) 8px,
+          rgba(255, 255, 255, 0.25) 16px
+        );
+        animation: ~'@{ant-prefix}-progress-indeterminate' 1s linear infinite;
+        content: '';
+      }
+    }
+  }
+
   &-status-exception {
     .@{progress-prefix-cls}-bg {
       background-color: @error-color;
@@ -204,6 +229,16 @@
   100% {
     transform: translateX(0) scaleX(1);
     opacity: 0;
+  }
+}
+
+@keyframes ~"@{ant-prefix}-progress-indeterminate" {
+  0% {
+    transform: translateX(0);
+  }
+
+  100% {
+    transform: translateX(-22.627px);
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Progress component is missing a state where the progress is indeterminate, in some cases, exact progress of certain tasks cannot be known until they are done.

Issue Number: #9679


## What is the new behavior?
Progress component now introduces a new prop `nzIndeterminate="true"` which makes the progress appear indefinite with an appropriate animation, note that it's only availalbe for progress with `nzType="line"`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
