### PR TITLE
fix(module:input-number): text overlaps handler when input too long

### DIFF
--- a/components/input-number/style/index.less
+++ b/components/input-number/style/index.less
@@ -142,7 +142,7 @@
     right: 0;
     width: 22px;
     height: 100%;
-    background: transparent;
+    background: @input-number-handler-bg;
     border-radius: 0 @control-border-radius @control-border-radius 0;
     opacity: 0;
     transition: opacity 0.24s linear 0.1s;


### PR DESCRIPTION
Set handler-wrap background to @input-number-handler-bg instead of transparent to properly occlude overflowing text content.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<img width="115" height="52" alt="image" src="https://github.com/user-attachments/assets/d9e9324b-6909-44a0-a759-e0e2966126fb" />
Issue Number: N/A


## What is the new behavior?
<img width="113" height="44" alt="image" src="https://github.com/user-attachments/assets/83fb54be-09bd-4579-9086-d5cc226e28fc" />

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
