### PR TITLE
fix(module:collapse): apply pointer cursor to full header

### DIFF
--- a/components/collapse/collapse-panel.component.ts
+++ b/components/collapse/collapse-panel.component.ts
@@ -45,8 +45,8 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapsePanel';
       role="button"
       [attr.aria-expanded]="active()"
       class="ant-collapse-header"
-      [class.ant-collapse-icon-collapsible-only]="nzCollapsible === 'icon'"
-      [class.ant-collapse-header-collapsible-only]="nzCollapsible === 'header'"
+      [class.ant-collapse-collapsible-icon]="nzCollapsible === 'icon'"
+      [class.ant-collapse-collapsible-header]="nzCollapsible === 'header'"
     >
       @if (nzShowArrow) {
         <div role="button" #collapseIcon class="ant-collapse-expand-icon">
@@ -55,7 +55,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapsePanel';
           </ng-container>
         </div>
       }
-      <span class="ant-collapse-header-text">
+      <span class="ant-collapse-title">
         <ng-container *nzStringTemplateOutlet="nzHeader">{{ nzHeader }}</ng-container>
       </span>
       @if (nzExtra) {
@@ -65,13 +65,13 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapsePanel';
       }
     </div>
     <div
-      class="ant-collapse-content"
-      [class.ant-collapse-content-active]="active()"
+      class="ant-collapse-panel"
+      [class.ant-collapse-panel-active]="active()"
       animation-collapse
       [open]="active()"
-      leavedClassName="ant-collapse-content-hidden"
+      leavedClassName="ant-collapse-panel-hidden"
     >
-      <div class="ant-collapse-content-box">
+      <div class="ant-collapse-body">
         <ng-content />
       </div>
     </div>

--- a/components/collapse/collapse.spec.ts
+++ b/components/collapse/collapse.spec.ts
@@ -211,12 +211,12 @@ describe('collapse', () => {
 
     it('should only toggle by icon when nzCollapsible is "icon"', () => {
       const headerEl = panel.nativeElement.querySelector('.ant-collapse-header') as HTMLElement;
-      expect(headerEl.classList).toContain('ant-collapse-icon-collapsible-only');
+      expect(headerEl.classList).toContain('ant-collapse-collapsible-icon');
       // initial state
       expect(panel.nativeElement.classList).not.toContain('ant-collapse-item-active');
 
       // click header text should NOT toggle
-      (panel.nativeElement.querySelector('.ant-collapse-header-text') as HTMLElement).click();
+      (panel.nativeElement.querySelector('.ant-collapse-title') as HTMLElement).click();
       fixture.detectChanges();
       expect(panel.nativeElement.classList).not.toContain('ant-collapse-item-active');
 
@@ -226,7 +226,7 @@ describe('collapse', () => {
       expect(panel.nativeElement.classList).toContain('ant-collapse-item-active');
 
       // click header text again should NOT toggle
-      (panel.nativeElement.querySelector('.ant-collapse-header-text') as HTMLElement).click();
+      (panel.nativeElement.querySelector('.ant-collapse-title') as HTMLElement).click();
       fixture.detectChanges();
       expect(panel.nativeElement.classList).toContain('ant-collapse-item-active');
 
@@ -259,16 +259,16 @@ describe('collapse', () => {
       const localPanel = localFixture.debugElement.query(By.directive(NzCollapsePanelComponent));
 
       const header = localPanel.nativeElement.querySelector('.ant-collapse-header') as HTMLElement;
-      expect(header.classList).toContain('ant-collapse-header-collapsible-only');
+      expect(header.classList).toContain('ant-collapse-collapsible-header');
       expect(localPanel.nativeElement.classList).not.toContain('ant-collapse-item-active');
 
       // click header toggles
-      (localPanel.nativeElement.querySelector('.ant-collapse-header-text') as HTMLElement).click();
+      (localPanel.nativeElement.querySelector('.ant-collapse-title') as HTMLElement).click();
       localFixture.detectChanges();
       expect(localPanel.nativeElement.classList).toContain('ant-collapse-item-active');
 
       // click header toggles again (close)
-      (localPanel.nativeElement.querySelector('.ant-collapse-header-text') as HTMLElement).click();
+      (localPanel.nativeElement.querySelector('.ant-collapse-title') as HTMLElement).click();
       localFixture.detectChanges();
       expect(localPanel.nativeElement.classList).not.toContain('ant-collapse-item-active');
 

--- a/components/collapse/style/index.less
+++ b/components/collapse/style/index.less
@@ -45,7 +45,7 @@
         }
       }
 
-      .@{collapse-prefix-cls}-header-text {
+      .@{collapse-prefix-cls}-title {
         flex: auto;
       }
 
@@ -58,14 +58,19 @@
       }
     }
 
-    .@{collapse-prefix-cls}-header-collapsible-only {
-      cursor: pointer;
-      .@{collapse-prefix-cls}-header-text {
+    // Sync with ant-design: when only header is clickable, pointer on title and expand-icon
+    .@{collapse-prefix-cls}-collapsible-header {
+      cursor: default;
+      .@{collapse-prefix-cls}-title {
         flex: none;
+        cursor: pointer;
+      }
+      .@{collapse-prefix-cls}-expand-icon {
+        cursor: pointer;
       }
     }
 
-    .@{collapse-prefix-cls}-icon-collapsible-only {
+    .@{collapse-prefix-cls}-collapsible-icon {
       cursor: default;
       .@{collapse-prefix-cls}-expand-icon {
         cursor: pointer;
@@ -99,12 +104,12 @@
     }
   }
 
-  &-content {
+  &-panel {
     color: @text-color;
     background-color: @collapse-content-bg;
     border-top: @border-width-base @border-style-base @border-color-base;
 
-    & > &-box {
+    & > &-body {
       padding: @collapse-content-padding;
     }
 
@@ -114,7 +119,7 @@
   }
 
   &-item:last-child {
-    > .@{collapse-prefix-cls}-content {
+    > .@{collapse-prefix-cls}-panel {
       border-radius: 0 0 @collapse-panel-border-radius @collapse-panel-border-radius;
     }
   }
@@ -138,12 +143,12 @@
     border-bottom: 0;
   }
 
-  &-borderless > &-item > &-content {
+  &-borderless > &-item > &-panel {
     background-color: transparent;
     border-top: 0;
   }
 
-  &-borderless > &-item > &-content > &-content-box {
+  &-borderless > &-item > &-panel > &-body {
     padding-top: 4px;
   }
 
@@ -152,10 +157,10 @@
     border: 0;
     > .@{collapse-prefix-cls}-item {
       border-bottom: 0;
-      > .@{collapse-prefix-cls}-content {
+      > .@{collapse-prefix-cls}-panel {
         background-color: transparent;
         border-top: 0;
-        > .@{collapse-prefix-cls}-content-box {
+        > .@{collapse-prefix-cls}-body {
           padding-top: 12px;
           padding-bottom: 12px;
         }
@@ -177,10 +182,8 @@
         padding: 8px 12px;
         padding-inline-start: 8px;
       }
-      > .@{collapse-prefix-cls}-content {
-        > .@{collapse-prefix-cls}-content-box {
-          padding: 12px;
-        }
+      > .@{collapse-prefix-cls}-panel > .@{collapse-prefix-cls}-body {
+        padding: 12px;
       }
     }
   }
@@ -193,10 +196,8 @@
         padding: 16px 24px;
         padding-inline-start: 16px;
       }
-      > .@{collapse-prefix-cls}-content {
-        > .@{collapse-prefix-cls}-content-box {
-          padding: 24px;
-        }
+      > .@{collapse-prefix-cls}-panel > .@{collapse-prefix-cls}-body {
+        padding: 24px;
       }
     }
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When `nzCollapsible="header"` is used, the entire header (including the arrow/icon) is clickable, but `cursor: pointer` is only applied to the `.ant-collapse-header-text` element. Hovering over the icon or padding shows the default cursor.

Issue Number: #9674


## What is the new behavior?

`cursor: pointer` is applied to the full header container (`.ant-collapse-header-collapsible-only`) when `nzCollapsible="header"`, so hovering anywhere on the header (text, icon, padding) shows the pointer cursor.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A