### PR TITLE
doc: append theme stylesheet to document head instead of body

### DIFF
--- a/scripts/site/doc/app/app.component.ts
+++ b/scripts/site/doc/app/app.component.ts
@@ -150,7 +150,7 @@ export class AppComponent implements OnInit {
       style.rel = 'stylesheet';
       style.id = `site-theme-${theme}`;
       style.href = `assets/${theme}.css`;
-      document.body.append(style);
+      document.head.append(style);
 
       style.onload = () => {
         successLoaded();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9692

When switching to dark/compact/aliyun theme on the documentation site, the theme CSS `<link>` element was appended to `document.body` instead of `document.head`. This causes the browser to potentially create a new compositor layer on `body` (triggered by the active `transition: background` animation). As a result, the containing block for `position: fixed` elements changes temporarily, causing the CDK `.cdk-overlay-container` to miscalculate its position relative to the viewport — the Date Picker popup appears at the wrong location in dark mode.


## What is the new behavior?

The theme stylesheet `<link>` is now appended to `document.head` instead of `document.body`, ensuring the CDK overlay container's `position: fixed` positioning context always refers to the viewport correctly.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The issue could not be reproduced on Stackblitz because it does not use the documentation site's theme-switching mechanism (no `<link>` appended to `body`).