### PR TITLE
refactor: remove redundant OnPush change detection declarations

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,7 +27,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep components small and focused on a single responsibility
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
-- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator
 - Prefer inline templates for small components
 - Prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead

--- a/.cursor/rules/cursor.mdc
+++ b/.cursor/rules/cursor.mdc
@@ -32,7 +32,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep components small and focused on a single responsibility
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
-- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator
 - Prefer inline templates for small components
 - Prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -27,7 +27,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep components small and focused on a single responsibility
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
-- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator
 - Prefer inline templates for small components
 - Prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep components small and focused on a single responsibility
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
-- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator
 - Prefer inline templates for small components
 - Prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -27,7 +27,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep components small and focused on a single responsibility
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
-- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator
 - Prefer inline templates for small components
 - Prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead

--- a/.windsurf/rules/guidelines.md
+++ b/.windsurf/rules/guidelines.md
@@ -27,7 +27,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep components small and focused on a single responsibility
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
-- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator
 - Prefer inline templates for small components
 - Prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Keep components small and focused on a single responsibility
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
-- Set `changeDetection: ChangeDetectionStrategy.OnPush` in `@Component` decorator
 - Prefer inline templates for small components
 - Prefer Reactive forms instead of Template-driven ones
 - Do NOT use `ngClass`, use `class` bindings instead

--- a/components/affix/affix.component.ts
+++ b/components/affix/affix.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { Platform } from '@angular/cdk/platform';
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   DOCUMENT,
@@ -48,7 +47,6 @@ const NOOP_EVENT = {} as Event;
       <ng-content />
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzAffixComponent implements OnChanges {

--- a/components/alert/alert-marquee.component.ts
+++ b/components/alert/alert-marquee.component.ts
@@ -6,7 +6,6 @@
 import {
   afterNextRender,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,
@@ -21,7 +20,6 @@ import {
 
 @Component({
   selector: 'nz-alert-marquee',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <div #track1 class="ant-alert-marquee-track" [style.animation-duration.s]="animationDuration()">

--- a/components/alert/alert.component.ts
+++ b/components/alert/alert.component.ts
@@ -8,7 +8,6 @@ import {
   ANIMATION_MODULE_TYPE,
   AnimationCallbackEvent,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -94,7 +93,6 @@ export type NzAlertType = 'success' | 'info' | 'warning' | 'error';
       </div>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzAlertComponent implements OnChanges {

--- a/components/anchor/anchor-link.component.ts
+++ b/components/anchor/anchor-link.component.ts
@@ -6,7 +6,6 @@
 import { Platform } from '@angular/cdk/platform';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   ContentChild,
   DestroyRef,
@@ -48,7 +47,6 @@ import { NzAnchorComponent } from './anchor.component';
     }
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-anchor-link'
   }

--- a/components/anchor/anchor.component.ts
+++ b/components/anchor/anchor.component.ts
@@ -8,7 +8,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -76,8 +75,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
       </div>
     </ng-template>
   `,
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzAnchorComponent implements AfterViewInit, OnChanges {
   public nzConfigService = inject(NzConfigService);

--- a/components/auto-complete/autocomplete-optgroup.component.ts
+++ b/components/auto-complete/autocomplete-optgroup.component.ts
@@ -3,14 +3,13 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 
 @Component({
   selector: 'nz-auto-optgroup',
   exportAs: 'nzAutoOptgroup',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [NzOutletModule],
   template: `

--- a/components/auto-complete/autocomplete-option.component.ts
+++ b/components/auto-complete/autocomplete-option.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -36,7 +35,6 @@ export class NzOptionSelectionChange {
 @Component({
   selector: 'nz-auto-option',
   exportAs: 'nzAutoOption',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <div class="ant-select-item-option-content">

--- a/components/auto-complete/autocomplete.component.ts
+++ b/components/auto-complete/autocomplete.component.ts
@@ -8,7 +8,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -65,7 +64,6 @@ function normalizeDataSource(value: AutocompleteDataSource): AutocompleteDataSou
 @Component({
   selector: 'nz-autocomplete',
   exportAs: 'nzAutocomplete',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [NgTemplateOutlet, NzAutocompleteOptionComponent, NzNoAnimationDirective],
   template: `

--- a/components/auto-complete/autocomplete.spec.ts
+++ b/components/auto-complete/autocomplete.spec.ts
@@ -1052,7 +1052,6 @@ class NzTestAutocompleteWithoutPanelComponent {
 
 @Component({
   imports: [NzAutocompleteModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div>
       <input [nzAutocomplete]="auto" />

--- a/components/avatar/avatar-group.component.ts
+++ b/components/avatar/avatar-group.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'nz-avatar-group',
   exportAs: 'nzAvatarGroup',
   template: `<ng-content />`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-avatar-group'
   }

--- a/components/avatar/avatar.component.ts
+++ b/components/avatar/avatar.component.ts
@@ -5,7 +5,6 @@
 
 import {
   afterEveryRender,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -68,7 +67,6 @@ type NzAvatarFetchPriority = 'high' | 'low' | 'auto';
     // nzSize type is number when customSize is true
     '[style.font-size.px]': '(hasIcon && customSize) ? $any(nzSize) / 2 : null'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzAvatarComponent implements OnChanges {

--- a/components/badge/badge-sup.component.ts
+++ b/components/badge/badge-sup.component.ts
@@ -5,7 +5,6 @@
 
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   inject,
   Input,
@@ -24,7 +23,6 @@ import { NgStyleInterface, NzSafeAny, NzSizeDSType } from 'ng-zorro-antd/core/ty
   selector: 'nz-badge-sup',
   exportAs: 'nzBadgeSup',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzNoAnimationDirective],
   template: `
     @if (count <= nzOverflowCount) {

--- a/components/badge/badge.component.ts
+++ b/components/badge/badge.component.ts
@@ -5,7 +5,6 @@
 
 import { Directionality } from '@angular/cdk/bidi';
 import {
-  ChangeDetectionStrategy,
   Component,
   Input,
   OnChanges,
@@ -31,7 +30,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'badge';
   selector: 'nz-badge',
   exportAs: 'nzBadge',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzBadgeSupComponent, NzOutletModule],
   template: `
     @if ((nzStatus || nzColor) && !showSup && !nzCount) {

--- a/components/badge/ribbon.component.ts
+++ b/components/badge/ribbon.component.ts
@@ -3,15 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnChanges,
-  SimpleChanges,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 
@@ -21,7 +13,6 @@ import { badgePresetColors } from './preset-colors';
   selector: 'nz-ribbon',
   exportAs: 'nzRibbon',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzOutletModule],
   template: `
     <ng-content />

--- a/components/breadcrumb/breadcrumb-item.component.ts
+++ b/components/breadcrumb/breadcrumb-item.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, Input, ViewEncapsulation } from '@angular/core';
+import { Component, inject, Input, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzDropdownMenuComponent, NzDropdownModule } from 'ng-zorro-antd/dropdown';
@@ -14,10 +14,9 @@ import { NzBreadcrumb } from './breadcrumb';
 import { NzBreadCrumbSeparatorComponent } from './breadcrumb-separator.component';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-breadcrumb-item',
   exportAs: 'nzBreadcrumbItem',
+  encapsulation: ViewEncapsulation.None,
   imports: [NgTemplateOutlet, NzBreadCrumbSeparatorComponent, NzDropdownModule, NzIconModule, NzOutletModule],
   template: `
     @if (!!nzOverlay) {

--- a/components/breadcrumb/breadcrumb.component.ts
+++ b/components/breadcrumb/breadcrumb.component.ts
@@ -5,7 +5,6 @@
 
 import { Directionality } from '@angular/cdk/bidi';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Injector,
@@ -52,7 +51,6 @@ export interface BreadcrumbOption {
     class: 'ant-breadcrumb',
     '[class.ant-breadcrumb-rtl]': `dir() === 'rtl'`
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzBreadCrumbComponent implements OnInit, NzBreadcrumb {

--- a/components/button/button.component.ts
+++ b/components/button/button.component.ts
@@ -9,7 +9,6 @@ import {
   afterEveryRender,
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -48,7 +47,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'button';
   selector: 'button[nz-button], a[nz-button]',
   exportAs: 'nzButton',
   imports: [NzIconModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzLoading) {

--- a/components/calendar/calendar-header.component.ts
+++ b/components/calendar/calendar-header.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -26,10 +25,9 @@ import { NzRadioModule } from 'ng-zorro-antd/radio';
 import { NzSelectModule, NzSelectSizeType } from 'ng-zorro-antd/select';
 
 @Component({
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'nz-calendar-header',
   exportAs: 'nzCalendarHeader',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzCustomHeader) {
       <ng-container *nzStringTemplateOutlet="nzCustomHeader">{{ nzCustomHeader }}</ng-container>

--- a/components/calendar/calendar.component.ts
+++ b/components/calendar/calendar.component.ts
@@ -5,7 +5,6 @@
 
 import { Directionality } from '@angular/cdk/bidi';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -86,8 +85,7 @@ type NzCalendarDateTemplate = TemplateRef<{ $implicit: Date }>;
     '[class.ant-picker-calendar-mini]': '!nzFullscreen',
     '[class.ant-picker-calendar-rtl]': `dir() === 'rtl'`
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzCalendarComponent implements ControlValueAccessor, OnChanges {
   private readonly cdr = inject(ChangeDetectorRef);

--- a/components/card/card-meta.component.ts
+++ b/components/card/card-meta.component.ts
@@ -4,14 +4,13 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 
 @Component({
   selector: 'nz-card-meta',
   exportAs: 'nzCardMeta',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzAvatar) {

--- a/components/card/card-tab.component.ts
+++ b/components/card/card-tab.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'nz-card-tab',
   exportAs: 'nzCardTab',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-template>
       <ng-content />

--- a/components/card/card.component.ts
+++ b/components/card/card.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -32,7 +31,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'card';
 @Component({
   selector: 'nz-card',
   exportAs: 'nzCard',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzTitle || nzExtra || listOfNzCardTabComponent) {

--- a/components/carousel/carousel.component.ts
+++ b/components/carousel/carousel.component.ts
@@ -10,7 +10,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -59,10 +58,9 @@ import {
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'carousel';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-carousel',
   exportAs: 'nzCarousel',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div
       class="slick-initialized slick-slider"

--- a/components/cascader/cascader-option.component.ts
+++ b/components/cascader/cascader-option.component.ts
@@ -6,7 +6,6 @@
 import { Direction } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -76,7 +75,6 @@ import { NzCascaderOption } from './typings';
     '[class.ant-cascader-menu-item-expand]': '!node.isLeaf',
     '[class.ant-cascader-menu-item-disabled]': 'node.isDisabled'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzCascaderOptionComponent implements OnInit {

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -15,7 +15,6 @@ import { _getEventTarget } from '@angular/cdk/platform';
 import { NgTemplateOutlet, SlicePipe } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -101,10 +100,9 @@ import {
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'cascader';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-cascader, [nz-cascader]',
   exportAs: 'nzCascader',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzShowInput) {
       <div #selectContainer class="ant-select-selector">

--- a/components/cdk/overflow/overflow-container.component.ts
+++ b/components/cdk/overflow/overflow-container.component.ts
@@ -5,7 +5,6 @@
 
 import {
   Component,
-  ChangeDetectionStrategy,
   ContentChildren,
   QueryList,
   ElementRef,
@@ -33,8 +32,7 @@ import { NzOverflowSuffixDirective } from './overflow-suffix.directive';
     <ng-content select="[appOverflowRest]" />
     <ng-content select="[appOverflowSuffix]" />
   `,
-  providers: [NzResizeObserver],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  providers: [NzResizeObserver]
 })
 export class NzOverflowContainerComponent implements OnInit, AfterContentInit {
   private nzResizeObserver = inject(NzResizeObserver);

--- a/components/check-list/check-list-button.component.ts
+++ b/components/check-list/check-list-button.component.ts
@@ -3,11 +3,10 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'nz-check-list-button',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `<ng-content />`,
   host: {

--- a/components/check-list/check-list-content.component.ts
+++ b/components/check-list/check-list-content.component.ts
@@ -4,16 +4,7 @@
  */
 
 import { DecimalPipe } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input,
-  output,
-  signal,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, computed, input, output, signal, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';
@@ -27,7 +18,6 @@ import { NzItemProps } from './typings';
 
 @Component({
   selector: 'nz-check-list-content',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [NzIconModule, NzProgressModule, NzOutletModule, NzCheckboxModule, NzButtonModule, FormsModule, DecimalPipe],
   template: `

--- a/components/check-list/check-list.component.ts
+++ b/components/check-list/check-list.component.ts
@@ -5,7 +5,6 @@
 
 import { DecimalPipe } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -29,7 +28,6 @@ import { NzItemProps } from './typings';
 
 @Component({
   selector: 'nz-check-list',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [
     NzPopoverModule,

--- a/components/checkbox/checkbox-group.component.ts
+++ b/components/checkbox/checkbox-group.component.ts
@@ -6,7 +6,6 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { Directionality } from '@angular/cdk/bidi';
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -68,8 +67,7 @@ export interface NzCheckboxOption {
     class: 'ant-checkbox-group',
     '[class.ant-checkbox-group-rtl]': `dir() === 'rtl'`
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzCheckboxGroupComponent implements ControlValueAccessor {
   private onChange: OnChangeType = () => {};

--- a/components/checkbox/checkbox.component.ts
+++ b/components/checkbox/checkbox.component.ts
@@ -7,7 +7,6 @@ import { FocusMonitor } from '@angular/cdk/a11y';
 import { Directionality } from '@angular/cdk/bidi';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -36,7 +35,6 @@ import { NZ_CHECKBOX_GROUP } from './tokens';
 @Component({
   selector: '[nz-checkbox]',
   exportAs: 'nzCheckbox',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <span

--- a/components/code-editor/code-editor.component.ts
+++ b/components/code-editor/code-editor.component.ts
@@ -8,7 +8,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -44,10 +43,9 @@ type IStandaloneDiffEditor = editor.IStandaloneDiffEditor;
 declare const monaco: NzSafeAny;
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-code-editor',
   exportAs: 'nzCodeEditor',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzLoading) {
       <div class="ant-code-editor-loading">

--- a/components/collapse/collapse-panel.component.ts
+++ b/components/collapse/collapse-panel.component.ts
@@ -6,7 +6,6 @@
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -37,7 +36,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapsePanel';
 @Component({
   selector: 'nz-collapse-panel',
   exportAs: 'nzCollapsePanel',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <div

--- a/components/collapse/collapse.component.ts
+++ b/components/collapse/collapse.component.ts
@@ -4,15 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  inject,
-  Input,
-  ViewEncapsulation
-} from '@angular/core';
+import { booleanAttribute, ChangeDetectorRef, Component, inject, Input, ViewEncapsulation } from '@angular/core';
 
 import { NzConfigKey, onConfigChangeEventForComponent, WithConfig } from 'ng-zorro-antd/core/config';
 import type { NzSizeLMSType } from 'ng-zorro-antd/core/types';
@@ -24,7 +16,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'collapse';
 @Component({
   selector: 'nz-collapse',
   exportAs: 'nzCollapse',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `<ng-content />`,
   host: {

--- a/components/color-picker/color-block.component.ts
+++ b/components/color-picker/color-block.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
 
@@ -13,7 +13,6 @@ import { defaultColor } from './src/util/util';
 @Component({
   selector: 'nz-color-block',
   exportAs: 'nzColorBlock',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgAntdColorPickerModule],
   template: `<ng-antd-color-block [color]="nzColor" (nzOnClick)="nzOnClick.emit()" />`,
   host: {

--- a/components/color-picker/color-format.component.ts
+++ b/components/color-picker/color-format.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   EventEmitter,
@@ -38,7 +37,6 @@ import { NzColorPickerFormatType, ValidFormKey } from './typings';
 @Component({
   selector: 'nz-color-format',
   exportAs: 'nzColorFormat',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [ReactiveFormsModule, NzSelectModule, NzInputModule, NzInputNumberModule],
   template: `
     <div class="ant-color-picker-format-select">

--- a/components/color-picker/color-picker.component.ts
+++ b/components/color-picker/color-picker.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -39,7 +38,6 @@ import { NzColor, NzColorPickerFormatType, NzColorPickerTriggerType, NzPresetCol
 @Component({
   selector: 'nz-color-picker',
   exportAs: 'nzColorPicker',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgAntdColorPickerModule,
     NzPopoverDirective,

--- a/components/color-picker/src/components/picker.component.ts
+++ b/components/color-picker/src/components/picker.component.ts
@@ -6,7 +6,6 @@
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DOCUMENT,
@@ -49,7 +48,6 @@ function getPosition(e: EventType): { pageX: number; pageY: number } {
       <div class="ant-color-picker-saturation" [style.background-color]="toHsb()"></div>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-color-picker-select',
     '(mousedown)': 'dragStartHandle($event)',

--- a/components/color-picker/src/components/slider.component.ts
+++ b/components/color-picker/src/components/slider.component.ts
@@ -6,7 +6,6 @@
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DOCUMENT,
@@ -50,7 +49,6 @@ function getPosition(e: EventType): { pageX: number; pageY: number } {
       <color-gradient [colors]="gradientColors" [direction]="direction" [type]="type" />
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-color-picker-slider',
     '[class]': `'ant-color-picker-slider-' + type`,

--- a/components/color-picker/src/ng-antd-color-block.component.ts
+++ b/components/color-picker/src/ng-antd-color-block.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import type { Color } from './interfaces/color';
 import { defaultColor, generateColor } from './util/util';
@@ -12,7 +12,6 @@ import { defaultColor, generateColor } from './util/util';
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'ng-antd-color-block',
   template: `<div class="ant-color-picker-color-block-inner" [style.background-color]="color"></div>`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-color-picker-color-block ant-color-picker-presets-color',
     '[class.ant-color-picker-presets-color-checked]': 'isChecked',

--- a/components/color-picker/src/ng-antd-color-picker.component.ts
+++ b/components/color-picker/src/ng-antd-color-picker.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -90,7 +89,6 @@ import { defaultColor, generateColor } from './util/util';
       }
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-color-picker-inner'
   }

--- a/components/color-picker/src/ng-antd-color-preset.component.ts
+++ b/components/color-picker/src/ng-antd-color-preset.component.ts
@@ -3,16 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  inject,
-  Input,
-  OnInit,
-  Output
-} from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, inject, Input, OnInit, Output } from '@angular/core';
 
 import { NzCollapseModule } from 'ng-zorro-antd/collapse';
 
@@ -24,7 +15,6 @@ import { generateColor } from './util/util';
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'ng-antd-color-preset',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzCollapseModule, NgAntdColorBlockComponent],
   template: `
     <div class="ant-color-picker-presets">

--- a/components/comment/comment-cells.ts
+++ b/components/comment/comment-cells.ts
@@ -6,7 +6,6 @@
 import { CdkPortalOutlet, TemplatePortal } from '@angular/cdk/portal';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   Directive,
   inject,
@@ -56,8 +55,7 @@ export class NzCommentActionHostDirective extends CdkPortalOutlet implements OnI
   selector: 'nz-comment-action',
   exportAs: 'nzCommentAction',
   template: '<ng-template><ng-content /></ng-template>',
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzCommentActionComponent implements OnInit {
   @ViewChild(TemplateRef, { static: true }) implicitContent!: TemplateRef<void>;

--- a/components/comment/comment.component.ts
+++ b/components/comment/comment.component.ts
@@ -4,16 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ContentChildren,
-  inject,
-  Input,
-  QueryList,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, ContentChildren, inject, Input, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 
@@ -57,7 +48,6 @@ import { NzCommentActionComponent as CommentAction, NzCommentActionHostDirective
     </div>
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.ant-comment]': `true`,
     '[class.ant-comment-rtl]': `dir() === "rtl"`

--- a/components/core/form/nz-form-item-feedback-icon.component.ts
+++ b/components/core/form/nz-form-item-feedback-icon.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { Component, computed, input, ViewEncapsulation } from '@angular/core';
 
 import { NzValidateStatus } from 'ng-zorro-antd/core/types';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -21,7 +21,6 @@ const CLASS_NAME = 'ant-form-item-feedback-icon';
   exportAs: 'nzFormFeedbackIcon',
   imports: [NzIconModule],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (iconType(); as type) {
       <nz-icon [nzType]="type" />

--- a/components/cron-expression/cron-expression-input.component.ts
+++ b/components/cron-expression/cron-expression-input.component.ts
@@ -3,15 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  ViewEncapsulation,
-  booleanAttribute
-} from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewEncapsulation, booleanAttribute } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NzInputModule } from 'ng-zorro-antd/input';
@@ -19,10 +11,9 @@ import { NzInputModule } from 'ng-zorro-antd/input';
 import { CronChangeType, TimeType } from './typings';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-cron-expression-input',
   exportAs: 'nzCronExpressionInput',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div class="ant-cron-expression-input">
       <input

--- a/components/cron-expression/cron-expression-label.component.ts
+++ b/components/cron-expression/cron-expression-label.component.ts
@@ -3,17 +3,16 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Component, ViewEncapsulation, ChangeDetectionStrategy, Input } from '@angular/core';
+import { Component, ViewEncapsulation, Input } from '@angular/core';
 
 import { NzCronExpressionLabelI18n } from 'ng-zorro-antd/i18n';
 
 import { TimeType } from './typings';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-cron-expression-label',
   exportAs: 'nzCronExpressionLabel',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div class="ant-cron-expression-label" [class.ant-cron-expression-label-foucs]="labelFocus === type">
       <label>

--- a/components/cron-expression/cron-expression-preview.component.ts
+++ b/components/cron-expression/cron-expression-preview.component.ts
@@ -5,7 +5,6 @@
 
 import { DatePipe, NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -21,10 +20,9 @@ import { NzCronExpressionCronErrorI18n } from 'ng-zorro-antd/i18n';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-cron-expression-preview',
   exportAs: 'nzCronExpressionPreview',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div class="ant-collapse ant-collapse-borderless ant-cron-expression-preview">
       <div class="ant-cron-expression-preview-dateTime" [class.ant-cron-expression-preview-dateTime-center]="!isExpand">

--- a/components/cron-expression/cron-expression.component.ts
+++ b/components/cron-expression/cron-expression.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -50,10 +49,9 @@ function labelsOfType(type: NzCronExpressionType): TimeType[] {
 }
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-cron-expression',
   exportAs: 'nzCronExpression',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div class="ant-cron-expression">
       <div class="ant-cron-expression-content">

--- a/components/date-picker/calendar-footer.component.ts
+++ b/components/date-picker/calendar-footer.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -79,8 +78,7 @@ import { PREFIX_CLASS } from './util';
       }
     </div>
   `,
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class CalendarFooterComponent implements OnChanges {
   private dateHelper = inject(DateHelperService);

--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -16,7 +16,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -108,10 +107,9 @@ export type NzDatePickerSizeType = 'large' | 'default' | 'small';
  * The base picker for all common APIs
  */
 @Component({
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'nz-date-picker,nz-week-picker,nz-month-picker,nz-quarter-picker,nz-year-picker,nz-range-picker',
   exportAs: 'nzDatePicker',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (!nzInline()) {
       @if (!isRange) {

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -7,7 +7,6 @@ import { Direction } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -54,10 +53,9 @@ import {
 import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
 
 @Component({
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'date-range-popup',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (isRange) {
       <div class="{{ prefixCls }}-range-wrapper {{ prefixCls }}-date-range-wrapper">

--- a/components/date-picker/inner-popup.component.ts
+++ b/components/date-picker/inner-popup.component.ts
@@ -5,7 +5,6 @@
 
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -30,7 +29,6 @@ import { PREFIX_CLASS } from './util';
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'inner-popup',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div (mouseleave)="onLeave()" [class.ant-picker-datetime-panel]="showTimePicker">
       <div class="{{ prefixCls }}-{{ panelMode }}-panel">

--- a/components/descriptions/descriptions-item.component.ts
+++ b/components/descriptions/descriptions-item.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   Input,
   OnChanges,
@@ -17,9 +16,8 @@ import {
 import { Subject } from 'rxjs';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-descriptions-item',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <ng-template>
       <ng-content />

--- a/components/descriptions/descriptions.component.ts
+++ b/components/descriptions/descriptions.component.ts
@@ -7,7 +7,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -46,10 +45,9 @@ const defaultColumnMap: ResponsiveLike<number> = {
 const DEFAULT_COLUMN_NUM = 3;
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-descriptions',
   exportAs: 'nzDescriptions',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzTitle || nzExtra) {
       <div class="ant-descriptions-header">

--- a/components/divider/divider.component.ts
+++ b/components/divider/divider.component.ts
@@ -3,14 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  TemplateRef,
-  ViewEncapsulation,
-  booleanAttribute
-} from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation, booleanAttribute } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import type { NzSizeLMSType } from 'ng-zorro-antd/core/types';
@@ -19,7 +12,6 @@ import type { NzSizeLMSType } from 'ng-zorro-antd/core/types';
   selector: 'nz-divider',
   exportAs: 'nzDivider',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (nzText) {
       <span class="ant-divider-inner-text">

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -19,7 +19,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -70,6 +69,7 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
 @Component({
   selector: 'nz-drawer',
   exportAs: 'nzDrawer',
+  imports: [NzNoAnimationDirective, NzOutletModule, NzIconModule, PortalModule, NgTemplateOutlet, CdkScrollable],
   template: `
     <ng-template #drawerTemplate>
       <div
@@ -148,24 +148,21 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'drawer';
         </div>
       </div>
     </ng-template>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NzNoAnimationDirective, NzOutletModule, NzIconModule, PortalModule, NgTemplateOutlet, CdkScrollable]
+  `
 })
 export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extends Partial<T> = NzSafeAny>
   extends NzDrawerRef<T, R>
   implements OnInit, AfterViewInit, OnChanges, NzDrawerOptionsOfComponent
 {
-  private cdr = inject(ChangeDetectorRef);
-  private renderer = inject(Renderer2);
-  private injector = inject(Injector);
-  private changeDetectorRef = inject(ChangeDetectorRef);
-  private focusTrapFactory = inject(FocusTrapFactory);
-  private viewContainerRef = inject(ViewContainerRef);
-  private overlayKeyboardDispatcher = inject(OverlayKeyboardDispatcher);
+  private readonly renderer = inject(Renderer2);
+  private readonly injector = inject(Injector);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly focusTrapFactory = inject(FocusTrapFactory);
+  private readonly viewContainerRef = inject(ViewContainerRef);
+  private readonly overlayKeyboardDispatcher = inject(OverlayKeyboardDispatcher);
   private readonly directionality = inject(Directionality);
-  private destroyRef = inject(DestroyRef);
-  private document = inject(DOCUMENT);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly document = inject(DOCUMENT);
 
   readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
 

--- a/components/dropdown/dropdown-menu.component.ts
+++ b/components/dropdown/dropdown-menu.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -38,6 +37,7 @@ export type NzPlacementType = 'bottomLeft' | 'bottomCenter' | 'bottomRight' | 't
       useValue: true
     }
   ],
+  imports: [NzNoAnimationDirective],
   template: `
     <ng-template>
       <div
@@ -66,18 +66,16 @@ export type NzPlacementType = 'bottomLeft' | 'bottomCenter' | 'bottomRight' | 't
       </div>
     </ng-template>
   `,
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NzNoAnimationDirective]
+  encapsulation: ViewEncapsulation.None
 })
 export class NzDropdownMenuComponent implements AfterContentInit {
-  private cdr = inject(ChangeDetectorRef);
-  private elementRef = inject(ElementRef);
-  private renderer = inject(Renderer2);
-  public viewContainerRef = inject(ViewContainerRef);
+  public readonly viewContainerRef = inject(ViewContainerRef);
+  public readonly nzMenuService = inject(MenuService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly elementRef = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
   protected readonly dir = inject(Directionality).valueSignal;
-  noAnimation = inject(NzNoAnimationDirective, { host: true, optional: true });
-  public nzMenuService = inject(MenuService);
+  protected readonly noAnimation = inject(NzNoAnimationDirective, { host: true, optional: true });
 
   isChildSubMenuOpen$ = this.nzMenuService.isChildSubMenuOpen$;
   descendantMenuItemClick$ = this.nzMenuService.descendantMenuItemClick$;

--- a/components/empty/embed-empty.component.ts
+++ b/components/empty/embed-empty.component.ts
@@ -5,7 +5,6 @@
 
 import { ComponentPortal, Portal, PortalModule } from '@angular/cdk/portal';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   inject,
@@ -45,10 +44,9 @@ function getEmptySize(componentName: string): NzEmptySize {
 type NzEmptyContentType = 'component' | 'template' | 'string';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-embed-empty',
   exportAs: 'nzEmbedEmpty',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (content) {
       @if (contentType === 'template' || contentType === 'string') {

--- a/components/empty/empty.component.ts
+++ b/components/empty/empty.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -28,10 +27,9 @@ const NzEmptyDefaultImages = ['default', 'simple'] as const;
 type NzEmptyNotFoundImageType = (typeof NzEmptyDefaultImages)[number] | null | string | TemplateRef<void>;
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-empty',
   exportAs: 'nzEmpty',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div class="ant-empty-image">
       @if (!isImageBuildIn) {

--- a/components/empty/partial/default.ts
+++ b/components/empty/partial/default.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-empty-default',
   exportAs: 'nzEmptyDefault',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <svg
       class="ant-empty-img-default"

--- a/components/empty/partial/simple.ts
+++ b/components/empty/partial/simple.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-empty-simple',
   exportAs: 'nzEmptySimple',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <svg class="ant-empty-img-simple" width="64" height="41" viewBox="0 0 64 41" xmlns="http://www.w3.org/2000/svg">
       <g transform="translate(0 1)" fill="none" fill-rule="evenodd">

--- a/components/experimental/image/image.component.ts
+++ b/components/experimental/image/image.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -49,7 +48,6 @@ const sizeBreakpoints = [16, 32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080,
       [attr.alt]="nzAlt || null"
     />
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [NzImageDirective]
 })

--- a/components/float-button/float-button-content.component.ts
+++ b/components/float-button/float-button-content.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, TemplateRef } from '@angular/core';
+import { Component, input, TemplateRef } from '@angular/core';
 
 import { NzBadgeComponent } from 'ng-zorro-antd/badge';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
@@ -17,7 +17,6 @@ import { NzFloatButtonBadge } from './typings';
   selector: 'nz-float-button-content',
   exportAs: 'nzFloatButtonContent',
   imports: [NzIconModule, NzOutletModule, NzBadgeComponent, NgTemplateOutlet],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (nzBadge()) {
       <nz-badge

--- a/components/float-button/float-button-group.component.ts
+++ b/components/float-button/float-button-group.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChildren,
@@ -33,7 +32,6 @@ const CLASS_NAME = 'ant-float-btn-group';
   selector: 'nz-float-button-group',
   exportAs: 'nzFloatButtonGroup',
   imports: [NzFloatButtonComponent, NzIconModule, NgTemplateOutlet],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (!isMenuMode()) {
       <ng-container *ngTemplateOutlet="menu" />

--- a/components/float-button/float-button-top.component.ts
+++ b/components/float-button/float-button-top.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { normalizePassiveListenerOptions, Platform } from '@angular/cdk/platform';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,
@@ -66,7 +65,6 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
   host: {
     '[class]': 'class()'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzFloatButtonTopComponent implements OnInit {

--- a/components/float-button/float-button.component.ts
+++ b/components/float-button/float-button.component.ts
@@ -5,16 +5,7 @@
 
 import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  input,
-  linkedSignal,
-  output,
-  TemplateRef
-} from '@angular/core';
+import { Component, computed, inject, input, linkedSignal, output, TemplateRef } from '@angular/core';
 
 import { NzBadgeModule } from 'ng-zorro-antd/badge';
 import { NzButtonModule } from 'ng-zorro-antd/button';
@@ -30,7 +21,6 @@ const CLASS_NAME = 'ant-float-btn';
   selector: 'nz-float-button',
   exportAs: 'nzFloatButton',
   imports: [NzButtonModule, NzFloatButtonContentComponent, NzBadgeModule, NgTemplateOutlet],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (!!nzHref()) {
       <a

--- a/components/form/form-control.component.ts
+++ b/components/form/form-control.component.ts
@@ -7,7 +7,6 @@ import {
   AfterContentInit,
   AnimationCallbackEvent,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -39,7 +38,6 @@ import { NzFormDirective } from './form.directive';
   selector: 'nz-form-control',
   exportAs: 'nzFormControl',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="ant-form-item-control-input">
       <div class="ant-form-item-control-input-content">

--- a/components/form/form-item.component.ts
+++ b/components/form/form-item.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component, inject, input, ViewEncapsulation } from '@angular/core';
 
 import type { NzFormItemLayout } from './types';
 
@@ -13,7 +13,6 @@ export type NzFormControlStatusType = 'success' | 'error' | 'warning' | 'validat
 @Component({
   selector: 'nz-form-item',
   exportAs: 'nzFormItem',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-form-item',

--- a/components/form/form-label.component.ts
+++ b/components/form/form-label.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Input,
@@ -42,7 +41,6 @@ function toTooltipIcon(value: string | NzFormTooltipIcon): Required<NzFormToolti
   selector: 'nz-form-label',
   exportAs: 'nzFormLabel',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <label
       [attr.for]="nzFor"

--- a/components/form/form-split.component.ts
+++ b/components/form/form-split.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'nz-form-split',
   exportAs: 'nzFormSplit',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content />`,
   host: {
     class: 'ant-form-split'

--- a/components/form/form-text.component.ts
+++ b/components/form/form-text.component.ts
@@ -3,12 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'nz-form-text',
   exportAs: 'nzFormText',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `<ng-content />`,
   host: {

--- a/components/graph/graph-edge.component.ts
+++ b/components/graph/graph-edge.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   Injector,
@@ -39,7 +38,6 @@ import { NzGraphEdge, NzGraphEdgeType } from './interface';
       </svg:g>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgTemplateOutlet]
 })
 export class NzGraphEdgeComponent implements OnInit, OnChanges {

--- a/components/graph/graph-minimap.component.ts
+++ b/components/graph/graph-minimap.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, NgZone } from '@angular/core';
+import { Component, DestroyRef, ElementRef, inject, NgZone } from '@angular/core';
 
 import type { ZoomBehavior } from 'd3-zoom';
 
@@ -35,7 +35,6 @@ import { NzZoomTransform } from './interface';
     <!-- Additional canvas to use as buffer to avoid flickering between updates -->
     <canvas class="buffer"></canvas>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.nz-graph-minimap]': 'true'
   }

--- a/components/graph/graph-node.component.ts
+++ b/components/graph/graph-node.component.ts
@@ -6,7 +6,6 @@
 import { coerceCssPixelValue } from '@angular/cdk/coercion';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -46,7 +45,6 @@ const translate = (x: number, y: number): string => `translate(${coerceCssPixelV
       }
     </svg:g>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[id]': 'node.id || node.name',
     '[class.nz-graph-node-expanded]': 'node.expanded',

--- a/components/graph/graph.component.ts
+++ b/components/graph/graph.component.ts
@@ -7,7 +7,6 @@ import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentChecked,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -71,10 +70,9 @@ function isDataSource(value: NzSafeAny): value is NzGraphData {
 }
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-graph',
   exportAs: 'nzGraph',
+  encapsulation: ViewEncapsulation.None,
   providers: [{ provide: NzGraph, useExisting: forwardRef(() => NzGraphComponent) }],
   template: `
     <ng-content />

--- a/components/hash-code/hash-code.component.ts
+++ b/components/hash-code/hash-code.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -22,10 +21,9 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzModeType } from './typings';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NzIconModule, NzStringTemplateOutletDirective],
   selector: 'nz-hash-code',
   exportAs: 'nzHashCode',
+  imports: [NzIconModule, NzStringTemplateOutletDirective],
   template: `
     @if (nzMode !== 'single' && nzMode !== 'rect') {
       <div class="ant-hash-code-header">

--- a/components/image/image-group.component.ts
+++ b/components/image/image-group.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ViewEncapsulation } from '@angular/core';
 
 import { NzImageDirective } from './image.directive';
 
@@ -11,7 +11,6 @@ import { NzImageDirective } from './image.directive';
   selector: 'nz-image-group',
   exportAs: 'nzImageGroup',
   template: '<ng-content />',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzImageGroupComponent {

--- a/components/image/image-preview.component.ts
+++ b/components/image/image-preview.component.ts
@@ -6,7 +6,6 @@
 import { CdkDrag, CdkDragEnd, CdkDragHandle } from '@angular/cdk/drag-drop';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -137,7 +136,6 @@ const NZ_DEFAULT_ROTATE = 0;
       </div>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-image-preview-root',

--- a/components/input-number/input-number.component.ts
+++ b/components/input-number/input-number.component.ts
@@ -10,7 +10,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   afterNextRender,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChild,
@@ -194,7 +193,6 @@ export interface NzInputNumberStepEvent {
     },
     { provide: NZ_SPACE_COMPACT_ITEM_TYPE, useValue: 'input-number' }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     '[class]': 'class()',

--- a/components/input/input-otp.component.ts
+++ b/components/input/input-otp.component.ts
@@ -6,7 +6,6 @@
 import { BACKSPACE, LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -40,7 +39,6 @@ import { NzInputDirective } from './input.directive';
   selector: 'nz-input-otp',
   exportAs: 'nzInputOtp',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @for (item of otpArray.controls; track $index) {
       <input

--- a/components/input/input-wrapper.component.ts
+++ b/components/input/input-wrapper.component.ts
@@ -9,7 +9,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   afterNextRender,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChild,
@@ -169,7 +168,6 @@ export interface NzCountConfig {
     { provide: NZ_SPACE_COMPACT_ITEM_TYPE, useValue: 'input' },
     { provide: NZ_INPUT_WRAPPER, useExisting: forwardRef(() => NzInputWrapperComponent) }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   hostDirectives: [NzSpaceCompactItemDirective],
   host: {

--- a/components/input/textarea-count.component.ts
+++ b/components/input/textarea-count.component.ts
@@ -5,7 +5,6 @@
 
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   Component,
   ContentChild,
   DestroyRef,
@@ -29,8 +28,7 @@ import { NzInputDirective } from './input.directive';
   template: `<ng-content select="textarea[nz-input]" />`,
   host: {
     class: 'ant-input-textarea-show-count'
-  },
-  changeDetection: ChangeDetectionStrategy.OnPush
+  }
 })
 export class NzTextareaCountComponent implements AfterContentInit {
   private renderer = inject(Renderer2);

--- a/components/layout/content.component.ts
+++ b/components/layout/content.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'nz-content',
   exportAs: 'nzContent',
   template: `<ng-content />`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-layout-content'

--- a/components/layout/footer.component.ts
+++ b/components/layout/footer.component.ts
@@ -3,14 +3,13 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'nz-footer',
   exportAs: 'nzFooter',
   template: `<ng-content />`,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-layout-footer'
   }

--- a/components/layout/header.component.ts
+++ b/components/layout/header.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'nz-header',
   exportAs: 'nzHeader',
   template: `<ng-content />`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-layout-header'

--- a/components/layout/layout.component.ts
+++ b/components/layout/layout.component.ts
@@ -4,14 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ContentChildren,
-  inject,
-  QueryList,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, ContentChildren, inject, QueryList, ViewEncapsulation } from '@angular/core';
 
 import { NzSiderComponent } from './sider.component';
 
@@ -20,7 +13,6 @@ import { NzSiderComponent } from './sider.component';
   exportAs: 'nzLayout',
   template: `<ng-content />`,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-layout',
     '[class.ant-layout-rtl]': `dir() === 'rtl'`,

--- a/components/layout/sider-trigger.component.ts
+++ b/components/layout/sider-trigger.component.ts
@@ -4,15 +4,7 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, Input, OnChanges, OnInit, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { Breakpoint } from 'ng-zorro-antd/core/services';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -21,7 +13,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   selector: '[nz-sider-trigger]',
   exportAs: 'nzSiderTrigger',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (isZeroTrigger) {
       <ng-template [ngTemplateOutlet]="nzZeroTrigger || defaultZeroTrigger" />

--- a/components/layout/sider.component.ts
+++ b/components/layout/sider.component.ts
@@ -6,7 +6,6 @@
 import { Platform } from '@angular/cdk/platform';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -34,7 +33,6 @@ import { NzSiderTriggerComponent } from './sider-trigger.component';
   selector: 'nz-sider',
   exportAs: 'nzSider',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="ant-layout-sider-children">
       <ng-content />

--- a/components/list/demo/infinite-load.ts
+++ b/components/list/demo/infinite-load.ts
@@ -1,7 +1,7 @@
 import { CollectionViewer, DataSource } from '@angular/cdk/collections';
 import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
@@ -57,8 +57,7 @@ interface Name {
     nz-list {
       padding: 24px;
     }
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class NzDemoListInfiniteLoadComponent implements OnInit {
   private http = inject(HttpClient);

--- a/components/list/list-cell.ts
+++ b/components/list/list-cell.ts
@@ -3,14 +3,13 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Directive, Input, TemplateRef } from '@angular/core';
+import { Component, Directive, Input, TemplateRef } from '@angular/core';
 
 import { NzEmptyModule } from 'ng-zorro-antd/empty';
 
 @Component({
   selector: 'nz-list-empty',
   exportAs: 'nzListHeader',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<nz-embed-empty nzComponentName="list" [specificContent]="nzNoResult" />`,
   host: {
     class: 'ant-list-empty-text'
@@ -24,7 +23,6 @@ export class NzListEmptyComponent {
 @Component({
   selector: 'nz-list-header',
   exportAs: 'nzListHeader',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content />`,
   host: {
     class: 'ant-list-header'
@@ -35,7 +33,6 @@ export class NzListHeaderComponent {}
 @Component({
   selector: 'nz-list-footer',
   exportAs: 'nzListFooter',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content />`,
   host: {
     class: 'ant-list-footer'
@@ -46,7 +43,6 @@ export class NzListFooterComponent {}
 @Component({
   selector: 'nz-list-pagination',
   exportAs: 'nzListPagination',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content />`,
   host: {
     class: 'ant-list-pagination'

--- a/components/list/list-item-cell.ts
+++ b/components/list/list-item-cell.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -26,7 +25,6 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
 @Component({
   selector: 'nz-list-item-extra, [nz-list-item-extra]',
   exportAs: 'nzListItemExtra',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content />`,
   host: {
     class: 'ant-list-item-extra'
@@ -37,7 +35,6 @@ export class NzListItemExtraComponent {}
 @Component({
   selector: 'nz-list-item-action',
   exportAs: 'nzListItemAction',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-template><ng-content /></ng-template>`
 })
 export class NzListItemActionComponent {
@@ -47,7 +44,6 @@ export class NzListItemActionComponent {
 @Component({
   selector: 'ul[nz-list-item-actions]',
   exportAs: 'nzListItemActions',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @for (i of actions; track i) {
       <li>

--- a/components/list/list-item-meta-cell.ts
+++ b/components/list/list-item-meta-cell.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 
@@ -14,8 +14,7 @@ import { NzAvatarModule } from 'ng-zorro-antd/avatar';
     <h4 class="ant-list-item-meta-title">
       <ng-content />
     </h4>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class NzListItemMetaTitleComponent {}
 
@@ -26,8 +25,7 @@ export class NzListItemMetaTitleComponent {}
     <div class="ant-list-item-meta-description">
       <ng-content />
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class NzListItemMetaDescriptionComponent {}
 
@@ -43,7 +41,6 @@ export class NzListItemMetaDescriptionComponent {}
       }
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzAvatarModule]
 })
 export class NzListItemMetaAvatarComponent {

--- a/components/list/list-item-meta.component.ts
+++ b/components/list/list-item-meta.component.ts
@@ -4,16 +4,7 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ContentChild,
-  ElementRef,
-  inject,
-  Input,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, ContentChild, ElementRef, inject, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 
@@ -66,7 +57,6 @@ import {
       </div>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-list-item-meta'

--- a/components/list/list-item.component.ts
+++ b/components/list/list-item.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -65,7 +64,6 @@ import { NzListComponent } from './list.component';
     }
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-list-item',
     '[class.ant-list-item-no-flex]': 'nzNoFlex'

--- a/components/list/list.component.ts
+++ b/components/list/list.component.ts
@@ -7,7 +7,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   Component,
   ContentChild,
   DestroyRef,
@@ -113,7 +112,6 @@ import {
     <ng-content select="nz-list-pagination, [nz-list-pagination]" />
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-list',
     '[class.ant-list-rtl]': `dir() === 'rtl'`,

--- a/components/mention/mention.component.ts
+++ b/components/mention/mention.component.ts
@@ -19,7 +19,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -131,7 +130,6 @@ export type MentionPlacement = 'top' | 'bottom';
       </span>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-mentions',
     '[class.ant-mentions-rtl]': `dir() === 'rtl'`,

--- a/components/menu/menu-group.component.ts
+++ b/components/menu/menu-group.component.ts
@@ -5,7 +5,6 @@
 
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   inject,
@@ -53,7 +52,6 @@ function MenuGroupFactory(): boolean {
     '[class.ant-menu-item-group]': '!isMenuInsideDropdown',
     '[class.ant-dropdown-menu-item-group]': 'isMenuInsideDropdown'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzMenuGroupComponent implements AfterViewInit {

--- a/components/menu/menu-item.component.ts
+++ b/components/menu/menu-item.component.ts
@@ -5,7 +5,6 @@
 
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   Component,
   ContentChildren,
   Input,
@@ -33,7 +32,6 @@ import { NzSubmenuService } from './submenu.service';
 @Component({
   selector: '[nz-menu-item]',
   exportAs: 'nzMenuItem',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <span class="ant-menu-title-content">

--- a/components/menu/submenu-inline-child.component.ts
+++ b/components/menu/submenu-inline-child.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import { ChangeDetectionStrategy, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
+import { Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
 
 import { NzAnimationCollapseDirective } from 'ng-zorro-antd/core/animation';
 import { generateClassName, getClassListFromValue } from 'ng-zorro-antd/core/util';
@@ -15,7 +15,6 @@ const MENU_PREFIX = 'ant-menu';
   selector: '[nz-submenu-inline-child]',
   exportAs: 'nzSubmenuInlineChild',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content />`,
   hostDirectives: [
     {

--- a/components/menu/submenu-non-inline-child.component.ts
+++ b/components/menu/submenu-non-inline-child.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import { ChangeDetectionStrategy, Component, computed, inject, input, output, ViewEncapsulation } from '@angular/core';
+import { Component, computed, inject, input, output, ViewEncapsulation } from '@angular/core';
 
 import { SLIDE_UP_ANIMATION_CLASS, withAnimationCheck } from 'ng-zorro-antd/core/animation';
 import { generateClassName, getClassListFromValue } from 'ng-zorro-antd/core/util';
@@ -30,7 +30,6 @@ const ANIMATION_CLASS = {
   selector: '[nz-submenu-none-inline-child]',
   exportAs: 'nzSubmenuNoneInlineChild',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div [class]="mergedMenuClass()">
       <ng-content />

--- a/components/menu/submenu-title.component.ts
+++ b/components/menu/submenu-title.component.ts
@@ -4,16 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  inject,
-  Input,
-  Output,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, EventEmitter, inject, Input, Output, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -25,7 +16,6 @@ import { NzMenuModeType, NzSubmenuTrigger } from './menu.types';
   selector: '[nz-submenu-title]',
   exportAs: 'nzSubmenuTitle',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (nzIcon) {
       <nz-icon [nzType]="nzIcon" />

--- a/components/menu/submenu.component.ts
+++ b/components/menu/submenu.component.ts
@@ -10,7 +10,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -65,7 +64,6 @@ const listOfHorizontalPositions = [
   exportAs: 'nzSubmenu',
   providers: [NzSubmenuService],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div
       nz-submenu-title

--- a/components/message/message-container.component.ts
+++ b/components/message/message-container.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Direction } from '@angular/cdk/bidi';
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 import { MessageConfig, onConfigChangeEventForComponent } from 'ng-zorro-antd/core/config';
 import { toCssPixel } from 'ng-zorro-antd/core/util';
@@ -24,10 +24,9 @@ const NZ_MESSAGE_DEFAULT_CONFIG: Required<MessageConfig> = {
 };
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-message-container',
   exportAs: 'nzMessageContainer',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div class="ant-message" [class.ant-message-rtl]="dir === 'rtl'" [style.top]="top">
       @for (instance of instances; track instance) {

--- a/components/message/message.component.ts
+++ b/components/message/message.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -62,7 +61,6 @@ import { NzMessageData } from './typings';
       </div>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzMessageComponent extends NzMNComponent implements OnInit {

--- a/components/modal/modal-close.component.ts
+++ b/components/modal/modal-close.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -24,7 +24,6 @@ import { ModalOptions } from './modal-types';
     class: 'ant-modal-close',
     'aria-label': 'Close'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzIconModule, NzOutletModule]
 })
 export class NzModalCloseComponent {

--- a/components/modal/modal-title.component.ts
+++ b/components/modal/modal-title.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 
@@ -22,7 +22,6 @@ import { ModalOptions } from './modal-types';
   host: {
     class: 'ant-modal-header'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzOutletModule]
 })
 export class NzModalTitleComponent {

--- a/components/modal/modal.component.ts
+++ b/components/modal/modal.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -39,8 +38,7 @@ import { getConfigFromComponent } from './utils';
 @Component({
   selector: 'nz-modal',
   exportAs: 'nzModal',
-  template: ``,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  template: ``
 })
 export class NzModalComponent<T extends ModalOptions = NzSafeAny, R = NzSafeAny>
   implements OnChanges, NzModalLegacyAPI<T, R>

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -1537,7 +1537,6 @@ class TestWithChildViewContainerComponent {
 
 @Component({
   selector: 'test-with-on-push-view-container',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: 'hello'
 })
 class TestWithOnPushViewContainerComponent {

--- a/components/notification/notification-container.component.ts
+++ b/components/notification/notification-container.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Direction } from '@angular/cdk/bidi';
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { NotificationConfig, onConfigChangeEventForComponent } from 'ng-zorro-antd/core/config';
@@ -28,10 +28,9 @@ const NZ_NOTIFICATION_DEFAULT_CONFIG: Required<NotificationConfig> = {
 };
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-notification-container',
   exportAs: 'nzNotificationContainer',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div
       class="ant-notification ant-notification-topLeft"

--- a/components/notification/notification.component.ts
+++ b/components/notification/notification.component.ts
@@ -4,16 +4,7 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  Output,
-  viewChild,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, Output, viewChild, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -107,7 +98,6 @@ import { NzNotificationData } from './typings';
       </a>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzNotificationComponent extends NzMNComponent {

--- a/components/page-header/page-header.component.ts
+++ b/components/page-header/page-header.component.ts
@@ -7,7 +7,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import { Location } from '@angular/common';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -80,7 +79,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'pageHeader';
     <ng-content select="nz-page-header-content, [nz-page-header-content]" />
     <ng-content select="nz-page-header-footer, [nz-page-header-footer]" />
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-page-header',

--- a/components/pagination/pagination-default.component.ts
+++ b/components/pagination/pagination-default.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -31,7 +30,6 @@ import { PaginationItemRenderContext } from './pagination.types';
 @Component({
   selector: 'nz-pagination-default',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-template #containerTemplate>
       <ul>

--- a/components/pagination/pagination-item.component.ts
+++ b/components/pagination/pagination-item.component.ts
@@ -24,7 +24,6 @@ import { PaginationItemRenderContext, PaginationItemType } from './pagination.ty
 @Component({
   selector: 'li[nz-pagination-item]',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-template #renderItemTemplate let-type let-page="page">
       @switch (type) {

--- a/components/pagination/pagination-options.component.ts
+++ b/components/pagination/pagination-options.component.ts
@@ -3,16 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  Output,
-  SimpleChanges,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { toNumber } from 'ng-zorro-antd/core/util';
@@ -22,7 +13,6 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 @Component({
   selector: 'li[nz-pagination-options]',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (showSizeChanger) {
       <nz-select

--- a/components/pagination/pagination-simple.component.ts
+++ b/components/pagination/pagination-simple.component.ts
@@ -5,7 +5,6 @@
 
 import { Directionality } from '@angular/cdk/bidi';
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -30,7 +29,6 @@ import { PaginationItemRenderContext } from './pagination.types';
 @Component({
   selector: 'nz-pagination-simple',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-template #containerTemplate>
       <ul>

--- a/components/pagination/pagination.component.ts
+++ b/components/pagination/pagination.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -40,7 +39,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'pagination';
   selector: 'nz-pagination',
   exportAs: 'nzPagination',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (showPagination) {
       @if (nzSimple) {

--- a/components/popconfirm/popconfirm.ts
+++ b/components/popconfirm/popconfirm.ts
@@ -7,7 +7,6 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   Directive,
@@ -240,7 +239,6 @@ export class NzPopconfirmDirective extends NzTooltipBaseDirective {
     NzButtonModule,
     NzI18nModule
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzPopconfirmComponent extends NzTooltipComponent {

--- a/components/popover/popover.ts
+++ b/components/popover/popover.ts
@@ -5,7 +5,6 @@
 
 import { OverlayModule } from '@angular/cdk/overlay';
 import {
-  ChangeDetectionStrategy,
   Component,
   Directive,
   ElementRef,
@@ -81,7 +80,6 @@ export class NzPopoverDirective extends NzTooltipBaseDirective {
 @Component({
   selector: 'nz-popover',
   exportAs: 'nzPopoverComponent',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <ng-template

--- a/components/progress/progress.component.ts
+++ b/components/progress/progress.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Input,
@@ -52,10 +51,9 @@ const statusColorMap = new Map([
 const defaultFormatter: NzProgressFormatter = (p: number): string => `${p}%`;
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-progress',
   exportAs: 'nzProgress',
+  encapsulation: ViewEncapsulation.None,
   imports: [NzIconModule, NzOutletModule, NgTemplateOutlet],
   template: `
     <ng-template #progressInfoTemplate>

--- a/components/qr-code/qrcode-canvas.component.ts
+++ b/components/qr-code/qrcode-canvas.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, input, viewChild } from '@angular/core';
+import { AfterViewInit, Component, effect, ElementRef, input, viewChild } from '@angular/core';
 
 import { CrossOrigin, Excavation, Modules } from './typing';
 import { DEFAULT_BACKGROUND_COLOR, DEFAULT_FRONT_COLOR, excavateModules, generatePath, isSupportPath2d } from './utils';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'nz-qrcode-canvas',
   exportAs: 'nzQRCodeCanvas',
   template: `

--- a/components/qr-code/qrcode-svg.component.ts
+++ b/components/qr-code/qrcode-svg.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, effect, input } from '@angular/core';
+import { Component, effect, input } from '@angular/core';
 
 import { CrossOrigin, Excavation, ImageSettings, Modules } from './typing';
 import { DEFAULT_BACKGROUND_COLOR, DEFAULT_FRONT_COLOR, excavateModules, generatePath } from './utils';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'nz-qrcode-svg',
   exportAs: 'nzQRCodeSVG',
   template: `

--- a/components/qr-code/qrcode.component.ts
+++ b/components/qr-code/qrcode.component.ts
@@ -5,7 +5,6 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -33,7 +32,6 @@ import { CrossOrigin, ErrorCorrectionLevel, Excavation, ImageSettings, Modules }
 import { DEFAULT_BACKGROUND_COLOR, DEFAULT_FRONT_COLOR, DEFAULT_MINVERSION } from './utils';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'nz-qrcode',
   exportAs: 'nzQRCode',
   template: `

--- a/components/radio/radio-group.component.ts
+++ b/components/radio/radio-group.component.ts
@@ -5,7 +5,6 @@
 
 import { Directionality } from '@angular/cdk/bidi';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -35,7 +34,6 @@ export type NzRadioButtonStyle = 'outline' | 'solid';
   exportAs: 'nzRadioGroup',
   template: `<ng-content />`,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     NzRadioService,
     {

--- a/components/radio/radio.component.ts
+++ b/components/radio/radio.component.ts
@@ -7,7 +7,6 @@ import { FocusMonitor } from '@angular/cdk/a11y';
 import { Directionality } from '@angular/cdk/bidi';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   Input,
@@ -57,7 +56,6 @@ import { NzRadioService } from './radio.service';
     <span><ng-content /></span>
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/components/rate/rate-item.component.ts
+++ b/components/rate/rate-item.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -18,10 +17,9 @@ import {
 import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: '[nz-rate-item]',
   exportAs: 'nzRateItem',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div
       class="ant-rate-star-second"

--- a/components/rate/rate.component.ts
+++ b/components/rate/rate.component.ts
@@ -7,7 +7,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -40,10 +39,9 @@ import { NzRateItemComponent } from './rate-item.component';
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'rate';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-rate',
   exportAs: 'nzRate',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <ul
       #ulElement

--- a/components/resizable/resize-handle.component.ts
+++ b/components/resizable/resize-handle.component.ts
@@ -5,7 +5,6 @@
 
 import { normalizePassiveListenerOptions } from '@angular/cdk/platform';
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -48,7 +47,6 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
   selector: 'nz-resize-handle, [nz-resize-handle]',
   exportAs: 'nzResizeHandle',
   template: `<ng-content />`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'nz-resizable-handle',
     '[class.nz-resizable-handle-top]': `nzDirection === 'top'`,

--- a/components/resizable/resize-handles.component.ts
+++ b/components/resizable/resize-handles.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 import { NzCursorType, NzResizeDirection, NzResizeHandleComponent } from './resize-handle.component';
 
@@ -44,7 +44,6 @@ function normalizeResizeHandleOptions(value: Array<NzResizeDirection | NzResizeH
       <nz-resize-handle [nzDirection]="option.direction" [nzCursorType]="option.cursorType" />
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzResizeHandleComponent]
 })
 export class NzResizeHandlesComponent implements OnChanges {

--- a/components/result/partial/not-found.ts
+++ b/components/result/partial/not-found.ts
@@ -3,11 +3,9 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-result-not-found',
   exportAs: 'nzResultNotFound',
   template: `

--- a/components/result/partial/server-error.component.ts
+++ b/components/result/partial/server-error.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-result-server-error',
   exportAs: 'nzResultServerError',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <svg width="254" height="294">
       <defs>

--- a/components/result/partial/unauthorized.ts
+++ b/components/result/partial/unauthorized.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-result-unauthorized',
   exportAs: 'nzResultUnauthorized',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <svg width="251" height="294">
       <g fill="none" fillRule="evenodd">

--- a/components/result/result.component.ts
+++ b/components/result/result.component.ts
@@ -4,15 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  input,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, computed, inject, input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -96,7 +88,6 @@ const ExceptionStatus = ['404', '500', '403'];
     NzResultServerErrorComponent,
     NzResultUnauthorizedComponent
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzResultComponent {

--- a/components/segmented/segmented-item.component.ts
+++ b/components/segmented/segmented-item.component.ts
@@ -7,7 +7,6 @@ import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keyc
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,
@@ -67,7 +66,6 @@ import { NzSegmentedService } from './segmented.service';
     '(click)': 'handleClick()',
     '(keydown)': 'handleKeydown($event)'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzSegmentedItemComponent implements OnInit {

--- a/components/segmented/segmented.component.ts
+++ b/components/segmented/segmented.component.ts
@@ -8,7 +8,6 @@ import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keyc
 import {
   afterNextRender,
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChildren,
@@ -43,10 +42,9 @@ import { normalizeOptions, NzSegmentedOption, NzSegmentedOptions } from './types
 const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'segmented';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-segmented',
   exportAs: 'nzSegmented',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <!-- thumb motion div -->
     <div class="ant-segmented-group">

--- a/components/select/option-container.component.ts
+++ b/components/select/option-container.component.ts
@@ -8,7 +8,6 @@ import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   inject,
@@ -34,7 +33,6 @@ import { NzSelectItemInterface, NzSelectModeType } from './select.types';
 @Component({
   selector: 'nz-option-container',
   exportAs: 'nzOptionContainer',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <div>

--- a/components/select/option-group.component.ts
+++ b/components/select/option-group.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnChanges, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnChanges, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -12,8 +12,7 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
   selector: 'nz-option-group',
   exportAs: 'nzOptionGroup',
   template: `<ng-content />`,
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzOptionGroupComponent implements OnChanges {
   @Input() nzLabel: string | number | TemplateRef<NzSafeAny> | null = null;

--- a/components/select/option-item-group.component.ts
+++ b/components/select/option-item-group.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -11,7 +11,6 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
 @Component({
   selector: 'nz-option-item-group',
   template: `<ng-container *nzStringTemplateOutlet="nzLabel">{{ nzLabel }}</ng-container>`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-select-item ant-select-item-group'

--- a/components/select/option-item.component.ts
+++ b/components/select/option-item.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -47,7 +46,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       </div>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-select-item ant-select-item-option',

--- a/components/select/option.component.ts
+++ b/components/select/option.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   Input,
   OnChanges,
@@ -28,7 +27,6 @@ import { NzOptionGroupComponent } from './option-group.component';
   selector: 'nz-option',
   exportAs: 'nzOption',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-template>
       <ng-content />

--- a/components/select/select-arrow.component.ts
+++ b/components/select/select-arrow.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -13,7 +13,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 @Component({
   selector: 'nz-select-arrow',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (isMaxMultipleCountSet) {
       <span>{{ listOfValue.length }} / {{ nzMaxMultipleCount }}</span>

--- a/components/select/select-clear.component.ts
+++ b/components/select/select-clear.component.ts
@@ -4,15 +4,7 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, EventEmitter, Input, Output, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -20,7 +12,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 @Component({
   selector: 'nz-select-clear',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (clearIcon) {
       <ng-template [ngTemplateOutlet]="clearIcon" />

--- a/components/select/select-item.component.ts
+++ b/components/select/select-item.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -22,7 +21,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 @Component({
   selector: 'nz-select-item',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-container *nzStringTemplateOutlet="contentTemplateOutlet; context: templateOutletContext">
       @if (displayLabelInHtml) {

--- a/components/select/select-placeholder.component.ts
+++ b/components/select/select-placeholder.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -11,7 +11,6 @@ import { NzSafeAny } from 'ng-zorro-antd/core/types';
 @Component({
   selector: 'nz-select-placeholder',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-container *nzStringTemplateOutlet="placeholder">
       {{ placeholder }}

--- a/components/select/select-search.component.ts
+++ b/components/select/select-search.component.ts
@@ -6,7 +6,6 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
 import {
   afterNextRender,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -24,7 +23,6 @@ import { COMPOSITION_BUFFER_MODE, FormsModule } from '@angular/forms';
 @Component({
   selector: 'nz-select-search',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <input
       #inputElement

--- a/components/select/select-top-control.component.ts
+++ b/components/select/select-top-control.component.ts
@@ -5,7 +5,6 @@
 
 import { BACKSPACE } from '@angular/cdk/keycodes';
 import {
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -43,7 +42,6 @@ import { NzSelectItemInterface, NzSelectModeType, NzSelectTopControlItemType } f
     NzSelectPlaceholderComponent,
     NzStringTemplateOutletDirective
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (prefix) {

--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -16,7 +16,6 @@ import { _getEventTarget, Platform } from '@angular/cdk/platform';
 import {
   AfterContentInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -110,7 +109,6 @@ export type NzSelectSizeType = NzSizeLDSType;
     },
     { provide: NZ_SPACE_COMPACT_ITEM_TYPE, useValue: 'select' }
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <nz-select-top-control

--- a/components/skeleton/skeleton-element.component.ts
+++ b/components/skeleton/skeleton-element.component.ts
@@ -3,15 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Directive,
-  Input,
-  OnChanges,
-  SimpleChanges,
-  booleanAttribute
-} from '@angular/core';
+import { Component, Directive, Input, OnChanges, SimpleChanges, booleanAttribute } from '@angular/core';
 
 import {
   NzSkeletonAvatarShape,
@@ -36,7 +28,6 @@ export class NzSkeletonElementDirective {
 }
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'nz-skeleton-element[nzType="button"]',
   template: `
@@ -56,7 +47,6 @@ export class NzSkeletonElementButtonComponent {
 }
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'nz-skeleton-element[nzType="avatar"]',
   template: `
@@ -87,7 +77,6 @@ export class NzSkeletonElementAvatarComponent implements OnChanges {
 }
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'nz-skeleton-element[nzType="input"]',
   template: `
@@ -103,7 +92,6 @@ export class NzSkeletonElementInputComponent {
 }
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'nz-skeleton-element[nzType="image"]',
   template: `

--- a/components/skeleton/skeleton.component.ts
+++ b/components/skeleton/skeleton.component.ts
@@ -5,7 +5,6 @@
 
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   inject,
@@ -64,7 +63,6 @@ import {
     }
   `,
   imports: [NzSkeletonElementDirective, NzSkeletonElementAvatarComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzSkeletonComponent implements OnInit, OnChanges {

--- a/components/slider/handle.component.ts
+++ b/components/slider/handle.component.ts
@@ -5,7 +5,6 @@
 
 import { Direction } from '@angular/cdk/bidi';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -46,7 +45,6 @@ import { NzSliderShowTooltip } from './typings';
     '(mouseleave)': 'leaveHandle()'
   },
   imports: [NzTooltipModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzSliderHandleComponent implements OnChanges {

--- a/components/slider/marks.component.ts
+++ b/components/slider/marks.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   Input,
   OnChanges,
@@ -34,7 +33,6 @@ import { NzDisplayedMark, NzExtendedMark, NzMark, NzMarkObj } from './typings';
   host: {
     class: 'ant-slider-mark'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzSliderMarksComponent implements OnChanges {

--- a/components/slider/slider.component.ts
+++ b/components/slider/slider.component.ts
@@ -7,7 +7,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 import { Platform } from '@angular/cdk/platform';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -53,10 +52,9 @@ import { NzSliderTrackComponent } from './track.component';
 import { NzExtendedMark, NzMarks, NzSliderHandler, NzSliderShowTooltip, NzSliderValue } from './typings';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-slider',
   exportAs: 'nzSlider',
+  encapsulation: ViewEncapsulation.None,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/components/slider/step.component.ts
+++ b/components/slider/step.component.ts
@@ -5,7 +5,6 @@
 
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   Input,
   numberAttribute,
@@ -17,10 +16,9 @@ import {
 import { NzDisplayedStep, NzExtendedMark } from './typings';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-slider-step',
   exportAs: 'nzSliderStep',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @for (step of steps; track step.value) {
       <span class="ant-slider-dot" [class.ant-slider-dot-active]="step.active" [style]="step.style!"></span>

--- a/components/slider/track.component.ts
+++ b/components/slider/track.component.ts
@@ -4,15 +4,7 @@
  */
 
 import { Direction } from '@angular/cdk/bidi';
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  numberAttribute,
-  OnChanges,
-  ViewEncapsulation
-} from '@angular/core';
+import { booleanAttribute, Component, Input, numberAttribute, OnChanges, ViewEncapsulation } from '@angular/core';
 
 export interface NzSliderTrackStyle {
   bottom?: string | null;
@@ -27,8 +19,7 @@ export interface NzSliderTrackStyle {
   selector: 'nz-slider-track',
   exportAs: 'nzSliderTrack',
   template: `<div class="ant-slider-track" [style]="style"></div>`,
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzSliderTrackComponent implements OnChanges {
   @Input({ transform: numberAttribute }) offset: number = 0;

--- a/components/space/space-compact.component.ts
+++ b/components/space/space-compact.component.ts
@@ -3,16 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  booleanAttribute,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  ElementRef,
-  inject,
-  input,
-  signal
-} from '@angular/core';
+import { booleanAttribute, Component, computed, ElementRef, inject, input, signal } from '@angular/core';
 
 import { NZ_FORM_SIZE } from 'ng-zorro-antd/core/form';
 import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
@@ -31,8 +22,7 @@ import { NZ_SPACE_COMPACT_ITEMS, NZ_SPACE_COMPACT_SIZE } from './space-compact.t
   providers: [
     { provide: NZ_SPACE_COMPACT_SIZE, useFactory: () => inject(NzSpaceCompactComponent).finalSize },
     { provide: NZ_SPACE_COMPACT_ITEMS, useFactory: () => signal([]) }
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  ]
 })
 export class NzSpaceCompactComponent {
   private readonly formSize = inject(NZ_FORM_SIZE, { optional: true });

--- a/components/space/space.component.ts
+++ b/components/space/space.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -38,7 +37,6 @@ const SPACE_SIZE: Record<NzSpaceType, number> = {
 @Component({
   selector: 'nz-space, [nz-space]',
   exportAs: 'nzSpace',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-content />
     @for (item of items; track item) {

--- a/components/splitter/splitter-bar.component.ts
+++ b/components/splitter/splitter-bar.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { coerceCssPixelValue } from '@angular/cdk/coercion';
-import { ChangeDetectionStrategy, Component, computed, input, output, ViewEncapsulation } from '@angular/core';
+import { Component, computed, input, output, ViewEncapsulation } from '@angular/core';
 
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { getEventWithPoint } from 'ng-zorro-antd/resizable';
@@ -57,8 +57,7 @@ import { NzSplitterCollapseOption } from './typings';
     '[attr.aria-valuemin]': 'getValidNumber(ariaMin())',
     '[attr.aria-valuemax]': 'getValidNumber(ariaMax())'
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzSplitterBarComponent {
   readonly ariaNow = input.required<number>();

--- a/components/splitter/splitter-panel.component.ts
+++ b/components/splitter/splitter-panel.component.ts
@@ -3,15 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  input,
-  TemplateRef,
-  Component,
-  ViewEncapsulation,
-  viewChild,
-  booleanAttribute,
-  ChangeDetectionStrategy
-} from '@angular/core';
+import { input, TemplateRef, Component, ViewEncapsulation, viewChild, booleanAttribute } from '@angular/core';
 
 import { NzSplitterCollapsible } from './typings';
 
@@ -23,8 +15,7 @@ import { NzSplitterCollapsible } from './typings';
       <ng-content />
     </ng-template>
   `,
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzSplitterPanelComponent {
   readonly nzDefaultSize = input<number | string>();

--- a/components/splitter/splitter.component.ts
+++ b/components/splitter/splitter.component.ts
@@ -9,7 +9,6 @@ import { normalizePassiveListenerOptions } from '@angular/cdk/platform';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   computed,
   contentChildren,
@@ -115,8 +114,7 @@ const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: t
     '[class.ant-splitter-vertical]': 'nzLayout() === "vertical"',
     '[class.ant-splitter-rtl]': 'dir() === "rtl"'
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzSplitterComponent {
   /** ------------------- Props ------------------- */

--- a/components/statistic/countdown.component.ts
+++ b/components/statistic/countdown.component.ts
@@ -6,7 +6,6 @@
 import { Platform } from '@angular/cdk/platform';
 import {
   ChangeDetectorRef,
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   EventEmitter,
@@ -27,10 +26,9 @@ import { NzStatisticComponent } from './statistic.component';
 const REFRESH_INTERVAL = 1000 / 30;
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-countdown',
   exportAs: 'nzCountdown',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <nz-statistic
       [nzValue]="diff"

--- a/components/statistic/statistic-content-value.component.ts
+++ b/components/statistic/statistic-content-value.component.ts
@@ -4,24 +4,14 @@
  */
 
 import { getLocaleNumberSymbol, NgTemplateOutlet, NumberSymbol } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  Input,
-  LOCALE_ID,
-  OnChanges,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, inject, Input, LOCALE_ID, OnChanges, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzStatisticValueType } from './typings';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-statistic-content-value',
   exportAs: 'nzStatisticContentValue',
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzValueTemplate) {
       <ng-container [ngTemplateOutlet]="nzValueTemplate" [ngTemplateOutletContext]="{ $implicit: nzValue }" />

--- a/components/statistic/statistic.component.ts
+++ b/components/statistic/statistic.component.ts
@@ -4,15 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  TemplateRef,
-  ViewEncapsulation,
-  booleanAttribute,
-  inject
-} from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation, booleanAttribute, inject } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NgStyleInterface } from 'ng-zorro-antd/core/types';
@@ -22,10 +14,10 @@ import { NzStatisticContentValueComponent } from './statistic-content-value.comp
 import { NzStatisticValueType } from './typings';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-statistic',
   exportAs: 'nzStatistic',
+  encapsulation: ViewEncapsulation.None,
+  imports: [NzSkeletonModule, NzStatisticContentValueComponent, NzOutletModule],
   template: `
     <div class="ant-statistic-title">
       <ng-container *nzStringTemplateOutlet="nzTitle">{{ nzTitle }}</ng-container>
@@ -51,8 +43,7 @@ import { NzStatisticValueType } from './typings';
   host: {
     class: 'ant-statistic',
     '[class.ant-statistic-rtl]': `dir() === 'rtl'`
-  },
-  imports: [NzSkeletonModule, NzStatisticContentValueComponent, NzOutletModule]
+  }
 })
 export class NzStatisticComponent {
   protected readonly dir = inject(Directionality).valueSignal;

--- a/components/steps/step.component.ts
+++ b/components/steps/step.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -29,10 +28,9 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzProgressFormatter, NzProgressModule } from 'ng-zorro-antd/progress';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-step',
   exportAs: 'nzStep',
+  encapsulation: ViewEncapsulation.None,
   template: `
     <div
       #itemContainer

--- a/components/steps/steps.component.ts
+++ b/components/steps/steps.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -37,10 +36,9 @@ export type NzStatusType = 'wait' | 'process' | 'finish' | 'error';
 export type NzProgressDotTemplate = TemplateRef<{ $implicit: TemplateRef<void>; status: string; index: number }>;
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-steps',
   exportAs: 'nzSteps',
+  encapsulation: ViewEncapsulation.None,
   template: `<ng-content />`,
   host: {
     class: 'ant-steps',

--- a/components/steps/steps.spec.ts
+++ b/components/steps/steps.spec.ts
@@ -523,8 +523,7 @@ describe('steps', () => {
       <span class="insert-span">{{ status }}{{ index }}</span>
       <ng-template [ngTemplateOutlet]="dot" />
     </ng-template>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class NzTestOuterStepsComponent {
   public readonly cdr = inject(ChangeDetectorRef);

--- a/components/switch/switch.component.ts
+++ b/components/switch/switch.component.ts
@@ -8,7 +8,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import { ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -43,7 +42,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'switch';
 @Component({
   selector: 'nz-switch',
   exportAs: 'nzSwitch',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   providers: [
     {

--- a/components/table/src/addon/filter-trigger.component.ts
+++ b/components/table/src/addon/filter-trigger.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -29,7 +28,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'filterTrigger';
 @Component({
   selector: 'nz-filter-trigger',
   exportAs: `nzFilterTrigger`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <span

--- a/components/table/src/addon/filter.component.ts
+++ b/components/table/src/addon/filter.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -42,7 +41,6 @@ interface NzThItemInterface {
 
 @Component({
   selector: 'nz-table-filter',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <span class="ant-table-column-title">

--- a/components/table/src/addon/selection.component.ts
+++ b/components/table/src/addon/selection.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
@@ -13,7 +13,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'nz-table-selection',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (showCheckbox) {

--- a/components/table/src/addon/sorters.component.ts
+++ b/components/table/src/addon/sorters.component.ts
@@ -4,15 +4,7 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnChanges,
-  SimpleChanges,
-  TemplateRef,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { NzIconModule } from 'ng-zorro-antd/icon';
@@ -21,7 +13,6 @@ import { NzTableSortOrder } from '../table.types';
 
 @Component({
   selector: 'nz-table-sorters',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <span class="ant-table-column-title"><ng-template [ngTemplateOutlet]="contentTemplate" /></span>

--- a/components/table/src/cell/td-addon.component.ts
+++ b/components/table/src/cell/td-addon.component.ts
@@ -6,7 +6,6 @@
 /* eslint-disable @angular-eslint/component-selector */
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -28,7 +27,6 @@ import { NzRowIndentDirective } from '../addon/row-indent.directive';
 @Component({
   selector:
     'td[nzChecked], td[nzDisabled], td[nzIndeterminate], td[nzIndentSize], td[nzExpand], td[nzShowExpand], td[nzShowCheckbox]',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (nzShowExpand || nzIndentSize > 0) {

--- a/components/table/src/cell/th-addon.component.ts
+++ b/components/table/src/cell/th-addon.component.ts
@@ -6,7 +6,6 @@
 /* eslint-disable @angular-eslint/component-selector */
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -46,7 +45,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
   selector:
     'th[nzColumnKey], th[nzSortFn], th[nzSortOrder], th[nzFilters], th[nzShowSort], th[nzShowFilter], th[nzCustomFilter]',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (nzShowFilter || nzCustomFilter) {
       <nz-table-filter

--- a/components/table/src/cell/th-selection.component.ts
+++ b/components/table/src/cell/th-selection.component.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable @angular-eslint/component-selector */
 import {
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -24,7 +23,6 @@ import { NzTableSelectionComponent } from '../addon/selection.component';
 @Component({
   selector: 'th[nzSelections],th[nzChecked],th[nzShowCheckbox],th[nzShowRowSelection]',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <nz-table-selection
       [checked]="nzChecked"

--- a/components/table/src/table/table-content.component.ts
+++ b/components/table/src/table/table-content.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
@@ -12,7 +12,6 @@ import { NzTableLayout } from '../table.types';
 
 @Component({
   selector: 'table[nz-table-content]',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (listOfColWidth.length > 0) {

--- a/components/table/src/table/table-fixed-row.component.ts
+++ b/components/table/src/table/table-fixed-row.component.ts
@@ -6,7 +6,6 @@
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -23,7 +22,6 @@ import { NzTableStyleService } from '../table-style.service';
 
 @Component({
   selector: 'tr[nz-table-fixed-row], tr[nzExpand]',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <td class="nz-disable-td ant-table-cell" #tdElement>

--- a/components/table/src/table/table-inner-default.component.ts
+++ b/components/table/src/table/table-inner-default.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
@@ -12,7 +12,6 @@ import { NzTableContentComponent } from './table-content.component';
 
 @Component({
   selector: 'nz-table-inner-default',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <div class="ant-table-content">

--- a/components/table/src/table/table-inner-scroll.component.ts
+++ b/components/table/src/table/table-inner-scroll.component.ts
@@ -8,7 +8,6 @@ import { CdkVirtualScrollViewport, ScrollingModule } from '@angular/cdk/scrollin
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -37,7 +36,6 @@ import { NzTbodyComponent } from './tbody.component';
 
 @Component({
   selector: 'nz-table-inner-scroll',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (scrollY) {

--- a/components/table/src/table/table.component.ts
+++ b/components/table/src/table/table.component.ts
@@ -8,7 +8,6 @@ import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   ContentChild,
   EventEmitter,
@@ -60,7 +59,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'table';
   selector: 'nz-table',
   exportAs: 'nzTable',
   providers: [NzTableStyleService, NzTableDataService],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <nz-spin [nzDelay]="nzLoadingDelay" [nzSpinning]="nzLoading" [nzIndicator]="nzLoadingIndicator">

--- a/components/table/src/table/tbody.component.ts
+++ b/components/table/src/table/tbody.component.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @angular-eslint/component-selector */
 
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, TemplateRef, ViewEncapsulation, inject } from '@angular/core';
+import { Component, TemplateRef, ViewEncapsulation, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject } from 'rxjs';
 
@@ -19,7 +19,6 @@ import { NzTrMeasureComponent } from './tr-measure.component';
 
 @Component({
   selector: 'tbody',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @if (listOfMeasureColumn$ | async; as listOfMeasureColumn) {

--- a/components/table/src/table/tfoot-summary.component.ts
+++ b/components/table/src/table/tfoot-summary.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   inject,
   Input,
@@ -30,7 +29,6 @@ function fixedAttribute(value: NzTableSummaryFixedType | boolean | unknown): NzT
 /* eslint-disable @angular-eslint/component-selector */
 @Component({
   selector: 'tfoot[nzSummary]',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <ng-template #contentTemplate>

--- a/components/table/src/table/thead.component.ts
+++ b/components/table/src/table/thead.component.ts
@@ -8,7 +8,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   ContentChildren,
   ElementRef,
@@ -36,7 +35,6 @@ import { NzTrDirective } from './tr.directive';
 
 @Component({
   selector: 'thead:not(.ant-table-thead)',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <ng-template #contentTemplate>

--- a/components/table/src/table/title-footer.component.ts
+++ b/components/table/src/table/title-footer.component.ts
@@ -3,14 +3,13 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 @Component({
   selector: 'nz-table-title-footer',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <ng-container *nzStringTemplateOutlet="title">{{ title }}</ng-container>

--- a/components/table/src/table/tr-measure.component.ts
+++ b/components/table/src/table/tr-measure.component.ts
@@ -5,7 +5,6 @@
 
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -26,7 +25,6 @@ import { NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
 
 @Component({
   selector: 'tr[nz-table-measure-row]',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     @for (th of listOfMeasureColumn; track $index) {

--- a/components/tabs/demo/guard.ts
+++ b/components/tabs/demo/guard.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { NzModalModule, NzModalService } from 'ng-zorro-antd/modal';
@@ -13,8 +13,7 @@ import { NzTabsCanDeactivateFn, NzTabsModule } from 'ng-zorro-antd/tabs';
         <nz-tab [nzTitle]="'Tab' + tab">Content of tab {{ tab }}</nz-tab>
       }
     </nz-tabs>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  `
 })
 export class NzDemoTabsGuardComponent {
   tabs = [1, 2, 3, 4];

--- a/components/tabs/tab-body.component.ts
+++ b/components/tabs/tab-body.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -48,8 +47,7 @@ const ANIMATION_CLASS_MAP: Record<AnimationState, string[]> = {
     '[attr.aria-hidden]': '!active()',
     '(transitionend)': '_onTransitionEnd($event)'
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.None
 })
 export class NzTabBodyComponent {
   private readonly elementRef = inject(ElementRef);

--- a/components/tabs/tab-nav-bar.component.ts
+++ b/components/tabs/tab-nav-bar.component.ts
@@ -12,7 +12,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentChecked,
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -124,7 +123,6 @@ const CSS_TRANSFORM_TIME = 150;
     class: 'ant-tabs-nav',
     '(keydown)': 'handleKeydown($event)'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzTabNavBarComponent implements AfterViewInit, AfterContentChecked, OnChanges {

--- a/components/tabs/tab-nav-operation.component.ts
+++ b/components/tabs/tab-nav-operation.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -30,7 +29,6 @@ import { NzTabNavItemDirective } from './tab-nav-item.directive';
 @Component({
   selector: 'nz-tab-nav-operation',
   exportAs: 'nzTabNavOperation',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <button

--- a/components/tabs/tab.component.ts
+++ b/components/tabs/tab.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   ContentChild,
   EventEmitter,
@@ -37,7 +36,6 @@ export const NZ_TAB_SET = new InjectionToken<NzSafeAny>(typeof ngDevMode !== 'un
   selector: 'nz-tab',
   exportAs: 'nzTab',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ng-template #tabLinkTemplate>
       <ng-content select="[nz-tab-link]" />

--- a/components/tag/tag.component.ts
+++ b/components/tag/tag.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -33,7 +32,6 @@ import { NzTagColor } from './typings';
       <nz-icon nzType="close" class="ant-tag-close-icon" tabindex="-1" (click)="closeTag($event)" />
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     class: 'ant-tag',

--- a/components/time-picker/time-picker-panel.component.ts
+++ b/components/time-picker/time-picker-panel.component.ts
@@ -5,7 +5,6 @@
 
 import { DecimalPipe, NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DebugElement,
@@ -44,7 +43,6 @@ export type NzTimePickerUnit = 'hour' | 'minute' | 'second' | '12-hour';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'nz-time-picker-panel',
   exportAs: 'nzTimePickerPanel',
   template: `

--- a/components/time-picker/time-picker.component.ts
+++ b/components/time-picker/time-picker.component.ts
@@ -9,7 +9,6 @@ import { Platform, _getEventTarget } from '@angular/cdk/platform';
 import { AsyncPipe } from '@angular/common';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -70,7 +69,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'timePicker';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'nz-time-picker',
   exportAs: 'nzTimePicker',
   template: `

--- a/components/timeline/timeline-item.component.ts
+++ b/components/timeline/timeline-item.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   inject,
@@ -60,7 +59,6 @@ function isDefaultColor(color?: string): boolean {
     </ng-template>
   `,
   imports: [NzOutletModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzTimelineItemComponent implements OnChanges {

--- a/components/timeline/timeline.component.ts
+++ b/components/timeline/timeline.component.ts
@@ -7,7 +7,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterContentInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChildren,
@@ -33,11 +32,10 @@ import { TimelineService } from './timeline.service';
 import { NzTimelineMode, NzTimelinePosition } from './typings';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
   selector: 'nz-timeline',
-  providers: [TimelineService],
   exportAs: 'nzTimeline',
+  encapsulation: ViewEncapsulation.None,
+  providers: [TimelineService],
   template: `
     <ul
       class="ant-timeline"

--- a/components/tooltip/tooltip.ts
+++ b/components/tooltip/tooltip.ts
@@ -6,7 +6,6 @@
 import { OverlayModule } from '@angular/cdk/overlay';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   Directive,
   ElementRef,
@@ -75,7 +74,6 @@ export class NzTooltipDirective extends NzTooltipBaseDirective {
 @Component({
   selector: 'nz-tooltip',
   exportAs: 'nzTooltipComponent',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
     <ng-template

--- a/components/transfer/transfer-list.component.ts
+++ b/components/transfer/transfer-list.component.ts
@@ -6,7 +6,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -160,7 +159,6 @@ import { RenderListContext, TransferDirection, TransferItem, TransferStat } from
     }
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-transfer-list',
     '[class.ant-transfer-list-with-footer]': '!!footer'

--- a/components/transfer/transfer.component.ts
+++ b/components/transfer/transfer.component.ts
@@ -5,7 +5,6 @@
 
 import { Directionality } from '@angular/cdk/bidi';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -48,6 +47,7 @@ import { NzTransferListComponent } from './transfer-list.component';
 @Component({
   selector: 'nz-transfer',
   exportAs: 'nzTransfer',
+  imports: [NzTransferListComponent, NzIconModule, NzButtonModule],
   template: `
     <nz-transfer-list
       class="ant-transfer-list"
@@ -170,9 +170,7 @@ import { NzTransferListComponent } from './transfer-list.component';
     '(window:keyup.shift)': 'onTriggerShiftUp()',
     '(mousedown)': 'onTriggerMouseDown($event)'
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NzTransferListComponent, NzIconModule, NzButtonModule]
+  encapsulation: ViewEncapsulation.None
 })
 export class NzTransferComponent implements OnInit, OnChanges {
   private destroyRef = inject(DestroyRef);

--- a/components/tree-view/checkbox.ts
+++ b/components/tree-view/checkbox.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -24,7 +23,6 @@ import { fromEventOutsideAngular } from 'ng-zorro-antd/core/util';
 @Component({
   selector: 'nz-tree-node-checkbox:not([builtin])',
   template: `<span class="ant-tree-checkbox-inner"></span>`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-tree-checkbox',
     '[class.ant-tree-checkbox-checked]': `nzChecked()`,

--- a/components/tree-view/indent.ts
+++ b/components/tree-view/indent.ts
@@ -3,15 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  DestroyRef,
-  Directive,
-  inject,
-  Input
-} from '@angular/core';
+import { ChangeDetectorRef, Component, DestroyRef, Directive, inject, Input } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { animationFrameScheduler, asapScheduler, merge } from 'rxjs';
 import { auditTime } from 'rxjs/operators';
@@ -42,7 +34,6 @@ const BUILD_INDENTS_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? a
       <span class="ant-tree-indent-unit" [class.ant-tree-indent-unit-end]="!isEnd"></span>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-tree-indent'
   }

--- a/components/tree-view/node.ts
+++ b/components/tree-view/node.ts
@@ -6,7 +6,6 @@
 import { CdkTreeNode, CdkTreeNodeDef, CdkTreeNodeOutletContext } from '@angular/cdk/tree';
 import {
   booleanAttribute,
-  ChangeDetectionStrategy,
   Component,
   Directive,
   effect,
@@ -37,7 +36,6 @@ export interface NzTreeVirtualNodeData<T> {
 @Component({
   selector: 'nz-tree-node:not([builtin])',
   exportAs: 'nzTreeNode',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: CdkTreeNode,

--- a/components/tree-view/option.ts
+++ b/components/tree-view/option.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   ElementRef,
   NgZone,
@@ -26,7 +25,6 @@ import { NzTreeNodeComponent } from './node';
 @Component({
   selector: 'nz-tree-node-option',
   template: `<span class="ant-tree-title"><ng-content /></span>`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-tree-node-content-wrapper',
     '[class.ant-tree-node-content-wrapper-open]': 'isExpanded',

--- a/components/tree-view/tree-view.ts
+++ b/components/tree-view/tree-view.ts
@@ -4,7 +4,7 @@
  */
 
 import { CdkTree } from '@angular/cdk/tree';
-import { ChangeDetectionStrategy, Component, forwardRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, forwardRef, ViewChild, ViewEncapsulation } from '@angular/core';
 
 import { NzAnimationTreeCollapseService } from 'ng-zorro-antd/core/animation';
 
@@ -23,7 +23,6 @@ import { NzTreeView } from './tree';
     </div>
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     NzAnimationTreeCollapseService,
     { provide: CdkTree, useExisting: forwardRef(() => NzTreeViewComponent) },

--- a/components/tree-view/tree-virtual-scroll-view.ts
+++ b/components/tree-view/tree-virtual-scroll-view.ts
@@ -6,7 +6,6 @@
 import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { CdkTree, CdkTreeNodeOutletContext } from '@angular/cdk/tree';
 import {
-  ChangeDetectionStrategy,
   Component,
   forwardRef,
   inject,
@@ -46,7 +45,6 @@ const DEFAULT_SIZE = 28;
     <ng-container nzTreeNodeOutlet />
   `,
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     NzAnimationTreeCollapseService,
     { provide: NzTreeView, useExisting: forwardRef(() => NzTreeVirtualScrollViewComponent) },

--- a/components/tree/tree-drop-indicator.component.ts
+++ b/components/tree/tree-drop-indicator.component.ts
@@ -4,15 +4,7 @@
  */
 
 import { Direction } from '@angular/cdk/bidi';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Input,
-  OnChanges,
-  numberAttribute,
-  inject
-} from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnChanges, numberAttribute, inject } from '@angular/core';
 
 import { NgStyleInterface } from 'ng-zorro-antd/core/types';
 
@@ -20,7 +12,6 @@ import { NgStyleInterface } from 'ng-zorro-antd/core/types';
   selector: 'nz-tree-drop-indicator',
   exportAs: 'nzTreeDropIndicator',
   template: ``,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ant-tree-drop-indicator',
     '[style]': 'style'

--- a/components/tree/tree-indent.component.ts
+++ b/components/tree/tree-indent.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 @Component({
   selector: 'nz-tree-indent',
@@ -20,7 +20,6 @@ import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } f
       ></span>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[attr.aria-hidden]': 'true',
     '[class.ant-tree-indent]': '!nzSelectMode',

--- a/components/tree/tree-node-checkbox.component.ts
+++ b/components/tree/tree-node-checkbox.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, booleanAttribute } from '@angular/core';
+import { Component, Input, booleanAttribute } from '@angular/core';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -11,7 +11,6 @@ import { ChangeDetectionStrategy, Component, Input, booleanAttribute } from '@an
   template: `
     <span [class.ant-tree-checkbox-inner]="!nzSelectMode" [class.ant-select-tree-checkbox-inner]="nzSelectMode"></span>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.ant-select-tree-checkbox]': `nzSelectMode`,
     '[class.ant-select-tree-checkbox-checked]': `nzSelectMode && isChecked`,

--- a/components/tree/tree-node-switcher.component.ts
+++ b/components/tree/tree-node-switcher.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, booleanAttribute } from '@angular/core';
+import { Component, Input, TemplateRef, booleanAttribute } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzTreeNode, NzTreeNodeOptions } from 'ng-zorro-antd/core/tree';
@@ -39,7 +39,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
       }
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.ant-select-tree-switcher]': 'nzSelectMode',
     '[class.ant-select-tree-switcher-noop]': 'nzSelectMode && isLeaf',

--- a/components/tree/tree-node-title.component.ts
+++ b/components/tree/tree-node-title.component.ts
@@ -5,7 +5,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Input,
@@ -54,7 +53,6 @@ import { NzTreeDropIndicatorComponent } from './tree-drop-indicator.component';
       <nz-tree-drop-indicator [dropPosition]="dragPosition" [level]="context.level" />
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[attr.title]': 'title',
     '[attr.draggable]': 'canDraggable',

--- a/components/tree/tree-node.component.ts
+++ b/components/tree/tree-node.component.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -96,7 +95,6 @@ import { NzTreeNodeTitleComponent } from './tree-node-title.component';
       (contextmenu)="contextMenu($event)"
     />
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.ant-select-tree-treenode]': `nzSelectMode`,
     '[class.ant-select-tree-treenode-disabled]': `nzSelectMode && isDisabled`,

--- a/components/tree/tree.component.ts
+++ b/components/tree/tree.component.ts
@@ -6,7 +6,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
@@ -174,7 +173,6 @@ const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'tree';
       }
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     NzTreeService,
     NzAnimationTreeCollapseService,

--- a/components/typography/text-copy.component.ts
+++ b/components/typography/text-copy.component.ts
@@ -5,7 +5,6 @@
 
 import { Clipboard } from '@angular/cdk/clipboard';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -46,7 +45,6 @@ import { NzTooltipModule } from 'ng-zorro-antd/tooltip';
       </ng-container>
     </button>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [NzTooltipModule, NzTransButtonModule, NzIconModule, NzOutletModule]
 })

--- a/components/typography/text-edit.component.ts
+++ b/components/typography/text-edit.component.ts
@@ -7,7 +7,6 @@ import { ENTER, ESCAPE } from '@angular/cdk/keycodes';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import {
   afterNextRender,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -59,7 +58,6 @@ import { NzTooltipModule } from 'ng-zorro-antd/tooltip';
       </button>
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NzTextEditComponent implements OnInit {

--- a/components/typography/typography.component.ts
+++ b/components/typography/typography.component.ts
@@ -9,7 +9,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -108,7 +107,6 @@ const EXPAND_ELEMENT_CLASSNAME = 'ant-typography-expand';
       />
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {
     '[class.ant-typography]': '!editing',

--- a/components/upload/upload-list.component.ts
+++ b/components/upload/upload-list.component.ts
@@ -7,7 +7,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import { Platform } from '@angular/cdk/platform';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
@@ -56,7 +55,6 @@ interface UploadListFile extends NzUploadFile {
     '[class]': 'class()'
   },
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzTooltipModule, NgTemplateOutlet, NzIconModule, NzButtonModule, NzProgressModule]
 })
 export class NzUploadListComponent implements OnChanges {

--- a/components/upload/upload.component.ts
+++ b/components/upload/upload.component.ts
@@ -9,7 +9,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -57,7 +56,6 @@ const CLASS_NAME = 'ant-upload';
   exportAs: 'nzUpload',
   templateUrl: './upload.component.html',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.ant-upload-picture-card-wrapper]': 'nzListType === "picture-card"'
   },

--- a/components/watermark/watermark.component.ts
+++ b/components/watermark/watermark.component.ts
@@ -6,7 +6,6 @@
 import { isPlatformServer } from '@angular/common';
 import {
   afterNextRender,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -34,7 +33,6 @@ const FontGap = 3;
 @Component({
   selector: 'nz-watermark',
   exportAs: 'nzWatermark',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-content />`,
   styles: `
     :host {

--- a/scripts/site/doc/app/app.component.ts
+++ b/scripts/site/doc/app/app.component.ts
@@ -1,7 +1,7 @@
 import { BidiModule } from '@angular/cdk/bidi';
 import { Platform } from '@angular/cdk/platform';
 import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, effect, inject, OnInit, Renderer2 } from '@angular/core';
+import { Component, computed, effect, inject, OnInit, Renderer2 } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { debounceTime, filter, startWith } from 'rxjs/operators';

--- a/scripts/site/doc/app/app.component.ts
+++ b/scripts/site/doc/app/app.component.ts
@@ -67,7 +67,6 @@ const defaultKeywords =
     NavProgressBar
   ],
   templateUrl: './app.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[dir]': 'dir()'
   },

--- a/scripts/site/doc/app/codebox/codebox.component.ts
+++ b/scripts/site/doc/app/codebox/codebox.component.ts
@@ -1,7 +1,6 @@
 import { Clipboard } from '@angular/cdk/clipboard';
 import { Platform } from '@angular/cdk/platform';
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,

--- a/scripts/site/doc/app/codebox/codebox.component.ts
+++ b/scripts/site/doc/app/codebox/codebox.component.ts
@@ -26,7 +26,6 @@ import { NzHighlightComponent } from './highlight.component';
 @Component({
   selector: 'nz-code-box',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzIconModule, NzTooltipModule, NzHighlightComponent],
   templateUrl: './codebox.component.html',
   styleUrl: './codebox.component.less',

--- a/scripts/site/doc/app/codebox/highlight.component.ts
+++ b/scripts/site/doc/app/codebox/highlight.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Component, input } from '@angular/core';
 
 import { NzSanitizerPipe } from 'ng-zorro-antd/pipes';
 

--- a/scripts/site/doc/app/codebox/highlight.component.ts
+++ b/scripts/site/doc/app/codebox/highlight.component.ts
@@ -5,7 +5,6 @@ import { NzSanitizerPipe } from 'ng-zorro-antd/pipes';
 @Component({
   selector: 'nz-highlight',
   imports: [NzSanitizerPipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <pre class="language-angular">
       <code [innerHTML]="nzCode() | nzSanitizer: 'html'"></code>

--- a/scripts/site/doc/app/components-overview/components-overview.component.ts
+++ b/scripts/site/doc/app/components-overview/components-overview.component.ts
@@ -1,6 +1,5 @@
 import {
   afterNextRender,
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,

--- a/scripts/site/doc/app/components-overview/components-overview.component.ts
+++ b/scripts/site/doc/app/components-overview/components-overview.component.ts
@@ -44,7 +44,6 @@ import { ROUTER_LIST } from '../router';
   ],
   templateUrl: './components-overview.component.html',
   styleUrl: './components-overview.component.less',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export default class ComponentsOverviewComponent {

--- a/scripts/site/doc/app/contributors-list/contributors-list.component.ts
+++ b/scripts/site/doc/app/contributors-list/contributors-list.component.ts
@@ -32,7 +32,6 @@ interface Contributor {
 
 @Component({
   selector: 'app-contributors-list',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzAvatarModule, NzTooltipModule, NzFlexModule],
   template: `
     <ul nz-flex nzWrap="wrap" nzGap="small" [style.margin-top.px]="120">

--- a/scripts/site/doc/app/contributors-list/contributors-list.component.ts
+++ b/scripts/site/doc/app/contributors-list/contributors-list.component.ts
@@ -1,6 +1,6 @@
 import { Platform } from '@angular/cdk/platform';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, ElementRef, inject, OnInit, signal } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { filter, map, take } from 'rxjs/operators';
 

--- a/scripts/site/doc/app/fixed-widgets/fixed-widgets.component.ts
+++ b/scripts/site/doc/app/fixed-widgets/fixed-widgets.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
+import { Component, computed, inject, input, output } from '@angular/core';
 
 import { NzDropdownModule } from 'ng-zorro-antd/dropdown';
 

--- a/scripts/site/doc/app/fixed-widgets/fixed-widgets.component.ts
+++ b/scripts/site/doc/app/fixed-widgets/fixed-widgets.component.ts
@@ -8,7 +8,6 @@ import { ThemingIcon } from './theming-icon';
 
 @Component({
   selector: 'app-fixed-widgets',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NzDropdownModule, ThemingIcon],
   template: `
     <div class="fixed-widgets">

--- a/scripts/site/doc/app/footer/footer-col.component.ts
+++ b/scripts/site/doc/app/footer/footer-col.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, input, Input } from '@angular/core'
 
 @Component({
   selector: 'div[app-footer-col]',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <h2>{{ title() }}</h2>
     <ng-content></ng-content>

--- a/scripts/site/doc/app/footer/footer-col.component.ts
+++ b/scripts/site/doc/app/footer/footer-col.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, Input } from '@angular/core';
+import { Component, input, Input } from '@angular/core';
 
 @Component({
   selector: 'div[app-footer-col]',

--- a/scripts/site/doc/app/footer/footer-item.component.ts
+++ b/scripts/site/doc/app/footer/footer-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, Input } from '@angular/core';
+import { Component, input, Input } from '@angular/core';
 
 import { NzIconModule } from 'ng-zorro-antd/icon';
 

--- a/scripts/site/doc/app/footer/footer-item.component.ts
+++ b/scripts/site/doc/app/footer/footer-item.component.ts
@@ -5,7 +5,6 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 @Component({
   selector: 'app-footer-item',
   imports: [NzIconModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (link()) {
       <a [attr.href]="link()" target="_blank" rel="noopener">

--- a/scripts/site/doc/app/footer/footer.component.ts
+++ b/scripts/site/doc/app/footer/footer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input, output } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 
 import { NzColor, NzColorPickerModule } from 'ng-zorro-antd/color-picker';
 

--- a/scripts/site/doc/app/footer/footer.component.ts
+++ b/scripts/site/doc/app/footer/footer.component.ts
@@ -111,7 +111,6 @@ import { FooterItemComponent } from './footer-item.component';
       </section>
     </footer>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FooterComponent {
   protected readonly language = inject(APP_LANGUAGE);

--- a/scripts/site/doc/app/header/github-button.component.ts
+++ b/scripts/site/doc/app/header/github-button.component.ts
@@ -1,6 +1,6 @@
 import { Platform } from '@angular/cdk/platform';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { AppService } from '../app.service';
 
 @Component({

--- a/scripts/site/doc/app/header/github-button.component.ts
+++ b/scripts/site/doc/app/header/github-button.component.ts
@@ -5,7 +5,6 @@ import { AppService } from '../app.service';
 
 @Component({
   selector: 'app-github-btn',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <a
       class="gh-btn"

--- a/scripts/site/doc/app/header/header.component.ts
+++ b/scripts/site/doc/app/header/header.component.ts
@@ -38,7 +38,6 @@ import { SearchbarComponent } from './searchbar.component';
     NavigationComponent,
     UpperCasePipe
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class HeaderComponent {
   private readonly nzConfigService = inject(NzConfigService);

--- a/scripts/site/doc/app/header/header.component.ts
+++ b/scripts/site/doc/app/header/header.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet, UpperCasePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, signal, Version } from '@angular/core';
+import { Component, inject, signal, Version } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';

--- a/scripts/site/doc/app/header/navigation.component.ts
+++ b/scripts/site/doc/app/header/navigation.component.ts
@@ -61,7 +61,6 @@ import { AppService } from '../app.service';
   host: {
     id: 'nav'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class NavigationComponent {

--- a/scripts/site/doc/app/header/navigation.component.ts
+++ b/scripts/site/doc/app/header/navigation.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
+import { Component, inject, ViewEncapsulation } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';

--- a/scripts/site/doc/app/header/searchbar.component.ts
+++ b/scripts/site/doc/app/header/searchbar.component.ts
@@ -1,5 +1,4 @@
 import {
-  ChangeDetectionStrategy,
   Component,
   effect,
   ElementRef,

--- a/scripts/site/doc/app/header/searchbar.component.ts
+++ b/scripts/site/doc/app/header/searchbar.component.ts
@@ -38,7 +38,6 @@ declare const docsearch: any;
     '[class.narrow-mode]': 'app.responsive()',
     '(document:keyup.s)': 'onKeyUp($any($event))'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
 export class SearchbarComponent {

--- a/scripts/site/doc/app/nav-bottom/nav-bottom.component.ts
+++ b/scripts/site/doc/app/nav-bottom/nav-bottom.component.ts
@@ -12,7 +12,6 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 @Component({
   selector: 'app-nav-bottom',
   imports: [RouterLink, NzIconModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <section class="prev-next-nav">
       @if (index() > 1) {

--- a/scripts/site/doc/app/nav-bottom/nav-bottom.component.ts
+++ b/scripts/site/doc/app/nav-bottom/nav-bottom.component.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@angular/cdk/platform';
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
 
 import { NzIconModule } from 'ng-zorro-antd/icon';

--- a/scripts/site/doc/app/nav-progress-bar/nav-progress-bar.component.ts
+++ b/scripts/site/doc/app/nav-progress-bar/nav-progress-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NavigationCancel, NavigationEnd, NavigationError, NavigationStart, Router } from '@angular/router';
 import { filter, map } from 'rxjs';

--- a/scripts/site/doc/app/nav-progress-bar/nav-progress-bar.component.ts
+++ b/scripts/site/doc/app/nav-progress-bar/nav-progress-bar.component.ts
@@ -7,7 +7,6 @@ import { filter, map } from 'rxjs';
   selector: 'app-nav-progress-bar',
   template: '',
   styleUrl: './nav-progress-bar.component.less',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'nav-progress-bar',
     '[hidden]': '!navigating()'

--- a/scripts/site/doc/app/side/side.component.ts
+++ b/scripts/site/doc/app/side/side.component.ts
@@ -1,5 +1,5 @@
 import { BidiModule } from '@angular/cdk/bidi';
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { RouterLink } from '@angular/router';
 

--- a/scripts/site/doc/app/side/side.component.ts
+++ b/scripts/site/doc/app/side/side.component.ts
@@ -20,7 +20,6 @@ type I18n<T> = {
   selector: 'app-side',
   imports: [RouterLink, NgTemplateOutlet, NzMenuModule, NzTagModule, BidiModule],
   templateUrl: './side.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SideComponent {
   protected readonly routerList = ROUTER_LIST;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

All components and directives explicitly declare `changeDetection: ChangeDetectionStrategy.OnPush` in their decorators.

Issue Number: N/A


## What is the new behavior?

Remove redundant `changeDetection: ChangeDetectionStrategy.OnPush` declarations. In Angular v22, `OnPush` is the default change detection strategy, making these explicit declarations unnecessary.

238 files changed, removing ~600 lines of boilerplate code.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information