### PR TITLE
test: migrate component specs to zoneless onpush

### DIFF
--- a/components/affix/affix.spec.ts
+++ b/components/affix/affix.spec.ts
@@ -4,15 +4,7 @@
  */
 
 import { Platform } from '@angular/cdk/platform';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DebugElement,
-  DOCUMENT,
-  ElementRef,
-  Renderer2,
-  ViewChild
-} from '@angular/core';
+import { Component, DebugElement, DOCUMENT, ElementRef, Renderer2, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Subscription } from 'rxjs';
@@ -127,7 +119,7 @@ describe('affix', () => {
   describe('resize', () => {
     it('should be reset placeholder size', async () => {
       const offsetTop = 150;
-      context.newOffset = offsetTop;
+      context.newOffset.set(offsetTop);
       await setupInitialState({ offsetTop: offsetTop + 1 });
       const offsetWidthSpy = spyOnProperty(componentObject.elementRef(), 'offsetWidth', 'get');
       await emitScroll(window, 2);
@@ -145,8 +137,8 @@ describe('affix', () => {
     it('should be reset placeholder size when container becomes greater', async () => {
       const target = componentObject.target();
       const clientHeightSpy = spyOnProperty(target, 'clientHeight', 'get');
-      context.fakeTarget = target;
-      context.newOffsetBottom = 10;
+      context.fakeTarget.set(target);
+      context.newOffsetBottom.set(10);
       clientHeightSpy.and.returnValue(10);
       await setupInitialState();
       await emitScroll(target, 11);
@@ -162,7 +154,7 @@ describe('affix', () => {
     const offsetTop = 150;
 
     beforeEach(() => {
-      context.newOffset = offsetTop;
+      context.newOffset.set(offsetTop);
     });
 
     describe('when scrolled within top offset', () => {
@@ -184,7 +176,7 @@ describe('affix', () => {
     });
 
     it('recreate bug https://github.com/NG-ZORRO/ng-zorro-antd/issues/868', async () => {
-      context.newOffset = offsetTop.toString() as NzSafeAny;
+      context.newOffset.set(offsetTop.toString() as NzSafeAny);
       await setupInitialState({ offsetTop: offsetTop + 1 });
       await emitScroll(window, 2);
 
@@ -199,8 +191,8 @@ describe('affix', () => {
     describe('with window', () => {
       beforeEach(() => {
         target = window;
-        context.fakeTarget = target;
-        context.newOffsetBottom = 10;
+        context.fakeTarget.set(target);
+        context.newOffsetBottom.set(10);
       });
 
       describe('when scrolled below the bottom offset', () => {
@@ -214,8 +206,8 @@ describe('affix', () => {
     describe('with target', () => {
       beforeEach(() => {
         target = componentObject.target();
-        context.fakeTarget = target;
-        context.newOffsetBottom = offsetTop;
+        context.fakeTarget.set(target);
+        context.newOffsetBottom.set(offsetTop);
       });
 
       describe('when scrolled within bottom offset', () => {
@@ -241,7 +233,7 @@ describe('affix', () => {
 
     beforeEach(() => {
       target = componentObject.target();
-      context.fakeTarget = target;
+      context.fakeTarget.set(target);
     });
 
     describe('when window is scrolled', () => {
@@ -275,7 +267,7 @@ describe('affix', () => {
       spyOn(component, 'updatePosition');
       expect(component.updatePosition).not.toHaveBeenCalled();
 
-      context.fakeTarget = '#target';
+      context.fakeTarget.set('#target');
       await fixture.whenStable();
 
       expect(component.updatePosition).toHaveBeenCalled();
@@ -396,18 +388,17 @@ describe('affix', () => {
 @Component({
   imports: [NzAffixComponent],
   template: `
-    <nz-affix id="affix" [nzTarget]="fakeTarget" [nzOffsetTop]="newOffset" [nzOffsetBottom]="newOffsetBottom">
+    <nz-affix id="affix" [nzTarget]="fakeTarget()" [nzOffsetTop]="newOffset()" [nzOffsetBottom]="newOffsetBottom()">
       <button id="content">Affix Button</button>
     </nz-affix>
     <div id="target"></div>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 class TestAffixComponent {
   @ViewChild(NzAffixComponent, { static: true }) nzAffixComponent!: NzAffixComponent;
-  fakeTarget?: string | Element | Window;
-  newOffset!: number;
-  newOffsetBottom!: number;
+  readonly fakeTarget = signal<string | Element | Window | undefined>(undefined);
+  readonly newOffset = signal<number | undefined>(undefined);
+  readonly newOffsetBottom = signal<number | undefined>(undefined);
 }
 
 describe('NzAffixComponent', () => {

--- a/components/card/card.spec.ts
+++ b/components/card/card.spec.ts
@@ -3,12 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, NO_ERRORS_SCHEMA, provideZoneChangeDetection } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, NO_ERRORS_SCHEMA, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Subject } from 'rxjs';
 
+import { provideNzNoAnimation } from 'ng-zorro-antd/core/animation';
 import { NzConfigService } from 'ng-zorro-antd/core/config';
 import { testDirectionality } from 'ng-zorro-antd/core/testing';
 import { NzSizeDSType } from 'ng-zorro-antd/core/types';
@@ -29,9 +29,8 @@ import { NzDemoCardTabsComponent } from './demo/tabs';
 
 describe('card', () => {
   beforeEach(() => {
-    // todo: use zoneless
     TestBed.configureTestingModule({
-      providers: [provideNoopAnimations(), provideNzIconsTesting(), provideZoneChangeDetection()],
+      providers: [provideNzNoAnimation(), provideNzIconsTesting()],
       schemas: [NO_ERRORS_SCHEMA]
     });
   });
@@ -126,7 +125,7 @@ describe('card', () => {
     const card = fixture.debugElement.query(By.directive(NzCardComponent));
     fixture.detectChanges();
     expect(card.nativeElement.classList).not.toContain('ant-card-small');
-    fixture.componentInstance.size = 'small';
+    fixture.componentInstance.size.set('small');
     fixture.detectChanges();
     expect(card.nativeElement.classList).toContain('ant-card-small');
   });
@@ -137,16 +136,15 @@ describe('card', () => {
 @Component({
   imports: [NzCardModule],
   template: `
-    <nz-card [nzSize]="size">
+    <nz-card [nzSize]="size()">
       <p>Card content</p>
       <p>Card content</p>
       <p>Card content</p>
     </nz-card>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 class TestCardSizeComponent {
-  size: NzSizeDSType = 'default';
+  readonly size = signal<NzSizeDSType>('default');
 }
 
 describe('card component', () => {
@@ -170,11 +168,10 @@ describe('card component', () => {
     component = fixture.componentInstance;
   });
 
-  it('should call markForCheck when changing nzConfig', fakeAsync(() => {
+  it('should call markForCheck when changing nzConfig', () => {
     spyOn(component['cdr'], 'markForCheck');
     fixture.detectChanges();
     configChangeEvent$.next();
-    tick();
     expect(component['cdr'].markForCheck).toHaveBeenCalled();
-  }));
+  });
 });

--- a/components/cascader/cascader.component.ts
+++ b/components/cascader/cascader.component.ts
@@ -1128,6 +1128,7 @@ export class NzCascaderComponent
     if (this.nzDisabled) {
       this.closeMenu();
     }
+    this.cdr.markForCheck();
   }
 
   closeMenu(): void {

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -48,6 +48,7 @@ import {
   dispatchKeyboardEvent,
   dispatchMouseEvent,
   provideMockDirectionality,
+  sleep,
   testDirectionality,
   updateNonSignalsInput
 } from 'ng-zorro-antd/core/testing';
@@ -67,6 +68,8 @@ import {
   NzCascaderTriggerType,
   NzShowSearchOptions
 } from './typings';
+
+const MOUSE_EVENT_DELAY = 150;
 
 describe('cascader', () => {
   let overlayContainer: OverlayContainer;
@@ -157,15 +160,14 @@ describe('cascader', () => {
 
     it('should not have EMPTY label', () => {
       fixture.detectChanges();
-      const label: HTMLElement = cascader.nativeElement.querySelector('.ant-select-selection-item');
+      const label = cascader.nativeElement.querySelector('.ant-select-selection-item');
       expect(label).toBeNull();
     });
 
     it('should placeholder work', () => {
-      const placeholder = 'placeholder test';
-      testComponent.nzPlaceHolder.set(placeholder);
+      testComponent.nzPlaceHolder.set('placeholder test');
       fixture.detectChanges();
-      expect(getPlaceholder()).toBe(placeholder);
+      expect(getPlaceholder()).toBe('placeholder test');
     });
 
     it('should show/hide placeholder when trigger compositionstart/compositionend event', () => {
@@ -188,6 +190,7 @@ describe('cascader', () => {
       testComponent.nzSize.set('small');
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-sm');
+
       testComponent.nzSize.set('large');
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-lg');
@@ -201,9 +204,9 @@ describe('cascader', () => {
       // label will not show if no item selected
       expect(getLabelElement()).toBeNull();
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('');
+
       testComponent.values.set([1, 2, 3]);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('1,2,3');
     });
@@ -214,9 +217,9 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(getLabelElement()).toBeNull();
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('');
+
       testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('zhejiang,hangzhou,xihu');
     });
@@ -226,6 +229,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow')).toBeDefined();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow .anticon').classList).toContain('anticon-down');
+
       testComponent.nzShowArrow.set(false);
       fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow')).toBeNull();
@@ -236,6 +240,7 @@ describe('cascader', () => {
       testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeDefined();
+
       testComponent.nzAllowClear.set(false);
       fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeNull();
@@ -288,13 +293,13 @@ describe('cascader', () => {
       expect(testComponent.nzDisabled()).toBe(false);
 
       cascader.nativeElement.click();
-      await updateNonSignalsInput(fixture, 200);
+      await sleep(MOUSE_EVENT_DELAY);
       fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
 
       cascader.nativeElement.click();
-      await updateNonSignalsInput(fixture, 200);
+      await sleep(MOUSE_EVENT_DELAY);
       fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
@@ -307,16 +312,16 @@ describe('cascader', () => {
       expect(testComponent.nzDisabled()).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
+
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(300);
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
 
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      await updateNonSignalsInput(fixture, 300);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await sleep(300);
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
     });
@@ -327,15 +332,15 @@ describe('cascader', () => {
       testComponent.nzMouseEnterDelay.set(0);
       testComponent.nzMouseLeaveDelay.set(0);
       fixture.detectChanges();
+
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
+
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
     });
@@ -344,26 +349,24 @@ describe('cascader', () => {
       testComponent.nzExpandTrigger.set('hover');
       fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
+
       testComponent.cascader.setMenuOpen(true);
       fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       const optionEl = getItemAtColumnAndRow(1, 1)!;
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(optionEl, 'mouseenter');
-      await updateNonSignalsInput(fixture, 10);
-      fixture.detectChanges();
+      await sleep(10); // < delay
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
+
       dispatchMouseEvent(optionEl, 'mouseleave');
-      await updateNonSignalsInput(fixture, 400);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(optionEl, 'mouseenter');
-      await updateNonSignalsInput(fixture, 400);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(optionEl.classList).toContain('ant-cascader-menu-item-active');
     });
 
@@ -374,14 +377,14 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-disabled');
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
+
       cascader.nativeElement.click();
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
+
       testComponent.cascader.setMenuOpen(true);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
     });
@@ -390,13 +393,12 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).not.toContain('ant-select-disabled');
       testComponent.cascader.setDisabledState(true);
-      cascader.injector.get(ChangeDetectorRef).markForCheck();
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-disabled');
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
+
       cascader.nativeElement.click();
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
     });
@@ -408,9 +410,9 @@ describe('cascader', () => {
       expect(testComponent.cascader.nzDisabled).toBe(true);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
+
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
 
@@ -421,11 +423,11 @@ describe('cascader', () => {
       expect(testComponent.cascader.nzDisabled).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
+
       testComponent.nzDisabled.set(true);
       fixture.detectChanges();
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
     });
@@ -435,8 +437,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
     });
@@ -446,10 +447,10 @@ describe('cascader', () => {
       testComponent.nzAllowClear.set(true);
       testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
-      fixture.detectChanges();
+
       spyOn(testComponent, 'onClear');
+      expect(testComponent.onClear).not.toHaveBeenCalled();
       cascader.nativeElement.querySelector('.ant-select-clear nz-icon').click();
       fixture.detectChanges();
       expect(testComponent.values()).toEqual([]);
@@ -460,9 +461,8 @@ describe('cascader', () => {
       fixture.detectChanges();
       testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
-      fixture.detectChanges();
+
       spyOn(testComponent, 'onClear');
       testComponent.cascader.clearSelection();
       fixture.detectChanges();
@@ -484,13 +484,14 @@ describe('cascader', () => {
     it('should input focus and blur work', async () => {
       const fakeInputFocusEvent = createFakeEvent('focus', false, true);
       const fakeInputBlurEvent = createFakeEvent('blur', false, true);
-
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).not.toContain('ant-select-focused');
+
       getInputEl().dispatchEvent(fakeInputFocusEvent);
       cascader.injector.get(ChangeDetectorRef).markForCheck();
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-focused');
+
       getInputEl().dispatchEvent(fakeInputBlurEvent);
       cascader.injector.get(ChangeDetectorRef).markForCheck();
       fixture.detectChanges();
@@ -501,6 +502,7 @@ describe('cascader', () => {
       cascader.injector.get(ChangeDetectorRef).markForCheck();
       fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-focused');
+
       getInputEl().dispatchEvent(fakeInputBlurEvent);
       cascader.injector.get(ChangeDetectorRef).markForCheck();
       fixture.detectChanges();
@@ -536,8 +538,7 @@ describe('cascader', () => {
     it('should menu class work', async () => {
       fixture.detectChanges();
       cascader.nativeElement.click();
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(overlayContainerElement.querySelector('.ant-cascader-menus')!.classList).toContain('menu-classA');
       expect(overlayContainerElement.querySelector('.ant-cascader-menu')!.classList).toContain('column-classA');
@@ -546,8 +547,7 @@ describe('cascader', () => {
     it('should menu style work', async () => {
       fixture.detectChanges();
       cascader.nativeElement.click();
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       const targetElement = overlayContainerElement.querySelector('.menu-classA') as HTMLElement;
       expect(targetElement.style.height).toBe('120px');
@@ -784,7 +784,7 @@ describe('cascader', () => {
 
       const itemEl4 = getItemAtColumnAndRow(2, 2)!;
       itemEl4.click(); // click leaf node
-      await updateNonSignalsInput(fixture, 300);
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.values()).toEqual(['zhejiang', 'ningbo']);
     });
@@ -849,8 +849,7 @@ describe('cascader', () => {
       expect(testComponent.cascader.menuOpen()).toBe(true);
 
       getItemAtColumnAndRow(3, 1)!.click();
-      await updateNonSignalsInput(fixture, 200);
-
+      await sleep(MOUSE_EVENT_DELAY);
       fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(getAllColumns().length).toBe(0);
@@ -968,6 +967,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
       fixture.detectChanges();
+
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       let itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1043,13 +1043,11 @@ describe('cascader', () => {
     it('when there is only one column activated, pressing LEFT should fold the menu', async () => {
       testComponent.values.set(['zhejiang', 'ningbo']);
       testComponent.cascader.setMenuOpen(true);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(getAllColumns().length).toBe(2);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      await updateNonSignalsInput(fixture);
       fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBeFalse();
     });
@@ -1079,7 +1077,7 @@ describe('cascader', () => {
       fixture.detectChanges();
 
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
-      await updateNonSignalsInput(fixture, 200);
+      await sleep(200);
       fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
@@ -1170,7 +1168,7 @@ describe('cascader', () => {
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(itemEl1, 'mouseenter');
-      await updateNonSignalsInput(fixture, 200);
+      await sleep(MOUSE_EVENT_DELAY);
       fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1186,8 +1184,7 @@ describe('cascader', () => {
       expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl2, 'mouseenter');
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(getAllColumns().length).toBe(3);
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1196,7 +1193,7 @@ describe('cascader', () => {
       expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl2, 'mouseleave');
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(getAllColumns().length).toBe(3);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
@@ -1204,8 +1201,7 @@ describe('cascader', () => {
       expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl3, 'mouseenter');
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(getAllColumns().length).toBe(3);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
@@ -1213,17 +1209,10 @@ describe('cascader', () => {
       expect(testComponent.values()).toBeNull(); // not select yet
 
       itemEl3.click();
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
 
-      const value = testComponent.values();
-      expect(value).toBeDefined();
-      expect(value!.length).toBe(3);
-      expect(value![0]).toBe('zhejiang');
-      expect(value![1]).toBe('hangzhou');
-      expect(value![2]).toBe('xihu');
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
@@ -1244,14 +1233,12 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(itemEl2, 'mouseenter');
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(1);
 
       dispatchMouseEvent(itemEl2, 'mouseleave');
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(1);
     });
@@ -1263,25 +1250,20 @@ describe('cascader', () => {
 
       testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       testComponent.cascader.setMenuOpen(true); // Open cascader dropdown.
-
-      await updateNonSignalsInput(fixture, 500);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(overlayContainerElement.querySelectorAll('.ant-cascader-menu').length).toBe(3);
 
       const c2i2 = overlayContainerElement.querySelector(
         '.ant-cascader-menu:nth-child(2) .ant-cascader-menu-item:nth-child(2)'
       ) as HTMLElement;
       dispatchMouseEvent(c2i2, 'mouseenter');
-
-      await updateNonSignalsInput(fixture, 500);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(overlayContainerElement.querySelectorAll('.ant-cascader-menu').length).toBe(2);
     });
 
     it('should change on select work', async () => {
       testComponent.nzChangeOnSelect.set(true);
       fixture.detectChanges();
-      expect(testComponent.values()).toBeNull();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.values()).toBeNull(); // not select yet
 
@@ -1322,12 +1304,9 @@ describe('cascader', () => {
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl3.click();
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
 
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
@@ -1347,10 +1326,9 @@ describe('cascader', () => {
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
-      dispatchMouseEvent(itemEl1, 'mouseenter');
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
 
+      dispatchMouseEvent(itemEl1, 'mouseenter');
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(2);
@@ -1359,10 +1337,9 @@ describe('cascader', () => {
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
-      dispatchMouseEvent(itemEl2, 'mouseenter');
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
 
+      dispatchMouseEvent(itemEl2, 'mouseenter');
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
@@ -1373,19 +1350,14 @@ describe('cascader', () => {
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
-      dispatchMouseEvent(itemEl3, 'mouseenter');
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
 
+      dispatchMouseEvent(itemEl3, 'mouseenter');
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.values()).toBeNull(); // mouseenter does not trigger selection
 
       itemEl3.click();
-      await updateNonSignalsInput(fixture, 200);
-      fixture.detectChanges();
-
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']); // click trigger selection
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
@@ -1411,9 +1383,7 @@ describe('cascader', () => {
       expect(testComponent.values()).toBeNull(); // not select yet
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 200);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.values()).toEqual(['zhejiang']);
     });
@@ -1434,8 +1404,7 @@ describe('cascader', () => {
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
@@ -1447,8 +1416,7 @@ describe('cascader', () => {
       testComponent.nzShowSearch.set(true);
       fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 0);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // input search value
       testComponent.cascader.inputValue = 'o';
@@ -1476,11 +1444,9 @@ describe('cascader', () => {
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
       await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ESCAPE);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       expect(testComponent.cascader.inputValue).toBe('');
       expect(testComponent.values()).toEqual(['zhengjiang', 'hangzhou', 'xihu']);
     });
@@ -1499,8 +1465,7 @@ describe('cascader', () => {
       expect(itemEl1.innerText).toBe('Zhejiang New / Hangzhou New / West Lake New');
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
@@ -1521,8 +1486,7 @@ describe('cascader', () => {
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
@@ -1544,8 +1508,7 @@ describe('cascader', () => {
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
@@ -1569,8 +1532,7 @@ describe('cascader', () => {
       expect(itemEl1.innerText).toBe('Jiangsu / Nanjing / Zhong Hua Men');
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
@@ -1588,8 +1550,7 @@ describe('cascader', () => {
       expect(testComponent.cascader.cascaderService.columns[0][0].isDisabled).toBe(true);
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 300);
-      fixture.detectChanges();
+      await sleep(MOUSE_EVENT_DELAY);
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.cascader.inputValue).toBe('o');
@@ -1615,15 +1576,13 @@ describe('cascader', () => {
       const itemEl2 = getItemAtColumnAndRow(1, 2)!;
       const itemEl4 = getItemAtColumnAndRow(1, 4)!;
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges();
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges();
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl4.classList).toContain('ant-cascader-menu-item-active');
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       expect(testComponent.values()).toEqual(['option1', 'option14']);
     });
 
@@ -1633,12 +1592,11 @@ describe('cascader', () => {
       testComponent.cascader.inputValue = 'o';
       testComponent.cascader.setMenuOpen(true);
       fixture.detectChanges();
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
-      fixture.detectChanges();
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      fixture.detectChanges();
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
     });
 
@@ -1714,9 +1672,7 @@ describe('cascader', () => {
     });
 
     it('should nzPlacement works', async () => {
-      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
       let element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(true);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(false);
@@ -1725,11 +1681,9 @@ describe('cascader', () => {
 
       const setNzPlacement = async (placement: NzCascaderPlacement): Promise<void> => {
         testComponent.cascader.setMenuOpen(false);
-        fixture.detectChanges();
         testComponent.nzPlacement.set(placement);
         testComponent.cascader.setMenuOpen(true);
-        await updateNonSignalsInput(fixture, 200);
-        fixture.detectChanges();
+        await fixture.whenStable();
       };
 
       await setNzPlacement('bottomRight');
@@ -1754,26 +1708,23 @@ describe('cascader', () => {
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(true);
     });
 
-    it('should cascade work when the value of ngModel that is not existed in options', async () => {
-      fixture.detectChanges();
+    it('should cascade work when the value of ngModel that is not existed in options', () => {
       testComponent.values.set(['zhejiang', 'a']);
       testComponent.cascader.setMenuOpen(true);
       fixture.detectChanges();
       getItemAtColumnAndRow(1, 1)!.click();
       getItemAtColumnAndRow(2, 1)!.click();
       getItemAtColumnAndRow(3, 1)!.click();
-      fixture.detectChanges();
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
     });
 
     it('should display activated column correctly after clicking outside and reopen', async () => {
-      fixture.detectChanges();
       testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       // First open - should display activated columns correctly
       testComponent.cascader.setMenuOpen(true);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(getAllColumns().length).toBe(3);
+
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       let itemEl2 = getItemAtColumnAndRow(2, 1)!;
       let itemEl3 = getItemAtColumnAndRow(3, 1)!;
@@ -1783,9 +1734,9 @@ describe('cascader', () => {
 
       // Click first column option (zhejiang) - should fold the third column
       itemEl1.click();
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(getAllColumns().length).toBe(2);
+
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl2 = getItemAtColumnAndRow(2, 1)!;
       itemEl3 = getItemAtColumnAndRow(3, 1)!;
@@ -1795,15 +1746,13 @@ describe('cascader', () => {
 
       // Click outside to close menu - value should remain unchanged
       dispatchFakeEvent(document.body, 'click');
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
 
       // Reopen menu - should display activated columns correctly based on current value
       testComponent.cascader.setMenuOpen(true);
-      await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(getAllColumns().length).toBe(3);
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1816,16 +1765,14 @@ describe('cascader', () => {
     describe('should nzOpen works', () => {
       beforeEach(async () => {
         testComponent.nzOpen.set(true);
-        await updateNonSignalsInput(fixture, 200);
-        fixture.detectChanges();
+        await fixture.whenStable();
       });
 
       it('should nzOpen can control the visibility of menu', async () => {
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
         testComponent.nzOpen.set(false);
-        await updateNonSignalsInput(fixture, 200);
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(testComponent.cascader.menuOpen()).toBe(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
       });
@@ -1835,8 +1782,7 @@ describe('cascader', () => {
         getItemAtColumnAndRow(1, 1)!.click();
         getItemAtColumnAndRow(2, 1)!.click();
         getItemAtColumnAndRow(3, 1)!.click(); // zhejiang, hangzhou, xihu
-        await updateNonSignalsInput(fixture);
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(testComponent.onValueChanges).toHaveBeenCalled();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         spyOn(testComponent.cascader, 'onClickOutside');
@@ -1855,9 +1801,8 @@ describe('cascader', () => {
         getItemAtColumnAndRow(2, 1)!.click();
         getItemAtColumnAndRow(3, 1)!.click(); // jiangsu, nanjing, zhonghuamen
         expect(testComponent.values()).toEqual([['zhejiang', 'hangzhou'], ['jiangsu']]);
-        await updateNonSignalsInput(fixture);
-        fixture.detectChanges();
         expect(testComponent.cascader.menuOpen()).toBe(true);
+
         spyOn(testComponent.cascader, 'clearSelection');
         expect(cascader.nativeElement.querySelector('.ant-select-clear .anticon')).toBeDefined();
         cascader.nativeElement.querySelector('.ant-select-clear .anticon').click();
@@ -1869,8 +1814,8 @@ describe('cascader', () => {
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
         expect(testComponent.cascader.menuOpen()).toBe(true);
         cascader.nativeElement.click();
-        await updateNonSignalsInput(fixture, 200);
-        fixture.detectChanges();
+        await sleep(200);
+        await fixture.whenStable();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
@@ -1880,15 +1825,14 @@ describe('cascader', () => {
         getItemAtColumnAndRow(2, 1)!.click();
         fixture.detectChanges();
         getItemAtColumnAndRow(3, 1)!.click();
-        await updateNonSignalsInput(fixture, 200);
-        fixture.detectChanges();
+        await sleep(200);
+        await fixture.whenStable();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(3);
 
         dispatchFakeEvent(document.body, 'click');
-        await updateNonSignalsInput(fixture);
-        fixture.detectChanges();
+        await fixture.whenStable();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(4);
@@ -1902,9 +1846,8 @@ describe('cascader', () => {
     let testComponent: NzDemoCascaderMultipleComponent;
 
     function setValues(len = 10): void {
-      testComponent.values.set(
-        testComponent.nzOptions[0].children!.slice(0, len).map(o => [testComponent.nzOptions[0].value, o.value])
-      );
+      const option = testComponent.nzOptions[0];
+      testComponent.values.set(option.children!.slice(0, len).map(o => [option.value, o.value]));
       fixture.detectChanges();
     }
 
@@ -1937,14 +1880,12 @@ describe('cascader', () => {
       // not exceed
       setValues(3);
       await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       let tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(3);
 
       // exceed maxTagCount
       setValues(10);
       await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(4); // maxTagCount + 1
     });
@@ -1952,17 +1893,14 @@ describe('cascader', () => {
     it('should remove item work', async () => {
       setValues(4);
       await updateNonSignalsInput(fixture);
-      fixture.detectChanges();
       const removeBtn = cascader.queryAll(By.css('.ant-select-selection-item-remove'))[2];
       removeBtn.nativeElement.click();
-      fixture.detectChanges();
       const tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(3);
     });
 
-    it('should check state conduct up and down', async () => {
+    it('should check state conduct up and down', () => {
       cascader.componentInstance.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 600);
       fixture.detectChanges();
 
       // firstly, expand all columns (for convenience)
@@ -2012,8 +1950,7 @@ describe('cascader', () => {
 
     it('should click checkbox not set option activated', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 600);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const option = getItemAtColumnAndRow(1, 1)!;
       const checkbox = getCheckboxAtColumnAndRow(1, 1)!;
@@ -2028,8 +1965,7 @@ describe('cascader', () => {
 
     it('should change check state when click leaf node', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 600);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       // firstly, expand all columns (for convenience)
       getItemAtColumnAndRow(1, 2)!.click();
@@ -2058,8 +1994,7 @@ describe('cascader', () => {
       spyOn(testComponent, 'onChanges');
       expect(testComponent.onChanges).not.toHaveBeenCalled();
       cascader.componentInstance.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 600);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.onChanges).not.toHaveBeenCalled();
 
       const checkbox = getCheckboxAtColumnAndRow(1, 1)!;
@@ -2070,8 +2005,7 @@ describe('cascader', () => {
 
     it('should support ENTER key to toggle option checked state in multiple mode', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 600);
-      fixture.detectChanges();
+      await fixture.whenStable();
       getItemAtColumnAndRow(1, 1)!.click();
       fixture.detectChanges();
       const optionEl = getItemAtColumnAndRow(2, 1)!;
@@ -2095,8 +2029,7 @@ describe('cascader', () => {
 
     it('should not activate option with isDisableCheckbox by pressing RIGHT ARROW key', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 600);
-      fixture.detectChanges();
+      await fixture.whenStable();
       getItemAtColumnAndRow(1, 2)!.click();
       fixture.detectChanges();
       getItemAtColumnAndRow(2, 1)!.click();
@@ -2114,8 +2047,7 @@ describe('cascader', () => {
 
     it('should not activate option with isDisableCheckbox in moveUpOrDown method', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 600);
-      fixture.detectChanges();
+      await fixture.whenStable();
       getItemAtColumnAndRow(1, 2)!.click();
       fixture.detectChanges();
       getItemAtColumnAndRow(2, 1)!.click();
@@ -2196,9 +2128,9 @@ describe('cascader', () => {
       testComponent.cascader.setMenuOpen(true);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(1);
-      await updateNonSignalsInput(fixture, 1000); // wait for first row to load finish
-      fixture.detectChanges();
 
+      await sleep(600); // wait for first row to load finish
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
       expect(testComponent.values()).toBeNull(); // not select yet
 
@@ -2206,7 +2138,7 @@ describe('cascader', () => {
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 600);
+      await sleep(600);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(2);
       expect(getAllColumns().length).toBe(2);
@@ -2217,7 +2149,7 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl2.click();
-      await updateNonSignalsInput(fixture, 600);
+      await sleep(600);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(3);
       expect(getAllColumns().length).toBe(3);
@@ -2229,15 +2161,13 @@ describe('cascader', () => {
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl3.click();
-      await updateNonSignalsInput(fixture, 600);
-      await updateNonSignalsInput(fixture);
+      await sleep(600);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(4);
       expect(testComponent.values()).toBeNull(); // not select yet
 
       itemEl3.click(); // re-click again, this time it is a leaf
-      await updateNonSignalsInput(fixture, 600);
-      await updateNonSignalsInput(fixture);
+      await sleep(600);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(4);
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
@@ -2246,7 +2176,7 @@ describe('cascader', () => {
     it('should nzLoadData work when specifies default value', async () => {
       spyOn(testComponent, 'addCallTimes');
       testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
-      await updateNonSignalsInput(fixture, 3000);
+      await sleep(3000);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(3);
       expect(testComponent.cascader.cascaderService.columns.length).toBe(3);
@@ -2256,28 +2186,26 @@ describe('cascader', () => {
     it('should not emit error after clear search and reopen it', async () => {
       fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      await updateNonSignalsInput(fixture, 1000); // wait for first row to load finish
+      await sleep(1000); // wait for first row to load finish
       fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
 
       itemEl1.click();
-      await updateNonSignalsInput(fixture, 600);
+      await sleep(600);
       fixture.detectChanges();
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
 
       itemEl2.click();
-      await updateNonSignalsInput(fixture, 600);
+      await sleep(600);
       fixture.detectChanges();
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
 
       itemEl3.click();
-      await updateNonSignalsInput(fixture, 600);
-      await updateNonSignalsInput(fixture);
+      await sleep(600);
       fixture.detectChanges();
 
       itemEl3.click(); // re-click again, this time it is a leaf
-      await updateNonSignalsInput(fixture, 600);
-      await updateNonSignalsInput(fixture);
+      await sleep(600);
       fixture.detectChanges();
       cascader.nativeElement.querySelector('.ant-select-clear .anticon').click();
       testComponent.cascader.setMenuOpen(true);
@@ -2377,7 +2305,7 @@ describe('cascader RTL behavior', () => {
   it('should menu class work', async () => {
     fixture.detectChanges();
     cascader.nativeElement.click();
-    await updateNonSignalsInput(fixture, 200);
+    await sleep(MOUSE_EVENT_DELAY);
     fixture.detectChanges();
     expect(overlayContainerElement.querySelector('.ant-cascader-menus')!.classList).toContain('ant-cascader-rtl');
   });
@@ -2431,9 +2359,6 @@ describe('nzPopupRender', () => {
     fixture.detectChanges();
 
     component.cascader.setMenuOpen(true);
-    await updateNonSignalsInput(fixture, 200);
-    fixture.detectChanges();
-
     const customFooter = overlayContainerElement.querySelector('.custom-footer');
     expect(customFooter).toBeTruthy();
     expect(customFooter?.textContent).toBe('Custom Footer');
@@ -2448,9 +2373,6 @@ describe('nzPopupRender', () => {
     fixture.detectChanges();
 
     component.cascader.setMenuOpen(true);
-    await updateNonSignalsInput(fixture, 200);
-    fixture.detectChanges();
-
     const menu = overlayContainerElement.querySelector('.ant-cascader-menus');
     expect(menu).toBeTruthy();
 
@@ -2487,6 +2409,7 @@ describe('finalSize', () => {
     fixture.detectChanges();
     expect(cascaderElement.classList).toContain('ant-select-lg');
   });
+
   it('should set correctly the size from the compactSize signal', () => {
     TestBed.configureTestingModule({
       providers: [{ provide: NZ_SPACE_COMPACT_SIZE, useValue: compactSizeSignal }]
@@ -2496,6 +2419,7 @@ describe('finalSize', () => {
     fixture.detectChanges();
     expect(cascaderElement.classList).toContain('ant-select-lg');
   });
+
   it('should set correctly the size from the component input', () => {
     fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -15,7 +15,6 @@ import {
   HOME,
   LEFT_ARROW,
   NINE,
-  O,
   PAGE_DOWN,
   PAGE_UP,
   RIGHT_ARROW,
@@ -27,17 +26,16 @@ import {
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   DebugElement,
   inject,
-  provideZoneChangeDetection,
   signal,
   TemplateRef,
   ViewChild,
   type WritableSignal
 } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, inject as testingInject, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, inject as testingInject } from '@angular/core/testing';
 import { FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -50,7 +48,9 @@ import {
   dispatchKeyboardEvent,
   dispatchMouseEvent,
   provideMockDirectionality,
-  testDirectionality
+  sleep,
+  testDirectionality,
+  updateNonSignalsInput
 } from 'ng-zorro-antd/core/testing';
 import { NzSafeAny, NzStatus, NzVariant, type NzSizeLDSType } from 'ng-zorro-antd/core/types';
 import { NzFormModule } from 'ng-zorro-antd/form';
@@ -68,6 +68,19 @@ import {
   NzCascaderTriggerType,
   NzShowSearchOptions
 } from './typings';
+
+function markForCheckAndDetectChanges<T>(fixture: ComponentFixture<T>): void {
+  fixture.debugElement.injector.get(ChangeDetectorRef).markForCheck();
+  fixture.detectChanges();
+}
+
+async function waitForChanges<T>(fixture: ComponentFixture<T>, ms?: number): Promise<void> {
+  if (typeof ms === 'number') {
+    await sleep(ms);
+  }
+  await fixture.whenStable();
+  markForCheckAndDetectChanges(fixture);
+}
 
 describe('cascader', () => {
   let overlayContainer: OverlayContainer;
@@ -90,11 +103,9 @@ describe('cascader', () => {
   }
 
   beforeEach(() => {
-    // todo: use zoneless
     TestBed.configureTestingModule({
-      providers: [provideNzIconsTesting(), provideNzNoAnimation(), provideZoneChangeDetection()]
+      providers: [provideNzIconsTesting(), provideNzNoAnimation()]
     });
-    (NzDemoCascaderMultipleComponent as NzSafeAny).ɵcmp.onPush = false;
   });
 
   beforeEach(
@@ -139,27 +150,27 @@ describe('cascader', () => {
     });
 
     it('should className correct', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.className).toContain('ant-cascader ant-select');
     });
 
     it('should have input', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getInputEl()).toBeDefined();
       expect(getPlaceholder()).toBe('please select');
     });
 
     it('should input change event stopPropagation', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const fakeInputChangeEvent = createFakeEvent('change', true, true);
       spyOn(fakeInputChangeEvent, 'stopPropagation');
       getInputEl().dispatchEvent(fakeInputChangeEvent);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(fakeInputChangeEvent.stopPropagation).toHaveBeenCalled();
     });
 
     it('should not have EMPTY label', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const label: HTMLElement = cascader.nativeElement.querySelector('.ant-select-selection-item');
       expect(label).toBeNull();
     });
@@ -167,501 +178,507 @@ describe('cascader', () => {
     it('should placeholder work', () => {
       const placeholder = 'placeholder test';
       testComponent.nzPlaceHolder = placeholder;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getPlaceholder()).toBe(placeholder);
     });
 
     it('should show/hide placeholder when trigger compositionstart/compositionend event', () => {
       testComponent.nzPlaceHolder = 'placeholder test';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       const placeholderElement = cascader.nativeElement.querySelector('.ant-select-selection-placeholder');
       const fakeCompositionstartEvent = createFakeEvent('compositionstart', true, true);
       getInputEl().dispatchEvent(fakeCompositionstartEvent);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(placeholderElement.style.display).toBe('none');
 
       const fakeCompositionendEvent = createFakeEvent('compositionend', true, true);
       getInputEl().dispatchEvent(fakeCompositionendEvent);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(placeholderElement.style.display).toBe('block');
     });
 
     it('should size work', () => {
       testComponent.nzSize = 'small';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-sm');
       testComponent.nzSize = 'large';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-lg');
     });
 
-    it('should value and label property work', fakeAsync(() => {
+    it('should value and label property work', async () => {
       testComponent.nzOptions = ID_NAME_LIST;
       testComponent.nzValueProperty = 'id';
       testComponent.nzLabelProperty = 'name';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       // label will not show if no item selected
       expect(getLabelElement()).toBeNull();
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('');
       testComponent.values = [1, 2, 3];
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('1,2,3');
-    }));
+    });
 
-    it('should no value and label property work', fakeAsync(() => {
+    it('should no value and label property work', async () => {
       testComponent.nzValueProperty = null!;
       testComponent.nzLabelProperty = null!;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelElement()).toBeNull();
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('');
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('zhejiang,hangzhou,xihu');
-    }));
+    });
 
     it('should showArrow work', () => {
       testComponent.nzShowArrow = true;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-arrow')).toBeDefined();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow .anticon').classList).toContain('anticon-down');
       testComponent.nzShowArrow = false;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-arrow')).toBeNull();
     });
 
     it('should allowClear work', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeDefined();
       testComponent.nzAllowClear = false;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeNull();
     });
 
     describe('should variant works', () => {
       it('outlined', () => {
         testComponent.nzVariant = 'outlined';
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         expect(cascader.nativeElement.classList).toContain('ant-select-outlined');
       });
       it('filled', () => {
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         expect(cascader.nativeElement.classList).not.toContain('ant-select-filled');
         testComponent.nzVariant = 'filled';
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         expect(cascader.nativeElement.classList).toContain('ant-select-filled');
       });
       it('borderless', () => {
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         expect(cascader.nativeElement.classList).not.toContain('ant-select-borderless');
         testComponent.nzVariant = 'borderless';
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         expect(cascader.nativeElement.classList).toContain('ant-select-borderless');
       });
       it('underlined', () => {
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         expect(cascader.nativeElement.classList).not.toContain('ant-select-underlined');
         testComponent.nzVariant = 'underlined';
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         expect(cascader.nativeElement.classList).toContain('ant-select-underlined');
       });
     });
 
     it('should open work', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).not.toContain('ant-select-open');
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-open');
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
       expect(testComponent.cascader.nzOptions).toEqual(options1());
     });
 
-    it('should click toggle open', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should click toggle open', async () => {
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.nzDisabled).toBe(false);
 
       cascader.nativeElement.click();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
 
       cascader.nativeElement.click();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
-    }));
+    });
 
-    it('should mouse hover toggle open', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should mouse hover toggle open', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.nzTriggerAction = 'hover';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.nzDisabled).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      tick(300);
-      fixture.detectChanges();
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
 
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      tick(300);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
-    }));
+    });
 
-    it('should mouse hover toggle open immediately', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should mouse hover toggle open immediately', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.nzTriggerAction = ['hover'];
       testComponent.nzMouseEnterDelay = 0;
       testComponent.nzMouseLeaveDelay = 0;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
-    }));
+    });
 
-    it('should clear timer on option mouseenter and mouseleave', fakeAsync(() => {
+    it('should clear timer on option mouseenter and mouseleave', async () => {
       testComponent.nzExpandTrigger = 'hover';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
-      flush();
-      fixture.detectChanges();
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       const optionEl = getItemAtColumnAndRow(1, 1)!;
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(optionEl, 'mouseenter');
-      fixture.detectChanges();
-      tick(10);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 10);
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(optionEl, 'mouseleave');
-      fixture.detectChanges();
-      tick(400);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 400);
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(optionEl, 'mouseenter');
-      fixture.detectChanges();
-      tick(400);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 400);
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl.classList).toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
-    it('should disabled work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should disabled work', async () => {
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).not.toContain('ant-select-disabled');
       testComponent.nzDisabled = true;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-disabled');
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       cascader.nativeElement.click();
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
-    }));
+    });
 
-    it('should disabled state work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should disabled state work', async () => {
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).not.toContain('ant-select-disabled');
       testComponent.cascader.setDisabledState(true);
-      fixture.detectChanges();
+      cascader.injector.get(ChangeDetectorRef).markForCheck();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-disabled');
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       cascader.nativeElement.click();
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
-    }));
+    });
 
-    it('should disabled mouse hover open', fakeAsync(() => {
+    it('should disabled mouse hover open', async () => {
       testComponent.nzTriggerAction = 'hover';
       testComponent.nzDisabled = true;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.nzDisabled).toBe(true);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      tick(300);
-      fixture.detectChanges();
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
 
       testComponent.nzDisabled = false;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.nzDisabled).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
       testComponent.nzDisabled = true;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      tick(300);
-      fixture.detectChanges();
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
-    }));
+    });
 
-    it('should mouse leave not work when menu not open', fakeAsync(() => {
+    it('should mouse leave not work when menu not open', async () => {
       testComponent.nzTriggerAction = ['hover'];
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      fixture.detectChanges();
-      tick(300);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
-    }));
+    });
 
-    it('should clear value work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should clear value work', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.nzAllowClear = true;
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
-      flush();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
       expect(testComponent.values!.length).toBe(3);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       spyOn(testComponent, 'onClear');
       cascader.nativeElement.querySelector('.ant-select-clear nz-icon').click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values!.length).toBe(0);
       expect(testComponent.onClear).toHaveBeenCalled();
-    }));
+    });
 
-    it('should clear value work 2', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should clear value work 2', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
-      flush();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
       expect(testComponent.values!.length).toBe(3);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       spyOn(testComponent, 'onClear');
       testComponent.cascader.clearSelection();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values!.length).toBe(0);
       expect(testComponent.onClear).toHaveBeenCalled();
-    }));
+    });
 
     it('should autofocus work', () => {
       testComponent.nzShowInput = true;
+      markForCheckAndDetectChanges(fixture);
       testComponent.nzAutoFocus = true;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getInputEl().getAttribute('autofocus')).toBe('autofocus');
       testComponent.nzAutoFocus = false;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getInputEl().getAttribute('autofocus')).toBe(null);
     });
 
-    it('should input focus and blur work', fakeAsync(() => {
+    it('should input focus and blur work', async () => {
       const fakeInputFocusEvent = createFakeEvent('focus', false, true);
       const fakeInputBlurEvent = createFakeEvent('blur', false, true);
 
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).not.toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputFocusEvent);
-      fixture.detectChanges();
+      cascader.injector.get(ChangeDetectorRef).markForCheck();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputBlurEvent);
-      fixture.detectChanges();
+      cascader.injector.get(ChangeDetectorRef).markForCheck();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).not.toContain('ant-select-focused');
 
       testComponent.cascader.setMenuOpen(true);
       getInputEl().dispatchEvent(fakeInputFocusEvent);
-      fixture.detectChanges();
+      cascader.injector.get(ChangeDetectorRef).markForCheck();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputBlurEvent);
-      fixture.detectChanges();
+      cascader.injector.get(ChangeDetectorRef).markForCheck();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-focused');
-    }));
+    });
 
     it('should focus and blur function work', () => {
       testComponent.nzShowInput = true;
       cascader.nativeElement.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getInputEl() === document.activeElement).toBe(false);
       testComponent.cascader.focus();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getInputEl() === document.activeElement).toBe(true);
       testComponent.cascader.blur();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getInputEl() === document.activeElement).toBe(false);
     });
 
     it('should focus and blur function work 2', () => {
       testComponent.nzShowInput = false;
       cascader.nativeElement.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement === document.activeElement).toBe(false);
       testComponent.cascader.focus();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement === document.activeElement).toBe(true);
       testComponent.cascader.blur();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement === document.activeElement).toBe(false);
     });
 
-    it('should menu class work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should menu class work', async () => {
+      markForCheckAndDetectChanges(fixture);
       cascader.nativeElement.click();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(overlayContainerElement.querySelector('.ant-cascader-menus')!.classList).toContain('menu-classA');
       expect(overlayContainerElement.querySelector('.ant-cascader-menu')!.classList).toContain('column-classA');
-    }));
+    });
 
-    it('should menu style work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should menu style work', async () => {
+      markForCheckAndDetectChanges(fixture);
       cascader.nativeElement.click();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       const targetElement = overlayContainerElement.querySelector('.menu-classA') as HTMLElement;
       expect(targetElement.style.height).toBe('120px');
-    }));
+    });
 
-    it('should show input false work', fakeAsync(() => {
+    it('should show input false work', async () => {
       testComponent.nzShowInput = false;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-selection-search-input')).toBeNull();
       testComponent.nzAllowClear = true;
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-selection-search-input')).toBeNull();
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeNull();
       expect(cascader.nativeElement.querySelector('.ant-select-selection-item')).toBeNull();
-    }));
+    });
 
-    it('should create label work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should create label work', async () => {
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-selection-item')).toBeNull();
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
-    }));
+    });
 
-    it('should label template work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should label template work', async () => {
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-selection-item')).toBeNull();
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       testComponent.nzLabelRender = testComponent.renderTpl;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText()).toBe('Zhejiang | Hangzhou | West Lake');
       // fix clear
       testComponent.cascader.clearSelection();
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       testComponent.nzLabelRender = testComponent.renderTpl;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText()).toBe('Zhejiang | Hangzhou | West Lake');
-    }));
+    });
 
-    it('should label template work on multiple', fakeAsync(() => {
+    it('should label template work on multiple', async () => {
       testComponent.nzMultiple = true;
       testComponent.values = [['zhejiang', 'hangzhou']];
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText()).toBe('Zhejiang / Hangzhou');
 
       testComponent.values = [['jiangsu']]; // 'Jiangsu / Nanjing / Zhong Hua Men'
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText()).toBe('Jiangsu');
 
       testComponent.nzLabelRender = testComponent.renderTpl;
       testComponent.values = [['zhejiang', 'hangzhou']];
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText().trim()).toBe('Zhejiang | Hangzhou');
 
       testComponent.values = [['jiangsu']]; // 'Jiangsu / Nanjing / Zhong Hua Men'
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getLabelText()).toBe('Jiangsu');
-    }));
+    });
 
-    it('should write value work', fakeAsync(() => {
+    it('should write value work', async () => {
       const control = testComponent.cascader;
       testComponent.nzOptions = options1();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(null);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(undefined);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue([]);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(0);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(1);
       control.writeValue('');
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(1);
       control.writeValue(['zhejiang']);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(1);
       expect(control.getSubmitValue()[0]).toBe('zhejiang');
       control.writeValue(['zhejiang', 'hangzhou', 'xihu']);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(3);
       const values = control.getSubmitValue();
       expect(values![0]).toBe('zhejiang');
@@ -669,135 +686,135 @@ describe('cascader', () => {
       expect(values![2]).toBe('xihu');
 
       testComponent.nzOptions = []; // empty collection
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       control.writeValue(['zhejiang', 'hangzhou', 'xihu']); // so these values are not match
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(3);
       const values3 = control.getSubmitValue();
       expect(values3[0]).toBe('zhejiang');
       expect(values3[1]).toBe('hangzhou');
       expect(values3[2]).toBe('xihu');
       expect(getLabelText()).toBe('zhejiang / hangzhou / xihu');
-    }));
+    });
 
-    it('should write value work on setting `nzOptions` async', fakeAsync(() => {
+    it('should write value work on setting `nzOptions` async', async () => {
       const control = testComponent.cascader;
       testComponent.nzOptions = null;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(null);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(undefined);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue([]);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(0);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(1);
       control.writeValue('');
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(1);
       control.writeValue(['zhejiang']);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(1);
       expect(control.getSubmitValue()[0]).toBe('zhejiang');
       expect(getLabelText()).toBe('zhejiang');
       testComponent.nzOptions = options1(); // update the nzOptions like async
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(1);
       expect(control.getSubmitValue()[0]).toBe('zhejiang');
       expect(getLabelText()).toBe('Zhejiang');
-    }));
+    });
 
-    it('should write value work on setting `nzOptions` async (match)', fakeAsync(() => {
+    it('should write value work on setting `nzOptions` async (match)', async () => {
       const control = testComponent.cascader;
       testComponent.nzOptions = null;
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
-      flush(); // force value to be written
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture); // force value to be written
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(3);
       expect(getLabelText()).toBe('zhejiang / hangzhou / xihu');
       testComponent.nzOptions = options1(); // update the nzOptions like async
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const values = control.getSubmitValue();
       expect(values![0]).toBe('zhejiang');
       expect(values![1]).toBe('hangzhou');
       expect(values![2]).toBe('xihu');
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
-    }));
+    });
 
-    it('should write value work on setting `nzOptions` async (not match)', fakeAsync(() => {
+    it('should write value work on setting `nzOptions` async (not match)', async () => {
       const control = testComponent.cascader;
       testComponent.nzOptions = null;
       testComponent.values = ['zhejiang2', 'hangzhou2', 'xihu2'];
-      fixture.detectChanges();
-      flush(); // force value to be written
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture); // force value to be written
+      markForCheckAndDetectChanges(fixture);
       expect(control.getSubmitValue().length).toBe(3);
       expect(getLabelText()).toBe('zhejiang2 / hangzhou2 / xihu2');
       testComponent.nzOptions = options1(); // update the nzOptions like async
-      fixture.detectChanges(); // but still the values is not match
+      markForCheckAndDetectChanges(fixture); // but still the values is not match
       const values = control.getSubmitValue();
       expect(values![0]).toBe('zhejiang2');
       expect(values![1]).toBe('hangzhou2');
       expect(values![2]).toBe('xihu2');
       expect(getLabelText()).toBe('zhejiang2 / hangzhou2 / xihu2');
-    }));
+    });
 
     it('should click option to expand', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(0);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(1);
       const itemEl1 = overlayContainerElement.querySelector('.ant-cascader-menu')!.firstElementChild as HTMLElement;
 
       itemEl1.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
       const col2 = getAllColumns().item(1);
       const itemEl2 = col2.firstElementChild as HTMLElement;
 
       itemEl2.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
     });
 
     it('should click option to change column count', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(0);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(1);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
 
       itemEl1.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
 
       itemEl2.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
 
       const itemEl3 = getItemAtColumnAndRow(1, 2)!;
 
       itemEl3.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
     });
 
-    it('should click option to change column count 2', fakeAsync(() => {
+    it('should click option to change column count 2', async () => {
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
-      cascader.nativeElement.click();
-      fixture.detectChanges();
-      flush(); // wait for cdk-overlay to open
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      testComponent.cascader.setMenuOpen(true);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture); // wait for cdk-overlay to open
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(getAllColumns().length).toBe(3);
 
@@ -810,9 +827,9 @@ describe('cascader', () => {
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl2 = getItemAtColumnAndRow(2, 1)!;
       itemEl3 = getItemAtColumnAndRow(3, 1)!;
@@ -824,25 +841,25 @@ describe('cascader', () => {
 
       const itemEl4 = getItemAtColumnAndRow(2, 2)!;
       itemEl4.click(); // click leaf node
-      fixture.detectChanges();
-      tick(300);
-      fixture.detectChanges();
-      flush(); // wait for cdk-overlay close
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture); // wait for cdk-overlay close
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.values!.join(',')).toBe('zhejiang,ningbo');
-    }));
+    });
 
     it('should click option to change column count 3', () => {
       testComponent.nzOptions = options3;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(1);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
 
       itemEl1.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
       let itemEl21 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl21.innerText.trim()).toBe('Hangzhou');
@@ -850,89 +867,89 @@ describe('cascader', () => {
       const itemEl2 = getItemAtColumnAndRow(1, 2)!;
 
       itemEl2.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
 
       itemEl21 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl21.innerText.trim()).toBe('Nanjing');
     });
 
-    it('should click disabled option false to expand', fakeAsync(() => {
+    it('should click disabled option false to expand', async () => {
       testComponent.nzOptions = options2;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const optionEl1 = getItemAtColumnAndRow(1, 1)!;
       const optionEl2 = getItemAtColumnAndRow(1, 2)!;
 
       expect(optionEl1.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
       optionEl1.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
       optionEl2.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
-    it('should click leaf option to close menu', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should click leaf option to close menu', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       getItemAtColumnAndRow(1, 1)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       getItemAtColumnAndRow(2, 1)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       getItemAtColumnAndRow(3, 1)!.click();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(getAllColumns().length).toBe(0);
-    }));
+    });
 
-    it('should open menu when press DOWN_ARROW', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should open menu when press DOWN_ARROW', async () => {
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
-    }));
+    });
 
-    it('should open menu when press UP_ARROW', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should open menu when press UP_ARROW', async () => {
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
-    }));
+    });
 
-    it('should close menu when press ESC', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should close menu when press ESC', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ESCAPE);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
-    }));
+    });
 
-    it('should init menu when selecting cancel', fakeAsync(() => {
+    it('should init menu when selecting cancel', async () => {
       // cancel select by ESCAPE
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl1.click();
@@ -943,14 +960,14 @@ describe('cascader', () => {
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ESCAPE);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.cascaderService.columns.length).toBe(1);
 
       // cancel select by clicking outside
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl1.click();
@@ -961,66 +978,66 @@ describe('cascader', () => {
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchFakeEvent(document.body, 'click');
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.cascaderService.columns.length).toBe(1);
-    }));
+    });
 
-    it('should nzBackdrop works', fakeAsync(() => {
+    it('should nzBackdrop works', async () => {
       testComponent.nzBackdrop = true;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const boundingBox = overlayContainerElement.children[0];
       expect(boundingBox.children[0].classList).toContain('cdk-overlay-backdrop');
-    }));
+    });
 
-    it('should navigate up when press UP_ARROW', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should navigate up when press UP_ARROW', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = overlayContainerElement.querySelector(
         '.ant-cascader-menu:nth-child(1) .ant-cascader-menu-item:last-child'
       ) as HTMLElement; // The last of the fisrt column
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       const itemEl2 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
-    it('should navigate down when press DOWN_ARROW', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should navigate down when press DOWN_ARROW', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
-    it('should navigate right when press RIGHT_ARROW', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should navigate right when press RIGHT_ARROW', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       let itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1029,15 +1046,15 @@ describe('cascader', () => {
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
-    it('should navigate left when press LEFT_ARROW', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should navigate left when press LEFT_ARROW', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
-      flush(); // wait for cdk-overlay to open
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture); // wait for cdk-overlay to open
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
@@ -1047,35 +1064,35 @@ describe('cascader', () => {
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl3).toBeNull();
       expect(getAllColumns().length).toBe(2);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBeFalse();
-    }));
+    });
 
-    it('should navigate left when press BACKSPACE', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should navigate left when press BACKSPACE', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
-      flush(); // wait for cdk-overlay to open
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture); // wait for cdk-overlay to open
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
@@ -1085,79 +1102,76 @@ describe('cascader', () => {
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', BACKSPACE);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
-    it('when there is only one column activated, pressing LEFT should fold the menu', fakeAsync(() => {
+    it('when there is only one column activated, pressing LEFT should fold the menu', async () => {
       testComponent.values = ['zhejiang', 'ningbo'];
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      flush();
-      fixture.detectChanges();
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBeFalse();
-    }));
+    });
 
-    it('should select option when press ENTER', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should select option when press ENTER', async () => {
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeNull();
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW); // active 1
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeNull(); // not select yet
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW); // active 2
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeNull(); // not select yet
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW); // active 3
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeNull(); // not select yet
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       expect(testComponent.values).toBeDefined();
       expect(testComponent.values!.length).toBe(3);
       expect(testComponent.values![0]).toBe('zhejiang');
       expect(testComponent.values![1]).toBe('hangzhou');
       expect(testComponent.values![2]).toBe('xihu');
-      flush();
-      fixture.detectChanges();
+      await updateNonSignalsInput(fixture, 200);
       expect(testComponent.cascader.menuOpen()).toBe(false);
-    }));
+    });
 
-    it('should key nav disabled option correct', fakeAsync(() => {
+    it('should key nav disabled option correct', async () => {
       testComponent.nzOptions = options2;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const optionEl1 = getItemAtColumnAndRow(1, 1)!;
       const optionEl2 = getItemAtColumnAndRow(1, 2)!;
 
       expect(optionEl1.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW); // active 1
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges(); // should NOT active the disabled option2
+      markForCheckAndDetectChanges(fixture); // should NOT active the disabled option2
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
@@ -1171,28 +1185,28 @@ describe('cascader', () => {
       expect(optionEl14.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW); // active 2
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl14.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl14.classList).toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl14.classList).not.toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
-    it('should ignore keyboardEvent on some key', fakeAsync(() => {
+    it('should ignore keyboardEvent on some key', async () => {
       const A = 65;
       const Z = 90;
       const keys = [PAGE_UP, PAGE_DOWN, TAB, HOME, END, SPACE, COMMA, DELETE];
@@ -1203,23 +1217,23 @@ describe('cascader', () => {
         keys.push(k);
       }
 
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       keys.forEach(key => {
         expect(testComponent.cascader.menuOpen()).toBe(false);
         dispatchKeyboardEvent(cascader.nativeElement, 'keydown', key);
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         expect(testComponent.cascader.menuOpen()).toBe(false);
       });
-    }));
+    });
 
-    it('should expand option on hover', fakeAsync(() => {
+    it('should expand option on hover', async () => {
       testComponent.nzExpandTrigger = 'hover';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(0); // 0 column
       expect(testComponent.values).toBeNull(); // not select yet
 
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(1);
       expect(testComponent.values).toBeNull(); // not select yet
 
@@ -1227,9 +1241,9 @@ describe('cascader', () => {
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(itemEl1, 'mouseenter');
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1237,16 +1251,16 @@ describe('cascader', () => {
       expect(testComponent.values).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl1, 'mouseleave');
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(testComponent.values).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl2, 'mouseenter');
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1255,7 +1269,7 @@ describe('cascader', () => {
       expect(testComponent.values).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl2, 'mouseleave');
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
@@ -1263,9 +1277,9 @@ describe('cascader', () => {
       expect(testComponent.values).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl3, 'mouseenter');
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
@@ -1273,29 +1287,29 @@ describe('cascader', () => {
       expect(testComponent.values).toBeNull(); // not select yet
 
       itemEl3.click();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeDefined();
       expect(testComponent.values!.length).toBe(3);
       expect(testComponent.values![0]).toBe('zhejiang');
       expect(testComponent.values![1]).toBe('hangzhou');
       expect(testComponent.values![2]).toBe('xihu');
-      flush();
-      fixture.detectChanges();
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
-    }));
+    });
 
-    it('should not expand disabled option on hover', fakeAsync(() => {
+    it('should not expand disabled option on hover', async () => {
       testComponent.nzExpandTrigger = 'hover';
       testComponent.nzOptions = options2;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.values).toBeNull(); // not select yet
 
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(1);
       expect(testComponent.values).toBeNull(); // not select yet
 
@@ -1303,31 +1317,31 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(itemEl2, 'mouseenter');
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(1);
 
       dispatchMouseEvent(itemEl2, 'mouseleave');
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(1);
-    }));
+    });
 
     // fix #3914
-    it('should drop selected items and columns if a leaf node is hovered', fakeAsync(() => {
+    it('should drop selected items and columns if a leaf node is hovered', async () => {
       testComponent.nzExpandTrigger = 'hover';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       testComponent.cascader.setMenuOpen(true); // Open cascader dropdown.
 
-      fixture.detectChanges();
-      tick(500);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 500);
+      markForCheckAndDetectChanges(fixture);
       expect(overlayContainerElement.querySelectorAll('.ant-cascader-menu').length).toBe(3);
 
       const c2i2 = overlayContainerElement.querySelector(
@@ -1335,21 +1349,21 @@ describe('cascader', () => {
       ) as HTMLElement;
       dispatchMouseEvent(c2i2, 'mouseenter');
 
-      fixture.detectChanges();
-      tick(500);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 500);
+      markForCheckAndDetectChanges(fixture);
       expect(overlayContainerElement.querySelectorAll('.ant-cascader-menu').length).toBe(2);
-    }));
+    });
 
-    it('should change on select work', fakeAsync(() => {
+    it('should change on select work', async () => {
       testComponent.nzChangeOnSelect = true;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeNull();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.values).toBeNull(); // not select yet
 
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(1);
       expect(testComponent.values).toBeNull(); // not select yet
 
@@ -1357,7 +1371,7 @@ describe('cascader', () => {
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl1.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1371,7 +1385,7 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl2.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1388,40 +1402,40 @@ describe('cascader', () => {
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl3.click();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
 
       expect(testComponent.values).toBeDefined();
       expect(testComponent.values!.length).toBe(3);
       expect(testComponent.values![0]).toBe('zhejiang');
       expect(testComponent.values![1]).toBe('hangzhou');
       expect(testComponent.values![2]).toBe('xihu');
-      flush();
-      fixture.detectChanges();
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
-    }));
+    });
 
-    it('should not change on hover work', fakeAsync(() => {
+    it('should not change on hover work', async () => {
       testComponent.nzChangeOnSelect = true;
       testComponent.nzExpandTrigger = 'hover';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeNull();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.values).toBeNull(); // not select yet
 
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(1);
       expect(testComponent.values).toBeNull(); // not select yet
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(itemEl1, 'mouseenter');
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
 
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1432,9 +1446,9 @@ describe('cascader', () => {
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(itemEl2, 'mouseenter');
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
 
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1447,34 +1461,34 @@ describe('cascader', () => {
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(itemEl3, 'mouseenter');
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
 
       expect(testComponent.values).toBeNull(); // mouseenter does not trigger selection
 
       itemEl3.click();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      markForCheckAndDetectChanges(fixture);
 
       expect(testComponent.values).toBeDefined(); // click trigger selection
       expect(testComponent.values!.length).toBe(3);
       expect(testComponent.values![0]).toBe('zhejiang');
       expect(testComponent.values![1]).toBe('hangzhou');
       expect(testComponent.values![2]).toBe('xihu');
-      flush();
-      fixture.detectChanges();
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
-    }));
+    });
 
-    it('should change on function work', fakeAsync(() => {
+    it('should change on function work', async () => {
       testComponent.nzChangeOn = testComponent.fakeChangeOn;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeNull();
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(1);
       expect(testComponent.values).toBeNull(); // not select yet
 
@@ -1484,58 +1498,58 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl2.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(testComponent.values).toBeNull(); // not select yet
 
       itemEl1.click();
-      fixture.detectChanges();
-      tick(200);
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 200);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.values).toBeDefined();
       expect(testComponent.values!.length).toBe(1);
       expect(testComponent.values![0]).toBe('zhejiang');
-    }));
+    });
 
-    it('should support search', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should support search', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.nzShowSearch = true;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const spy = spyOn(testComponent.cascader, 'focus');
       cascader.nativeElement.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(spy).toHaveBeenCalled();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
       expect(testComponent.values!.join(',')).toBe('zhejiang,hangzhou,xihu');
-    }));
+    });
 
-    it('should searching could be aborted', fakeAsync(() => {
+    it('should searching could be aborted', async () => {
       testComponent.values = ['zhengjiang', 'hangzhou', 'xihu'];
       testComponent.nzShowSearch = true;
-      fixture.detectChanges();
-      cascader.nativeElement.click();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      testComponent.cascader.setMenuOpen(true);
+      await waitForChanges(fixture, 0);
+      markForCheckAndDetectChanges(fixture);
 
       // input search value
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
@@ -1543,105 +1557,105 @@ describe('cascader', () => {
 
       // clear search value
       testComponent.cascader.inputValue = '';
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 10);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
 
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.innerText).toBe('Zhejiang');
-    }));
+    });
 
-    it('should clear input value when searching cancel', fakeAsync(() => {
+    it('should clear input value when searching cancel', async () => {
       testComponent.values = ['zhengjiang', 'hangzhou', 'xihu'];
       testComponent.nzShowSearch = true;
-      fixture.detectChanges();
-      cascader.nativeElement.click();
-      testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      expect(testComponent.cascader.menuOpen()).toBe(true);
-      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ESCAPE);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      expect(testComponent.cascader.inputValue).toBe('');
-      expect(testComponent.values).toEqual(['zhengjiang', 'hangzhou', 'xihu']);
-    }));
-
-    it('should support nzLabelProperty', fakeAsync(() => {
-      testComponent.nzShowSearch = true;
-      testComponent.nzLabelProperty = 'l';
-      fixture.detectChanges();
-      cascader.nativeElement.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
+      expect(testComponent.cascader.menuOpen()).toBe(true);
+      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ESCAPE);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
+      expect(testComponent.cascader.inputValue).toBe('');
+      expect(testComponent.values).toEqual(['zhengjiang', 'hangzhou', 'xihu']);
+    });
+
+    it('should support nzLabelProperty', async () => {
+      testComponent.nzShowSearch = true;
+      testComponent.nzLabelProperty = 'l';
+      markForCheckAndDetectChanges(fixture);
+      cascader.nativeElement.click();
+      markForCheckAndDetectChanges(fixture);
+      testComponent.cascader.setMenuOpen(true);
+      testComponent.cascader.inputValue = 'o';
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang New / Hangzhou New / West Lake New');
 
       itemEl1.click();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
       expect(testComponent.values!.join(',')).toBe('zhejiang,hangzhou,xihu');
-    }));
+    });
 
-    it('should support nzValueProperty', fakeAsync(() => {
+    it('should support nzValueProperty', async () => {
       testComponent.nzShowSearch = true;
       testComponent.nzValueProperty = 'v';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       cascader.nativeElement.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
       expect(testComponent.values!.join(',')).toBe('zhejiang-new,hangzhou-new,xihu-new');
-    }));
+    });
 
-    it('should support custom filter', fakeAsync(() => {
+    it('should support custom filter', async () => {
       testComponent.nzShowSearch = {
         filter(inputValue: string, path: NzCascaderOption[]): boolean {
           return path.some(p => p.label!.indexOf(inputValue) !== -1);
         }
       } as NzShowSearchOptions;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
       expect(testComponent.values!.join(',')).toBe('zhejiang,hangzhou,xihu');
-    }));
+    });
 
-    it('should support custom sorter', fakeAsync(() => {
+    it('should support custom sorter', async () => {
       testComponent.nzShowSearch = {
         sorter(a: NzCascaderOption[], b: NzCascaderOption[], _inputValue: string): number {
           const l1 = a[0].label;
@@ -1649,134 +1663,135 @@ describe('cascader', () => {
           return `${l1}`.localeCompare(l2!);
         }
       } as NzShowSearchOptions;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Jiangsu / Nanjing / Zhong Hua Men');
 
       itemEl1.click();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
       expect(testComponent.values!.join(',')).toBe('jiangsu,nanjing,zhonghuamen');
-    }));
+    });
 
-    it('should forbid disabled search options to be clicked', fakeAsync(() => {
+    it('should forbid disabled search options to be clicked', async () => {
       testComponent.nzOptions = options4;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
       expect(testComponent.cascader.cascaderService.columns[0][0].isDisabled).toBe(true);
 
       itemEl1.click();
-      tick(300);
-      fixture.detectChanges();
+      await waitForChanges(fixture, 300);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.cascader.inputValue).toBe('o');
-    }));
+    });
 
     it('should pass disabled property to children when searching', () => {
       testComponent.nzOptions = options4;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.cascaderService.columns[0][0].isDisabled).toBe(true);
       expect(testComponent.cascader.cascaderService.columns[0][1].isDisabled).toBe(false);
       expect(testComponent.cascader.cascaderService.columns[0][2].isDisabled).toBe(true);
     });
 
-    it('should support arrow in search mode', done => {
+    it('should support arrow in search mode', async () => {
       testComponent.nzOptions = options2;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl2 = getItemAtColumnAndRow(1, 2)!;
       const itemEl4 = getItemAtColumnAndRow(1, 4)!;
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl4.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expect(testComponent.values!.join(',')).toBe('option1,option14');
-        done();
-      });
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      expect(testComponent.values!.join(',')).toBe('option1,option14');
     });
 
     it('should not preventDefault left/right arrow in search mode', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.nzShowSearch = true;
       testComponent.cascader.inputValue = 'o';
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
     });
 
-    it('should not preventDefault BACKSPACE in search mode', fakeAsync(() => {
+    it('should not preventDefault BACKSPACE in search mode', async () => {
       testComponent.nzShowSearch = true;
-      dispatchMouseEvent(cascader.nativeElement, 'click');
-      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', O);
-      dispatchKeyboardEvent(cascader.nativeElement, 'keydown', BACKSPACE);
-      flush();
-      fixture.detectChanges();
+      testComponent.cascader.setMenuOpen(true);
+      testComponent.cascader.inputValue = 'o';
+      markForCheckAndDetectChanges(fixture);
+      const event = dispatchKeyboardEvent(cascader.nativeElement, 'keydown', BACKSPACE);
+      testComponent.cascader.inputValue = '';
+      await waitForChanges(fixture, 0);
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
+      expect(event.defaultPrevented).toBe(false);
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl1.innerText).toBe('Zhejiang');
       expect(testComponent.cascader.inputValue).toBe('');
-    }));
+    });
 
-    it('should support search a root node have no children ', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should support search a root node have no children ', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.nzShowSearch = true;
       testComponent.nzOptions = options5;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const spy = spyOn(testComponent.cascader, 'focus');
       cascader.nativeElement.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(spy).toHaveBeenCalled();
       testComponent.cascader.inputValue = 'Roo';
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText.trim()).toBe('暂无数据');
-      flush();
-    }));
+      await waitForChanges(fixture);
+    });
 
     it('should re-prepare search results when nzOptions change', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.nzShowSearch = true;
       cascader.nativeElement.click();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
       testComponent.nzOptions = options2;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.inSearchingMode).toBe(true);
 
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
@@ -1785,7 +1800,7 @@ describe('cascader', () => {
 
     it('should nzPrefix work', () => {
       testComponent.nzPrefix = 'prefix';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.querySelector('.ant-select-prefix')!.textContent?.trim()).toBe('prefix');
     });
 
@@ -1793,76 +1808,76 @@ describe('cascader', () => {
       testComponent.nzSuffixIcon = 'home';
       testComponent.nzExpandIcon = 'home';
 
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1);
       expect(itemEl1?.querySelector('.anticon-home')).toBeTruthy();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow .anticon')!.classList).toContain('anticon-home');
     });
 
-    it('should nzPlacement works', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should nzPlacement works', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       let element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(true);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(false);
 
-      const setNzPlacement = (placement: NzCascaderPlacement): void => {
+      const setNzPlacement = async (placement: NzCascaderPlacement): Promise<void> => {
         testComponent.cascader.setMenuOpen(false);
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         testComponent.nzPlacement = placement;
         testComponent.cascader.setMenuOpen(true);
-        fixture.detectChanges();
-        tick();
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
+        await waitForChanges(fixture, 200);
+        markForCheckAndDetectChanges(fixture);
       };
 
-      setNzPlacement('bottomRight');
+      await setNzPlacement('bottomRight');
       element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(true);
       expect(element.classList.contains('ant-select-dropdown-placement-topLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(false);
 
-      setNzPlacement('topLeft');
+      await setNzPlacement('topLeft');
       element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topLeft')).toBe(true);
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(false);
 
-      setNzPlacement('topRight');
+      await setNzPlacement('topRight');
       element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(true);
-    }));
+    });
 
-    it('should cascade work when the value of ngModel that is not existed in options', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should cascade work when the value of ngModel that is not existed in options', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.values = ['zhejiang', 'a'];
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(1, 1)!.click();
       getItemAtColumnAndRow(2, 1)!.click();
       getItemAtColumnAndRow(3, 1)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toEqual(['zhejiang', 'hangzhou', 'xihu']);
-    }));
+    });
 
-    it('should display activated column correctly after clicking outside and reopen', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should display activated column correctly after clicking outside and reopen', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
       // First open - should display activated columns correctly
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       let itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1873,9 +1888,9 @@ describe('cascader', () => {
 
       // Click first column option (zhejiang) - should fold the third column
       itemEl1.click();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(2);
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1886,17 +1901,17 @@ describe('cascader', () => {
 
       // Click outside to close menu - value should remain unchanged
       dispatchFakeEvent(document.body, 'click');
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.values).toEqual(['zhejiang', 'hangzhou', 'xihu']);
 
       // Reopen menu - should display activated columns correctly based on current value
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(getAllColumns().length).toBe(3);
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1904,89 +1919,90 @@ describe('cascader', () => {
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
     describe('should nzOpen works', () => {
-      beforeEach(fakeAsync(() => {
+      beforeEach(async () => {
         testComponent.nzOpen = true;
-        flush();
-        fixture.detectChanges();
-      }));
+        await waitForChanges(fixture, 200);
+        markForCheckAndDetectChanges(fixture);
+      });
 
-      it('should nzOpen can control the visibility of menu', fakeAsync(() => {
+      it('should nzOpen can control the visibility of menu', async () => {
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
         testComponent.nzOpen = false;
-        flush();
-        fixture.detectChanges();
+        await waitForChanges(fixture, 200);
+        markForCheckAndDetectChanges(fixture);
         expect(testComponent.cascader.menuOpen()).toBe(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
-      }));
+      });
 
-      it('should not hide menu by click leaf option or outside place when nzOpen is true', fakeAsync(() => {
+      it('should not hide menu by click leaf option or outside place when nzOpen is true', async () => {
         expect(testComponent.cascader.menuOpen()).toBe(true);
         getItemAtColumnAndRow(1, 1)!.click();
         getItemAtColumnAndRow(2, 1)!.click();
         getItemAtColumnAndRow(3, 1)!.click(); // zhejiang, hangzhou, xihu
-        flush();
-        fixture.detectChanges();
+        await waitForChanges(fixture);
+        markForCheckAndDetectChanges(fixture);
         expect(testComponent.onValueChanges).toHaveBeenCalled();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         spyOn(testComponent.cascader, 'onClickOutside');
         dispatchFakeEvent(document.body, 'click');
         expect(testComponent.cascader.onClickOutside).toHaveBeenCalled();
         expect(testComponent.cascader.menuOpen()).toBe(true);
-      }));
+      });
 
-      it('should not hide menu by clear options under multiple mode when nzOpen is true', fakeAsync(() => {
+      it('should not hide menu by clear options under multiple mode when nzOpen is true', async () => {
         testComponent.nzMultiple = true;
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         getItemAtColumnAndRow(1, 1)!.click();
         getItemAtColumnAndRow(2, 1)!.click();
         getItemAtColumnAndRow(3, 1)!.click(); // zhejiang, hangzhou, xihu
         getItemAtColumnAndRow(1, 2)!.click();
         getItemAtColumnAndRow(2, 1)!.click();
         getItemAtColumnAndRow(3, 1)!.click(); // jiangsu, nanjing, zhonghuamen
-        console.log(testComponent.values);
         expect(testComponent.values).toEqual([['zhejiang', 'hangzhou'], ['jiangsu']]);
-        flush();
-        fixture.detectChanges();
+        await waitForChanges(fixture);
+        markForCheckAndDetectChanges(fixture);
         expect(testComponent.cascader.menuOpen()).toBe(true);
         spyOn(testComponent.cascader, 'clearSelection');
         expect(cascader.nativeElement.querySelector('.ant-select-clear .anticon')).toBeDefined();
         cascader.nativeElement.querySelector('.ant-select-clear .anticon').click();
         expect(cascader.componentInstance.clearSelection).toHaveBeenCalled();
         expect(testComponent.cascader.menuOpen()).toBe(true);
-      }));
+      });
 
-      it('should still emit nzOpenChange event when user click outside / option / cascader self', fakeAsync(() => {
+      it('should still emit nzOpenChange event when user click outside / option / cascader self', async () => {
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
         expect(testComponent.cascader.menuOpen()).toBe(true);
         cascader.nativeElement.click();
-        fixture.detectChanges();
-        tick(200);
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
+        await waitForChanges(fixture, 200);
+        markForCheckAndDetectChanges(fixture);
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
 
         getItemAtColumnAndRow(1, 1)!.click();
+        markForCheckAndDetectChanges(fixture);
         getItemAtColumnAndRow(2, 1)!.click();
+        markForCheckAndDetectChanges(fixture);
         getItemAtColumnAndRow(3, 1)!.click();
-        flush();
-        fixture.detectChanges();
+        await waitForChanges(fixture, 200);
+        markForCheckAndDetectChanges(fixture);
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(3);
 
         dispatchFakeEvent(document.body, 'click');
-        fixture.detectChanges();
-        flush();
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
+        await waitForChanges(fixture);
+        markForCheckAndDetectChanges(fixture);
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(4);
-      }));
+      });
     });
   });
 
@@ -1996,10 +2012,10 @@ describe('cascader', () => {
     let testComponent: NzDemoCascaderMultipleComponent;
 
     function setValues(len = 10): void {
-      testComponent.values = testComponent.nzOptions[0]
-        .children!.slice(0, len)
-        .map(o => [testComponent.nzOptions[0].value, o.value]);
-      fixture.detectChanges();
+      testComponent.values.set(
+        testComponent.nzOptions[0].children!.slice(0, len).map(o => [testComponent.nzOptions[0].value, o.value])
+      );
+      markForCheckAndDetectChanges(fixture);
     }
 
     function getCheckboxAtColumnAndRow(column: number, row: number): HTMLElement | null {
@@ -2023,48 +2039,48 @@ describe('cascader', () => {
     });
 
     it('should have correct classes', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.classList).toContain('ant-select-multiple');
     });
 
-    it('should maxTagCount work', fakeAsync(() => {
+    it('should maxTagCount work', async () => {
       // not exceed
       setValues(3);
-      tick();
-      fixture.detectChanges();
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       let tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(3);
 
       // exceed maxTagCount
       setValues(10);
-      tick();
-      fixture.detectChanges();
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(4); // maxTagCount + 1
-    }));
+    });
 
-    it('should remove item work', fakeAsync(() => {
+    it('should remove item work', async () => {
       setValues(4);
-      tick();
-      fixture.detectChanges();
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       const removeBtn = cascader.queryAll(By.css('.ant-select-selection-item-remove'))[2];
       removeBtn.nativeElement.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(3);
-    }));
+    });
 
-    it('should check state conduct up and down', fakeAsync(() => {
+    it('should check state conduct up and down', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
 
       // firstly, expand all columns (for convenience)
       getItemAtColumnAndRow(1, 2)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(2, 1)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       const rootEl = getCheckboxAtColumnAndRow(1, 2)!;
       const parentEl = getCheckboxAtColumnAndRow(2, 1)!;
@@ -2072,7 +2088,7 @@ describe('cascader', () => {
 
       // check parent option
       parentEl.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(parentEl.classList).toContain('ant-cascader-checkbox-checked');
       // Conduct Down: then all children should be checked
       expect(children.every(c => c.classList.contains('ant-cascader-checkbox-checked'))).toBe(true);
@@ -2081,7 +2097,7 @@ describe('cascader', () => {
 
       // uncheck a child option
       children[0]!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       // Conduct Up: then parent should be half checked
       expect(parentEl.classList).toContain('ant-cascader-checkbox-indeterminate');
       // Conduct Up: and root should be half checked
@@ -2089,7 +2105,7 @@ describe('cascader', () => {
 
       // check the half checked parent option
       parentEl.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(parentEl.classList).toContain('ant-cascader-checkbox-checked');
       // Conduct Down: then all children should be checked
       expect(children.every(c => c.classList.contains('ant-cascader-checkbox-checked'))).toBe(true);
@@ -2098,41 +2114,41 @@ describe('cascader', () => {
 
       // uncheck the parent option
       parentEl.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       // Conduct Down: then all children should be unchecked
       expect(children.every(c => !c.classList.contains('ant-cascader-checkbox-checked'))).toBe(true);
       // Conduct Up: and its parent should be unchecked too
       expect(rootEl.classList).not.toContain('ant-cascader-checkbox-checked');
-    }));
+    });
 
-    it('should click checkbox not set option activated', fakeAsync(() => {
+    it('should click checkbox not set option activated', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
 
       const option = getItemAtColumnAndRow(1, 1)!;
       const checkbox = getCheckboxAtColumnAndRow(1, 1)!;
       expect(option.classList).not.toContain('ant-cascader-menu-item-active');
 
       checkbox.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       expect(option.classList).not.toContain('ant-cascader-menu-item-active');
       expect(checkbox.classList).toContain('ant-cascader-checkbox-checked');
-    }));
+    });
 
-    it('should change check state when click leaf node', fakeAsync(() => {
+    it('should change check state when click leaf node', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
 
       // firstly, expand all columns (for convenience)
       getItemAtColumnAndRow(1, 2)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(2, 1)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       const leaf = getItemAtColumnAndRow(3, 2)!;
       const checkbox = getCheckboxAtColumnAndRow(3, 2)!;
@@ -2141,130 +2157,129 @@ describe('cascader', () => {
       expect(checkbox.classList).not.toContain('ant-cascader-checkbox-checked');
 
       leaf.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(leaf.classList).toContain('ant-cascader-menu-item-active');
       expect(checkbox.classList).toContain('ant-cascader-checkbox-checked');
 
       leaf.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(leaf.classList).toContain('ant-cascader-menu-item-active');
       expect(checkbox.classList).not.toContain('ant-cascader-checkbox-checked');
-    }));
+    });
 
-    it('should change check state trigger ngModelChange', fakeAsync(() => {
+    it('should change check state trigger ngModelChange', async () => {
       spyOn(testComponent, 'onChanges');
       expect(testComponent.onChanges).not.toHaveBeenCalled();
       cascader.componentInstance.setMenuOpen(true);
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.onChanges).not.toHaveBeenCalled();
 
       const checkbox = getCheckboxAtColumnAndRow(1, 1)!;
       checkbox.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.onChanges).toHaveBeenCalledWith([['light']]);
-    }));
+    });
 
-    it('should support ENTER key to toggle option checked state in multiple mode', fakeAsync(() => {
+    it('should support ENTER key to toggle option checked state in multiple mode', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(1, 1)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       const optionEl = getItemAtColumnAndRow(2, 1)!;
       const checkboxEl = getCheckboxAtColumnAndRow(2, 1)!;
       // Initially, the option should not be checked
       expect(checkboxEl.classList).not.toContain('ant-cascader-checkbox-checked');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(optionEl.classList).toContain('ant-cascader-menu-item-active');
       // Press ENTER to toggle the option checked state
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       // The option should now be checked
       expect(checkboxEl.classList).toContain('ant-cascader-checkbox-checked');
       // Press ENTER again to toggle the option unchecked state
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       // The option should now be unchecked
       expect(checkboxEl.classList).not.toContain('ant-cascader-checkbox-checked');
-    }));
+    });
 
-    it('should not activate option with isDisableCheckbox by pressing RIGHT ARROW key', fakeAsync(() => {
+    it('should not activate option with isDisableCheckbox by pressing RIGHT ARROW key', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(1, 2)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(2, 1)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       // Try to navigate to a disabled checkbox option using keyboard
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       // The option with disableCheckbox should not be activatable via keyboard
       expect(getItemAtColumnAndRow(3, 1)!.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getCheckboxAtColumnAndRow(3, 1)!.classList).toContain('ant-cascader-checkbox-disabled');
       // activate item (3, 2)
       expect(getItemAtColumnAndRow(3, 2)!.classList).toContain('ant-cascader-menu-item-active');
       expect(getCheckboxAtColumnAndRow(3, 2)!.classList).not.toContain('ant-cascader-checkbox-disabled');
-    }));
+    });
 
-    it('should not activate option with isDisableCheckbox in moveUpOrDown method', fakeAsync(() => {
+    it('should not activate option with isDisableCheckbox in moveUpOrDown method', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(1, 2)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(2, 1)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       getItemAtColumnAndRow(3, 2)!.click();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(getItemAtColumnAndRow(3, 2)!.classList).toContain('ant-cascader-menu-item-active');
       // Up key
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
       // The option with disableCheckbox should not be activatable via keyboard
       expect(getItemAtColumnAndRow(3, 1)!.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getItemAtColumnAndRow(3, 2)!.classList).toContain('ant-cascader-menu-item-active');
-    }));
+    });
 
     describe('should cascade work when the value of ngModel includes nodes that are not existed in options', () => {
-      it('should remove item work', fakeAsync(() => {
+      it('should remove item work', async () => {
         setValues(2);
-        testComponent.values![0] = ['light', 'a'];
-        tick();
-        fixture.detectChanges();
+        testComponent.values()[0] = ['light', 'a'];
+        await waitForChanges(fixture);
+        markForCheckAndDetectChanges(fixture);
         const removeBtn = cascader.queryAll(By.css('.ant-select-selection-item-remove'))[0];
         removeBtn.nativeElement.click();
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         const tags = cascader.queryAll(By.directive(NzSelectItemComponent));
         expect(tags.length).toBe(1);
-      }));
+      });
 
-      it('should add item work', fakeAsync(() => {
+      it('should add item work', async () => {
         spyOn(testComponent, 'onChanges');
         setValues(2);
-        testComponent.values![0] = ['light', 'a'];
-        console.log(testComponent.values);
-        tick();
-        fixture.detectChanges();
+        testComponent.values()[0] = ['light', 'a'];
+        await waitForChanges(fixture);
+        markForCheckAndDetectChanges(fixture);
         cascader.componentInstance.setMenuOpen(true);
-        fixture.detectChanges();
+        markForCheckAndDetectChanges(fixture);
         const checkbox = getCheckboxAtColumnAndRow(2, 3)!;
         checkbox.click();
-        fixture.detectChanges();
-        expect(testComponent.values!.length).toBe(3);
+        markForCheckAndDetectChanges(fixture);
+        expect(testComponent.values().length).toBe(3);
         const selectedNodes = [
           ['light', 1],
           ['light', 'a'],
           ['light', 2]
         ];
-        expect(testComponent.values).toEqual(selectedNodes);
+        expect(testComponent.values()).toEqual(selectedNodes);
         expect(testComponent.onChanges).toHaveBeenCalledWith(selectedNodes);
-      }));
+      });
     });
   });
 
@@ -2286,20 +2301,20 @@ describe('cascader', () => {
       cascader = fixture.debugElement.query(By.directive(NzCascaderComponent));
     });
 
-    it('should nzLoadData work', fakeAsync(() => {
+    it('should nzLoadData work', async () => {
       spyOn(testComponent, 'addCallTimes');
 
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values).toBeNull();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.values).toBeNull(); // not select yet
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(0);
 
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(1);
-      tick(1000); // wait for first row to load finish
-      fixture.detectChanges();
+      await waitForChanges(fixture, 1000); // wait for first row to load finish
+      markForCheckAndDetectChanges(fixture);
 
       expect(getAllColumns().length).toBe(1);
       expect(testComponent.values).toBeNull(); // not select yet
@@ -2308,9 +2323,9 @@ describe('cascader', () => {
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl1.click();
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(2);
       expect(getAllColumns().length).toBe(2);
       expect(testComponent.values).toBeNull(); // not select yet
@@ -2320,9 +2335,9 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl2.click();
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(3);
       expect(getAllColumns().length).toBe(3);
       expect(testComponent.values).toBeNull(); // not select yet
@@ -2333,77 +2348,77 @@ describe('cascader', () => {
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl3.click();
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(4);
       expect(testComponent.values).toBeNull(); // not select yet
 
       itemEl3.click(); // re-click again, this time it is a leaf
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(4);
       expect(testComponent.values).toBeDefined();
       expect(testComponent.values!.length).toBe(3);
       expect(testComponent.values![0]).toBe('zhejiang');
       expect(testComponent.values![1]).toBe('hangzhou');
       expect(testComponent.values![2]).toBe('xihu');
-    }));
+    });
 
-    it('should nzLoadData work when specifies default value', fakeAsync(() => {
+    it('should nzLoadData work when specifies default value', async () => {
       spyOn(testComponent, 'addCallTimes');
       testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      fixture.detectChanges();
-      tick(3000);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 3000);
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(3);
       expect(testComponent.cascader.cascaderService.columns.length).toBe(3);
       expect(testComponent.values.join(',')).toBe('zhejiang,hangzhou,xihu');
-    }));
+    });
 
-    it('should not emit error after clear search and reopen it', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should not emit error after clear search and reopen it', async () => {
+      markForCheckAndDetectChanges(fixture);
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
-      tick(1000); // wait for first row to load finish
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 1000); // wait for first row to load finish
+      markForCheckAndDetectChanges(fixture);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
 
       itemEl1.click();
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
 
       itemEl2.click();
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
 
       itemEl3.click();
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
 
       itemEl3.click(); // re-click again, this time it is a leaf
-      fixture.detectChanges();
-      tick(600);
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture, 600);
+      markForCheckAndDetectChanges(fixture);
+      await waitForChanges(fixture);
+      markForCheckAndDetectChanges(fixture);
       cascader.nativeElement.querySelector('.ant-select-clear .anticon').click();
       testComponent.cascader.setMenuOpen(true);
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(testComponent.values!.length).toBe(0);
-    }));
+    });
   });
 
   describe('Status', () => {
@@ -2416,15 +2431,15 @@ describe('cascader', () => {
     });
 
     it('should className correct', () => {
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.className).toContain('ant-select-status-error');
 
       fixture.componentInstance.status = 'warning';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.className).toContain('ant-select-status-warning');
 
       fixture.componentInstance.status = '';
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       expect(cascader.nativeElement.className).not.toContain('ant-select-status-warning');
     });
   });
@@ -2440,7 +2455,7 @@ describe('cascader', () => {
       fixture = TestBed.createComponent(NzDemoCascaderInFormComponent);
       cascader = fixture.debugElement.query(By.directive(NzCascaderComponent));
       formGroup = fixture.componentInstance.validateForm;
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
     });
 
     it('should className correct', () => {
@@ -2449,7 +2464,7 @@ describe('cascader', () => {
       formGroup.controls.demo.markAsDirty();
       formGroup.controls.demo.setValue(null);
       formGroup.controls.demo.updateValueAndValidity();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
 
       // show error
       expect(cascader.nativeElement.className).toContain('ant-select-status-error');
@@ -2461,7 +2476,7 @@ describe('cascader', () => {
       formGroup.controls.demo.markAsDirty();
       formGroup.controls.demo.setValue(['a', 'b']);
       formGroup.controls.demo.updateValueAndValidity();
-      fixture.detectChanges();
+      markForCheckAndDetectChanges(fixture);
       // show success
       expect(cascader.nativeElement.className).toContain('ant-select-status-success');
       expect(cascader.nativeElement.querySelector('nz-form-item-feedback-icon')).toBeTruthy();
@@ -2494,22 +2509,22 @@ describe('cascader RTL behavior', () => {
     cascader = fixture.debugElement.query(By.directive(NzCascaderComponent));
   });
 
-  it('should menu class work', fakeAsync(() => {
-    fixture.detectChanges();
+  it('should menu class work', async () => {
+    markForCheckAndDetectChanges(fixture);
     cascader.nativeElement.click();
-    fixture.detectChanges();
-    tick(200);
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
+    await waitForChanges(fixture, 200);
+    markForCheckAndDetectChanges(fixture);
     expect(overlayContainerElement.querySelector('.ant-cascader-menus')!.classList).toContain('ant-cascader-rtl');
-  }));
+  });
 
-  it('should pressing the left and right keys can correctly expand and collapse content', fakeAsync(() => {
+  it('should pressing the left and right keys can correctly expand and collapse content', async () => {
     testComponent.nzOptions = options3;
     testComponent.cascader.setMenuOpen(true);
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
     dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     const zhejiangItemEl = overlayContainerElement
       .querySelectorAll('.ant-cascader-menu')[0]
       ?.querySelectorAll('.ant-cascader-menu-item')[0];
@@ -2519,10 +2534,10 @@ describe('cascader RTL behavior', () => {
     expect(zhejiangItemEl!.classList).toContain('ant-cascader-menu-item-active');
     expect(hangzhouItemEl!.classList).toContain('ant-cascader-menu-item-active');
     dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(hangzhouItemEl!.classList).not.toContain('ant-cascader-menu-item-active');
     expect(zhejiangItemEl!.classList).toContain('ant-cascader-menu-item-active');
-  }));
+  });
 });
 
 describe('nzPopupRender', () => {
@@ -2531,7 +2546,7 @@ describe('nzPopupRender', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideNzIconsTesting(), provideNzNoAnimation(), provideZoneChangeDetection()]
+      providers: [provideNzIconsTesting(), provideNzNoAnimation()]
     });
   });
 
@@ -2546,15 +2561,15 @@ describe('nzPopupRender', () => {
     overlayContainer.ngOnDestroy();
   });
 
-  it('should render custom footer when nzPopupRender is provided', fakeAsync(() => {
+  it('should render custom footer when nzPopupRender is provided', async () => {
     const fixture = TestBed.createComponent(NzDemoCascaderPopupRenderComponent);
     const component = fixture.componentInstance;
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
 
     component.cascader.setMenuOpen(true);
-    fixture.detectChanges();
-    tick(200);
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
+    await waitForChanges(fixture, 200);
+    markForCheckAndDetectChanges(fixture);
 
     const customFooter = overlayContainerElement.querySelector('.custom-footer');
     expect(customFooter).toBeTruthy();
@@ -2562,24 +2577,24 @@ describe('nzPopupRender', () => {
 
     const menu = overlayContainerElement.querySelector('.ant-cascader-menus');
     expect(menu).toBeTruthy();
-  }));
+  });
 
-  it('should render default menu when nzPopupRender is not provided', fakeAsync(() => {
+  it('should render default menu when nzPopupRender is not provided', async () => {
     const fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     const component = fixture.componentInstance;
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
 
     component.cascader.setMenuOpen(true);
-    fixture.detectChanges();
-    tick(200);
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
+    await waitForChanges(fixture, 200);
+    markForCheckAndDetectChanges(fixture);
 
     const menu = overlayContainerElement.querySelector('.ant-cascader-menus');
     expect(menu).toBeTruthy();
 
     const customFooter = overlayContainerElement.querySelector('.custom-footer');
     expect(customFooter).toBeFalsy();
-  }));
+  });
 });
 
 describe('finalSize', () => {
@@ -2605,9 +2620,9 @@ describe('finalSize', () => {
     });
     fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     formSizeSignal.set('large');
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(cascaderElement.classList).toContain('ant-select-lg');
   });
   it('should set correctly the size from the compactSize signal', () => {
@@ -2616,14 +2631,14 @@ describe('finalSize', () => {
     });
     fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(cascaderElement.classList).toContain('ant-select-lg');
   });
   it('should set correctly the size from the component input', () => {
     fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
     fixture.componentInstance.nzSize = 'large';
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(cascaderElement.classList).toContain('ant-select-lg');
   });
 });
@@ -2647,9 +2662,9 @@ describe('finalVariant', () => {
     });
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     formVariantSignal.set('filled');
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(cascaderElement.classList).toContain('ant-select-filled');
   });
 
@@ -2660,9 +2675,9 @@ describe('finalVariant', () => {
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
     fixture.componentInstance.variant.set('borderless');
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     formVariantSignal.set('filled');
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(cascaderElement.classList).toContain('ant-select-borderless');
     expect(cascaderElement.classList).not.toContain('ant-select-filled');
   });
@@ -2671,14 +2686,14 @@ describe('finalVariant', () => {
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
     fixture.componentInstance.variant.set('filled');
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(cascaderElement.classList).toContain('ant-select-filled');
   });
 
   it('should use outlined as default when neither nzVariant nor formVariant is provided', () => {
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(cascaderElement.classList).not.toContain('ant-select-filled');
     expect(cascaderElement.classList).not.toContain('ant-select-borderless');
     expect(cascaderElement.classList).not.toContain('ant-select-underlined');
@@ -2691,9 +2706,9 @@ describe('finalVariant', () => {
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
     fixture.componentInstance.variant.set('outlined');
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     formVariantSignal.set('filled');
-    fixture.detectChanges();
+    markForCheckAndDetectChanges(fixture);
     expect(cascaderElement.classList).not.toContain('ant-select-filled');
   });
 });
@@ -2962,8 +2977,7 @@ const options5: NzSafeAny[] = [];
         {{ label }}{{ $last ? '' : ' | ' }}
       }
     </ng-template>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzDemoCascaderDefaultComponent {
   @ViewChild(NzCascaderComponent, { static: true }) cascader!: NzCascaderComponent;
@@ -3016,8 +3030,7 @@ export class NzDemoCascaderDefaultComponent {
       (ngModelChange)="onValueChanges($event)"
       (nzOpenChange)="onOpenChange($event)"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzDemoCascaderLoadDataComponent {
   @ViewChild(NzCascaderComponent, { static: true }) cascader!: NzCascaderComponent;
@@ -3067,12 +3080,19 @@ export class NzDemoCascaderLoadDataComponent {
 
 @Component({
   imports: [FormsModule, NzCascaderModule],
-  template: `<nz-cascader [nzOptions]="nzOptions" [nzStatus]="status" />`,
-  changeDetection: ChangeDetectionStrategy.Eager
+  template: `<nz-cascader [nzOptions]="nzOptions" [nzStatus]="status" />`
 })
 export class NzDemoCascaderStatusComponent {
   nzOptions: NzSafeAny[] | null = options1();
-  status: NzStatus = 'error';
+  private readonly statusSignal = signal<NzStatus>('error');
+
+  get status(): NzStatus {
+    return this.statusSignal();
+  }
+
+  set status(value: NzStatus) {
+    this.statusSignal.set(value);
+  }
 }
 
 @Component({
@@ -3085,8 +3105,7 @@ export class NzDemoCascaderStatusComponent {
         </nz-form-control>
       </nz-form-item>
     </form>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzDemoCascaderInFormComponent {
   private fb = inject(FormBuilder);
@@ -3098,8 +3117,7 @@ export class NzDemoCascaderInFormComponent {
 
 @Component({
   imports: [NzCascaderModule],
-  template: ` <nz-cascader [nzVariant]="variant()" /> `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  template: `<nz-cascader [nzVariant]="variant()" />`
 })
 export class TestCascaderFinalVariantComponent {
   readonly variant = signal<NzVariant | undefined>(undefined);
@@ -3114,8 +3132,7 @@ export class TestCascaderFinalVariantComponent {
       <ng-container [ngTemplateOutlet]="menu" />
       <div class="custom-footer">Custom Footer</div>
     </ng-template>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzDemoCascaderPopupRenderComponent {
   @ViewChild(NzCascaderComponent, { static: true }) cascader!: NzCascaderComponent;

--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -48,7 +48,6 @@ import {
   dispatchKeyboardEvent,
   dispatchMouseEvent,
   provideMockDirectionality,
-  sleep,
   testDirectionality,
   updateNonSignalsInput
 } from 'ng-zorro-antd/core/testing';
@@ -68,19 +67,6 @@ import {
   NzCascaderTriggerType,
   NzShowSearchOptions
 } from './typings';
-
-function markForCheckAndDetectChanges<T>(fixture: ComponentFixture<T>): void {
-  fixture.debugElement.injector.get(ChangeDetectorRef).markForCheck();
-  fixture.detectChanges();
-}
-
-async function waitForChanges<T>(fixture: ComponentFixture<T>, ms?: number): Promise<void> {
-  if (typeof ms === 'number') {
-    await sleep(ms);
-  }
-  await fixture.whenStable();
-  markForCheckAndDetectChanges(fixture);
-}
 
 describe('cascader', () => {
   let overlayContainer: OverlayContainer;
@@ -150,361 +136,348 @@ describe('cascader', () => {
     });
 
     it('should className correct', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.className).toContain('ant-cascader ant-select');
     });
 
     it('should have input', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getInputEl()).toBeDefined();
       expect(getPlaceholder()).toBe('please select');
     });
 
     it('should input change event stopPropagation', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const fakeInputChangeEvent = createFakeEvent('change', true, true);
       spyOn(fakeInputChangeEvent, 'stopPropagation');
       getInputEl().dispatchEvent(fakeInputChangeEvent);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(fakeInputChangeEvent.stopPropagation).toHaveBeenCalled();
     });
 
     it('should not have EMPTY label', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const label: HTMLElement = cascader.nativeElement.querySelector('.ant-select-selection-item');
       expect(label).toBeNull();
     });
 
     it('should placeholder work', () => {
       const placeholder = 'placeholder test';
-      testComponent.nzPlaceHolder = placeholder;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzPlaceHolder.set(placeholder);
+      fixture.detectChanges();
       expect(getPlaceholder()).toBe(placeholder);
     });
 
     it('should show/hide placeholder when trigger compositionstart/compositionend event', () => {
-      testComponent.nzPlaceHolder = 'placeholder test';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzPlaceHolder.set('placeholder test');
+      fixture.detectChanges();
 
       const placeholderElement = cascader.nativeElement.querySelector('.ant-select-selection-placeholder');
       const fakeCompositionstartEvent = createFakeEvent('compositionstart', true, true);
       getInputEl().dispatchEvent(fakeCompositionstartEvent);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(placeholderElement.style.display).toBe('none');
 
       const fakeCompositionendEvent = createFakeEvent('compositionend', true, true);
       getInputEl().dispatchEvent(fakeCompositionendEvent);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(placeholderElement.style.display).toBe('block');
     });
 
     it('should size work', () => {
-      testComponent.nzSize = 'small';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzSize.set('small');
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-sm');
-      testComponent.nzSize = 'large';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzSize.set('large');
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-lg');
     });
 
     it('should value and label property work', async () => {
-      testComponent.nzOptions = ID_NAME_LIST;
-      testComponent.nzValueProperty = 'id';
-      testComponent.nzLabelProperty = 'name';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(ID_NAME_LIST);
+      testComponent.nzValueProperty.set('id');
+      testComponent.nzLabelProperty.set('name');
+      fixture.detectChanges();
       // label will not show if no item selected
       expect(getLabelElement()).toBeNull();
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('');
-      testComponent.values = [1, 2, 3];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set([1, 2, 3]);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('1,2,3');
     });
 
     it('should no value and label property work', async () => {
-      testComponent.nzValueProperty = null!;
-      testComponent.nzLabelProperty = null!;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzValueProperty.set(null!);
+      testComponent.nzLabelProperty.set(null!);
+      fixture.detectChanges();
       expect(getLabelElement()).toBeNull();
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('');
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
       expect(testComponent.cascader.getSubmitValue().join(',')).toBe('zhejiang,hangzhou,xihu');
     });
 
     it('should showArrow work', () => {
-      testComponent.nzShowArrow = true;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzShowArrow.set(true);
+      fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow')).toBeDefined();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow .anticon').classList).toContain('anticon-down');
-      testComponent.nzShowArrow = false;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzShowArrow.set(false);
+      fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow')).toBeNull();
     });
 
     it('should allowClear work', () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeDefined();
-      testComponent.nzAllowClear = false;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzAllowClear.set(false);
+      fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeNull();
     });
 
     describe('should variant works', () => {
       it('outlined', () => {
-        testComponent.nzVariant = 'outlined';
-        markForCheckAndDetectChanges(fixture);
+        testComponent.nzVariant.set('outlined');
+        fixture.detectChanges();
         expect(cascader.nativeElement.classList).toContain('ant-select-outlined');
       });
+
       it('filled', () => {
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         expect(cascader.nativeElement.classList).not.toContain('ant-select-filled');
-        testComponent.nzVariant = 'filled';
-        markForCheckAndDetectChanges(fixture);
+        testComponent.nzVariant.set('filled');
+        fixture.detectChanges();
         expect(cascader.nativeElement.classList).toContain('ant-select-filled');
       });
+
       it('borderless', () => {
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         expect(cascader.nativeElement.classList).not.toContain('ant-select-borderless');
-        testComponent.nzVariant = 'borderless';
-        markForCheckAndDetectChanges(fixture);
+        testComponent.nzVariant.set('borderless');
+        fixture.detectChanges();
         expect(cascader.nativeElement.classList).toContain('ant-select-borderless');
       });
+
       it('underlined', () => {
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         expect(cascader.nativeElement.classList).not.toContain('ant-select-underlined');
-        testComponent.nzVariant = 'underlined';
-        markForCheckAndDetectChanges(fixture);
+        testComponent.nzVariant.set('underlined');
+        fixture.detectChanges();
         expect(cascader.nativeElement.classList).toContain('ant-select-underlined');
       });
     });
 
     it('should open work', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).not.toContain('ant-select-open');
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-open');
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
       expect(testComponent.cascader.nzOptions).toEqual(options1());
     });
 
     it('should click toggle open', async () => {
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.nzDisabled).toBe(false);
+      fixture.detectChanges();
+      expect(testComponent.nzDisabled()).toBe(false);
 
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
 
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
     });
 
     it('should mouse hover toggle open', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.nzTriggerAction = 'hover';
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.nzDisabled).toBe(false);
+      fixture.detectChanges();
+      testComponent.nzTriggerAction.set('hover');
+      fixture.detectChanges();
+      expect(testComponent.nzDisabled()).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
 
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
     });
 
     it('should mouse hover toggle open immediately', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.nzTriggerAction = ['hover'];
-      testComponent.nzMouseEnterDelay = 0;
-      testComponent.nzMouseLeaveDelay = 0;
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
+      testComponent.nzTriggerAction.set(['hover']);
+      testComponent.nzMouseEnterDelay.set(0);
+      testComponent.nzMouseLeaveDelay.set(0);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
     });
 
     it('should clear timer on option mouseenter and mouseleave', async () => {
-      testComponent.nzExpandTrigger = 'hover';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzExpandTrigger.set('hover');
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       const optionEl = getItemAtColumnAndRow(1, 1)!;
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(optionEl, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 10);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 10);
+      fixture.detectChanges();
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(optionEl, 'mouseleave');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 400);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 400);
+      fixture.detectChanges();
       expect(optionEl.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(optionEl, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 400);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 400);
+      fixture.detectChanges();
       expect(optionEl.classList).toContain('ant-cascader-menu-item-active');
     });
 
     it('should disabled work', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).not.toContain('ant-select-disabled');
-      testComponent.nzDisabled = true;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzDisabled.set(true);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-disabled');
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
     });
 
     it('should disabled state work', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).not.toContain('ant-select-disabled');
       testComponent.cascader.setDisabledState(true);
       cascader.injector.get(ChangeDetectorRef).markForCheck();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-disabled');
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
     });
 
     it('should disabled mouse hover open', async () => {
-      testComponent.nzTriggerAction = 'hover';
-      testComponent.nzDisabled = true;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzTriggerAction.set('hover');
+      testComponent.nzDisabled.set(true);
+      fixture.detectChanges();
       expect(testComponent.cascader.nzDisabled).toBe(true);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
       dispatchMouseEvent(cascader.nativeElement, 'mouseenter');
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
 
-      testComponent.nzDisabled = false;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzDisabled.set(false);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.nzDisabled).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
-      testComponent.nzDisabled = true;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzDisabled.set(true);
+      fixture.detectChanges();
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
     });
 
     it('should mouse leave not work when menu not open', async () => {
-      testComponent.nzTriggerAction = ['hover'];
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzTriggerAction.set(['hover']);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchMouseEvent(cascader.nativeElement, 'mouseleave');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.onOpenChange).toHaveBeenCalledTimes(0);
     });
 
     it('should clear value work', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.nzAllowClear = true;
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      expect(testComponent.values!.length).toBe(3);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
+      testComponent.nzAllowClear.set(true);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
+      fixture.detectChanges();
       spyOn(testComponent, 'onClear');
       cascader.nativeElement.querySelector('.ant-select-clear nz-icon').click();
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values!.length).toBe(0);
+      fixture.detectChanges();
+      expect(testComponent.values()).toEqual([]);
       expect(testComponent.onClear).toHaveBeenCalled();
     });
 
     it('should clear value work 2', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      expect(testComponent.values!.length).toBe(3);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
+      fixture.detectChanges();
       spyOn(testComponent, 'onClear');
       testComponent.cascader.clearSelection();
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values!.length).toBe(0);
+      fixture.detectChanges();
+      expect(testComponent.values()).toEqual([]);
       expect(testComponent.onClear).toHaveBeenCalled();
     });
 
     it('should autofocus work', () => {
-      testComponent.nzShowInput = true;
-      markForCheckAndDetectChanges(fixture);
-      testComponent.nzAutoFocus = true;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzShowInput.set(true);
+      fixture.detectChanges();
+      testComponent.nzAutoFocus.set(true);
+      fixture.detectChanges();
       expect(getInputEl().getAttribute('autofocus')).toBe('autofocus');
-      testComponent.nzAutoFocus = false;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzAutoFocus.set(false);
+      fixture.detectChanges();
       expect(getInputEl().getAttribute('autofocus')).toBe(null);
     });
 
@@ -512,218 +485,196 @@ describe('cascader', () => {
       const fakeInputFocusEvent = createFakeEvent('focus', false, true);
       const fakeInputBlurEvent = createFakeEvent('blur', false, true);
 
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).not.toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputFocusEvent);
       cascader.injector.get(ChangeDetectorRef).markForCheck();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputBlurEvent);
       cascader.injector.get(ChangeDetectorRef).markForCheck();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).not.toContain('ant-select-focused');
 
       testComponent.cascader.setMenuOpen(true);
       getInputEl().dispatchEvent(fakeInputFocusEvent);
       cascader.injector.get(ChangeDetectorRef).markForCheck();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-focused');
       getInputEl().dispatchEvent(fakeInputBlurEvent);
       cascader.injector.get(ChangeDetectorRef).markForCheck();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-focused');
     });
 
     it('should focus and blur function work', () => {
-      testComponent.nzShowInput = true;
+      testComponent.nzShowInput.set(true);
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getInputEl() === document.activeElement).toBe(false);
       testComponent.cascader.focus();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getInputEl() === document.activeElement).toBe(true);
       testComponent.cascader.blur();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getInputEl() === document.activeElement).toBe(false);
     });
 
     it('should focus and blur function work 2', () => {
-      testComponent.nzShowInput = false;
+      testComponent.nzShowInput.set(false);
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement === document.activeElement).toBe(false);
       testComponent.cascader.focus();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement === document.activeElement).toBe(true);
       testComponent.cascader.blur();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement === document.activeElement).toBe(false);
     });
 
     it('should menu class work', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(overlayContainerElement.querySelector('.ant-cascader-menus')!.classList).toContain('menu-classA');
       expect(overlayContainerElement.querySelector('.ant-cascader-menu')!.classList).toContain('column-classA');
     });
 
     it('should menu style work', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       const targetElement = overlayContainerElement.querySelector('.menu-classA') as HTMLElement;
       expect(targetElement.style.height).toBe('120px');
     });
 
     it('should show input false work', async () => {
-      testComponent.nzShowInput = false;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzShowInput.set(false);
+      fixture.detectChanges();
+
       expect(cascader.nativeElement.querySelector('.ant-select-selection-search-input')).toBeNull();
-      testComponent.nzAllowClear = true;
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzAllowClear.set(true);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      await updateNonSignalsInput(fixture);
+
       expect(cascader.nativeElement.querySelector('.ant-select-selection-search-input')).toBeNull();
       expect(cascader.nativeElement.querySelector('.ant-select-clear')).toBeNull();
       expect(cascader.nativeElement.querySelector('.ant-select-selection-item')).toBeNull();
     });
 
     it('should create label work', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-selection-item')).toBeNull();
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      await updateNonSignalsInput(fixture);
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
     });
 
     it('should label template work', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-selection-item')).toBeNull();
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      testComponent.nzLabelRender = testComponent.renderTpl;
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      testComponent.nzLabelRender.set(testComponent.renderTpl);
+      await updateNonSignalsInput(fixture);
       expect(getLabelText()).toBe('Zhejiang | Hangzhou | West Lake');
+
       // fix clear
       testComponent.cascader.clearSelection();
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      testComponent.nzLabelRender = testComponent.renderTpl;
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      testComponent.nzLabelRender.set(testComponent.renderTpl);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getLabelText()).toBe('Zhejiang | Hangzhou | West Lake');
     });
 
     it('should label template work on multiple', async () => {
-      testComponent.nzMultiple = true;
-      testComponent.values = [['zhejiang', 'hangzhou']];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzMultiple.set(true);
+      testComponent.values.set([['zhejiang', 'hangzhou']]);
+      await updateNonSignalsInput(fixture);
       expect(getLabelText()).toBe('Zhejiang / Hangzhou');
 
-      testComponent.values = [['jiangsu']]; // 'Jiangsu / Nanjing / Zhong Hua Men'
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set([['jiangsu']]); // 'Jiangsu / Nanjing / Zhong Hua Men'
+      await updateNonSignalsInput(fixture);
       expect(getLabelText()).toBe('Jiangsu');
 
-      testComponent.nzLabelRender = testComponent.renderTpl;
-      testComponent.values = [['zhejiang', 'hangzhou']];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzLabelRender.set(testComponent.renderTpl);
+      testComponent.values.set([['zhejiang', 'hangzhou']]);
+      await updateNonSignalsInput(fixture);
       expect(getLabelText().trim()).toBe('Zhejiang | Hangzhou');
 
-      testComponent.values = [['jiangsu']]; // 'Jiangsu / Nanjing / Zhong Hua Men'
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set([['jiangsu']]); // 'Jiangsu / Nanjing / Zhong Hua Men'
+      await updateNonSignalsInput(fixture);
       expect(getLabelText()).toBe('Jiangsu');
     });
 
     it('should write value work', async () => {
       const control = testComponent.cascader;
-      testComponent.nzOptions = options1();
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options1());
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(null);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(undefined);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue([]);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(0);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       control.writeValue('');
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       control.writeValue(['zhejiang']);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       expect(control.getSubmitValue()[0]).toBe('zhejiang');
       control.writeValue(['zhejiang', 'hangzhou', 'xihu']);
-      markForCheckAndDetectChanges(fixture);
-      expect(control.getSubmitValue().length).toBe(3);
-      const values = control.getSubmitValue();
-      expect(values![0]).toBe('zhejiang');
-      expect(values![1]).toBe('hangzhou');
-      expect(values![2]).toBe('xihu');
+      fixture.detectChanges();
+      expect(control.getSubmitValue()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
 
-      testComponent.nzOptions = []; // empty collection
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set([]); // empty collection
+      fixture.detectChanges();
       control.writeValue(['zhejiang', 'hangzhou', 'xihu']); // so these values are not match
-      markForCheckAndDetectChanges(fixture);
-      expect(control.getSubmitValue().length).toBe(3);
-      const values3 = control.getSubmitValue();
-      expect(values3[0]).toBe('zhejiang');
-      expect(values3[1]).toBe('hangzhou');
-      expect(values3[2]).toBe('xihu');
+      fixture.detectChanges();
+      expect(control.getSubmitValue()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
       expect(getLabelText()).toBe('zhejiang / hangzhou / xihu');
     });
 
     it('should write value work on setting `nzOptions` async', async () => {
       const control = testComponent.cascader;
-      testComponent.nzOptions = null;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(null);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(null);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(undefined);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue([]);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(0);
       control.writeValue(0);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       control.writeValue('');
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       control.writeValue(['zhejiang']);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       expect(control.getSubmitValue()[0]).toBe('zhejiang');
       expect(getLabelText()).toBe('zhejiang');
-      testComponent.nzOptions = options1(); // update the nzOptions like async
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options1()); // update the nzOptions like async
+      fixture.detectChanges();
       expect(control.getSubmitValue().length).toBe(1);
       expect(control.getSubmitValue()[0]).toBe('zhejiang');
       expect(getLabelText()).toBe('Zhejiang');
@@ -731,90 +682,82 @@ describe('cascader', () => {
 
     it('should write value work on setting `nzOptions` async (match)', async () => {
       const control = testComponent.cascader;
-      testComponent.nzOptions = null;
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture); // force value to be written
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(null);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      await updateNonSignalsInput(fixture); // force value to be written
       expect(control.getSubmitValue().length).toBe(3);
       expect(getLabelText()).toBe('zhejiang / hangzhou / xihu');
-      testComponent.nzOptions = options1(); // update the nzOptions like async
-      markForCheckAndDetectChanges(fixture);
-      const values = control.getSubmitValue();
-      expect(values![0]).toBe('zhejiang');
-      expect(values![1]).toBe('hangzhou');
-      expect(values![2]).toBe('xihu');
+
+      testComponent.nzOptions.set(options1()); // update the nzOptions like async
+      fixture.detectChanges();
+      expect(control.getSubmitValue()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
       expect(getLabelText()).toBe('Zhejiang / Hangzhou / West Lake');
     });
 
     it('should write value work on setting `nzOptions` async (not match)', async () => {
       const control = testComponent.cascader;
-      testComponent.nzOptions = null;
-      testComponent.values = ['zhejiang2', 'hangzhou2', 'xihu2'];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture); // force value to be written
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(null);
+      testComponent.values.set(['zhejiang2', 'hangzhou2', 'xihu2']);
+      await updateNonSignalsInput(fixture); // force value to be written
       expect(control.getSubmitValue().length).toBe(3);
       expect(getLabelText()).toBe('zhejiang2 / hangzhou2 / xihu2');
-      testComponent.nzOptions = options1(); // update the nzOptions like async
-      markForCheckAndDetectChanges(fixture); // but still the values is not match
-      const values = control.getSubmitValue();
-      expect(values![0]).toBe('zhejiang2');
-      expect(values![1]).toBe('hangzhou2');
-      expect(values![2]).toBe('xihu2');
+
+      testComponent.nzOptions.set(options1()); // update the nzOptions like async
+      fixture.detectChanges(); // but still the values is not match
+      expect(control.getSubmitValue()).toEqual(['zhejiang2', 'hangzhou2', 'xihu2']);
       expect(getLabelText()).toBe('zhejiang2 / hangzhou2 / xihu2');
     });
 
     it('should click option to expand', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0);
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
-      const itemEl1 = overlayContainerElement.querySelector('.ant-cascader-menu')!.firstElementChild as HTMLElement;
 
+      const itemEl1 = overlayContainerElement.querySelector('.ant-cascader-menu')!.firstElementChild as HTMLElement;
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
+
       const col2 = getAllColumns().item(1);
       const itemEl2 = col2.firstElementChild as HTMLElement;
-
       itemEl2.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(3);
     });
 
     it('should click option to change column count', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0);
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
 
       itemEl2.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(3);
 
       const itemEl3 = getItemAtColumnAndRow(1, 2)!;
 
       itemEl3.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
     });
 
     it('should click option to change column count 2', async () => {
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture); // wait for cdk-overlay to open
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture); // wait for cdk-overlay to open
+      fixture.detectChanges();
+
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(getAllColumns().length).toBe(3);
 
@@ -827,9 +770,9 @@ describe('cascader', () => {
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl2 = getItemAtColumnAndRow(2, 1)!;
       itemEl3 = getItemAtColumnAndRow(3, 1)!;
@@ -837,37 +780,32 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl3).toBeNull();
       expect(getAllColumns().length).toBe(2);
-      expect(testComponent.values!.join(',')).toBe('zhejiang,hangzhou,xihu');
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
 
       const itemEl4 = getItemAtColumnAndRow(2, 2)!;
       itemEl4.click(); // click leaf node
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture); // wait for cdk-overlay close
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
       expect(testComponent.cascader.menuOpen()).toBe(false);
-      expect(testComponent.values!.join(',')).toBe('zhejiang,ningbo');
+      expect(testComponent.values()).toEqual(['zhejiang', 'ningbo']);
     });
 
     it('should click option to change column count 3', () => {
-      testComponent.nzOptions = options3;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options3);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
       let itemEl21 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl21.innerText.trim()).toBe('Hangzhou');
 
       const itemEl2 = getItemAtColumnAndRow(1, 2)!;
-
       itemEl2.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
 
       itemEl21 = getItemAtColumnAndRow(2, 1)!;
@@ -875,81 +813,78 @@ describe('cascader', () => {
     });
 
     it('should click disabled option false to expand', async () => {
-      testComponent.nzOptions = options2;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options2);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const optionEl1 = getItemAtColumnAndRow(1, 1)!;
       const optionEl2 = getItemAtColumnAndRow(1, 2)!;
 
       expect(optionEl1.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
+
       optionEl1.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
+
       optionEl2.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
     });
 
     it('should click leaf option to close menu', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
+
       getItemAtColumnAndRow(1, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
+
       getItemAtColumnAndRow(2, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
+
       getItemAtColumnAndRow(3, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(getAllColumns().length).toBe(0);
     });
 
     it('should open menu when press DOWN_ARROW', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(true);
     });
 
     it('should open menu when press UP_ARROW', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(true);
     });
 
     it('should close menu when press ESC', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ESCAPE);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
 
     it('should init menu when selecting cancel', async () => {
       // cancel select by ESCAPE
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl1.click();
@@ -959,15 +894,14 @@ describe('cascader', () => {
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ESCAPE);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.cascaderService.columns.length).toBe(1);
 
       // cancel select by clicking outside
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl1.click();
@@ -977,67 +911,69 @@ describe('cascader', () => {
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
+
       dispatchFakeEvent(document.body, 'click');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await fixture.whenStable();
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.cascaderService.columns.length).toBe(1);
     });
 
     it('should nzBackdrop works', async () => {
-      testComponent.nzBackdrop = true;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzBackdrop.set(true);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const boundingBox = overlayContainerElement.children[0];
       expect(boundingBox.children[0].classList).toContain('cdk-overlay-backdrop');
     });
 
     it('should navigate up when press UP_ARROW', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = overlayContainerElement.querySelector(
         '.ant-cascader-menu:nth-child(1) .ant-cascader-menu-item:last-child'
       ) as HTMLElement; // The last of the fisrt column
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      await fixture.whenStable();
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
+
       const itemEl2 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      await fixture.whenStable();
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
     });
 
     it('should navigate down when press DOWN_ARROW', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
     });
 
     it('should navigate right when press RIGHT_ARROW', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       let itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
 
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1049,12 +985,10 @@ describe('cascader', () => {
     });
 
     it('should navigate left when press LEFT_ARROW', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
+      fixture.detectChanges();
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture); // wait for cdk-overlay to open
-      markForCheckAndDetectChanges(fixture);
+      await fixture.whenStable();
       expect(getAllColumns().length).toBe(3);
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
@@ -1063,36 +997,34 @@ describe('cascader', () => {
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
+
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
+
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
+
       itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl3).toBeNull();
       expect(getAllColumns().length).toBe(2);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBeFalse();
     });
 
     it('should navigate left when press BACKSPACE', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
+      fixture.detectChanges();
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture); // wait for cdk-overlay to open
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture); // wait for cdk-overlay to open
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(3);
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
@@ -1102,76 +1034,73 @@ describe('cascader', () => {
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', BACKSPACE);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
     });
 
     it('when there is only one column activated, pressing LEFT should fold the menu', async () => {
-      testComponent.values = ['zhejiang', 'ningbo'];
+      testComponent.values.set(['zhejiang', 'ningbo']);
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
+
       expect(getAllColumns().length).toBe(2);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBeFalse();
     });
 
     it('should select option when press ENTER', async () => {
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeNull();
+      fixture.detectChanges();
+      expect(testComponent.values()).toBeNull();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW); // active 1
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeNull(); // not select yet
+      fixture.detectChanges();
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW); // active 2
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeNull(); // not select yet
+      fixture.detectChanges();
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW); // active 3
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeNull(); // not select yet
+      fixture.detectChanges();
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
 
-      expect(testComponent.values).toBeDefined();
-      expect(testComponent.values!.length).toBe(3);
-      expect(testComponent.values![0]).toBe('zhejiang');
-      expect(testComponent.values![1]).toBe('hangzhou');
-      expect(testComponent.values![2]).toBe('xihu');
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
       await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
 
     it('should key nav disabled option correct', async () => {
-      testComponent.nzOptions = options2;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options2);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const optionEl1 = getItemAtColumnAndRow(1, 1)!;
       const optionEl2 = getItemAtColumnAndRow(1, 2)!;
 
       expect(optionEl1.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW); // active 1
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      markForCheckAndDetectChanges(fixture); // should NOT active the disabled option2
+      fixture.detectChanges(); // should NOT active the disabled option2
       expect(optionEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
@@ -1185,21 +1114,21 @@ describe('cascader', () => {
       expect(optionEl14.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW); // active 2
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl14.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl14.classList).toContain('ant-cascader-menu-item-active');
 
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(optionEl11.classList).not.toContain('ant-cascader-menu-item-active');
       expect(optionEl12.classList).toContain('ant-cascader-menu-item-active');
       expect(optionEl13.classList).not.toContain('ant-cascader-menu-item-active');
@@ -1217,131 +1146,126 @@ describe('cascader', () => {
         keys.push(k);
       }
 
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       keys.forEach(key => {
         expect(testComponent.cascader.menuOpen()).toBe(false);
         dispatchKeyboardEvent(cascader.nativeElement, 'keydown', key);
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         expect(testComponent.cascader.menuOpen()).toBe(false);
       });
     });
 
     it('should expand option on hover', async () => {
-      testComponent.nzExpandTrigger = 'hover';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzExpandTrigger.set('hover');
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0); // 0 column
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(itemEl1, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl1, 'mouseleave');
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl2, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(3);
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl2, 'mouseleave');
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(3);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       dispatchMouseEvent(itemEl3, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(3);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       itemEl3.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeDefined();
-      expect(testComponent.values!.length).toBe(3);
-      expect(testComponent.values![0]).toBe('zhejiang');
-      expect(testComponent.values![1]).toBe('hangzhou');
-      expect(testComponent.values![2]).toBe('xihu');
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
+
+      const value = testComponent.values();
+      expect(value).toBeDefined();
+      expect(value!.length).toBe(3);
+      expect(value![0]).toBe('zhejiang');
+      expect(value![1]).toBe('hangzhou');
+      expect(value![2]).toBe('xihu');
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
 
     it('should not expand disabled option on hover', async () => {
-      testComponent.nzExpandTrigger = 'hover';
-      testComponent.nzOptions = options2;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzExpandTrigger.set('hover');
+      testComponent.nzOptions.set(options2);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       const itemEl2 = getItemAtColumnAndRow(1, 2)!;
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       dispatchMouseEvent(itemEl2, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(1);
 
       dispatchMouseEvent(itemEl2, 'mouseleave');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(1);
     });
 
     // fix #3914
     it('should drop selected items and columns if a leaf node is hovered', async () => {
-      testComponent.nzExpandTrigger = 'hover';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzExpandTrigger.set('hover');
+      fixture.detectChanges();
 
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       testComponent.cascader.setMenuOpen(true); // Open cascader dropdown.
 
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 500);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 500);
+      fixture.detectChanges();
       expect(overlayContainerElement.querySelectorAll('.ant-cascader-menu').length).toBe(3);
 
       const c2i2 = overlayContainerElement.querySelector(
@@ -1349,52 +1273,48 @@ describe('cascader', () => {
       ) as HTMLElement;
       dispatchMouseEvent(c2i2, 'mouseenter');
 
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 500);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 500);
+      fixture.detectChanges();
       expect(overlayContainerElement.querySelectorAll('.ant-cascader-menu').length).toBe(2);
     });
 
     it('should change on select work', async () => {
-      testComponent.nzChangeOnSelect = true;
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeNull();
+      testComponent.nzChangeOnSelect.set(true);
+      fixture.detectChanges();
+      expect(testComponent.values()).toBeNull();
       expect(getAllColumns().length).toBe(0);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
 
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(2);
-      expect(testComponent.values).toBeDefined();
-      expect(testComponent.values!.length).toBe(1);
-      expect(testComponent.values![0]).toBe('zhejiang');
+
+      const value = testComponent.values();
+      expect(value![0]).toBe('zhejiang');
 
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl2.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
 
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(3);
-      expect(testComponent.values).toBeDefined();
-      expect(testComponent.values!.length).toBe(2);
-      expect(testComponent.values![0]).toBe('zhejiang');
-      expect(testComponent.values![1]).toBe('hangzhou');
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou']);
 
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -1402,95 +1322,82 @@ describe('cascader', () => {
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl3.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
 
-      expect(testComponent.values).toBeDefined();
-      expect(testComponent.values!.length).toBe(3);
-      expect(testComponent.values![0]).toBe('zhejiang');
-      expect(testComponent.values![1]).toBe('hangzhou');
-      expect(testComponent.values![2]).toBe('xihu');
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
 
     it('should not change on hover work', async () => {
-      testComponent.nzChangeOnSelect = true;
-      testComponent.nzExpandTrigger = 'hover';
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeNull();
+      testComponent.nzChangeOnSelect.set(true);
+      testComponent.nzExpandTrigger.set('hover');
+      fixture.detectChanges();
+      expect(testComponent.values()).toBeNull();
       expect(getAllColumns().length).toBe(0);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(itemEl1, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
 
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(2);
-      expect(testComponent.values).toBeNull(); // mouseenter does not trigger selection
+      expect(testComponent.values()).toBeNull(); // mouseenter does not trigger selection
 
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(itemEl2, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
 
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(getAllColumns().length).toBe(3);
-      expect(testComponent.values).toBeNull(); // mouseenter does not trigger selection
+      expect(testComponent.values()).toBeNull(); // mouseenter does not trigger selection
 
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchMouseEvent(itemEl3, 'mouseenter');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
 
-      expect(testComponent.values).toBeNull(); // mouseenter does not trigger selection
+      expect(testComponent.values()).toBeNull(); // mouseenter does not trigger selection
 
       itemEl3.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      fixture.detectChanges();
 
-      expect(testComponent.values).toBeDefined(); // click trigger selection
-      expect(testComponent.values!.length).toBe(3);
-      expect(testComponent.values![0]).toBe('zhejiang');
-      expect(testComponent.values![1]).toBe('hangzhou');
-      expect(testComponent.values![2]).toBe('xihu');
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']); // click trigger selection
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(0);
       expect(testComponent.cascader.menuOpen()).toBe(false);
     });
 
     it('should change on function work', async () => {
-      testComponent.nzChangeOn = testComponent.fakeChangeOn;
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeNull();
+      testComponent.nzChangeOn.set(testComponent.fakeChangeOn);
+      fixture.detectChanges();
+      expect(testComponent.values()).toBeNull();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       const itemEl2 = getItemAtColumnAndRow(1, 2)!;
@@ -1498,58 +1405,54 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl2.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 200);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 200);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
-      expect(testComponent.values).toBeDefined();
-      expect(testComponent.values!.length).toBe(1);
-      expect(testComponent.values![0]).toBe('zhejiang');
+      expect(testComponent.values()).toEqual(['zhejiang']);
     });
 
     it('should support search', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.nzShowSearch = true;
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
+      testComponent.nzShowSearch.set(true);
+      fixture.detectChanges();
       const spy = spyOn(testComponent.cascader, 'focus');
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(spy).toHaveBeenCalled();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
-      expect(testComponent.values!.join(',')).toBe('zhejiang,hangzhou,xihu');
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
     });
 
     it('should searching could be aborted', async () => {
-      testComponent.values = ['zhengjiang', 'hangzhou', 'xihu'];
-      testComponent.nzShowSearch = true;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set(['zhengjiang', 'hangzhou', 'xihu']);
+      testComponent.nzShowSearch.set(true);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      await waitForChanges(fixture, 0);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 0);
+      fixture.detectChanges();
 
       // input search value
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
@@ -1557,9 +1460,8 @@ describe('cascader', () => {
 
       // clear search value
       testComponent.cascader.inputValue = '';
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 10);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 10);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.cascader.inSearchingMode).toBe(false);
 
@@ -1568,193 +1470,187 @@ describe('cascader', () => {
     });
 
     it('should clear input value when searching cancel', async () => {
-      testComponent.values = ['zhengjiang', 'hangzhou', 'xihu'];
-      testComponent.nzShowSearch = true;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set(['zhengjiang', 'hangzhou', 'xihu']);
+      testComponent.nzShowSearch.set(true);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(true);
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ESCAPE);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.inputValue).toBe('');
-      expect(testComponent.values).toEqual(['zhengjiang', 'hangzhou', 'xihu']);
+      expect(testComponent.values()).toEqual(['zhengjiang', 'hangzhou', 'xihu']);
     });
 
     it('should support nzLabelProperty', async () => {
-      testComponent.nzShowSearch = true;
-      testComponent.nzLabelProperty = 'l';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzShowSearch.set(true);
+      testComponent.nzLabelProperty.set('l');
+      fixture.detectChanges();
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang New / Hangzhou New / West Lake New');
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
-      expect(testComponent.values!.join(',')).toBe('zhejiang,hangzhou,xihu');
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
     });
 
     it('should support nzValueProperty', async () => {
-      testComponent.nzShowSearch = true;
-      testComponent.nzValueProperty = 'v';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzShowSearch.set(true);
+      testComponent.nzValueProperty.set('v');
+      fixture.detectChanges();
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
-      expect(testComponent.values!.join(',')).toBe('zhejiang-new,hangzhou-new,xihu-new');
+      expect(testComponent.values()).toEqual(['zhejiang-new', 'hangzhou-new', 'xihu-new']);
     });
 
     it('should support custom filter', async () => {
-      testComponent.nzShowSearch = {
+      testComponent.nzShowSearch.set({
         filter(inputValue: string, path: NzCascaderOption[]): boolean {
           return path.some(p => p.label!.indexOf(inputValue) !== -1);
         }
-      } as NzShowSearchOptions;
-      markForCheckAndDetectChanges(fixture);
+      } as NzShowSearchOptions);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
-      expect(testComponent.values!.join(',')).toBe('zhejiang,hangzhou,xihu');
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
     });
 
     it('should support custom sorter', async () => {
-      testComponent.nzShowSearch = {
+      testComponent.nzShowSearch.set({
         sorter(a: NzCascaderOption[], b: NzCascaderOption[], _inputValue: string): number {
           const l1 = a[0].label;
           const l2 = b[0].label; // all reversed, just to be sure it works
           return `${l1}`.localeCompare(l2!);
         }
-      } as NzShowSearchOptions;
-      markForCheckAndDetectChanges(fixture);
+      } as NzShowSearchOptions);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Jiangsu / Nanjing / Zhong Hua Men');
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.inSearchingMode).toBe(false);
       expect(testComponent.cascader.menuOpen()).toBe(false);
       expect(testComponent.cascader.inputValue).toBe('');
-      expect(testComponent.values!.join(',')).toBe('jiangsu,nanjing,zhonghuamen');
+      expect(testComponent.values()).toEqual(['jiangsu', 'nanjing', 'zhonghuamen']);
     });
 
     it('should forbid disabled search options to be clicked', async () => {
-      testComponent.nzOptions = options4;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options4);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
       expect(testComponent.cascader.cascaderService.columns[0][0].isDisabled).toBe(true);
 
       itemEl1.click();
-      await waitForChanges(fixture, 300);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 300);
+      fixture.detectChanges();
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(testComponent.cascader.menuOpen()).toBe(true);
       expect(testComponent.cascader.inputValue).toBe('o');
     });
 
     it('should pass disabled property to children when searching', () => {
-      testComponent.nzOptions = options4;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options4);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.cascaderService.columns[0][0].isDisabled).toBe(true);
       expect(testComponent.cascader.cascaderService.columns[0][1].isDisabled).toBe(false);
       expect(testComponent.cascader.cascaderService.columns[0][2].isDisabled).toBe(true);
     });
 
     it('should support arrow in search mode', async () => {
-      testComponent.nzOptions = options2;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options2);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl2 = getItemAtColumnAndRow(1, 2)!;
       const itemEl4 = getItemAtColumnAndRow(1, 4)!;
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(itemEl2.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', DOWN_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
       expect(itemEl4.classList).toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      expect(testComponent.values!.join(',')).toBe('option1,option14');
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
+      expect(testComponent.values()).toEqual(['option1', 'option14']);
     });
 
     it('should not preventDefault left/right arrow in search mode', () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.nzShowSearch = true;
+      fixture.detectChanges();
+      testComponent.nzShowSearch.set(true);
       testComponent.cascader.inputValue = 'o';
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
     });
 
     it('should not preventDefault BACKSPACE in search mode', async () => {
-      testComponent.nzShowSearch = true;
+      testComponent.nzShowSearch.set(true);
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const event = dispatchKeyboardEvent(cascader.nativeElement, 'keydown', BACKSPACE);
       testComponent.cascader.inputValue = '';
-      await waitForChanges(fixture, 0);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 0);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(event.defaultPrevented).toBe(false);
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
@@ -1763,35 +1659,36 @@ describe('cascader', () => {
     });
 
     it('should support search a root node have no children ', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.nzShowSearch = true;
-      testComponent.nzOptions = options5;
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
+      testComponent.nzShowSearch.set(true);
+      testComponent.nzOptions.set(options5);
+      fixture.detectChanges();
       const spy = spyOn(testComponent.cascader, 'focus');
       cascader.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(spy).toHaveBeenCalled();
       testComponent.cascader.inputValue = 'Roo';
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText.trim()).toBe('暂无数据');
-      await waitForChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
     });
 
     it('should re-prepare search results when nzOptions change', () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.nzShowSearch = true;
+      fixture.detectChanges();
+      testComponent.nzShowSearch.set(true);
       cascader.nativeElement.click();
       testComponent.cascader.setMenuOpen(true);
       testComponent.cascader.inputValue = 'o';
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(testComponent.cascader.inSearchingMode).toBe(true);
       expect(itemEl1.innerText).toBe('Zhejiang / Hangzhou / West Lake');
-      testComponent.nzOptions = options2;
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzOptions.set(options2);
+      fixture.detectChanges();
       expect(testComponent.cascader.inSearchingMode).toBe(true);
 
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
@@ -1799,27 +1696,27 @@ describe('cascader', () => {
     });
 
     it('should nzPrefix work', () => {
-      testComponent.nzPrefix = 'prefix';
-      markForCheckAndDetectChanges(fixture);
+      testComponent.nzPrefix.set('prefix');
+      fixture.detectChanges();
       expect(cascader.nativeElement.querySelector('.ant-select-prefix')!.textContent?.trim()).toBe('prefix');
     });
 
     it('should support changing icon', () => {
-      testComponent.nzSuffixIcon = 'home';
-      testComponent.nzExpandIcon = 'home';
+      testComponent.nzSuffixIcon.set('home');
+      testComponent.nzExpandIcon.set('home');
 
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1);
       expect(itemEl1?.querySelector('.anticon-home')).toBeTruthy();
       expect(cascader.nativeElement.querySelector('.ant-select-arrow .anticon')!.classList).toContain('anticon-home');
     });
 
     it('should nzPlacement works', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       let element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(true);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(false);
@@ -1828,12 +1725,11 @@ describe('cascader', () => {
 
       const setNzPlacement = async (placement: NzCascaderPlacement): Promise<void> => {
         testComponent.cascader.setMenuOpen(false);
-        markForCheckAndDetectChanges(fixture);
-        testComponent.nzPlacement = placement;
+        fixture.detectChanges();
+        testComponent.nzPlacement.set(placement);
         testComponent.cascader.setMenuOpen(true);
-        markForCheckAndDetectChanges(fixture);
-        await waitForChanges(fixture, 200);
-        markForCheckAndDetectChanges(fixture);
+        await updateNonSignalsInput(fixture, 200);
+        fixture.detectChanges();
       };
 
       await setNzPlacement('bottomRight');
@@ -1859,25 +1755,24 @@ describe('cascader', () => {
     });
 
     it('should cascade work when the value of ngModel that is not existed in options', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.values = ['zhejiang', 'a'];
+      fixture.detectChanges();
+      testComponent.values.set(['zhejiang', 'a']);
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       getItemAtColumnAndRow(1, 1)!.click();
       getItemAtColumnAndRow(2, 1)!.click();
       getItemAtColumnAndRow(3, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toEqual(['zhejiang', 'hangzhou', 'xihu']);
+      fixture.detectChanges();
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
     });
 
     it('should display activated column correctly after clicking outside and reopen', async () => {
-      markForCheckAndDetectChanges(fixture);
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
+      fixture.detectChanges();
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
       // First open - should display activated columns correctly
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(3);
       let itemEl1 = getItemAtColumnAndRow(1, 1)!;
       let itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1888,9 +1783,8 @@ describe('cascader', () => {
 
       // Click first column option (zhejiang) - should fold the third column
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(2);
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1901,17 +1795,15 @@ describe('cascader', () => {
 
       // Click outside to close menu - value should remain unchanged
       dispatchFakeEvent(document.body, 'click');
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.cascader.menuOpen()).toBe(false);
-      expect(testComponent.values).toEqual(['zhejiang', 'hangzhou', 'xihu']);
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
 
       // Reopen menu - should display activated columns correctly based on current value
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(getAllColumns().length).toBe(3);
       itemEl1 = getItemAtColumnAndRow(1, 1)!;
       itemEl2 = getItemAtColumnAndRow(2, 1)!;
@@ -1923,17 +1815,17 @@ describe('cascader', () => {
 
     describe('should nzOpen works', () => {
       beforeEach(async () => {
-        testComponent.nzOpen = true;
-        await waitForChanges(fixture, 200);
-        markForCheckAndDetectChanges(fixture);
+        testComponent.nzOpen.set(true);
+        await updateNonSignalsInput(fixture, 200);
+        fixture.detectChanges();
       });
 
       it('should nzOpen can control the visibility of menu', async () => {
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
-        testComponent.nzOpen = false;
-        await waitForChanges(fixture, 200);
-        markForCheckAndDetectChanges(fixture);
+        testComponent.nzOpen.set(false);
+        await updateNonSignalsInput(fixture, 200);
+        fixture.detectChanges();
         expect(testComponent.cascader.menuOpen()).toBe(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
       });
@@ -1943,8 +1835,8 @@ describe('cascader', () => {
         getItemAtColumnAndRow(1, 1)!.click();
         getItemAtColumnAndRow(2, 1)!.click();
         getItemAtColumnAndRow(3, 1)!.click(); // zhejiang, hangzhou, xihu
-        await waitForChanges(fixture);
-        markForCheckAndDetectChanges(fixture);
+        await updateNonSignalsInput(fixture);
+        fixture.detectChanges();
         expect(testComponent.onValueChanges).toHaveBeenCalled();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         spyOn(testComponent.cascader, 'onClickOutside');
@@ -1954,17 +1846,17 @@ describe('cascader', () => {
       });
 
       it('should not hide menu by clear options under multiple mode when nzOpen is true', async () => {
-        testComponent.nzMultiple = true;
-        markForCheckAndDetectChanges(fixture);
+        testComponent.nzMultiple.set(true);
+        fixture.detectChanges();
         getItemAtColumnAndRow(1, 1)!.click();
         getItemAtColumnAndRow(2, 1)!.click();
         getItemAtColumnAndRow(3, 1)!.click(); // zhejiang, hangzhou, xihu
         getItemAtColumnAndRow(1, 2)!.click();
         getItemAtColumnAndRow(2, 1)!.click();
         getItemAtColumnAndRow(3, 1)!.click(); // jiangsu, nanjing, zhonghuamen
-        expect(testComponent.values).toEqual([['zhejiang', 'hangzhou'], ['jiangsu']]);
-        await waitForChanges(fixture);
-        markForCheckAndDetectChanges(fixture);
+        expect(testComponent.values()).toEqual([['zhejiang', 'hangzhou'], ['jiangsu']]);
+        await updateNonSignalsInput(fixture);
+        fixture.detectChanges();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         spyOn(testComponent.cascader, 'clearSelection');
         expect(cascader.nativeElement.querySelector('.ant-select-clear .anticon')).toBeDefined();
@@ -1977,28 +1869,26 @@ describe('cascader', () => {
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(1);
         expect(testComponent.cascader.menuOpen()).toBe(true);
         cascader.nativeElement.click();
-        markForCheckAndDetectChanges(fixture);
-        await waitForChanges(fixture, 200);
-        markForCheckAndDetectChanges(fixture);
+        await updateNonSignalsInput(fixture, 200);
+        fixture.detectChanges();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(2);
 
         getItemAtColumnAndRow(1, 1)!.click();
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         getItemAtColumnAndRow(2, 1)!.click();
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         getItemAtColumnAndRow(3, 1)!.click();
-        await waitForChanges(fixture, 200);
-        markForCheckAndDetectChanges(fixture);
+        await updateNonSignalsInput(fixture, 200);
+        fixture.detectChanges();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(3);
 
         dispatchFakeEvent(document.body, 'click');
-        markForCheckAndDetectChanges(fixture);
-        await waitForChanges(fixture);
-        markForCheckAndDetectChanges(fixture);
+        await updateNonSignalsInput(fixture);
+        fixture.detectChanges();
         expect(testComponent.cascader.menuOpen()).toBe(true);
         expect(testComponent.onOpenChange).toHaveBeenCalledWith(false);
         expect(testComponent.onOpenChange).toHaveBeenCalledTimes(4);
@@ -2015,7 +1905,7 @@ describe('cascader', () => {
       testComponent.values.set(
         testComponent.nzOptions[0].children!.slice(0, len).map(o => [testComponent.nzOptions[0].value, o.value])
       );
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
     }
 
     function getCheckboxAtColumnAndRow(column: number, row: number): HTMLElement | null {
@@ -2039,48 +1929,47 @@ describe('cascader', () => {
     });
 
     it('should have correct classes', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.classList).toContain('ant-select-multiple');
     });
 
     it('should maxTagCount work', async () => {
       // not exceed
       setValues(3);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       let tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(3);
 
       // exceed maxTagCount
       setValues(10);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(4); // maxTagCount + 1
     });
 
     it('should remove item work', async () => {
       setValues(4);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       const removeBtn = cascader.queryAll(By.css('.ant-select-selection-item-remove'))[2];
       removeBtn.nativeElement.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const tags = cascader.queryAll(By.directive(NzSelectItemComponent));
       expect(tags.length).toBe(3);
     });
 
     it('should check state conduct up and down', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
 
       // firstly, expand all columns (for convenience)
       getItemAtColumnAndRow(1, 2)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       getItemAtColumnAndRow(2, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
 
       const rootEl = getCheckboxAtColumnAndRow(1, 2)!;
       const parentEl = getCheckboxAtColumnAndRow(2, 1)!;
@@ -2088,7 +1977,7 @@ describe('cascader', () => {
 
       // check parent option
       parentEl.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(parentEl.classList).toContain('ant-cascader-checkbox-checked');
       // Conduct Down: then all children should be checked
       expect(children.every(c => c.classList.contains('ant-cascader-checkbox-checked'))).toBe(true);
@@ -2097,7 +1986,7 @@ describe('cascader', () => {
 
       // uncheck a child option
       children[0]!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       // Conduct Up: then parent should be half checked
       expect(parentEl.classList).toContain('ant-cascader-checkbox-indeterminate');
       // Conduct Up: and root should be half checked
@@ -2105,7 +1994,7 @@ describe('cascader', () => {
 
       // check the half checked parent option
       parentEl.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(parentEl.classList).toContain('ant-cascader-checkbox-checked');
       // Conduct Down: then all children should be checked
       expect(children.every(c => c.classList.contains('ant-cascader-checkbox-checked'))).toBe(true);
@@ -2114,7 +2003,7 @@ describe('cascader', () => {
 
       // uncheck the parent option
       parentEl.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       // Conduct Down: then all children should be unchecked
       expect(children.every(c => !c.classList.contains('ant-cascader-checkbox-checked'))).toBe(true);
       // Conduct Up: and its parent should be unchecked too
@@ -2123,16 +2012,15 @@ describe('cascader', () => {
 
     it('should click checkbox not set option activated', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
 
       const option = getItemAtColumnAndRow(1, 1)!;
       const checkbox = getCheckboxAtColumnAndRow(1, 1)!;
       expect(option.classList).not.toContain('ant-cascader-menu-item-active');
 
       checkbox.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
 
       expect(option.classList).not.toContain('ant-cascader-menu-item-active');
       expect(checkbox.classList).toContain('ant-cascader-checkbox-checked');
@@ -2140,15 +2028,14 @@ describe('cascader', () => {
 
     it('should change check state when click leaf node', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
 
       // firstly, expand all columns (for convenience)
       getItemAtColumnAndRow(1, 2)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       getItemAtColumnAndRow(2, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
 
       const leaf = getItemAtColumnAndRow(3, 2)!;
       const checkbox = getCheckboxAtColumnAndRow(3, 2)!;
@@ -2157,12 +2044,12 @@ describe('cascader', () => {
       expect(checkbox.classList).not.toContain('ant-cascader-checkbox-checked');
 
       leaf.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(leaf.classList).toContain('ant-cascader-menu-item-active');
       expect(checkbox.classList).toContain('ant-cascader-checkbox-checked');
 
       leaf.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(leaf.classList).toContain('ant-cascader-menu-item-active');
       expect(checkbox.classList).not.toContain('ant-cascader-checkbox-checked');
     });
@@ -2171,55 +2058,52 @@ describe('cascader', () => {
       spyOn(testComponent, 'onChanges');
       expect(testComponent.onChanges).not.toHaveBeenCalled();
       cascader.componentInstance.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
       expect(testComponent.onChanges).not.toHaveBeenCalled();
 
       const checkbox = getCheckboxAtColumnAndRow(1, 1)!;
       checkbox.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.onChanges).toHaveBeenCalledWith([['light']]);
     });
 
     it('should support ENTER key to toggle option checked state in multiple mode', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
       getItemAtColumnAndRow(1, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       const optionEl = getItemAtColumnAndRow(2, 1)!;
       const checkboxEl = getCheckboxAtColumnAndRow(2, 1)!;
       // Initially, the option should not be checked
       expect(checkboxEl.classList).not.toContain('ant-cascader-checkbox-checked');
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(optionEl.classList).toContain('ant-cascader-menu-item-active');
       // Press ENTER to toggle the option checked state
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       // The option should now be checked
       expect(checkboxEl.classList).toContain('ant-cascader-checkbox-checked');
       // Press ENTER again to toggle the option unchecked state
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', ENTER);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       // The option should now be unchecked
       expect(checkboxEl.classList).not.toContain('ant-cascader-checkbox-checked');
     });
 
     it('should not activate option with isDisableCheckbox by pressing RIGHT ARROW key', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
       getItemAtColumnAndRow(1, 2)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       getItemAtColumnAndRow(2, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       // Try to navigate to a disabled checkbox option using keyboard
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       // The option with disableCheckbox should not be activatable via keyboard
       expect(getItemAtColumnAndRow(3, 1)!.classList).not.toContain('ant-cascader-menu-item-active');
       expect(getCheckboxAtColumnAndRow(3, 1)!.classList).toContain('ant-cascader-checkbox-disabled');
@@ -2230,15 +2114,14 @@ describe('cascader', () => {
 
     it('should not activate option with isDisableCheckbox in moveUpOrDown method', async () => {
       cascader.componentInstance.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
       getItemAtColumnAndRow(1, 2)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       getItemAtColumnAndRow(2, 1)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       getItemAtColumnAndRow(3, 2)!.click();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(getItemAtColumnAndRow(3, 2)!.classList).toContain('ant-cascader-menu-item-active');
       // Up key
       dispatchKeyboardEvent(cascader.nativeElement, 'keydown', UP_ARROW);
@@ -2250,12 +2133,12 @@ describe('cascader', () => {
     describe('should cascade work when the value of ngModel includes nodes that are not existed in options', () => {
       it('should remove item work', async () => {
         setValues(2);
-        testComponent.values()[0] = ['light', 'a'];
-        await waitForChanges(fixture);
-        markForCheckAndDetectChanges(fixture);
+        testComponent.values.update(values => [['light', 'a'], ...values.slice(1)]);
+        await updateNonSignalsInput(fixture);
+        fixture.detectChanges();
         const removeBtn = cascader.queryAll(By.css('.ant-select-selection-item-remove'))[0];
         removeBtn.nativeElement.click();
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         const tags = cascader.queryAll(By.directive(NzSelectItemComponent));
         expect(tags.length).toBe(1);
       });
@@ -2263,14 +2146,14 @@ describe('cascader', () => {
       it('should add item work', async () => {
         spyOn(testComponent, 'onChanges');
         setValues(2);
-        testComponent.values()[0] = ['light', 'a'];
-        await waitForChanges(fixture);
-        markForCheckAndDetectChanges(fixture);
+        testComponent.values.update(values => [['light', 'a'], ...values.slice(1)]);
+        await updateNonSignalsInput(fixture);
+        fixture.detectChanges();
         cascader.componentInstance.setMenuOpen(true);
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         const checkbox = getCheckboxAtColumnAndRow(2, 3)!;
         checkbox.click();
-        markForCheckAndDetectChanges(fixture);
+        fixture.detectChanges();
         expect(testComponent.values().length).toBe(3);
         const selectedNodes = [
           ['light', 1],
@@ -2304,43 +2187,41 @@ describe('cascader', () => {
     it('should nzLoadData work', async () => {
       spyOn(testComponent, 'addCallTimes');
 
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values).toBeNull();
+      fixture.detectChanges();
+      expect(testComponent.values()).toBeNull();
       expect(getAllColumns().length).toBe(0);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(0);
 
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(1);
-      await waitForChanges(fixture, 1000); // wait for first row to load finish
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 1000); // wait for first row to load finish
+      fixture.detectChanges();
 
       expect(getAllColumns().length).toBe(1);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(2);
       expect(getAllColumns().length).toBe(2);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl2.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(3);
       expect(getAllColumns().length).toBe(3);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
       expect(itemEl1.classList).toContain('ant-cascader-menu-item-active');
@@ -2348,76 +2229,60 @@ describe('cascader', () => {
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl3.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(4);
-      expect(testComponent.values).toBeNull(); // not select yet
+      expect(testComponent.values()).toBeNull(); // not select yet
 
       itemEl3.click(); // re-click again, this time it is a leaf
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(4);
-      expect(testComponent.values).toBeDefined();
-      expect(testComponent.values!.length).toBe(3);
-      expect(testComponent.values![0]).toBe('zhejiang');
-      expect(testComponent.values![1]).toBe('hangzhou');
-      expect(testComponent.values![2]).toBe('xihu');
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
     });
 
     it('should nzLoadData work when specifies default value', async () => {
       spyOn(testComponent, 'addCallTimes');
-      testComponent.values = ['zhejiang', 'hangzhou', 'xihu'];
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 3000);
-      markForCheckAndDetectChanges(fixture);
+      testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
+      await updateNonSignalsInput(fixture, 3000);
+      fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(3);
       expect(testComponent.cascader.cascaderService.columns.length).toBe(3);
-      expect(testComponent.values.join(',')).toBe('zhejiang,hangzhou,xihu');
+      expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
     });
 
     it('should not emit error after clear search and reopen it', async () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 1000); // wait for first row to load finish
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 1000); // wait for first row to load finish
+      fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
 
       itemEl1.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
 
       itemEl2.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      fixture.detectChanges();
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
 
       itemEl3.click();
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
 
       itemEl3.click(); // re-click again, this time it is a leaf
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture, 600);
-      markForCheckAndDetectChanges(fixture);
-      await waitForChanges(fixture);
-      markForCheckAndDetectChanges(fixture);
+      await updateNonSignalsInput(fixture, 600);
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
       cascader.nativeElement.querySelector('.ant-select-clear .anticon').click();
       testComponent.cascader.setMenuOpen(true);
-      markForCheckAndDetectChanges(fixture);
-      expect(testComponent.values!.length).toBe(0);
+      fixture.detectChanges();
+      expect(testComponent.values()).toEqual([]);
     });
   });
 
@@ -2431,15 +2296,15 @@ describe('cascader', () => {
     });
 
     it('should className correct', () => {
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       expect(cascader.nativeElement.className).toContain('ant-select-status-error');
 
-      fixture.componentInstance.status = 'warning';
-      markForCheckAndDetectChanges(fixture);
+      fixture.componentInstance.status.set('warning');
+      fixture.detectChanges();
       expect(cascader.nativeElement.className).toContain('ant-select-status-warning');
 
-      fixture.componentInstance.status = '';
-      markForCheckAndDetectChanges(fixture);
+      fixture.componentInstance.status.set('');
+      fixture.detectChanges();
       expect(cascader.nativeElement.className).not.toContain('ant-select-status-warning');
     });
   });
@@ -2455,7 +2320,7 @@ describe('cascader', () => {
       fixture = TestBed.createComponent(NzDemoCascaderInFormComponent);
       cascader = fixture.debugElement.query(By.directive(NzCascaderComponent));
       formGroup = fixture.componentInstance.validateForm;
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
     });
 
     it('should className correct', () => {
@@ -2464,7 +2329,7 @@ describe('cascader', () => {
       formGroup.controls.demo.markAsDirty();
       formGroup.controls.demo.setValue(null);
       formGroup.controls.demo.updateValueAndValidity();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
 
       // show error
       expect(cascader.nativeElement.className).toContain('ant-select-status-error');
@@ -2476,7 +2341,7 @@ describe('cascader', () => {
       formGroup.controls.demo.markAsDirty();
       formGroup.controls.demo.setValue(['a', 'b']);
       formGroup.controls.demo.updateValueAndValidity();
-      markForCheckAndDetectChanges(fixture);
+      fixture.detectChanges();
       // show success
       expect(cascader.nativeElement.className).toContain('ant-select-status-success');
       expect(cascader.nativeElement.querySelector('nz-form-item-feedback-icon')).toBeTruthy();
@@ -2510,21 +2375,20 @@ describe('cascader RTL behavior', () => {
   });
 
   it('should menu class work', async () => {
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     cascader.nativeElement.click();
-    markForCheckAndDetectChanges(fixture);
-    await waitForChanges(fixture, 200);
-    markForCheckAndDetectChanges(fixture);
+    await updateNonSignalsInput(fixture, 200);
+    fixture.detectChanges();
     expect(overlayContainerElement.querySelector('.ant-cascader-menus')!.classList).toContain('ant-cascader-rtl');
   });
 
   it('should pressing the left and right keys can correctly expand and collapse content', async () => {
-    testComponent.nzOptions = options3;
+    testComponent.nzOptions.set(options3);
     testComponent.cascader.setMenuOpen(true);
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
     dispatchKeyboardEvent(cascader.nativeElement, 'keydown', LEFT_ARROW);
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     const zhejiangItemEl = overlayContainerElement
       .querySelectorAll('.ant-cascader-menu')[0]
       ?.querySelectorAll('.ant-cascader-menu-item')[0];
@@ -2534,7 +2398,7 @@ describe('cascader RTL behavior', () => {
     expect(zhejiangItemEl!.classList).toContain('ant-cascader-menu-item-active');
     expect(hangzhouItemEl!.classList).toContain('ant-cascader-menu-item-active');
     dispatchKeyboardEvent(cascader.nativeElement, 'keydown', RIGHT_ARROW);
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     expect(hangzhouItemEl!.classList).not.toContain('ant-cascader-menu-item-active');
     expect(zhejiangItemEl!.classList).toContain('ant-cascader-menu-item-active');
   });
@@ -2564,12 +2428,11 @@ describe('nzPopupRender', () => {
   it('should render custom footer when nzPopupRender is provided', async () => {
     const fixture = TestBed.createComponent(NzDemoCascaderPopupRenderComponent);
     const component = fixture.componentInstance;
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
 
     component.cascader.setMenuOpen(true);
-    markForCheckAndDetectChanges(fixture);
-    await waitForChanges(fixture, 200);
-    markForCheckAndDetectChanges(fixture);
+    await updateNonSignalsInput(fixture, 200);
+    fixture.detectChanges();
 
     const customFooter = overlayContainerElement.querySelector('.custom-footer');
     expect(customFooter).toBeTruthy();
@@ -2582,12 +2445,11 @@ describe('nzPopupRender', () => {
   it('should render default menu when nzPopupRender is not provided', async () => {
     const fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     const component = fixture.componentInstance;
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
 
     component.cascader.setMenuOpen(true);
-    markForCheckAndDetectChanges(fixture);
-    await waitForChanges(fixture, 200);
-    markForCheckAndDetectChanges(fixture);
+    await updateNonSignalsInput(fixture, 200);
+    fixture.detectChanges();
 
     const menu = overlayContainerElement.querySelector('.ant-cascader-menus');
     expect(menu).toBeTruthy();
@@ -2620,9 +2482,9 @@ describe('finalSize', () => {
     });
     fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     formSizeSignal.set('large');
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     expect(cascaderElement.classList).toContain('ant-select-lg');
   });
   it('should set correctly the size from the compactSize signal', () => {
@@ -2631,14 +2493,14 @@ describe('finalSize', () => {
     });
     fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     expect(cascaderElement.classList).toContain('ant-select-lg');
   });
   it('should set correctly the size from the component input', () => {
     fixture = TestBed.createComponent(NzDemoCascaderDefaultComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    fixture.componentInstance.nzSize = 'large';
-    markForCheckAndDetectChanges(fixture);
+    fixture.componentInstance.nzSize.set('large');
+    fixture.detectChanges();
     expect(cascaderElement.classList).toContain('ant-select-lg');
   });
 });
@@ -2662,9 +2524,9 @@ describe('finalVariant', () => {
     });
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     formVariantSignal.set('filled');
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     expect(cascaderElement.classList).toContain('ant-select-filled');
   });
 
@@ -2675,9 +2537,9 @@ describe('finalVariant', () => {
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
     fixture.componentInstance.variant.set('borderless');
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     formVariantSignal.set('filled');
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     expect(cascaderElement.classList).toContain('ant-select-borderless');
     expect(cascaderElement.classList).not.toContain('ant-select-filled');
   });
@@ -2686,14 +2548,14 @@ describe('finalVariant', () => {
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
     fixture.componentInstance.variant.set('filled');
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     expect(cascaderElement.classList).toContain('ant-select-filled');
   });
 
   it('should use outlined as default when neither nzVariant nor formVariant is provided', () => {
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     expect(cascaderElement.classList).not.toContain('ant-select-filled');
     expect(cascaderElement.classList).not.toContain('ant-select-borderless');
     expect(cascaderElement.classList).not.toContain('ant-select-underlined');
@@ -2706,9 +2568,9 @@ describe('finalVariant', () => {
     fixture = TestBed.createComponent(TestCascaderFinalVariantComponent);
     cascaderElement = fixture.debugElement.query(By.directive(NzCascaderComponent)).nativeElement;
     fixture.componentInstance.variant.set('outlined');
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     formVariantSignal.set('filled');
-    markForCheckAndDetectChanges(fixture);
+    fixture.detectChanges();
     expect(cascaderElement.classList).not.toContain('ant-select-filled');
   });
 });
@@ -2937,37 +2799,37 @@ const options5: NzSafeAny[] = [];
   selector: 'nz-test-cascader-default',
   template: `
     <nz-cascader
-      [(ngModel)]="values"
-      [nzOpen]="nzOpen"
-      [nzOptions]="nzOptions"
-      [nzAllowClear]="nzAllowClear"
-      [nzAutoFocus]="nzAutoFocus"
-      [nzChangeOn]="nzChangeOn"
-      [nzChangeOnSelect]="nzChangeOnSelect"
+      [ngModel]="values()"
+      (ngModelChange)="values.set($event); onValueChanges($event)"
+      [nzOpen]="nzOpen()"
+      [nzOptions]="nzOptions()"
+      [nzAllowClear]="nzAllowClear()"
+      [nzAutoFocus]="nzAutoFocus()"
+      [nzChangeOn]="nzChangeOn()"
+      [nzChangeOnSelect]="nzChangeOnSelect()"
       [nzColumnClassName]="nzColumnClassName"
-      [nzDisabled]="nzDisabled"
-      [nzExpandIcon]="nzExpandIcon"
-      [nzExpandTrigger]="nzExpandTrigger"
-      [nzLabelProperty]="nzLabelProperty"
-      [nzValueProperty]="nzValueProperty"
-      [nzLabelRender]="nzLabelRender"
+      [nzDisabled]="nzDisabled()"
+      [nzExpandIcon]="nzExpandIcon()"
+      [nzExpandTrigger]="nzExpandTrigger()"
+      [nzLabelProperty]="nzLabelProperty()"
+      [nzValueProperty]="nzValueProperty()"
+      [nzLabelRender]="nzLabelRender()"
       [nzMenuClassName]="nzMenuClassName"
       [nzMenuStyle]="nzMenuStyle"
-      [nzMultiple]="nzMultiple"
-      [nzMouseEnterDelay]="nzMouseEnterDelay"
-      [nzMouseLeaveDelay]="nzMouseLeaveDelay"
-      [nzPlaceHolder]="nzPlaceHolder"
-      [nzShowArrow]="nzShowArrow"
-      [nzShowInput]="nzShowInput"
-      [nzShowSearch]="nzShowSearch"
-      [nzSize]="nzSize"
-      [nzTriggerAction]="nzTriggerAction"
-      [nzPrefix]="nzPrefix"
-      [nzSuffixIcon]="nzSuffixIcon"
-      [nzBackdrop]="nzBackdrop"
-      [nzPlacement]="nzPlacement"
-      [nzVariant]="nzVariant"
-      (ngModelChange)="onValueChanges($event)"
+      [nzMultiple]="nzMultiple()"
+      [nzMouseEnterDelay]="nzMouseEnterDelay()"
+      [nzMouseLeaveDelay]="nzMouseLeaveDelay()"
+      [nzPlaceHolder]="nzPlaceHolder()"
+      [nzShowArrow]="nzShowArrow()"
+      [nzShowInput]="nzShowInput()"
+      [nzShowSearch]="nzShowSearch()"
+      [nzSize]="nzSize()"
+      [nzTriggerAction]="nzTriggerAction()"
+      [nzPrefix]="nzPrefix()"
+      [nzSuffixIcon]="nzSuffixIcon()"
+      [nzBackdrop]="nzBackdrop()"
+      [nzPlacement]="nzPlacement()"
+      [nzVariant]="nzVariant()"
       (nzOpenChange)="onOpenChange($event)"
       (nzClear)="onClear()"
     />
@@ -2983,37 +2845,37 @@ export class NzDemoCascaderDefaultComponent {
   @ViewChild(NzCascaderComponent, { static: true }) cascader!: NzCascaderComponent;
   @ViewChild('renderTpl', { static: true }) renderTpl!: TemplateRef<NzSafeAny>;
 
-  nzOptions: NzSafeAny[] | null = options1();
-  values: string[] | string[][] | number[] | null = null;
+  readonly nzOptions = signal<NzSafeAny[] | null>(options1());
+  readonly values = signal<string[] | string[][] | number[] | null>(null);
 
-  nzOpen: boolean | undefined;
-  nzMultiple = false;
-  nzAllowClear = true;
-  nzAutoFocus = false;
+  readonly nzOpen = signal<boolean | undefined>(undefined);
+  readonly nzMultiple = signal(false);
+  readonly nzAllowClear = signal(true);
+  readonly nzAutoFocus = signal(false);
   nzMenuClassName = 'menu-classA menu-classB';
   nzColumnClassName = 'column-classA column-classB';
   nzMenuStyle = { height: '120px' };
-  nzExpandTrigger: NzCascaderExpandTrigger = 'click';
-  nzDisabled = false;
-  nzLabelProperty: string = 'label';
-  nzValueProperty: string = 'value';
-  nzPlaceHolder = 'please select';
-  nzShowArrow = true;
-  nzShowInput = true;
-  nzShowSearch: boolean | NzShowSearchOptions = false;
-  nzSize: NzCascaderSize = 'default';
-  nzLabelRender: TemplateRef<NzSafeAny> | null = null;
-  nzChangeOn: NzSafeAny = null;
-  nzChangeOnSelect = false;
-  nzTriggerAction: NzCascaderTriggerType | NzCascaderTriggerType[] = 'click';
-  nzMouseEnterDelay = 150; // ms
-  nzMouseLeaveDelay = 150; // ms
-  nzPrefix: string | null = null;
-  nzSuffixIcon = 'down';
-  nzExpandIcon = 'right';
-  nzBackdrop = false;
-  nzPlacement: NzCascaderPlacement = 'bottomLeft';
-  nzVariant: NzVariant = 'outlined';
+  readonly nzExpandTrigger = signal<NzCascaderExpandTrigger>('click');
+  readonly nzDisabled = signal(false);
+  readonly nzLabelProperty = signal<string>('label');
+  readonly nzValueProperty = signal<string>('value');
+  readonly nzPlaceHolder = signal('please select');
+  readonly nzShowArrow = signal(true);
+  readonly nzShowInput = signal(true);
+  readonly nzShowSearch = signal<boolean | NzShowSearchOptions>(false);
+  readonly nzSize = signal<NzCascaderSize>('default');
+  readonly nzLabelRender = signal<TemplateRef<NzSafeAny> | null>(null);
+  readonly nzChangeOn = signal<NzSafeAny>(null);
+  readonly nzChangeOnSelect = signal(false);
+  readonly nzTriggerAction = signal<NzCascaderTriggerType | NzCascaderTriggerType[]>('click');
+  readonly nzMouseEnterDelay = signal(150);
+  readonly nzMouseLeaveDelay = signal(150);
+  readonly nzPrefix = signal<string | null>(null);
+  readonly nzSuffixIcon = signal('down');
+  readonly nzExpandIcon = signal('right');
+  readonly nzBackdrop = signal(false);
+  readonly nzPlacement = signal<NzCascaderPlacement>('bottomLeft');
+  readonly nzVariant = signal<NzVariant>('outlined');
 
   onOpenChange = jasmine.createSpy<(open: boolean) => void>('open change');
   onValueChanges = jasmine.createSpy('value change');
@@ -3025,9 +2887,9 @@ export class NzDemoCascaderDefaultComponent {
   imports: [FormsModule, NzCascaderModule],
   template: `
     <nz-cascader
-      [(ngModel)]="values"
+      [ngModel]="values()"
+      (ngModelChange)="values.set($event); onValueChanges($event)"
       [nzLoadData]="nzLoadData"
-      (ngModelChange)="onValueChanges($event)"
       (nzOpenChange)="onOpenChange($event)"
     />
   `
@@ -3035,7 +2897,7 @@ export class NzDemoCascaderDefaultComponent {
 export class NzDemoCascaderLoadDataComponent {
   @ViewChild(NzCascaderComponent, { static: true }) cascader!: NzCascaderComponent;
 
-  values: string[] | null = null;
+  readonly values = signal<string[] | null>(null);
 
   nzLoadData = (node: NzSafeAny, index: number): PromiseLike<NzSafeAny> => {
     this.addCallTimes();
@@ -3080,19 +2942,11 @@ export class NzDemoCascaderLoadDataComponent {
 
 @Component({
   imports: [FormsModule, NzCascaderModule],
-  template: `<nz-cascader [nzOptions]="nzOptions" [nzStatus]="status" />`
+  template: `<nz-cascader [nzOptions]="nzOptions" [nzStatus]="status()" />`
 })
 export class NzDemoCascaderStatusComponent {
   nzOptions: NzSafeAny[] | null = options1();
-  private readonly statusSignal = signal<NzStatus>('error');
-
-  get status(): NzStatus {
-    return this.statusSignal();
-  }
-
-  set status(value: NzStatus) {
-    this.statusSignal.set(value);
-  }
+  readonly status = signal<NzStatus>('error');
 }
 
 @Component({

--- a/components/cascader/demo/multiple.ts
+++ b/components/cascader/demo/multiple.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NzCascaderModule, NzCascaderOption } from 'ng-zorro-antd/cascader';
@@ -56,9 +56,7 @@ const getOptions = (): NzCascaderOption[] => [
 })
 export class NzDemoCascaderMultipleComponent {
   readonly nzOptions: NzCascaderOption[] = getOptions();
-  values: NzSafeAny[][] | null = null;
+  readonly values = signal<NzSafeAny[][]>([]);
 
-  onChanges(values: NzSafeAny[][]): void {
-    console.log(values, this.values);
-  }
+  onChanges(_values: NzSafeAny[][]): void {}
 }

--- a/components/comment/comment.spec.ts
+++ b/components/comment/comment.spec.ts
@@ -3,12 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { NO_ERRORS_SCHEMA, provideZoneChangeDetection } from '@angular/core';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { testDirectionality } from 'ng-zorro-antd/core/testing';
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { testDirectionality, updateNonSignalsInput } from 'ng-zorro-antd/core/testing';
 import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 
 import { NzCommentComponent } from './comment.component';
@@ -19,18 +18,9 @@ import { NzDemoCommentNestedComponent } from './demo/nested';
 
 describe('comment', () => {
   beforeEach(() => {
-    // todo: use zoneless
     TestBed.configureTestingModule({
-      providers: [provideNzIconsTesting(), provideZoneChangeDetection()],
+      providers: [provideNzIconsTesting()],
       schemas: [NO_ERRORS_SCHEMA]
-    });
-    [
-      NzDemoCommentBasicComponent,
-      NzDemoCommentListComponent,
-      NzDemoCommentEditorComponent,
-      NzDemoCommentNestedComponent
-    ].forEach(comp => {
-      (comp as NzSafeAny).ɵcmp.onPush = false;
     });
   });
 
@@ -92,15 +82,15 @@ describe('comment', () => {
       );
     });
 
-    it('should list work', () => {
+    it('should list work', async () => {
       const fixture = TestBed.createComponent(NzDemoCommentListComponent);
       const component = fixture.componentInstance;
-      fixture.detectChanges();
+      fixture.autoDetectChanges();
+      await fixture.whenStable();
       let comments = fixture.debugElement.queryAll(By.directive(NzCommentComponent));
-      fixture.detectChanges();
-      expect(component.data.length === comments.length).toBeTruthy();
+      expect(component.data().length === comments.length).toBeTruthy();
 
-      component.data.forEach((e, i) => {
+      component.data().forEach((e, i) => {
         const comment = comments[i];
         expect(comment.nativeElement.querySelector('nz-avatar[nz-comment-avatar]')).toBeTruthy();
         expect(comment.nativeElement.querySelector('.ant-comment-content-author-name').innerText).toBe(e.author);
@@ -108,16 +98,17 @@ describe('comment', () => {
         expect(comment.nativeElement.querySelector('.ant-comment-content-author-time').innerText).toBe(e.datetime);
       });
 
-      component.data = [{ ...component.data[0] }];
-      fixture.detectChanges();
+      component.data.set([{ ...component.data()[0] }]);
+      await fixture.whenStable();
       comments = fixture.debugElement.queryAll(By.directive(NzCommentComponent));
-      expect(component.data.length === comments.length).toBeTruthy();
+      expect(component.data().length === comments.length).toBeTruthy();
     });
 
-    it('should editor work', fakeAsync(() => {
+    it('should editor work', async () => {
       const fixture = TestBed.createComponent(NzDemoCommentEditorComponent);
       const component = fixture.componentInstance;
-      fixture.detectChanges();
+      fixture.autoDetectChanges();
+      await fixture.whenStable();
       expect(fixture.debugElement.query(By.css('nz-comment .ant-comment-content-detail textarea'))).toBeTruthy();
       let comments = fixture.debugElement.queryAll(By.css('nz-list nz-comment'));
       expect(comments.length).toBe(0);
@@ -125,13 +116,11 @@ describe('comment', () => {
 
       component.value.set('Test Comment 0');
       component.handleSubmit();
-      tick(1000);
-      fixture.detectChanges();
+      await updateNonSignalsInput(fixture, 1000);
 
       component.value.set('Test Comment 1');
       component.handleSubmit();
-      tick(1000);
-      fixture.detectChanges();
+      await updateNonSignalsInput(fixture, 1000);
 
       comments = fixture.debugElement.queryAll(By.css('nz-list nz-comment'));
       expect(comments.length).toBeGreaterThan(0);
@@ -144,7 +133,7 @@ describe('comment', () => {
         expect(comment.nativeElement.querySelector('.ant-comment-content-detail p').innerText).toBe(e.content);
         expect(comment.nativeElement.querySelector('.ant-comment-content-author-time').innerText).toBe(e.displayTime);
       });
-    }));
+    });
 
     it('should nested work', () => {
       const fixture = TestBed.createComponent(NzDemoCommentNestedComponent);

--- a/components/comment/demo/list.ts
+++ b/components/comment/demo/list.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 
 import { addDays, formatDistance } from 'date-fns';
 
@@ -10,7 +10,7 @@ import { NzListModule } from 'ng-zorro-antd/list';
   selector: 'nz-demo-comment-list',
   imports: [NzAvatarModule, NzCommentModule, NzListModule],
   template: `
-    <nz-list [nzDataSource]="data" [nzRenderItem]="item" nzItemLayout="horizontal">
+    <nz-list [nzDataSource]="data()" [nzRenderItem]="item" nzItemLayout="horizontal">
       <ng-template #item let-item>
         <nz-comment [nzAuthor]="item.author" [nzDatetime]="item.datetime">
           <nz-avatar nz-comment-avatar nzIcon="user" [nzSrc]="item.avatar" />
@@ -24,7 +24,7 @@ import { NzListModule } from 'ng-zorro-antd/list';
   `
 })
 export class NzDemoCommentListComponent {
-  data = [
+  readonly data = signal([
     {
       author: 'Han Solo',
       avatar: 'https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png',
@@ -41,5 +41,5 @@ export class NzDemoCommentListComponent {
         '(Sketch and Axure), to help people create their product prototypes beautifully and efficiently.',
       datetime: formatDistance(new Date(), addDays(new Date(), 2))
     }
-  ];
+  ]);
 }

--- a/components/descriptions/descriptions.spec.ts
+++ b/components/descriptions/descriptions.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import { ChangeDetectionStrategy, Component, provideZoneChangeDetection } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { provideMockDirectionality } from 'ng-zorro-antd/core/testing';
+import { provideMockDirectionality, updateNonSignalsInput } from 'ng-zorro-antd/core/testing';
 
 import { NzDescriptionsComponent } from './descriptions.component';
 import { NzDescriptionsModule } from './descriptions.module';
@@ -18,10 +18,7 @@ declare const viewport: any;
 
 describe('descriptions', () => {
   beforeEach(() => {
-    // todo: use zoneless
-    TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection()]
-    });
+    TestBed.configureTestingModule({});
   });
 
   describe('with different spans', () => {
@@ -44,7 +41,7 @@ describe('descriptions', () => {
       expect(title).toBeTruthy();
       expect(view).toBeTruthy();
 
-      testComponent.title = '';
+      testComponent.title.set('');
       fixture.detectChanges();
       title = componentElement.querySelector('.ant-descriptions-title');
       expect(title).toBeFalsy();
@@ -56,7 +53,7 @@ describe('descriptions', () => {
       rows = componentElement.querySelectorAll('.ant-descriptions-row');
       expect(rows.length).toBe(1);
 
-      testComponent.colspanArray = [1, 1, 1, 2, 3, 1, 5];
+      testComponent.colspanArray.set([1, 1, 1, 2, 3, 1, 5]);
       fixture.detectChanges();
       rows = componentElement.querySelectorAll('.ant-descriptions-row');
       expect(rows.length).toBe(3);
@@ -64,21 +61,21 @@ describe('descriptions', () => {
       expect(spyOnWarn).toHaveBeenCalledWith('[NG-ZORRO]:', '"nzColumn" is 3 but we have row length 5');
       expect(spyOnWarn).toHaveBeenCalledWith('[NG-ZORRO]:', '"nzColumn" is 3 but we have row length 6');
 
-      testComponent.column = 5;
-      testComponent.colspanArray = [1, 2, 3];
+      testComponent.column.set(5);
+      testComponent.colspanArray.set([1, 2, 3]);
       fixture.detectChanges();
       rows = componentElement.querySelectorAll('.ant-descriptions-row');
       expect(rows.length).toBe(1);
       expect(spyOnWarn).toHaveBeenCalledTimes(4);
       expect(spyOnWarn).toHaveBeenCalledWith('[NG-ZORRO]:', '"nzColumn" is 5 but we have row length 6');
 
-      testComponent.colspanArray = [1, 2, 2];
+      testComponent.colspanArray.set([1, 2, 2]);
       fixture.detectChanges();
       rows = componentElement.querySelectorAll('.ant-descriptions-row');
       expect(rows.length).toBe(1);
 
       // Should the last fill the rest space.
-      testComponent.colspanArray = [1, 1];
+      testComponent.colspanArray.set([1, 1]);
       fixture.detectChanges();
       rows = componentElement.querySelectorAll('.ant-descriptions-row');
       const tds = componentElement.querySelectorAll('.ant-descriptions-item');
@@ -87,21 +84,21 @@ describe('descriptions', () => {
       spyOnWarn.calls.reset();
     });
 
-    it('should responsive work', fakeAsync(() => {
-      testComponent.column = {
+    it('should responsive work', async () => {
+      testComponent.column.set({
         xxl: 3,
         xl: 3,
         lg: 3,
         md: 3,
         sm: 2,
         xs: 1
-      };
-      testComponent.colspanArray = [1, 1, 1, 2, 3, 1, 5];
+      });
+      testComponent.colspanArray.set([1, 1, 1, 2, 3, 1, 5]);
 
       viewport.set(1024, 1024);
       window.dispatchEvent(new Event('resize'));
       fixture.detectChanges();
-      tick(1000);
+      await updateNonSignalsInput(fixture, 1000);
       fixture.detectChanges();
       rows = componentElement.querySelectorAll('.ant-descriptions-row');
       expect(rows.length).toBe(3);
@@ -109,27 +106,27 @@ describe('descriptions', () => {
       viewport.set(320, 320);
       window.dispatchEvent(new Event('resize'));
       fixture.detectChanges();
-      tick(1000);
+      await updateNonSignalsInput(fixture, 1000);
       fixture.detectChanges();
 
       rows = componentElement.querySelectorAll('.ant-descriptions-row');
       expect(rows.length).toBe(7);
 
       viewport.reset();
-    }));
+    });
 
     // fix #3795
-    it('should change to use content work', fakeAsync(() => {
+    it('should change to use content work', async () => {
       let firstTitle = componentElement.querySelector('.ant-descriptions-item-label') as HTMLSpanElement;
       expect(firstTitle.innerText).toBe('Item Title 0');
 
-      testComponent.itemTitle = 'Item ';
+      testComponent.itemTitle.set('Item ');
       fixture.detectChanges();
-      tick(16);
+      await updateNonSignalsInput(fixture, 16);
       fixture.detectChanges();
       firstTitle = componentElement.querySelector('.ant-descriptions-item-label') as HTMLSpanElement;
       expect(firstTitle.innerText).toBe('Item 0');
-    }));
+    });
   });
 
   describe('RTL', () => {
@@ -163,18 +160,17 @@ describe('descriptions', () => {
   imports: [NzDescriptionsModule],
   selector: 'nz-test-descriptions',
   template: `
-    <nz-descriptions [nzTitle]="title" [nzBordered]="bordered" [nzColumn]="column">
-      @for (col of colspanArray; track $index) {
-        <nz-descriptions-item [nzTitle]="itemTitle + $index" [nzSpan]="col" />
+    <nz-descriptions [nzTitle]="title()" [nzBordered]="bordered()" [nzColumn]="column()">
+      @for (col of colspanArray(); track $index) {
+        <nz-descriptions-item [nzTitle]="itemTitle() + $index" [nzSpan]="col" />
       }
     </nz-descriptions>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestDescriptionsComponent {
-  bordered = false;
-  colspanArray: number[] = [1, 1, 1];
-  column: NzDescriptionsComponent['nzColumn'] = 3;
-  title = 'Title';
-  itemTitle = 'Item Title ';
+  readonly bordered = signal(false);
+  readonly colspanArray = signal<number[]>([1, 1, 1]);
+  readonly column = signal<NzDescriptionsComponent['nzColumn']>(3);
+  readonly title = signal('Title');
+  readonly itemTitle = signal('Item Title ');
 }

--- a/components/divider/divider.spec.ts
+++ b/components/divider/divider.spec.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, DebugElement, provideZoneChangeDetection, ViewChild } from '@angular/core';
+import { Component, DebugElement, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -19,9 +19,8 @@ describe('divider', () => {
   let dl: DebugElement;
 
   beforeEach(() => {
-    // todo: use zoneless
     TestBed.configureTestingModule({
-      providers: [provideNzIconsTesting(), provideZoneChangeDetection()]
+      providers: [provideNzIconsTesting()]
     });
     fixture = TestBed.createComponent(TestDividerComponent);
     context = fixture.componentInstance;
@@ -32,7 +31,7 @@ describe('divider', () => {
   describe('#nzDashed', () => {
     for (const value of [true, false]) {
       it(`[${value}]`, () => {
-        context.nzDashed = value;
+        context.nzDashed.set(value);
         fixture.detectChanges();
         expect(dl.query(By.css('.ant-divider-dashed')) != null).toBe(value);
       });
@@ -42,7 +41,7 @@ describe('divider', () => {
   describe('#nzType', () => {
     for (const value of ['horizontal', 'vertical'] as const) {
       it(`[${value}]`, () => {
-        context.nzType = value;
+        context.nzType.set(value);
         fixture.detectChanges();
         expect(dl.query(By.css(`.ant-divider-${value}`)) != null).toBe(true);
       });
@@ -55,7 +54,7 @@ describe('divider', () => {
       { text: undefined, ret: false }
     ]) {
       it(`[${item.text}]`, () => {
-        context.nzText = item.text;
+        context.nzText.set(item.text);
         fixture.detectChanges();
         expect(dl.query(By.css('.ant-divider-inner-text')) != null).toBe(item.ret);
       });
@@ -64,16 +63,16 @@ describe('divider', () => {
     it('should be custom template', () => {
       const fixture = TestBed.createComponent(TestDividerTextTemplateComponent);
       fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('.anticon-plus')) != null).toBe(true);
+      expect(fixture.debugElement.query(By.css('.anticon-plus'))).not.toBeNull();
     });
   });
 
   describe('#nzOrientation', () => {
     (['center', 'left', 'right'] as const).forEach(type => {
       it(`with ${type}`, () => {
-        context.nzOrientation = type;
+        context.nzOrientation.set(type);
         fixture.detectChanges();
-        expect(dl.query(By.css(`.ant-divider-with-text-${type}`)) != null).toBe(true);
+        expect(dl.query(By.css(`.ant-divider-with-text-${type}`))).not.toBeNull();
       });
     });
   });
@@ -81,9 +80,9 @@ describe('divider', () => {
   describe('#nzVariant', () => {
     (['dashed', 'dotted'] as const).forEach(type => {
       it(`with ${type}`, () => {
-        context.comp.nzVariant = type;
+        context.nzVariant.set(type);
         fixture.detectChanges();
-        expect(dl.query(By.css(`.ant-divider-${type}`)) != null).toBe(true);
+        expect(dl.query(By.css(`.ant-divider-${type}`))).not.toBeNull();
       });
     });
 
@@ -95,7 +94,7 @@ describe('divider', () => {
   describe('#nzPlain', () => {
     for (const value of [true, false]) {
       it(`[${value}]`, () => {
-        context.comp.nzPlain = value;
+        context.nzPlain.set(value);
         fixture.detectChanges();
         expect(dl.query(By.css('.ant-divider-plain')) != null).toBe(value);
       });
@@ -113,7 +112,7 @@ describe('divider', () => {
 
     (['small', 'middle', 'large'] as const).forEach(size => {
       it(`with ${size}`, () => {
-        context.comp.nzSize = size;
+        context.nzSize.set(size);
         fixture.detectChanges();
         const el = dl.query(By.css('.ant-divider'))!.nativeElement as HTMLElement;
         expect(el.classList.contains('ant-divider-sm')).toBe(size === 'small');
@@ -126,15 +125,15 @@ describe('divider', () => {
 
   describe('#with text class', () => {
     it('should have ant-divider-with-text when nzText set', () => {
-      context.nzText = 'text';
+      context.nzText.set('text');
       fixture.detectChanges();
-      expect(dl.query(By.css('.ant-divider-with-text')) != null).toBe(true);
+      expect(dl.query(By.css('.ant-divider-with-text'))).not.toBeNull();
     });
 
     it('should not have ant-divider-with-text when nzText removed', () => {
-      context.nzText = undefined;
+      context.nzText.set(undefined);
       fixture.detectChanges();
-      expect(dl.query(By.css('.ant-divider-with-text')) == null).toBe(true);
+      expect(dl.query(By.css('.ant-divider-with-text'))).toBeNull();
     });
   });
 });
@@ -142,16 +141,27 @@ describe('divider', () => {
 @Component({
   imports: [NzDividerModule],
   template: `
-    <nz-divider #comp [nzDashed]="nzDashed" [nzType]="nzType" [nzText]="nzText" [nzOrientation]="nzOrientation" />
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+    <nz-divider
+      #comp
+      [nzDashed]="nzDashed()"
+      [nzType]="nzType()"
+      [nzText]="nzText()"
+      [nzOrientation]="nzOrientation()"
+      [nzVariant]="nzVariant()"
+      [nzPlain]="nzPlain()"
+      [nzSize]="nzSize()"
+    />
+  `
 })
 class TestDividerComponent {
   @ViewChild('comp', { static: false }) comp!: NzDividerComponent;
-  nzDashed = false;
-  nzType: 'vertical' | 'horizontal' = 'horizontal';
-  nzText?: string = 'with text';
-  nzOrientation!: 'left' | 'right' | 'center';
+  readonly nzDashed = signal(false);
+  readonly nzType = signal<'vertical' | 'horizontal'>('horizontal');
+  readonly nzText = signal<string | undefined>('with text');
+  readonly nzOrientation = signal<'left' | 'right' | 'center'>('center');
+  readonly nzVariant = signal<'dashed' | 'dotted' | 'solid'>('solid');
+  readonly nzPlain = signal(false);
+  readonly nzSize = signal<'small' | 'middle' | 'large' | undefined>(undefined);
 }
 
 @Component({
@@ -163,7 +173,6 @@ class TestDividerComponent {
         Add
       </ng-template>
     </nz-divider>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 class TestDividerTextTemplateComponent {}

--- a/components/flex/flex.spec.ts
+++ b/components/flex/flex.spec.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, provideZoneChangeDetection } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -27,13 +27,6 @@ describe('flex', () => {
   let element: HTMLElement;
 
   beforeEach(() => {
-    // todo: use zoneless
-    TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection()]
-    });
-  });
-
-  beforeEach(() => {
     fixture = TestBed.createComponent(TestFlexComponent);
     element = fixture.debugElement.query(By.directive(NzFlexDirective)).nativeElement;
     component = fixture.componentInstance;
@@ -45,10 +38,10 @@ describe('flex', () => {
   });
 
   it('should have correct direction', () => {
-    component.isVertical = false;
+    component.isVertical.set(false);
     fixture.detectChanges();
     expect(element.className).not.toContain('vertical');
-    component.isVertical = true;
+    component.isVertical.set(true);
     fixture.detectChanges();
     expect(element.className).toContain('vertical');
   });
@@ -69,7 +62,7 @@ describe('flex', () => {
       'normal'
     ];
     listOfJustifications.forEach(justification => {
-      component.justify = justification;
+      component.justify.set(justification);
       fixture.detectChanges();
       expect(element.className).toContain(justification);
     });
@@ -78,7 +71,7 @@ describe('flex', () => {
   it('should have correct alignment value', () => {
     const listOfAlignments: NzAlign[] = ['flex-start', 'center', 'flex-end', 'start', 'end', 'stretch', 'normal'];
     listOfAlignments.forEach(alignment => {
-      component.align = alignment;
+      component.align.set(alignment);
       fixture.detectChanges();
       expect(element.className).toContain(alignment);
     });
@@ -87,7 +80,7 @@ describe('flex', () => {
   it('should have correct gap value', () => {
     const listOfGaps: NzGap[] = ['small', 'middle', 'large', 10, 20, 30, 40];
     listOfGaps.forEach(gap => {
-      component.gap = gap;
+      component.gap.set(gap);
       fixture.detectChanges();
       let gapValue: string;
       switch (gap) {
@@ -107,7 +100,7 @@ describe('flex', () => {
       expect(getComputedStyle(element).getPropertyValue('gap')).toEqual(gapValue);
     });
 
-    component.gap = '10rem';
+    component.gap.set('10rem');
     fixture.detectChanges();
     expect(getComputedStyle(element).getPropertyValue('gap')).toEqual(`${10 * 16}px`);
   });
@@ -115,7 +108,7 @@ describe('flex', () => {
   it('should have correct wrap value', () => {
     const listOfWraps: NzWrap[] = ['wrap', 'nowrap', 'wrap-reverse'];
     listOfWraps.forEach(wrap => {
-      component.wrap = wrap;
+      component.wrap.set(wrap);
       fixture.detectChanges();
       expect(element.className).toContain(`flex-wrap-${wrap}`);
     });
@@ -124,12 +117,12 @@ describe('flex', () => {
   it('should have correct flex value', () => {
     const listOfFlexes: NzFlex[] = ['0 0 auto', '1 1 100%', '0 1 50px'];
     listOfFlexes.forEach(flex => {
-      component.flex = flex;
+      component.flex.set(flex);
       fixture.detectChanges();
       expect(getComputedStyle(element).getPropertyValue('flex')).toEqual(flex);
     });
 
-    component.flex = '1 0 50rem';
+    component.flex.set('1 0 50rem');
     fixture.detectChanges();
     expect(getComputedStyle(element).getPropertyValue('flex')).toEqual('1 0 800px');
   });
@@ -164,25 +157,24 @@ describe('flex', () => {
   template: `
     <div
       nz-flex
-      [nzVertical]="isVertical"
-      [nzJustify]="justify"
-      [nzAlign]="align"
-      [nzGap]="gap"
-      [nzWrap]="wrap"
-      [nzFlex]="flex"
+      [nzVertical]="isVertical()"
+      [nzJustify]="justify()"
+      [nzAlign]="align()"
+      [nzGap]="gap()"
+      [nzWrap]="wrap()"
+      [nzFlex]="flex()"
     >
       <div></div>
       <div></div>
       <div></div>
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class TestFlexComponent {
-  isVertical = false;
-  justify: NzJustify = 'normal';
-  align: NzAlign = 'normal';
-  gap: 'small' | 'middle' | 'large' | NzCustomGap = 0;
-  wrap: 'wrap' | 'nowrap' | 'wrap-reverse' = 'nowrap';
-  flex: `${NzFlexShrink} ${NzFlexGrow} ${NzFlexBasis}` | 'unset' = 'unset';
+  readonly isVertical = signal(false);
+  readonly justify = signal<NzJustify>('normal');
+  readonly align = signal<NzAlign>('normal');
+  readonly gap = signal<'small' | 'middle' | 'large' | NzCustomGap>(0);
+  readonly wrap = signal<'wrap' | 'nowrap' | 'wrap-reverse'>('nowrap');
+  readonly flex = signal<`${NzFlexShrink} ${NzFlexGrow} ${NzFlexBasis}` | 'unset'>('unset');
 }

--- a/components/float-button/float-button-group.component.spec.ts
+++ b/components/float-button/float-button-group.component.spec.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, DebugElement, provideZoneChangeDetection } from '@angular/core';
+import { Component, DebugElement, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -17,9 +17,8 @@ import { NzFloatButtonModule } from './float-button.module';
 
 describe('nz-float-button-group', () => {
   beforeEach(() => {
-    // todo: use zoneless
     TestBed.configureTestingModule({
-      providers: [provideNzIconsTesting(), provideZoneChangeDetection()]
+      providers: [provideNzIconsTesting()]
     });
   });
 
@@ -43,7 +42,7 @@ describe('nz-float-button-group', () => {
     });
 
     it('nzShape', () => {
-      testComponent.nzShape = 'square';
+      testComponent.nzShape.set('square');
       fixture.detectChanges();
       expect(resultEl.nativeElement.classList).toContain('ant-float-btn-group-square');
       const innerButtons = [
@@ -56,38 +55,38 @@ describe('nz-float-button-group', () => {
     });
 
     it('nzTrigger hover', () => {
-      testComponent.nzTrigger = 'hover';
+      testComponent.nzTrigger.set('hover');
       fixture.detectChanges();
       resultEl.nativeElement.getElementsByClassName('ant-float-btn')[0].dispatchEvent(new MouseEvent('mouseover'));
       fixture.detectChanges();
       expect(resultEl.nativeElement.getElementsByClassName('anticon')[0].getAttribute('nztype') === 'close').toBe(true);
-      expect(testComponent.isClick).toBe(true);
+      expect(testComponent.isClick()).toBe(true);
       resultEl.nativeElement.dispatchEvent(new MouseEvent('mouseleave'));
       fixture.detectChanges();
       expect(resultEl.nativeElement.getElementsByClassName('anticon')[0].getAttribute('nztype') === 'close').toBe(
         false
       );
-      expect(testComponent.isClick).toBe(false);
+      expect(testComponent.isClick()).toBe(false);
     });
 
     it('nzTrigger click', () => {
-      testComponent.nzTrigger = 'click';
+      testComponent.nzTrigger.set('click');
       fixture.detectChanges();
       resultEl.nativeElement.getElementsByClassName('ant-btn')[0].dispatchEvent(new MouseEvent('click'));
       fixture.detectChanges();
       expect(resultEl.nativeElement.getElementsByClassName('anticon')[0].getAttribute('nztype') === 'close').toBe(true);
-      expect(testComponent.isClick).toBe(true);
+      expect(testComponent.isClick()).toBe(true);
       resultEl.nativeElement.getElementsByClassName('ant-btn')[0].dispatchEvent(new MouseEvent('click'));
       fixture.detectChanges();
       expect(resultEl.nativeElement.getElementsByClassName('anticon')[0].getAttribute('nztype') === 'close').toBe(
         false
       );
-      expect(testComponent.isClick).toBe(false);
+      expect(testComponent.isClick()).toBe(false);
     });
 
     it('nzOpen true', () => {
-      testComponent.nzOpen = true;
-      testComponent.nzTrigger = 'click';
+      testComponent.nzOpen.set(true);
+      testComponent.nzTrigger.set('click');
       fixture.detectChanges();
       const openChangeSpy = spyOn(groupComponent.nzOpenChange, 'emit');
       resultEl.nativeElement.getElementsByClassName('ant-btn')[0].dispatchEvent(new MouseEvent('click'));
@@ -98,8 +97,8 @@ describe('nz-float-button-group', () => {
     });
 
     it('nzOpen false', () => {
-      testComponent.nzOpen = false;
-      testComponent.nzTrigger = 'click';
+      testComponent.nzOpen.set(false);
+      testComponent.nzTrigger.set('click');
       fixture.detectChanges();
       const openChangeSpy = spyOn(groupComponent.nzOpenChange, 'emit');
       resultEl.nativeElement.getElementsByClassName('ant-btn')[0].dispatchEvent(new MouseEvent('click'));
@@ -112,8 +111,8 @@ describe('nz-float-button-group', () => {
     });
 
     it('nzOpenChange should emit in controlled mode', () => {
-      testComponent.nzOpen = true;
-      testComponent.nzTrigger = 'click';
+      testComponent.nzOpen.set(true);
+      testComponent.nzTrigger.set('click');
       fixture.detectChanges();
       const openChangeSpy = spyOn(groupComponent.nzOpenChange, 'emit');
       resultEl.nativeElement.getElementsByClassName('ant-btn')[0].dispatchEvent(new MouseEvent('click'));
@@ -123,45 +122,45 @@ describe('nz-float-button-group', () => {
 
     describe('float-button-group placement', () => {
       it('should set correct class for nzPlacement top', () => {
-        testComponent.nzTrigger = 'click';
-        testComponent.nzPlacement = 'top';
+        testComponent.nzTrigger.set('click');
+        testComponent.nzPlacement.set('top');
         fixture.detectChanges();
         expect(resultEl.nativeElement.classList).toContain('ant-float-btn-group-top');
         // is not menu mode
-        testComponent.nzTrigger = null;
+        testComponent.nzTrigger.set(null);
         fixture.detectChanges();
         expect(resultEl.nativeElement.classList).not.toContain('ant-float-btn-group-top');
       });
 
       it('should set correct class for nzPlacement bottom', () => {
-        testComponent.nzTrigger = 'click';
-        testComponent.nzPlacement = 'bottom';
+        testComponent.nzTrigger.set('click');
+        testComponent.nzPlacement.set('bottom');
         fixture.detectChanges();
         expect(resultEl.nativeElement.classList).toContain('ant-float-btn-group-bottom');
         // is not menu mode
-        testComponent.nzTrigger = null;
+        testComponent.nzTrigger.set(null);
         fixture.detectChanges();
         expect(resultEl.nativeElement.classList).not.toContain('ant-float-btn-group-bottom');
       });
 
       it('should set correct class for nzPlacement left', () => {
-        testComponent.nzTrigger = 'click';
-        testComponent.nzPlacement = 'left';
+        testComponent.nzTrigger.set('click');
+        testComponent.nzPlacement.set('left');
         fixture.detectChanges();
         expect(resultEl.nativeElement.classList).toContain('ant-float-btn-group-left');
         // is not menu mode
-        testComponent.nzTrigger = null;
+        testComponent.nzTrigger.set(null);
         fixture.detectChanges();
         expect(resultEl.nativeElement.classList).not.toContain('ant-float-btn-group-left');
       });
 
       it('should set correct class for nzPlacement right', () => {
-        testComponent.nzTrigger = 'click';
-        testComponent.nzPlacement = 'right';
+        testComponent.nzTrigger.set('click');
+        testComponent.nzPlacement.set('right');
         fixture.detectChanges();
         expect(resultEl.nativeElement.classList).toContain('ant-float-btn-group-right');
         // is not menu mode
-        testComponent.nzTrigger = null;
+        testComponent.nzTrigger.set(null);
         fixture.detectChanges();
         expect(resultEl.nativeElement.classList).not.toContain('ant-float-btn-group-right');
       });
@@ -172,7 +171,7 @@ describe('nz-float-button-group', () => {
         const { enterAnimation, leaveAnimation } = groupComponent;
         expect(enterAnimation()).toBe('ant-float-btn-enter-top');
         expect(leaveAnimation()).toBe('ant-float-btn-leave-top');
-        testComponent.nzPlacement = 'right';
+        testComponent.nzPlacement.set('right');
         fixture.detectChanges();
         expect(enterAnimation()).toBe('ant-float-btn-enter-right');
         expect(leaveAnimation()).toBe('ant-float-btn-leave-right');
@@ -193,24 +192,23 @@ describe('nz-float-button-group', () => {
   template: `
     <nz-float-button-group
       nzIcon="question-circle"
-      [nzShape]="nzShape"
-      [nzTrigger]="nzTrigger"
-      [nzOpen]="nzOpen"
-      [nzPlacement]="nzPlacement"
+      [nzShape]="nzShape()"
+      [nzTrigger]="nzTrigger()"
+      [nzOpen]="nzOpen()"
+      [nzPlacement]="nzPlacement()"
       (nzOnOpenChange)="onClick($event)"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestFloatButtonGroupBasicComponent {
-  nzShape: NzShapeSCType = 'circle';
-  nzTrigger: 'click' | 'hover' | null = null;
-  nzOpen: boolean | null = null;
-  nzPlacement: NzFourDirectionType = 'top';
+  readonly nzShape = signal<NzShapeSCType>('circle');
+  readonly nzTrigger = signal<'click' | 'hover' | null>(null);
+  readonly nzOpen = signal<boolean | null>(null);
+  readonly nzPlacement = signal<NzFourDirectionType>('top');
 
-  isClick: boolean = false;
+  readonly isClick = signal(false);
 
   onClick(value: boolean): void {
-    this.isClick = value;
+    this.isClick.set(value);
   }
 }

--- a/components/grid/grid.spec.ts
+++ b/components/grid/grid.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { Directionality } from '@angular/cdk/bidi';
-import { ChangeDetectionStrategy, Component, signal, WritableSignal } from '@angular/core';
+import { Component, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -294,8 +294,7 @@ describe('grid', () => {
     <div nz-row [nzGutter]="gutter()" [nzJustify]="justify()" [nzAlign]="align()" [nzWrap]="wrap()">
       <div nz-col></div>
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class TestGridComponent {
   gutter = signal<Gutter | [Gutter, Gutter] | null>(null);
@@ -326,8 +325,7 @@ export class TestGridComponent {
         [nzXXXl]="xxxl()"
       ></div>
     </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class TestColComponent {
   span = signal<number | null>(null);

--- a/components/hash-code/hash-code.component.spec.ts
+++ b/components/hash-code/hash-code.component.spec.ts
@@ -3,11 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, DebugElement, provideZoneChangeDetection } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, DebugElement, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
+import { dispatchMouseEvent, updateNonSignalsInput } from 'ng-zorro-antd/core/testing';
 
 import { NzHashCodeComponent } from './hash-code.component';
 import { NzHashCodeModule } from './hash-code.module';
@@ -18,17 +18,14 @@ describe('hash-code', () => {
   let testComponent: NzTestHashCodeBasicComponent;
   let resultEl: DebugElement;
 
-  function waitingForTooltipToggling(): void {
+  async function waitingForTooltipToggling(): Promise<void> {
     fixture.detectChanges();
-    tick(500);
+    await updateNonSignalsInput(fixture, 500);
     fixture.detectChanges();
   }
 
   beforeEach(() => {
-    // todo: use zoneless
-    TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection()]
-    });
+    TestBed.configureTestingModule({});
   });
 
   beforeEach(() => {
@@ -48,20 +45,21 @@ describe('hash-code', () => {
   });
 
   it('should value length work', () => {
-    testComponent.value =
-      '683109f0f40ca72a15e05cc20931f8e6683109f0f40ca72a15e05cc20931f8e6683109f0f40ca72a15e05cc20931f8e6683109f0f40ca72a15e05cc20931f8e6';
+    testComponent.value.set(
+      '683109f0f40ca72a15e05cc20931f8e6683109f0f40ca72a15e05cc20931f8e6683109f0f40ca72a15e05cc20931f8e6683109f0f40ca72a15e05cc20931f8e6'
+    );
     fixture.detectChanges();
     expect(resultEl.nativeElement.querySelectorAll('.ant-hash-code-code-value-block').length).toBe(8);
-    testComponent.value = '683109f0f40ca72a15e05cc20931f8e6';
+    testComponent.value.set('683109f0f40ca72a15e05cc20931f8e6');
     fixture.detectChanges();
     expect(resultEl.nativeElement.querySelectorAll('.ant-hash-code-code-value-block').length).toBe(8);
-    testComponent.value = '683109f0f40ca72a';
+    testComponent.value.set('683109f0f40ca72a');
     fixture.detectChanges();
     expect(resultEl.nativeElement.querySelectorAll('.ant-hash-code-code-value-block').length).toBe(4);
   });
 
   it('should mode single work', () => {
-    testComponent.mode = 'single';
+    testComponent.mode.set('single');
     fixture.detectChanges();
     expect(!!resultEl.nativeElement.querySelector('.ant-hash-code-header')).toBeFalse();
     expect(!!resultEl.nativeElement.querySelector('.ant-hash-code-header-copy')).toBeTrue();
@@ -69,13 +67,13 @@ describe('hash-code', () => {
   });
 
   it('should mode strip work', () => {
-    testComponent.mode = 'strip';
+    testComponent.mode.set('strip');
     fixture.detectChanges();
     expect(resultEl.nativeElement.classList).toContain('ant-hash-code-strip');
   });
 
   it('should rect mode work', () => {
-    testComponent.mode = 'rect';
+    testComponent.mode.set('rect');
     fixture.detectChanges();
     expect(!!resultEl.nativeElement.querySelector('.ant-hash-code-header')).toBeFalse();
     expect(!!resultEl.nativeElement.querySelector('.ant-hash-code-header-copy')).toBeTrue();
@@ -83,43 +81,42 @@ describe('hash-code', () => {
   });
 
   it('should type work', () => {
-    testComponent.type = 'primary';
+    testComponent.type.set('primary');
     fixture.detectChanges();
     expect(resultEl.nativeElement.classList).toContain('ant-hash-code-primary');
   });
 
-  it('should copy work', fakeAsync(() => {
+  it('should copy work', async () => {
     fixture.detectChanges();
     const copy = resultEl.nativeElement.querySelector('.ant-hash-code-header-copy');
     dispatchMouseEvent(copy, 'click');
-    waitingForTooltipToggling();
-    expect(testComponent.copyValue).toBe(testComponent.value);
-  }));
+    await waitingForTooltipToggling();
+    expect(testComponent.copyValue()).toBe(testComponent.value());
+  });
 });
 
 @Component({
   imports: [NzHashCodeModule],
   template: `
     <nz-hash-code
-      [nzValue]="value"
-      [nzTitle]="title"
-      [nzLogo]="logo"
-      [nzMode]="mode"
-      [nzType]="type"
+      [nzValue]="value()"
+      [nzTitle]="title()"
+      [nzLogo]="logo()"
+      [nzMode]="mode()"
+      [nzType]="type()"
       (nzOnCopy)="onCopy($event)"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestHashCodeBasicComponent {
-  value = 'dfb5fe9ef7b99b2b1db102114a6d7d445d992f40a5d575f801c148990199a068';
-  title = 'HashCode';
-  logo = 'Antd';
-  mode: NzModeType = 'double';
-  type: 'default' | 'primary' = 'default';
-  copyValue = '';
+  readonly value = signal('dfb5fe9ef7b99b2b1db102114a6d7d445d992f40a5d575f801c148990199a068');
+  readonly title = signal('HashCode');
+  readonly logo = signal('Antd');
+  readonly mode = signal<NzModeType>('double');
+  readonly type = signal<'default' | 'primary'>('default');
+  readonly copyValue = signal('');
 
   onCopy(value: string): void {
-    this.copyValue = value;
+    this.copyValue.set(value);
   }
 }

--- a/components/page-header/page-header.spec.ts
+++ b/components/page-header/page-header.spec.ts
@@ -4,13 +4,11 @@
  */
 
 import { Location } from '@angular/common';
-import { provideZoneChangeDetection } from '@angular/core';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { testDirectionality } from 'ng-zorro-antd/core/testing';
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 
 import { NzDemoPageHeaderBasicComponent } from './demo/basic';
@@ -24,18 +22,8 @@ describe('page-header', () => {
   let location: Location;
 
   beforeEach(() => {
-    // todo: use zoneless
     TestBed.configureTestingModule({
-      providers: [provideNoopAnimations(), provideNzIconsTesting(), provideZoneChangeDetection()]
-    });
-    [
-      NzDemoPageHeaderBasicComponent,
-      NzDemoPageHeaderBreadcrumbComponent,
-      NzDemoPageHeaderContentComponent,
-      NzDemoPageHeaderGhostComponent,
-      NzDemoPageHeaderResponsiveComponent
-    ].forEach(comp => {
-      (comp as NzSafeAny).ɵcmp.onPush = false;
+      providers: [provideNoopAnimations(), provideNzIconsTesting()]
     });
     location = TestBed.inject(Location);
     spyOn(location, 'getState').and.returnValue({ navigationId: 2 });
@@ -87,28 +75,26 @@ describe('page-header', () => {
     expect(location.back).toHaveBeenCalled();
   });
 
-  it('should not show the back button if there is no history of navigation', fakeAsync(() => {
+  it('should not show the back button if there is no history of navigation', async () => {
     const fixture = TestBed.createComponent(NzDemoPageHeaderResponsiveComponent);
     const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
     spyOn(location, 'getState').and.returnValue({ navigationId: 1 });
-    fixture.detectChanges();
+    fixture.autoDetectChanges();
     pageHeader.componentInstance.ngAfterViewInit();
-    tick();
-    fixture.detectChanges();
+    await fixture.whenStable();
     const back = pageHeader.nativeElement.querySelector('.ant-page-header-back-button');
     expect(back).toBeNull();
-  }));
+  });
 
-  it('should show the back button if there is history of navigation', fakeAsync(() => {
+  it('should show the back button if there is history of navigation', async () => {
     const fixture = TestBed.createComponent(NzDemoPageHeaderResponsiveComponent);
     const pageHeader = fixture.debugElement.query(By.directive(NzPageHeaderComponent));
-    fixture.detectChanges();
+    fixture.autoDetectChanges();
     pageHeader.componentInstance.ngAfterViewInit();
-    tick();
-    fixture.detectChanges();
+    await fixture.whenStable();
     const back = pageHeader.nativeElement.querySelector('.ant-page-header-back-button');
     expect(back as HTMLDivElement).toBeTruthy();
-  }));
+  });
 
   it('should content work', () => {
     const fixture = TestBed.createComponent(NzDemoPageHeaderContentComponent);
@@ -171,5 +157,5 @@ describe('page-header', () => {
 });
 
 testDirectionality(() => NzDemoPageHeaderBasicComponent, By.directive(NzPageHeaderComponent), 'ant-page-header', {
-  providers: [provideNoopAnimations(), provideNzIconsTesting(), provideZoneChangeDetection()]
+  providers: [provideNoopAnimations(), provideNzIconsTesting()]
 });

--- a/components/qr-code/qrcode.component.spec.ts
+++ b/components/qr-code/qrcode.component.spec.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, DebugElement, provideZoneChangeDetection } from '@angular/core';
+import { Component, DebugElement, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -14,9 +14,8 @@ import { NzQRCodeModule } from './qrcode.module';
 
 describe('qrcode', () => {
   beforeEach(() => {
-    // todo: use zoneless
     TestBed.configureTestingModule({
-      providers: [provideNzIconsTesting(), provideZoneChangeDetection()]
+      providers: [provideNzIconsTesting()]
     });
   });
 
@@ -33,27 +32,27 @@ describe('qrcode', () => {
     });
 
     it('qr code bordered', () => {
-      testComponent.bordered = false;
+      testComponent.bordered.set(false);
       fixture.detectChanges();
       expect(resultEl.nativeElement.classList).not.toContain('ant-qrcode-border');
     });
 
     it('qr code width', () => {
-      testComponent.size = 200;
+      testComponent.size.set(200);
       fixture.detectChanges();
       const widthView = resultEl.nativeElement.querySelector('.ant-qrcode > nz-qrcode-canvas > canvas');
       expect(widthView.style.width).toBe('200px');
     });
 
     it('qr code type', () => {
-      testComponent.type = 'svg';
+      testComponent.type.set('svg');
       fixture.detectChanges();
       const widthView = resultEl.nativeElement.querySelector('.ant-qrcode > nz-qrcode-svg > svg');
       expect(widthView.nodeName).toBe('svg');
     });
 
     it('qr code custom status', () => {
-      testComponent.statusRender = 'custom status';
+      testComponent.statusRender.set('custom status');
       fixture.detectChanges();
       const statusView = resultEl.nativeElement.querySelector('.ant-qrcode-mask');
       expect(statusView.innerText).toBe('custom status');
@@ -63,7 +62,7 @@ describe('qrcode', () => {
       const statusList: Array<'active' | 'expired' | 'loading' | 'scanned'> = ['expired', 'loading', 'scanned'];
 
       for (let i = 0; i < statusList.length; i++) {
-        testComponent.status = statusList[i];
+        testComponent.status.set(statusList[i]);
         fixture.detectChanges();
         const statusView = resultEl.nativeElement.querySelector('.ant-qrcode-mask');
         if (i === 1) {
@@ -78,21 +77,22 @@ describe('qrcode', () => {
 
 @Component({
   imports: [NzQRCodeModule],
-  template: `<nz-qrcode
-    [nzValue]="value"
-    [nzSize]="size"
-    [nzType]="type"
-    [nzBordered]="bordered"
-    [nzStatus]="status"
-    [nzStatusRender]="statusRender"
-  />`,
-  changeDetection: ChangeDetectionStrategy.Eager
+  template: `
+    <nz-qrcode
+      [nzValue]="value"
+      [nzSize]="size()"
+      [nzType]="type()"
+      [nzBordered]="bordered()"
+      [nzStatus]="status()"
+      [nzStatusRender]="statusRender()"
+    />
+  `
 })
 export class NzTestQrCodeBasicComponent {
   value: string = 'https://ng.ant.design/';
-  type: 'svg' | 'canvas' = 'canvas';
-  size: number = 160;
-  bordered: boolean = true;
-  statusRender: string | null = null;
-  status: 'active' | 'expired' | 'loading' | 'scanned' = 'active';
+  readonly type = signal<'svg' | 'canvas'>('canvas');
+  readonly size = signal(160);
+  readonly bordered = signal(true);
+  readonly statusRender = signal<string | null>(null);
+  readonly status = signal<'active' | 'expired' | 'loading' | 'scanned'>('active');
 }

--- a/components/resizable/demo/grid.ts
+++ b/components/resizable/demo/grid.ts
@@ -18,7 +18,7 @@ import { NzResizableModule, NzResizeEvent, NzResizeHandleOption } from 'ng-zorro
         [nzGridColumnCount]="24"
         [nzSpan]="col()"
       >
-        <nz-resize-handles [nzDirections]="directions" />
+        <nz-resize-handles [nzDirections]="directions()" />
         col-{{ col() }}
       </div>
       <div class="col right" nz-col [nzSpan]="24 - col()">col-{{ 24 - col() }}</div>
@@ -44,12 +44,12 @@ import { NzResizableModule, NzResizeEvent, NzResizeHandleOption } from 'ng-zorro
 export class NzDemoResizableGridComponent {
   readonly col = signal(8);
   id = -1;
-  directions: NzResizeHandleOption[] = [
+  readonly directions = signal<NzResizeHandleOption[]>([
     {
       direction: 'right',
       cursorType: 'grid'
     }
-  ];
+  ]);
 
   onResize({ col }: NzResizeEvent): void {
     cancelAnimationFrame(this.id);

--- a/components/resizable/resizable.spec.ts
+++ b/components/resizable/resizable.spec.ts
@@ -3,20 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import {
-  ApplicationRef,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  NgZone,
-  provideZoneChangeDetection,
-  ViewChild
-} from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { ApplicationRef, Component, ElementRef, NgZone, signal, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { dispatchMouseEvent, dispatchTouchEvent, MockNgZone } from 'ng-zorro-antd/core/testing';
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { dispatchMouseEvent, dispatchTouchEvent, MockNgZone, updateNonSignalsInput } from 'ng-zorro-antd/core/testing';
 import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 import { NzResizableModule } from 'ng-zorro-antd/resizable/resizable.module';
 
@@ -31,11 +22,9 @@ import { DEFAULT_RESIZE_DIRECTION } from './resize-handles.component';
 describe('resizable', () => {
   let zone: MockNgZone;
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        // todo: use zoneless
-        provideZoneChangeDetection(),
         provideNzIconsTesting(),
         {
           provide: NgZone,
@@ -46,16 +35,7 @@ describe('resizable', () => {
         }
       ]
     });
-    [
-      NzDemoResizableBasicComponent,
-      NzDemoResizableCustomizeComponent,
-      NzDemoResizableGridComponent,
-      NzDemoResizableLockAspectRatioComponent,
-      NzDemoResizablePreviewComponent
-    ].forEach(comp => {
-      (comp as NzSafeAny).ɵcmp.onPush = false;
-    });
-  }));
+  });
 
   describe('basic', () => {
     let fixture: ComponentFixture<NzDemoResizableBasicComponent>;
@@ -626,16 +606,16 @@ describe('resizable', () => {
       });
     });
 
-    it('should cursor type work', () => {
+    it('should cursor type work', async () => {
       expect(resizableEle.querySelector('.nz-resizable-handle-cursor-type-window')).toBeFalsy();
       expect(resizableEle.querySelector('.nz-resizable-handle-cursor-type-grid')).toBeTruthy();
-      testComponent.directions = [
+      testComponent.directions.set([
         {
           direction: 'right',
           cursorType: 'window'
         }
-      ];
-      fixture.detectChanges();
+      ]);
+      await updateNonSignalsInput(fixture);
       expect(resizableEle.querySelector('.nz-resizable-handle-cursor-type-window')).toBeTruthy();
       expect(resizableEle.querySelector('.nz-resizable-handle-cursor-type-grid')).toBeFalsy();
     });
@@ -670,6 +650,7 @@ describe('resizable', () => {
       fixture.detectChanges();
 
       afterNextFrameRender(() => {
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         expect(testComponent.width).toBe(200);
         expect(testComponent.height).toBe(200);
@@ -680,6 +661,7 @@ describe('resizable', () => {
     it('should element ref bounds work', done => {
       const rect = resizableEle.getBoundingClientRect();
       testComponent.bounds = testComponent.boxRef;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       const handle = resizableEle.querySelector('.nz-resizable-handle-bottomRight') as HTMLElement;
       mouseMoveTrigger(
@@ -696,6 +678,7 @@ describe('resizable', () => {
       fixture.detectChanges();
 
       afterNextFrameRender(() => {
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         expect(testComponent.width).toBe(256);
         expect(testComponent.height).toBe(256);
@@ -706,6 +689,7 @@ describe('resizable', () => {
     it('should window bounds work', done => {
       const rect = resizableEle.getBoundingClientRect();
       testComponent.bounds = 'window';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       const handle = resizableEle.querySelector('.nz-resizable-handle-bottomRight') as HTMLElement;
       mouseMoveTrigger(
@@ -722,11 +706,13 @@ describe('resizable', () => {
       fixture.detectChanges();
 
       afterNextFrameRender(() => {
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         expect(testComponent.width).toBe(300);
         expect(testComponent.height).toBe(300);
         testComponent.maxHeight = window.innerHeight * 2;
         testComponent.maxWidth = window.innerWidth * 2;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         mouseMoveTrigger(
           handle,
@@ -742,6 +728,7 @@ describe('resizable', () => {
         fixture.detectChanges();
 
         afterNextFrameRender(() => {
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           expect(testComponent.width).toBe(window.innerWidth);
           expect(testComponent.height).toBe(window.innerHeight);
@@ -800,17 +787,56 @@ function afterNextFrameRender(callbackFn: () => void): void {
       width: 200px;
       height: 200px;
     }
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 class NzTestResizableBoundsComponent {
   @ViewChild('boxRef', { static: false }) boxRef!: ElementRef<HTMLDivElement>;
-  bounds: 'window' | 'parent' | ElementRef = 'parent';
-  maxWidth = 300;
-  maxHeight = 300;
-  width = 100;
-  height = 100;
+  private readonly boundsSignal = signal<'window' | 'parent' | ElementRef>('parent');
+  private readonly maxWidthSignal = signal(300);
+  private readonly maxHeightSignal = signal(300);
+  private readonly widthSignal = signal(100);
+  private readonly heightSignal = signal(100);
   id = -1;
+
+  get bounds(): 'window' | 'parent' | ElementRef {
+    return this.boundsSignal();
+  }
+
+  set bounds(value: 'window' | 'parent' | ElementRef) {
+    this.boundsSignal.set(value);
+  }
+
+  get maxWidth(): number {
+    return this.maxWidthSignal();
+  }
+
+  set maxWidth(value: number) {
+    this.maxWidthSignal.set(value);
+  }
+
+  get maxHeight(): number {
+    return this.maxHeightSignal();
+  }
+
+  set maxHeight(value: number) {
+    this.maxHeightSignal.set(value);
+  }
+
+  get width(): number {
+    return this.widthSignal();
+  }
+
+  set width(value: number) {
+    this.widthSignal.set(value);
+  }
+
+  get height(): number {
+    return this.heightSignal();
+  }
+
+  set height(value: number) {
+    this.heightSignal.set(value);
+  }
 
   onResize({ width, height }: NzResizeEvent): void {
     cancelAnimationFrame(this.id);

--- a/components/timeline/timeline.spec.ts
+++ b/components/timeline/timeline.spec.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, DebugElement, provideZoneChangeDetection, ViewChild } from '@angular/core';
+import { Component, DebugElement, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -16,10 +16,7 @@ import { NzTimelineMode } from './typings';
 
 describe('nz-timeline', () => {
   beforeEach(() => {
-    // todo: use zoneless
-    TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection()]
-    });
+    TestBed.configureTestingModule({});
   });
 
   describe('basic', () => {
@@ -47,10 +44,10 @@ describe('nz-timeline', () => {
     it('should color work', () => {
       fixture.detectChanges();
       expect(items[0].querySelector('.ant-timeline-item-head')!.classList).toContain('ant-timeline-item-head-blue');
-      testComponent.color = 'red';
+      testComponent.color.set('red');
       fixture.detectChanges();
       expect(items[0].querySelector('.ant-timeline-item-head')!.classList).toContain('ant-timeline-item-head-red');
-      testComponent.color = 'green';
+      testComponent.color.set('green');
       fixture.detectChanges();
       expect(items[0].querySelector('.ant-timeline-item-head')!.classList).toContain('ant-timeline-item-head-green');
     });
@@ -64,7 +61,7 @@ describe('nz-timeline', () => {
     it('should last work', () => {
       fixture.detectChanges();
       expect(items.length).toBe(4);
-      testComponent.last = true;
+      testComponent.last.set(true);
       fixture.detectChanges();
       items = Array.from((fixture.debugElement.nativeElement as HTMLElement).querySelectorAll('.ant-timeline-item'));
       expect(items.length).toBe(5);
@@ -74,18 +71,18 @@ describe('nz-timeline', () => {
     it('should pending work', () => {
       fixture.detectChanges();
       expect(timeline.nativeElement.querySelector('.ant-timeline-item-pending')).toBeNull();
-      testComponent.pending = true;
+      testComponent.pending.set(true);
       fixture.detectChanges();
       expect(timeline.nativeElement.querySelector('.ant-timeline-item-pending').innerText).toBe('');
-      testComponent.pending = 'pending';
+      testComponent.pending.set('pending');
       fixture.detectChanges();
       expect(timeline.nativeElement.querySelector('.ant-timeline-item-pending').innerText).toBe('pending');
     });
 
     it('should reverse work', () => {
       fixture.detectChanges();
-      testComponent.pending = true;
-      testComponent.reverse = true;
+      testComponent.pending.set(true);
+      testComponent.reverse.set(true);
       fixture.detectChanges();
       expect(timeline.nativeElement.firstElementChild.firstElementChild!.classList).toContain(
         'ant-timeline-item-pending'
@@ -96,7 +93,7 @@ describe('nz-timeline', () => {
 
     it('should alternate position work', () => {
       fixture.detectChanges();
-      testComponent.mode = 'alternate';
+      testComponent.mode.set('alternate');
       fixture.detectChanges();
       expect(timeline.nativeElement.firstElementChild!.classList).toContain('ant-timeline-alternate');
       expect(items[0].classList).toContain('ant-timeline-item-left');
@@ -106,7 +103,7 @@ describe('nz-timeline', () => {
 
     it('should alternate right position work', () => {
       fixture.detectChanges();
-      testComponent.mode = 'right';
+      testComponent.mode.set('right');
       fixture.detectChanges();
       expect(timeline.nativeElement.firstElementChild!.classList).toContain('ant-timeline-right');
       expect(items[0].classList).toContain('ant-timeline-item-right');
@@ -227,25 +224,24 @@ describe('nz-timeline', () => {
   selector: 'nz-test-basic-timeline',
   template: `
     <ng-template #dotTemplate>template</ng-template>
-    <nz-timeline [nzPending]="pending" [nzReverse]="reverse" [nzMode]="mode">
-      <nz-timeline-item [nzColor]="color" [nzDot]="dot">Create a services site 2015-09-01</nz-timeline-item>
+    <nz-timeline [nzPending]="pending()" [nzReverse]="reverse()" [nzMode]="mode()">
+      <nz-timeline-item [nzColor]="color()" [nzDot]="dot()">Create a services site 2015-09-01</nz-timeline-item>
       <nz-timeline-item [nzDot]="dotTemplate">Solve initial network problems 2015-09-01</nz-timeline-item>
       <nz-timeline-item>Technical testing 2015-09-01</nz-timeline-item>
       <nz-timeline-item>Network problems being solved 2015-09-01</nz-timeline-item>
-      @if (last) {
+      @if (last()) {
         <nz-timeline-item>Network problems being solved 2015-09-01</nz-timeline-item>
       }
     </nz-timeline>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTimelineBasicComponent {
-  color = 'blue';
-  dot = 'dot';
-  pending: boolean | string = false;
-  last = false;
-  reverse = false;
-  mode: NzTimelineMode = 'left';
+  readonly color = signal('blue');
+  readonly dot = signal('dot');
+  readonly pending = signal<boolean | string>(false);
+  readonly last = signal(false);
+  readonly reverse = signal(false);
+  readonly mode = signal<NzTimelineMode>('left');
 }
 
 @Component({
@@ -257,8 +253,7 @@ export class NzTestTimelineBasicComponent {
       <nz-timeline-item nzColor="#781241">Technical testing 2015-09-01</nz-timeline-item>
       <nz-timeline-item nzColor="red">Network problems being solved 2015-09-01</nz-timeline-item>
     </nz-timeline>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTimelineCustomColorComponent {}
 
@@ -270,8 +265,7 @@ export class NzTestTimelineCustomColorComponent {}
       <nz-timeline-item>Technical testing 2015-09-01</nz-timeline-item>
       <nz-timeline-item>Network problems being solved 2015-09-01</nz-timeline-item>
     </nz-timeline>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTimelinePendingComponent {}
 
@@ -282,8 +276,7 @@ export class NzTestTimelinePendingComponent {}
       <nz-timeline-item nzPosition="right">Right</nz-timeline-item>
       <nz-timeline-item nzPosition="left">Left</nz-timeline-item>
     </nz-timeline>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTimelineCustomPositionComponent {}
 
@@ -291,19 +284,18 @@ export class NzTestTimelineCustomPositionComponent {}
   imports: [NzTimelineModule],
   template: `
     <nz-timeline nzMode="custom">
-      @for (item of data; track item) {
+      @for (item of data(); track item) {
         <nz-timeline-item>{{ item }}</nz-timeline-item>
       }
     </nz-timeline>
     <span (click)="reset()">reset</span>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTimelineClearItemsComponent {
   @ViewChild(NzTimelineComponent)
   nzTimeLine!: NzTimelineComponent;
-  data = [1, 2, 3];
+  readonly data = signal([1, 2, 3]);
   reset(): void {
-    this.data = [];
+    this.data.set([]);
   }
 }

--- a/components/tree-select/tree-select.component.ts
+++ b/components/tree-select/tree-select.component.ts
@@ -596,6 +596,7 @@ export class NzTreeSelectComponent extends NzTreeBase implements ControlValueAcc
       if (this.nzShowSearch || this.isMultiple) {
         this.focusOnInput();
       }
+      this.cdr.markForCheck();
     }
   }
 

--- a/components/tree-select/tree-select.spec.ts
+++ b/components/tree-select/tree-select.spec.ts
@@ -7,21 +7,12 @@ import { BACKSPACE } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { TestKey } from '@angular/cdk/testing';
 import { UnitTestElement } from '@angular/cdk/testing/testbed';
-import {
-  ChangeDetectorRef,
-  Component,
-  DebugElement,
-  NgZone,
-  signal,
-  TemplateRef,
-  ViewChild,
-  WritableSignal
-} from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
+import { Component, DebugElement, NgZone, signal, TemplateRef, ViewChild, WritableSignal } from '@angular/core';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
+import { provideNzNoAnimation } from 'ng-zorro-antd/core/animation';
 import { NZ_FORM_SIZE, NZ_FORM_VARIANT } from 'ng-zorro-antd/core/form';
 import {
   createKeyboardEvent,
@@ -29,7 +20,8 @@ import {
   dispatchMouseEvent,
   MockNgZone,
   sleep,
-  typeInElement
+  typeInElement,
+  updateNonSignalsInput
 } from 'ng-zorro-antd/core/testing';
 import { NzTreeNode, NzTreeNodeOptions } from 'ng-zorro-antd/core/tree';
 import { NzSizeLDSType, NzStatus, NzVariant } from 'ng-zorro-antd/core/types';
@@ -47,7 +39,7 @@ describe('tree-select', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        provideNoopAnimations(),
+        provideNzNoAnimation(),
         {
           provide: NgZone,
           useFactory: () => {
@@ -75,34 +67,25 @@ describe('tree-select', () => {
     let treeSelectComponent: NzTreeSelectComponent;
     let treeSelect: DebugElement;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(NzTestTreeSelectBasicComponent);
       fixture.detectChanges();
       testComponent = fixture.debugElement.componentInstance;
       treeSelect = fixture.debugElement.query(By.directive(NzTreeSelectComponent));
       treeSelectComponent = treeSelect.componentInstance;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
-    }));
+    });
 
-    it('should size work', fakeAsync(() => {
+    it('should size work', () => {
       testComponent.size.set('small');
       fixture.detectChanges();
       expect(treeSelect.nativeElement.classList).toContain('ant-select-sm');
       testComponent.size.set('large');
       fixture.detectChanges();
       expect(treeSelect.nativeElement.classList).toContain('ant-select-lg');
-    }));
+    });
 
-    it('should placement works', fakeAsync(() => {
-      const treeSelectChangeDetector = treeSelect.injector.get(ChangeDetectorRef);
-
-      fixture.detectChanges();
+    it('should placement works', async () => {
       treeSelectComponent.openDropdown();
-      treeSelectChangeDetector.markForCheck();
       fixture.detectChanges();
       let element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(true);
@@ -110,39 +93,37 @@ describe('tree-select', () => {
       expect(element.classList.contains('ant-select-dropdown-placement-topLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(false);
 
-      const setPlacement = (placement: NzPlacementType): void => {
+      const setPlacement = async (placement: NzPlacementType): Promise<void> => {
         treeSelectComponent.closeDropdown();
         fixture.detectChanges();
         testComponent.placement.set(placement);
         fixture.detectChanges();
         treeSelectComponent.openDropdown();
-        treeSelectChangeDetector.markForCheck();
         fixture.detectChanges();
-        tick();
-        fixture.detectChanges();
+        await fixture.whenStable();
       };
 
-      setPlacement('bottomRight');
+      await setPlacement('bottomRight');
       element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(true);
       expect(element.classList.contains('ant-select-dropdown-placement-topLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(false);
 
-      setPlacement('topLeft');
+      await setPlacement('topLeft');
       element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topLeft')).toBe(true);
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(false);
 
-      setPlacement('topRight');
+      await setPlacement('topRight');
       element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-bottomRight')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topLeft')).toBe(false);
       expect(element.classList.contains('ant-select-dropdown-placement-topRight')).toBe(true);
-    }));
+    });
 
     describe('should variant works', () => {
       it('outlined', () => {
@@ -176,12 +157,12 @@ describe('tree-select', () => {
       });
     });
 
-    it('should allowClear work', () => {
+    it('should allowClear work', async () => {
       const nativeElement = treeSelect.nativeElement as HTMLElement;
       expect(nativeElement.classList).not.toContain('ant-select-allow-clear');
       expect(nativeElement.querySelector('nz-select-clear')).toBeNull();
       testComponent.allowClear.set(true);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(nativeElement.classList).toContain('ant-select-allow-clear');
       expect(nativeElement.querySelector('nz-select-clear')).not.toBeNull();
 
@@ -210,20 +191,15 @@ describe('tree-select', () => {
       fixture.detectChanges();
     });
 
-    it('should disabled work', fakeAsync(() => {
+    it('should disabled work', async () => {
       testComponent.disabled.set(true);
       fixture.detectChanges();
       expect(treeSelect.nativeElement.classList).toContain('ant-select-disabled');
       expect(treeSelectComponent.nzOpen).toBe(false);
       treeSelect.nativeElement.click();
-      fixture.detectChanges();
-      tick();
+      await fixture.whenStable();
       expect(treeSelectComponent.nzOpen).toBe(false);
-      treeSelectComponent.openDropdown();
-      treeSelect.nativeElement.click();
-      fixture.detectChanges();
-      tick();
-    }));
+    });
 
     it('should dropdownMatchSelectWidth work', async () => {
       testComponent.dropdownMatchSelectWidth.set(true);
@@ -245,107 +221,90 @@ describe('tree-select', () => {
       expect(overlayPane.style.minWidth).toBe('250px');
     });
 
-    it('should clear value work', fakeAsync(() => {
+    it('should clear value work', async () => {
       testComponent.allowClear.set(true);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.value()).toBe('10001');
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
       treeSelect.nativeElement.querySelector('nz-select-clear').click();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.value()).toBe(null);
-    }));
+    });
 
-    it('should set null value work', fakeAsync(() => {
+    it('should set null value work', async () => {
       fixture.detectChanges();
       expect(testComponent.value()).toBe('10001');
       testComponent.nzSelectTreeComponent.updateSelectedNodes();
       fixture.detectChanges();
       testComponent.setNull();
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.value()).toBe(null);
       expect(testComponent.nzSelectTreeComponent.selectedNodes.length).toEqual(0);
       expect(testComponent.nzSelectTreeComponent.value.length).toBe(0);
-    }));
+    });
 
-    it('should dropdown style work', fakeAsync(() => {
+    it('should dropdown style work', () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
-      flush();
       const targetElement = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(targetElement.style.height).toBe('120px');
-    }));
+    });
 
-    it('should dropdown classname work', fakeAsync(() => {
+    it('should dropdown classname work', () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
-      flush();
       const targetElement = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(targetElement.classList).toContain('class1');
       expect(targetElement.classList).toContain('class2');
-    }));
+    });
 
-    it('should click option close dropdown', fakeAsync(() => {
+    it('should click option close dropdown', async () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
       fixture.detectChanges();
       const targetNode = overlayContainerElement.querySelectorAll('.ant-select-tree-node-content-wrapper')[2];
       dispatchMouseEvent(targetNode, 'click');
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       expect(treeSelectComponent.nzOpen).toBe(false);
-    }));
+    });
 
-    it('should be focusable', fakeAsync(() => {
+    it('should be focusable', async () => {
       const focusTrigger = treeSelect.query(By.css('.ant-select-selection-search-input')).nativeElement;
       expect(treeSelect.nativeElement.classList).not.toContain('ant-select-focused');
       dispatchFakeEvent(focusTrigger, 'focus');
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(treeSelect.nativeElement.classList).toContain('ant-select-focused');
-    }));
+    });
 
-    it('should open dropdown when keydown', fakeAsync(async () => {
-      const testElement = new UnitTestElement(treeSelect.nativeElement, async () => {
-        fixture.detectChanges();
-        flush();
-        fixture.detectChanges();
-      });
+    async function noop(): Promise<void> {
+      // noop
+    }
+
+    it('should open dropdown when keydown', async () => {
+      const testElement = new UnitTestElement(treeSelect.nativeElement, noop);
       expect(treeSelectComponent.nzOpen).toBe(false);
+
       await testElement.sendKeys(TestKey.ESCAPE);
       expect(treeSelectComponent.nzOpen).toBe(false);
 
       await testElement.sendKeys(TestKey.ENTER);
       expect(treeSelectComponent.nzOpen).toBe(true);
-    }));
+    });
 
-    it('should close dropdown when TAB keydown', fakeAsync(async () => {
-      const testElement = new UnitTestElement(treeSelect.nativeElement, async () => {
-        fixture.detectChanges();
-        flush();
-        fixture.detectChanges();
-      });
+    it('should close dropdown when TAB keydown', async () => {
+      const testElement = new UnitTestElement(treeSelect.nativeElement, noop);
 
       treeSelectComponent.nzOpen = true;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-
+      await updateNonSignalsInput(fixture);
       await testElement.sendKeys(TestKey.TAB);
       expect(treeSelectComponent.nzOpen).toBe(false);
-    }));
+    });
 
-    it('should showSearch work', fakeAsync(() => {
+    it('should showSearch work', async () => {
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
       testComponent.showSearch.set(true);
@@ -357,13 +316,10 @@ describe('tree-select', () => {
       expect(searchInput.style.opacity).toBe('');
       testComponent.showSearch.set(false);
       fixture.detectChanges();
-      tick();
       expect(searchInput.style.opacity).toBe('0');
-      flush();
-      fixture.detectChanges();
-    }));
+    });
 
-    it('should display no data', fakeAsync(() => {
+    it('should display no data', async () => {
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
       testComponent.showSearch.set(true);
@@ -374,94 +330,85 @@ describe('tree-select', () => {
       expect(overlayContainerElement.querySelector('.ant-select-not-found')).toBeFalsy();
       fixture.detectChanges();
       treeSelectComponent.inputValue = 'invalid_value';
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      await updateNonSignalsInput(fixture);
       expect(overlayContainerElement.querySelector('nz-tree')!.getAttribute('hidden')).toBe('');
       expect(overlayContainerElement.querySelector('.ant-select-not-found')).toBeTruthy();
-    }));
+    });
 
-    it('should clean search value when reopen', fakeAsync(() => {
+    it('should clean search value when reopen', async () => {
       testComponent.showSearch.set(true);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       treeSelectComponent.inputValue = 'invalid_value';
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      await updateNonSignalsInput(fixture);
       expect(overlayContainerElement.querySelector('.ant-select-not-found')).toBeTruthy();
 
       treeSelect.nativeElement.click();
-      fixture.detectChanges();
-      tick(200);
+      await fixture.whenStable();
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
 
       expect(overlayContainerElement.querySelector('.ant-select-not-found')).toBeFalsy();
-    }));
+    });
 
-    it('should max tag count work', fakeAsync(() => {
+    it('should max tag count work', async () => {
       fixture.detectChanges();
       testComponent.multiple.set(true);
       fixture.detectChanges();
       testComponent.value.set(['1001', '10001', '100011', '100012']);
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      await updateNonSignalsInput(fixture);
       expect(treeSelect.nativeElement.querySelectorAll('nz-select-item').length).toBe(4);
+
       testComponent.maxTagCount.set(2);
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      await updateNonSignalsInput(fixture);
       expect(treeSelect.nativeElement.querySelectorAll('nz-select-item').length).toBe(3);
       const maxTagPlaceholderElement = treeSelect.nativeElement.querySelectorAll('nz-select-item')[2];
       expect(maxTagPlaceholderElement).toBeTruthy();
       expect(maxTagPlaceholderElement.innerText.trim()).toBe(
         `+ ${testComponent.value()!.length - testComponent.maxTagCount()} ...`
       );
-    }));
+    });
 
-    it('should set selectable', fakeAsync(() => {
+    it('should set selectable', async () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
+
       let node = overlayContainerElement.querySelector('.ant-select-tree-node-content-wrapper')!;
       dispatchMouseEvent(node, 'click');
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       expect(treeSelectComponent.nzOpen).toBe(false);
+
       testComponent.nodes.update(nodes => [{ ...nodes[0], selectable: false }, ...nodes.slice(1)]);
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
+
       node = overlayContainerElement.querySelector('nz-tree-node[builtin]')!;
       dispatchMouseEvent(node, 'click');
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       expect(treeSelectComponent.nzOpen).toBe(true);
-    }));
+    });
 
-    it('should nzBackdrop work', fakeAsync(() => {
+    it('should nzBackdrop work', () => {
       testComponent.hasBackdrop.set(true);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       const boundingBox = overlayContainerElement.children[0];
       expect(boundingBox.children[0].classList).toContain('cdk-overlay-backdrop');
-    }));
+    });
 
-    it('should isComposing/inputValue is correct', fakeAsync(() => {
+    it('should isComposing/inputValue is correct', async () => {
       treeSelectComponent.inputValue = '';
       treeSelectComponent.isComposingChange(true);
       treeSelectComponent.setInputValue('1011');
-      flush();
+      await updateNonSignalsInput(fixture);
       expect(treeSelectComponent.isComposing).toBe(true);
       expect(treeSelectComponent.inputValue).toBe('');
-    }));
+    });
 
     it('should nzPrefix work', () => {
       const host = fixture.debugElement.nativeElement;
@@ -489,136 +436,106 @@ describe('tree-select', () => {
     let treeSelectComponent: NzTreeSelectComponent;
     let treeSelect: DebugElement;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(NzTestTreeSelectCheckableComponent);
       fixture.detectChanges();
       testComponent = fixture.debugElement.componentInstance;
       treeSelect = fixture.debugElement.query(By.directive(NzTreeSelectComponent));
       treeSelectComponent = treeSelect.componentInstance;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
-    }));
+    });
 
-    it('should is multiple', fakeAsync(() => {
+    it('should is multiple', async () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
       expect(treeSelectComponent.isMultiple).toBe(true);
-      flush();
-    }));
+    });
 
-    it('should update input width', fakeAsync(() => {
+    it('should update input width', async () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       testComponent.showSearch.set(true);
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       const input = treeSelect.nativeElement.querySelector('input') as HTMLInputElement;
       typeInElement('test', input);
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       typeInElement('test test test', input);
-      fixture.detectChanges();
-      flush();
-      treeSelectComponent.inputValue = '';
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       typeInElement('', input);
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       zone.simulateZoneExit();
       fixture.detectChanges();
-      expect(input.style.width === '').toBe(true);
-    }));
+      expect(input.style.width === '').toBeTrue();
+    });
 
-    it('should set null value work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should set null value work', async () => {
       expect(testComponent.value()![0]).toBe('1000122');
       testComponent.setNull();
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.value()).toBe(null);
       expect(testComponent.nzSelectTreeComponent.selectedNodes.length).toBe(0);
       expect(testComponent.nzSelectTreeComponent.value.length).toBe(0);
-    }));
+    });
 
-    it('should not check strictly work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should not check strictly work', async () => {
       testComponent.value.set(['1001', '10001', '100012']);
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.nzSelectTreeComponent.selectedNodes.length).toBe(1);
-      flush();
-    }));
+    });
 
-    it('should check strictly work', fakeAsync(() => {
-      fixture.detectChanges();
+    it('should check strictly work', async () => {
       testComponent.checkStrictly.set(true);
       testComponent.value.set(['1001', '10001', '100012']);
-      fixture.detectChanges();
-      tick();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.nzSelectTreeComponent.selectedNodes.length).toBe(3);
       testComponent.checkStrictly.set(false);
-      flush();
       fixture.detectChanges();
-    }));
+    });
 
-    it('should remove checked when press backs', fakeAsync(() => {
+    it('should remove checked when press backs', async () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       testComponent.showSearch.set(true);
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
+
       const input = treeSelect.nativeElement.querySelector('input') as HTMLInputElement;
       const BACKSPACE_EVENT = createKeyboardEvent('keydown', BACKSPACE, input);
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
-      expect(treeSelectComponent.selectedNodes.length === 1).toBe(true);
-      treeSelectComponent.onKeyDownInput(BACKSPACE_EVENT);
-      fixture.detectChanges();
-      tick(200);
-      expect(treeSelectComponent.selectedNodes.length === 0).toBe(true);
-      treeSelectComponent.onKeyDownInput(BACKSPACE_EVENT);
-      fixture.detectChanges();
-      tick(200);
-      expect(treeSelectComponent.selectedNodes.length === 0).toBe(true);
-    }));
+      expect(treeSelectComponent.selectedNodes.length).toBe(1);
 
-    it('should click option not close dropdown', fakeAsync(() => {
+      treeSelectComponent.onKeyDownInput(BACKSPACE_EVENT);
+      await updateNonSignalsInput(fixture);
+      expect(treeSelectComponent.selectedNodes.length).toBe(0);
+
+      treeSelectComponent.onKeyDownInput(BACKSPACE_EVENT);
+      await updateNonSignalsInput(fixture);
+      expect(treeSelectComponent.selectedNodes.length).toBe(0);
+    });
+
+    it('should click option not close dropdown', async () => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
-      fixture.detectChanges();
+
       const targetNode = overlayContainerElement.querySelectorAll('nz-tree-node[builtin]')[2];
       dispatchMouseEvent(targetNode, 'click');
-      fixture.detectChanges();
-      flush();
+      await fixture.whenStable();
       expect(treeSelectComponent.nzOpen).toBe(true);
-    }));
+    });
 
-    it('should prevent open the dropdown when click remove', fakeAsync(() => {
+    it('should prevent open the dropdown when click remove', async () => {
       testComponent.value.set(['1000122']);
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(treeSelectComponent.selectedNodes.length).toBe(1);
+
       treeSelect.nativeElement.querySelector('.ant-select-selection-item-remove').click();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(treeSelectComponent.selectedNodes.length).toBe(0);
       expect(treeSelectComponent.nzOpen).toBe(false);
-    }));
+    });
 
-    it('should display no data', fakeAsync(() => {
+    it('should display no data', async () => {
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
       testComponent.showSearch.set(true);
@@ -627,14 +544,12 @@ describe('tree-select', () => {
       fixture.detectChanges();
       expect(overlayContainerElement.querySelector('nz-tree')!.getAttribute('hidden')).toBeNull();
       expect(overlayContainerElement.querySelector('.ant-select-not-found')).toBeFalsy();
-      fixture.detectChanges();
+
       treeSelectComponent.inputValue = 'invalid_value';
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(overlayContainerElement.querySelector('nz-tree')!.getAttribute('hidden')).toBe('');
       expect(overlayContainerElement.querySelector('.ant-select-not-found')).toBeTruthy();
-    }));
+    });
   });
 
   describe('form', () => {
@@ -651,34 +566,25 @@ describe('tree-select', () => {
       treeSelectComponent = treeSelect.componentInstance;
     });
 
-    it('should set disabled work', fakeAsync(() => {
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+    it('should set disabled work', async () => {
       const nativeElement = treeSelect.nativeElement as HTMLElement;
       expect(nativeElement.classList).not.toContain('ant-select-disabled');
       expect(nativeElement.querySelector('nz-select-clear')).not.toBeNull();
+
       testComponent.disable();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(nativeElement.classList).toContain('ant-select-disabled');
       expect(nativeElement.querySelector('nz-select-clear')).toBeNull();
-    }));
+    });
 
-    it('should set null value work', fakeAsync(() => {
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+    it('should set null value work', async () => {
       expect(testComponent.formControl.value).toBe('10021');
       testComponent.setNull();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(testComponent.formControl.value).toBe(null);
       expect(treeSelectComponent.selectedNodes.length).toBe(0);
       expect(treeSelectComponent.value.length).toBe(0);
-    }));
+    });
   });
 
   describe('tree component', () => {
@@ -687,18 +593,13 @@ describe('tree-select', () => {
     let treeSelectComponent: NzTreeSelectComponent;
     let treeSelect: DebugElement;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(NzTestTreeSelectCheckableComponent);
       fixture.detectChanges();
       testComponent = fixture.debugElement.componentInstance;
       treeSelect = fixture.debugElement.query(By.directive(NzTreeSelectComponent));
       treeSelectComponent = treeSelect.componentInstance;
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
-      tick(200);
-      fixture.detectChanges();
-    }));
+    });
 
     it('should keep expand state', () => {
       testComponent.expandKeys.set([]);
@@ -708,15 +609,17 @@ describe('tree-select', () => {
       expect(treeSelectComponent.nzOpen).toBe(true);
       let targetSwitcher = overlayContainerElement.querySelector('.ant-select-tree-switcher')!;
       expect(targetSwitcher.classList.contains('ant-select-tree-switcher_close')).toBe(true);
-      fixture.detectChanges();
+
       dispatchMouseEvent(targetSwitcher, 'click');
       fixture.detectChanges();
       targetSwitcher = overlayContainerElement.querySelector('.ant-select-tree-switcher')!;
       expect(targetSwitcher.classList.contains('ant-select-tree-switcher_open')).toBe(true);
       expect(treeSelectComponent.nzExpandedKeys[0] === '1001').toBe(true);
+
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(false);
+
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       targetSwitcher = overlayContainerElement.querySelector('.ant-select-tree-switcher')!;
@@ -729,18 +632,18 @@ describe('tree-select', () => {
   describe('customized icon', () => {
     let fixture: ComponentFixture<NzTestTreeSelectCustomizedIconComponent>;
     let treeSelect: DebugElement;
+
     beforeEach(() => {
       fixture = TestBed.createComponent(NzTestTreeSelectCustomizedIconComponent);
       treeSelect = fixture.debugElement.query(By.directive(NzTreeSelectComponent));
     });
 
-    it('should display', fakeAsync(() => {
+    it('should display', async () => {
       fixture.detectChanges();
       treeSelect.nativeElement.click();
-      flush();
-      fixture.detectChanges();
+      await fixture.whenStable();
       expect(overlayContainerElement.querySelector('.anticon.anticon-frown-o')).toBeTruthy();
-    }));
+    });
   });
 
   describe('Status', () => {
@@ -802,31 +705,25 @@ describe('tree-select', () => {
       treeSelect = fixture.debugElement.query(By.directive(NzTreeSelectComponent));
     });
 
-    it('should set nzVirtualHeight work', fakeAsync(() => {
+    it('should set nzVirtualHeight work', async () => {
       fixture.detectChanges();
       treeSelect.nativeElement.click();
-      flush();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      await fixture.whenStable();
       const virtualScrollViewport = overlayContainerElement.querySelector('.cdk-virtual-scroll-viewport')!;
       expect(window.getComputedStyle(virtualScrollViewport).height).toBe('300px');
-    }));
+    });
 
-    it('should support x-scroll when the length of node label is greater than the length of select dropdown', fakeAsync(() => {
+    it('should support x-scroll when the length of node label is greater than the length of select dropdown', async () => {
       fixture.detectChanges();
       treeSelect.nativeElement.click();
-      flush();
-      fixture.detectChanges();
-      flush();
-      fixture.detectChanges();
+      await fixture.whenStable();
       overlayContainerElement
         .querySelector('.cdk-virtual-scroll-content-wrapper')!
         .setAttribute('style', 'width: 250px');
       const virtualScrollViewport = overlayContainerElement.querySelector('.cdk-virtual-scroll-content-wrapper')!;
       expect(virtualScrollViewport.clientWidth).toBe(250);
       expect(virtualScrollViewport.scrollWidth).toBeGreaterThan(250);
-    }));
+    });
   });
 });
 
@@ -840,6 +737,7 @@ describe('tree-select finalSize', () => {
     compactSizeSignal = signal<NzSizeLDSType>('large');
     formSizeSignal = signal<NzSizeLDSType>('default');
   });
+
   afterEach(() => {
     TestBed.resetTestingModule();
   });
@@ -858,6 +756,7 @@ describe('tree-select finalSize', () => {
     fixture.detectChanges();
     expect(treeSelectElement.classList).toContain('ant-select-lg');
   });
+
   it('should set correctly the size from the compactSize signal', () => {
     TestBed.configureTestingModule({
       providers: [{ provide: NZ_SPACE_COMPACT_SIZE, useValue: compactSizeSignal }]
@@ -867,6 +766,7 @@ describe('tree-select finalSize', () => {
     fixture.detectChanges();
     expect(treeSelectElement.classList).toContain('ant-select-lg');
   });
+
   it('should set correctly the size from the component input', () => {
     fixture = TestBed.createComponent(TestTreeSelectFinalSizeComponent);
     treeSelectElement = fixture.debugElement.query(By.directive(NzTreeSelectComponent)).nativeElement;
@@ -884,9 +784,11 @@ describe('finalVariant', () => {
   beforeEach(() => {
     formVariantSignal = signal<NzVariant>('outlined');
   });
+
   afterEach(() => {
     TestBed.resetTestingModule();
   });
+
   it('should use formVariant when nzVariant is not set (undefined by default)', () => {
     TestBed.configureTestingModule({
       providers: [{ provide: NZ_FORM_VARIANT, useValue: formVariantSignal }]

--- a/components/tree-select/tree-select.spec.ts
+++ b/components/tree-select/tree-select.spec.ts
@@ -8,11 +8,10 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { TestKey } from '@angular/cdk/testing';
 import { UnitTestElement } from '@angular/cdk/testing/testbed';
 import {
-  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   DebugElement,
   NgZone,
-  provideZoneChangeDetection,
   signal,
   TemplateRef,
   ViewChild,
@@ -33,7 +32,7 @@ import {
   typeInElement
 } from 'ng-zorro-antd/core/testing';
 import { NzTreeNode, NzTreeNodeOptions } from 'ng-zorro-antd/core/tree';
-import { NzSafeAny, NzSizeLDSType, NzStatus, NzVariant } from 'ng-zorro-antd/core/types';
+import { NzSizeLDSType, NzStatus, NzVariant } from 'ng-zorro-antd/core/types';
 import { NzFormControlStatusType, NzFormModule } from 'ng-zorro-antd/form';
 import { NZ_SPACE_COMPACT_SIZE } from 'ng-zorro-antd/space';
 
@@ -48,8 +47,6 @@ describe('tree-select', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        // todo: use zoneless
-        provideZoneChangeDetection(),
         provideNoopAnimations(),
         {
           provide: NgZone,
@@ -60,7 +57,6 @@ describe('tree-select', () => {
         }
       ]
     });
-    (NzTreeSelectComponent as NzSafeAny).ɵcmp.onPush = false;
   });
 
   beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
@@ -93,17 +89,20 @@ describe('tree-select', () => {
     }));
 
     it('should size work', fakeAsync(() => {
-      testComponent.size = 'small';
+      testComponent.size.set('small');
       fixture.detectChanges();
       expect(treeSelect.nativeElement.classList).toContain('ant-select-sm');
-      testComponent.size = 'large';
+      testComponent.size.set('large');
       fixture.detectChanges();
       expect(treeSelect.nativeElement.classList).toContain('ant-select-lg');
     }));
 
     it('should placement works', fakeAsync(() => {
+      const treeSelectChangeDetector = treeSelect.injector.get(ChangeDetectorRef);
+
       fixture.detectChanges();
       treeSelectComponent.openDropdown();
+      treeSelectChangeDetector.markForCheck();
       fixture.detectChanges();
       let element = overlayContainerElement.querySelector('.ant-select-dropdown') as HTMLElement;
       expect(element.classList.contains('ant-select-dropdown-placement-bottomLeft')).toBe(true);
@@ -114,8 +113,10 @@ describe('tree-select', () => {
       const setPlacement = (placement: NzPlacementType): void => {
         treeSelectComponent.closeDropdown();
         fixture.detectChanges();
-        testComponent.placement = placement;
+        testComponent.placement.set(placement);
+        fixture.detectChanges();
         treeSelectComponent.openDropdown();
+        treeSelectChangeDetector.markForCheck();
         fixture.detectChanges();
         tick();
         fixture.detectChanges();
@@ -145,7 +146,7 @@ describe('tree-select', () => {
 
     describe('should variant works', () => {
       it('outlined', () => {
-        testComponent.variant = 'outlined';
+        testComponent.variant.set('outlined');
         fixture.detectChanges();
         expect(treeSelect.nativeElement.classList).toContain('ant-select-outlined');
       });
@@ -153,7 +154,7 @@ describe('tree-select', () => {
       it('filled', () => {
         fixture.detectChanges();
         expect(treeSelect.nativeElement.classList).not.toContain('ant-select-filled');
-        testComponent.variant = 'filled';
+        testComponent.variant.set('filled');
         fixture.detectChanges();
         expect(treeSelect.nativeElement.classList).toContain('ant-select-filled');
       });
@@ -161,7 +162,7 @@ describe('tree-select', () => {
       it('borderless', () => {
         fixture.detectChanges();
         expect(treeSelect.nativeElement.classList).not.toContain('ant-select-borderless');
-        testComponent.variant = 'borderless';
+        testComponent.variant.set('borderless');
         fixture.detectChanges();
         expect(treeSelect.nativeElement.classList).toContain('ant-select-borderless');
       });
@@ -169,7 +170,7 @@ describe('tree-select', () => {
       it('underlined', () => {
         fixture.detectChanges();
         expect(treeSelect.nativeElement.classList).not.toContain('ant-select-underlined');
-        testComponent.variant = 'underlined';
+        testComponent.variant.set('underlined');
         fixture.detectChanges();
         expect(treeSelect.nativeElement.classList).toContain('ant-select-underlined');
       });
@@ -179,7 +180,7 @@ describe('tree-select', () => {
       const nativeElement = treeSelect.nativeElement as HTMLElement;
       expect(nativeElement.classList).not.toContain('ant-select-allow-clear');
       expect(nativeElement.querySelector('nz-select-clear')).toBeNull();
-      testComponent.allowClear = true;
+      testComponent.allowClear.set(true);
       fixture.detectChanges();
       expect(nativeElement.classList).toContain('ant-select-allow-clear');
       expect(nativeElement.querySelector('nz-select-clear')).not.toBeNull();
@@ -210,7 +211,7 @@ describe('tree-select', () => {
     });
 
     it('should disabled work', fakeAsync(() => {
-      testComponent.disabled = true;
+      testComponent.disabled.set(true);
       fixture.detectChanges();
       expect(treeSelect.nativeElement.classList).toContain('ant-select-disabled');
       expect(treeSelectComponent.nzOpen).toBe(false);
@@ -225,7 +226,7 @@ describe('tree-select', () => {
     }));
 
     it('should dropdownMatchSelectWidth work', async () => {
-      testComponent.dropdownMatchSelectWidth = true;
+      testComponent.dropdownMatchSelectWidth.set(true);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
@@ -235,7 +236,7 @@ describe('tree-select', () => {
       expect(overlayPane.style.width).toBe('250px');
       treeSelectComponent.closeDropdown();
       fixture.detectChanges();
-      testComponent.dropdownMatchSelectWidth = false;
+      testComponent.dropdownMatchSelectWidth.set(false);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
@@ -245,21 +246,21 @@ describe('tree-select', () => {
     });
 
     it('should clear value work', fakeAsync(() => {
-      testComponent.allowClear = true;
+      testComponent.allowClear.set(true);
       fixture.detectChanges();
-      expect(testComponent.value).toBe('10001');
+      expect(testComponent.value()).toBe('10001');
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
       treeSelect.nativeElement.querySelector('nz-select-clear').click();
       fixture.detectChanges();
       flush();
       fixture.detectChanges();
-      expect(testComponent.value).toBe(null);
+      expect(testComponent.value()).toBe(null);
     }));
 
     it('should set null value work', fakeAsync(() => {
       fixture.detectChanges();
-      expect(testComponent.value).toBe('10001');
+      expect(testComponent.value()).toBe('10001');
       testComponent.nzSelectTreeComponent.updateSelectedNodes();
       fixture.detectChanges();
       testComponent.setNull();
@@ -268,7 +269,7 @@ describe('tree-select', () => {
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
-      expect(testComponent.value).toBe(null);
+      expect(testComponent.value()).toBe(null);
       expect(testComponent.nzSelectTreeComponent.selectedNodes.length).toEqual(0);
       expect(testComponent.nzSelectTreeComponent.value.length).toBe(0);
     }));
@@ -347,14 +348,14 @@ describe('tree-select', () => {
     it('should showSearch work', fakeAsync(() => {
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
-      testComponent.showSearch = true;
+      testComponent.showSearch.set(true);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       const searchInput = treeSelect.nativeElement.querySelector('nz-select-search .ant-select-selection-search-input');
       expect(searchInput).toBeTruthy();
       expect(searchInput.style.opacity).toBe('');
-      testComponent.showSearch = false;
+      testComponent.showSearch.set(false);
       fixture.detectChanges();
       tick();
       expect(searchInput.style.opacity).toBe('0');
@@ -365,7 +366,7 @@ describe('tree-select', () => {
     it('should display no data', fakeAsync(() => {
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
-      testComponent.showSearch = true;
+      testComponent.showSearch.set(true);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
@@ -381,7 +382,7 @@ describe('tree-select', () => {
     }));
 
     it('should clean search value when reopen', fakeAsync(() => {
-      testComponent.showSearch = true;
+      testComponent.showSearch.set(true);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
@@ -405,14 +406,14 @@ describe('tree-select', () => {
 
     it('should max tag count work', fakeAsync(() => {
       fixture.detectChanges();
-      testComponent.multiple = true;
+      testComponent.multiple.set(true);
       fixture.detectChanges();
-      testComponent.value = ['1001', '10001', '100011', '100012'];
+      testComponent.value.set(['1001', '10001', '100011', '100012']);
       fixture.detectChanges();
       tick(200);
       fixture.detectChanges();
       expect(treeSelect.nativeElement.querySelectorAll('nz-select-item').length).toBe(4);
-      testComponent.maxTagCount = 2;
+      testComponent.maxTagCount.set(2);
       fixture.detectChanges();
       tick(200);
       fixture.detectChanges();
@@ -420,7 +421,7 @@ describe('tree-select', () => {
       const maxTagPlaceholderElement = treeSelect.nativeElement.querySelectorAll('nz-select-item')[2];
       expect(maxTagPlaceholderElement).toBeTruthy();
       expect(maxTagPlaceholderElement.innerText.trim()).toBe(
-        `+ ${testComponent.value.length - testComponent.maxTagCount} ...`
+        `+ ${testComponent.value()!.length - testComponent.maxTagCount()} ...`
       );
     }));
 
@@ -433,7 +434,7 @@ describe('tree-select', () => {
       fixture.detectChanges();
       flush();
       expect(treeSelectComponent.nzOpen).toBe(false);
-      testComponent.nodes[0].selectable = false;
+      testComponent.nodes.update(nodes => [{ ...nodes[0], selectable: false }, ...nodes.slice(1)]);
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzOpen).toBe(true);
@@ -445,7 +446,7 @@ describe('tree-select', () => {
     }));
 
     it('should nzBackdrop work', fakeAsync(() => {
-      testComponent.hasBackdrop = true;
+      testComponent.hasBackdrop.set(true);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
@@ -464,11 +465,11 @@ describe('tree-select', () => {
 
     it('should nzPrefix work', () => {
       const host = fixture.debugElement.nativeElement;
-      testComponent.prefix = 'prefix';
+      testComponent.prefix.set('prefix');
       fixture.detectChanges();
       expect(host.querySelector('.ant-select-prefix')!.textContent?.trim()).toBe('prefix');
 
-      testComponent.prefix = testComponent.affixTemplate;
+      testComponent.prefix.set(testComponent.affixTemplate);
       fixture.detectChanges();
       expect(host.querySelector('.ant-select-prefix')!.textContent?.trim()).toBe('icon');
     });
@@ -476,7 +477,7 @@ describe('tree-select', () => {
     it('should nzSuffixIcon work', () => {
       const host = fixture.debugElement.nativeElement;
       expect(host.querySelector('.anticon-down')).toBeTruthy();
-      testComponent.suffixIcon = testComponent.affixTemplate;
+      testComponent.suffixIcon.set(testComponent.affixTemplate);
       fixture.detectChanges();
       expect(host.querySelector('nz-select-arrow')!.textContent?.trim()).toBe('icon');
     });
@@ -512,7 +513,7 @@ describe('tree-select', () => {
     it('should update input width', fakeAsync(() => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
-      testComponent.showSearch = true;
+      testComponent.showSearch.set(true);
       fixture.detectChanges();
       flush();
       const input = treeSelect.nativeElement.querySelector('input') as HTMLInputElement;
@@ -535,21 +536,21 @@ describe('tree-select', () => {
 
     it('should set null value work', fakeAsync(() => {
       fixture.detectChanges();
-      expect(testComponent.value![0]).toBe('1000122');
+      expect(testComponent.value()![0]).toBe('1000122');
       testComponent.setNull();
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
-      expect(testComponent.value).toBe(null);
+      expect(testComponent.value()).toBe(null);
       expect(testComponent.nzSelectTreeComponent.selectedNodes.length).toBe(0);
       expect(testComponent.nzSelectTreeComponent.value.length).toBe(0);
     }));
 
     it('should not check strictly work', fakeAsync(() => {
       fixture.detectChanges();
-      testComponent.value = ['1001', '10001', '100012'];
+      testComponent.value.set(['1001', '10001', '100012']);
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
@@ -559,13 +560,13 @@ describe('tree-select', () => {
 
     it('should check strictly work', fakeAsync(() => {
       fixture.detectChanges();
-      testComponent.checkStrictly = true;
-      testComponent.value = ['1001', '10001', '100012'];
+      testComponent.checkStrictly.set(true);
+      testComponent.value.set(['1001', '10001', '100012']);
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
       expect(testComponent.nzSelectTreeComponent.selectedNodes.length).toBe(3);
-      testComponent.checkStrictly = false;
+      testComponent.checkStrictly.set(false);
       flush();
       fixture.detectChanges();
     }));
@@ -573,7 +574,7 @@ describe('tree-select', () => {
     it('should remove checked when press backs', fakeAsync(() => {
       treeSelect.nativeElement.click();
       fixture.detectChanges();
-      testComponent.showSearch = true;
+      testComponent.showSearch.set(true);
       fixture.detectChanges();
       flush();
       const input = treeSelect.nativeElement.querySelector('input') as HTMLInputElement;
@@ -604,7 +605,7 @@ describe('tree-select', () => {
     }));
 
     it('should prevent open the dropdown when click remove', fakeAsync(() => {
-      testComponent.value = ['1000122'];
+      testComponent.value.set(['1000122']);
       fixture.detectChanges();
       tick(200);
       fixture.detectChanges();
@@ -620,7 +621,7 @@ describe('tree-select', () => {
     it('should display no data', fakeAsync(() => {
       treeSelectComponent.updateSelectedNodes();
       fixture.detectChanges();
-      testComponent.showSearch = true;
+      testComponent.showSearch.set(true);
       fixture.detectChanges();
       treeSelect.nativeElement.click();
       fixture.detectChanges();
@@ -700,7 +701,7 @@ describe('tree-select', () => {
     }));
 
     it('should keep expand state', () => {
-      testComponent.expandKeys = [];
+      testComponent.expandKeys.set([]);
       treeSelect.nativeElement.click();
       fixture.detectChanges();
       expect(treeSelectComponent.nzExpandedKeys.length === 0).toBe(true);
@@ -755,11 +756,11 @@ describe('tree-select', () => {
       fixture.detectChanges();
       expect(treeSelect.nativeElement.className).toContain('ant-select-status-error');
 
-      fixture.componentInstance.status = 'warning';
+      fixture.componentInstance.status.set('warning');
       fixture.detectChanges();
       expect(treeSelect.nativeElement.className).toContain('ant-select-status-warning');
 
-      fixture.componentInstance.status = '';
+      fixture.componentInstance.status.set('');
       fixture.detectChanges();
       expect(treeSelect.nativeElement.className).not.toContain('ant-select-status-warning');
     });
@@ -778,15 +779,15 @@ describe('tree-select', () => {
       fixture.detectChanges();
       expect(treeSelect.classList).toContain('ant-select-status-error');
 
-      fixture.componentInstance.status = 'warning';
+      fixture.componentInstance.status.set('warning');
       fixture.detectChanges();
       expect(treeSelect.classList).toContain('ant-select-status-warning');
 
-      fixture.componentInstance.status = 'success';
+      fixture.componentInstance.status.set('success');
       fixture.detectChanges();
       expect(treeSelect.classList).toContain('ant-select-status-success');
 
-      fixture.componentInstance.feedback = false;
+      fixture.componentInstance.feedback.set(false);
       fixture.detectChanges();
       expect(treeSelect.querySelector('nz-form-item-feedback-icon')).toBeNull();
     });
@@ -869,7 +870,7 @@ describe('tree-select finalSize', () => {
   it('should set correctly the size from the component input', () => {
     fixture = TestBed.createComponent(TestTreeSelectFinalSizeComponent);
     treeSelectElement = fixture.debugElement.query(By.directive(NzTreeSelectComponent)).nativeElement;
-    fixture.componentInstance.size = 'large';
+    fixture.componentInstance.size.set('large');
     fixture.detectChanges();
     expect(treeSelectElement.classList).toContain('ant-select-lg');
   });
@@ -949,44 +950,44 @@ describe('finalVariant', () => {
     <nz-tree-select
       style="width:250px;position: relative;display: block;"
       nzPlaceHolder="Please select"
-      [nzExpandedKeys]="expandKeys"
-      [nzNodes]="nodes"
-      [(ngModel)]="value"
-      [nzSize]="size"
-      [nzVariant]="variant"
-      [nzAllowClear]="allowClear"
-      [nzDropdownMatchSelectWidth]="dropdownMatchSelectWidth"
-      [nzDisabled]="disabled"
-      [nzShowSearch]="showSearch"
-      [nzMultiple]="multiple"
-      [nzMaxTagCount]="maxTagCount"
+      [nzExpandedKeys]="expandKeys()"
+      [nzNodes]="nodes()"
+      [ngModel]="value()"
+      (ngModelChange)="value.set($event)"
+      [nzSize]="size()"
+      [nzVariant]="variant()"
+      [nzAllowClear]="allowClear()"
+      [nzDropdownMatchSelectWidth]="dropdownMatchSelectWidth()"
+      [nzDisabled]="disabled()"
+      [nzShowSearch]="showSearch()"
+      [nzMultiple]="multiple()"
+      [nzMaxTagCount]="maxTagCount()"
       [nzDropdownStyle]="{ height: '120px' }"
-      [nzBackdrop]="hasBackdrop"
-      [nzPrefix]="prefix"
-      [nzSuffixIcon]="suffixIcon"
-      [nzPlacement]="placement"
+      [nzBackdrop]="hasBackdrop()"
+      [nzPrefix]="prefix()"
+      [nzSuffixIcon]="suffixIcon()"
+      [nzPlacement]="placement()"
       nzDropdownClassName="class1 class2"
     />
     <ng-template #affixTemplate>icon</ng-template>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTreeSelectBasicComponent {
   @ViewChild(NzTreeSelectComponent, { static: false }) nzSelectTreeComponent!: NzTreeSelectComponent;
   @ViewChild('affixTemplate', { static: false }) affixTemplate!: TemplateRef<void>;
-  expandKeys = ['1001', '10001'];
-  value: string | string[] | null = '10001';
-  size: NzSizeLDSType = 'default';
-  variant: NzVariant = 'outlined';
-  allowClear = false;
-  disabled = false;
-  showSearch = false;
-  dropdownMatchSelectWidth = true;
-  multiple = false;
-  maxTagCount = Infinity;
-  prefix: string | TemplateRef<void> | null = null;
-  suffixIcon: string | TemplateRef<void> | null = null;
-  nodes: NzTreeNodeOptions[] = [
+  readonly expandKeys = signal(['1001', '10001']);
+  readonly value = signal<string | string[] | null>('10001');
+  readonly size = signal<NzSizeLDSType>('default');
+  readonly variant = signal<NzVariant>('outlined');
+  readonly allowClear = signal(false);
+  readonly disabled = signal(false);
+  readonly showSearch = signal(false);
+  readonly dropdownMatchSelectWidth = signal(true);
+  readonly multiple = signal(false);
+  readonly maxTagCount = signal(Infinity);
+  readonly prefix = signal<string | TemplateRef<void> | null>(null);
+  readonly suffixIcon = signal<string | TemplateRef<void> | null>(null);
+  readonly nodes = signal<NzTreeNodeOptions[]>([
     {
       title: 'root1',
       key: '1001',
@@ -1044,12 +1045,12 @@ export class NzTestTreeSelectBasicComponent {
         }
       ]
     }
-  ];
-  hasBackdrop = false;
-  placement: NzPlacementType = 'bottomLeft';
+  ]);
+  readonly hasBackdrop = signal(false);
+  readonly placement = signal<NzPlacementType>('bottomLeft');
 
   setNull(): void {
-    this.value = null;
+    this.value.set(null);
   }
 }
 
@@ -1058,23 +1059,23 @@ export class NzTestTreeSelectBasicComponent {
   template: `
     <nz-tree-select
       nzPlaceHolder="Please select"
-      [nzExpandedKeys]="expandKeys"
-      [nzNodes]="nodes"
-      [nzShowSearch]="showSearch"
+      [nzExpandedKeys]="expandKeys()"
+      [nzNodes]="nodes()"
+      [nzShowSearch]="showSearch()"
       [nzCheckable]="true"
-      [nzCheckStrictly]="checkStrictly"
-      [(ngModel)]="value"
+      [nzCheckStrictly]="checkStrictly()"
+      [ngModel]="value()"
+      (ngModelChange)="value.set($event)"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTreeSelectCheckableComponent {
   @ViewChild(NzTreeSelectComponent, { static: false }) nzSelectTreeComponent!: NzTreeSelectComponent;
-  expandKeys = ['1001', '10001'];
-  value: string[] | null = ['1000122'];
-  showSearch = false;
-  checkStrictly = false;
-  nodes = [
+  readonly expandKeys = signal(['1001', '10001']);
+  readonly value = signal<string[] | null>(['1000122']);
+  readonly showSearch = signal(false);
+  readonly checkStrictly = signal(false);
+  readonly nodes = signal([
     {
       title: 'root1',
       key: '1001',
@@ -1132,10 +1133,10 @@ export class NzTestTreeSelectCheckableComponent {
         }
       ]
     }
-  ];
+  ]);
 
   setNull(): void {
-    this.value = null;
+    this.value.set(null);
   }
 }
 
@@ -1145,8 +1146,7 @@ export class NzTestTreeSelectCheckableComponent {
     <form>
       <nz-tree-select [formControl]="formControl" [nzNodes]="nodes" />
     </form>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTreeSelectFormComponent {
   formControl = new FormControl('10021');
@@ -1187,8 +1187,7 @@ export class NzTestTreeSelectFormComponent {
         </span>
       </ng-template>
     </nz-tree-select>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTreeSelectCustomizedIconComponent {
   value?: string;
@@ -1216,15 +1215,14 @@ export class NzTestTreeSelectCustomizedIconComponent {
     <nz-tree-select
       [nzNodes]="nodes"
       nzShowSearch
-      [nzStatus]="status"
+      [nzStatus]="status()"
       nzPlaceHolder="Please select"
       [(ngModel)]="value"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTreeSelectStatusComponent {
-  status: NzStatus = 'error';
+  readonly status = signal<NzStatus>('error');
   value?: string = '1001';
   nodes = [
     {
@@ -1254,17 +1252,16 @@ export class NzTestTreeSelectStatusComponent {
   template: `
     <form nz-form>
       <nz-form-item>
-        <nz-form-control [nzHasFeedback]="feedback" [nzValidateStatus]="status">
+        <nz-form-control [nzHasFeedback]="feedback()" [nzValidateStatus]="status()">
           <nz-tree-select [nzNodes]="[]" />
         </nz-form-control>
       </nz-form-item>
     </form>
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTreeSelectInFormComponent {
-  status: NzFormControlStatusType = 'error';
-  feedback = true;
+  readonly status = signal<NzFormControlStatusType>('error');
+  readonly feedback = signal(true);
 }
 
 function dig(path = '0', level = 3): NzTreeNodeOptions[] {
@@ -1302,8 +1299,7 @@ function dig(path = '0', level = 3): NzTreeNodeOptions[] {
       nzHideUnMatched="true"
       [nzDropdownMatchSelectWidth]="true"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestTreeSelectVirtualScrollComponent {
   nodes: NzTreeNodeOptions[] = dig();
@@ -1311,17 +1307,15 @@ export class NzTestTreeSelectVirtualScrollComponent {
 
 @Component({
   imports: [NzTreeSelectModule],
-  template: `<nz-tree-select [nzNodes]="[]" [nzSize]="size" />`,
-  changeDetection: ChangeDetectionStrategy.Eager
+  template: `<nz-tree-select [nzNodes]="[]" [nzSize]="size()" />`
 })
 export class TestTreeSelectFinalSizeComponent {
-  size: NzSizeLDSType = 'default';
+  readonly size = signal<NzSizeLDSType>('default');
 }
 
 @Component({
   imports: [NzTreeSelectComponent],
-  template: `<nz-tree-select [nzVariant]="variant()" />`,
-  changeDetection: ChangeDetectionStrategy.Eager
+  template: `<nz-tree-select [nzVariant]="variant()" />`
 })
 export class TestTreeSelectFinalVariantComponent {
   readonly variant = signal<NzVariant | undefined>(undefined);

--- a/components/watermark/watermark.spec.ts
+++ b/components/watermark/watermark.spec.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ApplicationRef, ChangeDetectionStrategy, Component, DebugElement, destroyPlatform } from '@angular/core';
+import { ApplicationRef, Component, DebugElement, destroyPlatform, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { bootstrapApplication, By } from '@angular/platform-browser';
 import { renderApplication } from '@angular/platform-server';
@@ -34,7 +34,8 @@ describe('watermark', () => {
   });
 
   it('basic', async () => {
-    testComponent.nzContent = 'NG Ant Design';
+    testComponent.nzContent.set('NG Ant Design');
+    fixture.detectChanges();
     await fixture.whenStable();
     const view = resultEl.nativeElement.querySelector('.watermark > div');
     expect(view).toBeTruthy();
@@ -42,8 +43,10 @@ describe('watermark', () => {
   });
 
   it('image', async () => {
-    testComponent.nzImage =
-      'https://img.alicdn.com/imgextra/i3/O1CN01UR3Zkq1va9fnZsZcr_!!6000000006188-55-tps-424-64.svg';
+    testComponent.nzImage.set(
+      'https://img.alicdn.com/imgextra/i3/O1CN01UR3Zkq1va9fnZsZcr_!!6000000006188-55-tps-424-64.svg'
+    );
+    fixture.detectChanges();
     await fixture.whenStable();
     const view = resultEl.nativeElement.querySelector('.watermark > div');
     expect(view).toBeTruthy();
@@ -54,7 +57,8 @@ describe('watermark', () => {
     mockSrcSpy.and.callFake(() => {
       resultEl.componentInstance['onImageError']?.();
     });
-    testComponent.nzImage = 'https://img.alicdn.com/test.svg';
+    testComponent.nzImage.set('https://img.alicdn.com/test.svg');
+    fixture.detectChanges();
     await fixture.whenStable();
     const view = resultEl.nativeElement.querySelector('.watermark > div');
     expect(view).toBeTruthy();
@@ -62,8 +66,9 @@ describe('watermark', () => {
   });
 
   it('should offset work', async () => {
-    testComponent.nzContent = ['Angular', 'NG Ant Design'];
-    testComponent.nzOffset = [200, 200];
+    testComponent.nzContent.set(['Angular', 'NG Ant Design']);
+    testComponent.nzOffset.set([200, 200]);
+    fixture.detectChanges();
     await fixture.whenStable();
 
     const view = resultEl.nativeElement.querySelector('.watermark > div');
@@ -74,10 +79,11 @@ describe('watermark', () => {
   });
 
   it('should backgroundSize work', async () => {
-    testComponent.nzContent = 'NG Ant Design';
-    testComponent.nzGap = [100, 100];
-    testComponent.nzWidth = 200;
-    testComponent.nzHeight = 200;
+    testComponent.nzContent.set('NG Ant Design');
+    testComponent.nzGap.set([100, 100]);
+    testComponent.nzWidth.set(200);
+    testComponent.nzHeight.set(200);
+    fixture.detectChanges();
     await fixture.whenStable();
 
     const view = resultEl.nativeElement.querySelector('.watermark > div');
@@ -85,7 +91,8 @@ describe('watermark', () => {
   });
 
   it('should MutationObserver work', async () => {
-    testComponent.nzContent = 'NG Ant Design';
+    testComponent.nzContent.set('NG Ant Design');
+    fixture.detectChanges();
     await fixture.whenStable();
 
     const view = resultEl.nativeElement.querySelector('.watermark > div');
@@ -96,7 +103,8 @@ describe('watermark', () => {
   });
 
   it('should observe the modification of style', async () => {
-    testComponent.nzContent = 'NG Ant Design';
+    testComponent.nzContent.set('NG Ant Design');
+    fixture.detectChanges();
     await fixture.whenStable();
 
     const view = resultEl.nativeElement.querySelector('.watermark > div');
@@ -143,28 +151,27 @@ describe('watermark (SSR)', () => {
   imports: [NzWatermarkModule],
   template: `
     <nz-watermark
-      [nzContent]="nzContent"
-      [nzWidth]="nzWidth"
-      [nzHeight]="nzHeight"
-      [nzRotate]="nzRotate"
-      [nzZIndex]="nzZIndex"
-      [nzImage]="nzImage"
-      [nzFont]="nzFont"
-      [nzGap]="nzGap"
-      [nzOffset]="nzOffset"
+      [nzContent]="nzContent()"
+      [nzWidth]="nzWidth()"
+      [nzHeight]="nzHeight()"
+      [nzRotate]="nzRotate()"
+      [nzZIndex]="nzZIndex()"
+      [nzImage]="nzImage()"
+      [nzFont]="nzFont()"
+      [nzGap]="nzGap()"
+      [nzOffset]="nzOffset()"
       class="watermark"
     />
-  `,
-  changeDetection: ChangeDetectionStrategy.Eager
+  `
 })
 export class NzTestWatermarkBasicComponent {
-  nzContent: string | string[] = 'NG Ant Design';
-  nzWidth: number = 120;
-  nzHeight: number = 64;
-  nzRotate: number = -22;
-  nzZIndex: number = 9;
-  nzImage: string = '';
-  nzFont: FontType = {};
-  nzGap: [number, number] = [100, 100];
-  nzOffset: [number, number] = [50, 50];
+  readonly nzContent = signal<string | string[]>('NG Ant Design');
+  readonly nzWidth = signal(120);
+  readonly nzHeight = signal(64);
+  readonly nzRotate = signal(-22);
+  readonly nzZIndex = signal(9);
+  readonly nzImage = signal('');
+  readonly nzFont = signal<FontType>({});
+  readonly nzGap = signal<[number, number]>([100, 100]);
+  readonly nzOffset = signal<[number, number]>([50, 50]);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24100,31 +24100,6 @@
         "which": "bin/which"
       }
     },
-    "node_modules/sugarss": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-5.0.1.tgz",
-      "integrity": "sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Some component specs still depended on zone-based testing helpers or eager change detection overrides while Angular v22 defaults to OnPush and zoneless testing.

Issue Number: N/A


## What is the new behavior?

Migrates the affected specs to run under the default OnPush + zoneless testing mode by removing zone/eager overrides, replacing fakeAsync/tick usage where needed, and using signal-backed test hosts for mutable inputs.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

`ONPUSH_ZONELESS_TEST_MIGRATION_NOTES.md` was intentionally not included in this PR.