### PR TITLE
docs(module:descriptions): fix nzTitle API table type and default value

### DIFF
--- a/components/descriptions/doc/index.en-US.md
+++ b/components/descriptions/doc/index.en-US.md
@@ -27,7 +27,7 @@ Commonly displayed on the details page.
 
 ### nz-descriptions-item
 
-| Property    | Description                    | Type      | Default                       |
-| ----------- | ------------------------------ | --------- | ----------------------------- |
-| `[nzTitle]` | Description of the content     | `boolean` | `string \| TemplateRef<void>` |
-| `[nzSpan]`  | The number of columns included | `number`  | `1`                           |
+| Property    | Description                    | Type                          | Default |
+| ----------- | ------------------------------ | ----------------------------- | ------- |
+| `[nzTitle]` | Description of the content     | `string \| TemplateRef<void>` | -       |
+| `[nzSpan]`  | The number of columns included | `number`                      | `1`     |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The english docs for `nz-descriptions-item` have the `nzTitle` type as `boolean`

Issue Number: N/A

## What is the new behavior?

The docs are correct

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
