### PR TITLE
ci: add dependabot configuration with npm mirror registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
+
+registries:
+  npm-mirror:
+    type: npm-registry
+    url: https://registry.npmmirror.com
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    registries:
+      - npm-mirror
+    schedule:
+      interval: daily
+      time: "05:00"
+      timezone: Asia/Shanghai
+    groups:
+      dependencies:
+        dependency-type: production
+        update-types: [major, minor]
+      dev-dependencies:
+        dependency-type: development
+        update-types: [major]
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@ant-design*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - github-actions
+      - dependencies


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Issue Number: N/A

Dependabot currently uses the default `registry.npmjs.org` when updating `package-lock.json`, but the project uses `registry.npmmirror.com`. This causes resolved URLs to be mismatched (e.g., PR #9764 changed the registry from `registry.npmmirror.com` to `registry.npmjs.org`).

## What is the new behavior?

This PR adds a `dependabot.yml` configuration that:
- Configures `registry.npmmirror.com` as the npm registry for Dependabot
- Groups production and development dependencies to reduce PR noise
- Runs daily at 05:00 Shanghai time
- Ignores `@ant-design*` packages (controlled internally)
- Adds GitHub Actions dependency updates with proper labels

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Reference: ant-design's [dependabot.yml](https://github.com/ant-design/ant-design/blob/master/.github/dependabot.yml)