### PR TITLE
fix(module:descriptions): use track functions in @for loops

### DIFF
--- a/components/descriptions/descriptions.component.ts
+++ b/components/descriptions/descriptions.component.ts
@@ -69,9 +69,9 @@ const defaultColumnMap: Record<NzBreakpointEnum, number> = {
       <table>
         <tbody>
           @if (nzLayout === 'horizontal') {
-            @for (row of itemMatrix; track row; let i = $index) {
+            @for (row of itemMatrix; track trackItems(row); let i = $index) {
               <tr class="ant-descriptions-row">
-                @for (item of row; track item; let isLast = $last) {
+                @for (item of row; track trackItem(item); let isLast = $last) {
                   @if (!nzBordered) {
                     <td class="ant-descriptions-item" [colSpan]="item.span">
                       <div class="ant-descriptions-item-container">
@@ -102,9 +102,9 @@ const defaultColumnMap: Record<NzBreakpointEnum, number> = {
 
           @if (nzLayout === 'vertical') {
             @if (!nzBordered) {
-              @for (row of itemMatrix; track row; let i = $index) {
+              @for (row of itemMatrix; track trackItems(row); let i = $index) {
                 <tr class="ant-descriptions-row">
-                  @for (item of row; track item; let isLast = $last) {
+                  @for (item of row; track trackItem(item); let isLast = $last) {
                     <td class="ant-descriptions-item" [colSpan]="item.span">
                       <div class="ant-descriptions-item-container">
                         <span class="ant-descriptions-item-label" [class.ant-descriptions-item-no-colon]="!nzColon">
@@ -117,7 +117,7 @@ const defaultColumnMap: Record<NzBreakpointEnum, number> = {
                   }
                 </tr>
                 <tr class="ant-descriptions-row">
-                  @for (item of row; track item; let isLast = $last) {
+                  @for (item of row; track trackItem(item); let isLast = $last) {
                     <td class="ant-descriptions-item" [colSpan]="item.span">
                       <div class="ant-descriptions-item-container">
                         <span class="ant-descriptions-item-content">
@@ -129,9 +129,9 @@ const defaultColumnMap: Record<NzBreakpointEnum, number> = {
                 </tr>
               }
             } @else {
-              @for (row of itemMatrix; track row; let i = $index) {
+              @for (row of itemMatrix; track trackItems(row); let i = $index) {
                 <tr class="ant-descriptions-row">
-                  @for (item of row; track item; let isLast = $last) {
+                  @for (item of row; track trackItem(item); let isLast = $last) {
                     <td class="ant-descriptions-item-label" [colSpan]="item.span">
                       <ng-container *nzStringTemplateOutlet="item.title">
                         {{ item.title }}
@@ -140,7 +140,7 @@ const defaultColumnMap: Record<NzBreakpointEnum, number> = {
                   }
                 </tr>
                 <tr class="ant-descriptions-row">
-                  @for (item of row; track item; let isLast = $last) {
+                  @for (item of row; track trackItem(item); let isLast = $last) {
                     <td class="ant-descriptions-item-content" [colSpan]="item.span">
                       <ng-template [ngTemplateOutlet]="item.content" />
                     </td>
@@ -212,6 +212,14 @@ export class NzDescriptionsComponent implements OnChanges, AfterContentInit, OnI
         this.prepareMatrix();
         this.cdr.markForCheck();
       });
+  }
+
+  protected trackItems(items: NzDescriptionsItemRenderProps[]): NzDescriptionsItemRenderProps[] {
+    return items;
+  }
+
+  protected trackItem(item: NzDescriptionsItemRenderProps): NzDescriptionsItemRenderProps {
+    return item;
   }
 
   /**


### PR DESCRIPTION
Replaces object references used directly as track expressions with protected track functions, resolving the NG0956 warning logged to the console.  This is the most direct approach to getting rid of the warning message. I suppose it is possible to refactor the component so that each row and item of `itemMatrix` has a unique identifier that the `track` function can use but I'm not sure such an approach is necessary here.

Resolves #9587

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Users are experiencing the NG0956 warning message being logged when using the `nz-descriptions` component.

Issue Number: 9587

## What is the new behavior?

There is no more warning message

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
