### PR TITLE
chore: disabled color-function-alias-notation stylelint rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -44,6 +44,7 @@
     "custom-property-pattern": null,
     "number-max-precision": 8,
     "alpha-value-notation": "number",
+    "color-function-alias-notation": null,
     "color-function-notation": "legacy",
     "selector-class-pattern": null,
     "selector-id-pattern": null,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

stylelint 会错误的将 `rgba(r, g, b, a)` 格式化为 `rgb(r, g, b, a)`

## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
