### PR TITLE
fix(module:select): fix dropdown position in Safari

### DIFF
--- a/components/select/style/patch.less
+++ b/components/select/style/patch.less
@@ -1,5 +1,4 @@
 .ant-select-dropdown {
-  position: relative;
   top: 100%;
   left: 0;
   display: block;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The select dropdown position is incorrect in Safari browser because `position: relative` was set on `.ant-select-dropdown`, which overrides the absolute positioning applied by CDK overlay, causing the dropdown to appear in the wrong position.

Issue Number: #9689


## What is the new behavior?

Remove `position: relative` from `.ant-select-dropdown` in `patch.less`. The dropdown now renders at the correct position in Safari browser.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information