### PR TITLE
docs(module:tag): add draggable tag demo

### DIFF
--- a/components/tag/demo/draggable.md
+++ b/components/tag/demo/draggable.md
@@ -1,0 +1,14 @@
+---
+order: 6
+title:
+  zh-CN: 可拖拽标签
+  en-US: Draggable Tag
+---
+
+## zh-CN
+
+通过 CDK `DragDropModule` 实现标签可拖拽。
+
+## en-US
+
+Use CDK `DragDropModule` to make tags draggable.

--- a/components/tag/demo/draggable.ts
+++ b/components/tag/demo/draggable.ts
@@ -1,0 +1,43 @@
+import { CdkDrag, CdkDragDrop, CdkDropList, moveItemInArray } from '@angular/cdk/drag-drop';
+import { Component } from '@angular/core';
+
+import { NzTagModule } from 'ng-zorro-antd/tag';
+
+@Component({
+  selector: 'nz-demo-tag-draggable',
+  imports: [CdkDropList, CdkDrag, NzTagModule],
+  template: `
+    <div class="tag-list" cdkDropList cdkDropListOrientation="horizontal" (cdkDropListDropped)="drop($event)">
+      @for (tag of tags; track tag) {
+        <nz-tag cdkDrag>{{ tag }}</nz-tag>
+      }
+    </div>
+  `,
+  styles: `
+    .tag-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .tag-list nz-tag {
+      margin-inline-end: 0;
+      cursor: move;
+    }
+
+    .tag-list.cdk-drop-list-dragging nz-tag:not(.cdk-drag-placeholder) {
+      transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+    }
+
+    .tag-list .cdk-drag-placeholder {
+      opacity: 0;
+    }
+  `
+})
+export class NzDemoTagDraggableComponent {
+  tags = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4', 'Tag 5'];
+
+  drop(event: CdkDragDrop<string[]>): void {
+    moveItemInArray(this.tags, event.previousIndex, event.currentIndex);
+  }
+}

--- a/components/tag/demo/draggable.ts
+++ b/components/tag/demo/draggable.ts
@@ -7,7 +7,7 @@ import { NzTagModule } from 'ng-zorro-antd/tag';
   selector: 'nz-demo-tag-draggable',
   imports: [CdkDropList, CdkDrag, NzTagModule],
   template: `
-    <div class="tag-list" cdkDropList cdkDropListOrientation="horizontal" (cdkDropListDropped)="drop($event)">
+    <div class="tag-list" cdkDropList cdkDropListOrientation="mixed" (cdkDropListDropped)="drop($event)">
       @for (tag of tags; track tag) {
         <nz-tag cdkDrag>{{ tag }}</nz-tag>
       }
@@ -23,10 +23,6 @@ import { NzTagModule } from 'ng-zorro-antd/tag';
     .tag-list nz-tag {
       margin-inline-end: 0;
       cursor: move;
-    }
-
-    .tag-list.cdk-drop-list-dragging nz-tag:not(.cdk-drag-placeholder) {
-      transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
     }
 
     .tag-list .cdk-drag-placeholder {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The Tag component documentation does not have a draggable tag demo showing drag-and-drop sorting functionality.

Issue Number: NONE

## What is the new behavior?

Added a Draggable Tag showcase demo to the Tag component documentation. Users can now see how to implement drag-and-drop sorting for tags, similar to the Ant Design React implementation.

Reference: https://ant.design/components/tag#tag-demo-draggable

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

This PR adds a demo component demonstrating how to implement drag-and-drop sorting for Tag components using Angular CDK.

Multica: ANT-29
