### PR TITLE
fix(module:color-picker): hue slider invisible with nzDisabledAlpha

### DIFF
--- a/components/color-picker/style/index.less
+++ b/components/color-picker/style/index.less
@@ -53,7 +53,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    background-image: linear-gradient(0deg, #000, transparent), linear-gradient(90deg, #fff, hsla(0deg, 0%, 100%, 0));
+    background-image: linear-gradient(0deg, #000, transparent), linear-gradient(90deg, #fff, hsl(0deg, 0%, 100%, 0));
     border-radius: inherit;
   }
 
@@ -94,9 +94,9 @@
 
     &-alpha {
       background-image: conic-gradient(
-        rgba(0, 0, 0, 0.06) 0 25%,
+        rgb(0, 0, 0, 0.06) 0 25%,
         transparent 0 50%,
-        rgba(0, 0, 0, 0.06) 0 75%,
+        rgb(0, 0, 0, 0.06) 0 75%,
         transparent 0
       );
       background-size: 8px 8px;
@@ -169,6 +169,7 @@
         align-items: center;
 
         .@{color-picker-prefix-cls}-slider {
+          flex: 1;
           margin-bottom: 0;
         }
       }
@@ -360,7 +361,7 @@
     // For bright backgrounds, use dark tick for contrast
     &-color-bright&-color-checked::after,
     &-color-checked&-color-bright::after {
-      border-color: rgba(0, 0, 0, 0.88);
+      border-color: rgb(0, 0, 0, 0.88);
     }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
[9791](https://github.com/NG-ZORRO/ng-zorro-antd/issues/9791)
<img width="457" height="384" alt="image" src="https://github.com/user-attachments/assets/486854bf-0faa-4854-a07f-c897d2428565" />
AI ：找到根本原因了！
    CSS 链是这样的：
     - .ant-color-picker-slider-group 设了 flex: 1
     - 当加上 -disabled-alpha 修饰符时，它变成 display: flex; align-items: center
     - 内部 color-slider 是默认 display: block，但它是 flex 容器的直接子元素
     - color-slider（.ant-color-picker-slider）没有显式 `width`
     - 由于父元素是 display: flex 且方向默认 row，子元素只占内容宽度。子元素本身没有内容（palette 是 absolute 定位），所以 slider 宽度为 0
     - 同时 .ant-color-picker-palette 是 display: block、position: relative，高度由内容决定，但内部 gradient 是 position: absolute; inset: 0，自身不撑开高度
     - 在非 disabled-alpha 模式下 slider-group 是普通块级布局，slider 自然 100% 宽度。但 flex 模式下宽度塌陷

    对比 ant-design React 源码的处理：他们在 disabled-alpha 模式下让 hue slider 占满宽度即可。

    修复方法：让 -disabled-alpha 模式下的 slider 加 flex: 1：

Issue Number: [9791](https://github.com/NG-ZORRO/ng-zorro-antd/issues/9791)


## What is the new behavior?
<img width="426" height="396" alt="image" src="https://github.com/user-attachments/assets/83475ccf-21f9-41fd-8ad0-96b1d257c87b" />

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
