### PR TITLE
test(schematics): add regression test esModule

### DIFF
--- a/schematics/utils/es-module-compat.spec.ts
+++ b/schematics/utils/es-module-compat.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { createRequire } from 'module';
+import { join } from 'path';
+
+describe('schematics es module compatibility', () => {
+  it('should ship a commonjs package.json in schematics', () => {
+    const packageJsonPath = join(__dirname, '../package.json');
+
+    expect(existsSync(packageJsonPath)).toBe(true);
+    expect(JSON.parse(readFileSync(packageJsonPath, 'utf8'))).toEqual({ type: 'commonjs' });
+  });
+
+  it('should load migrations when the library root package uses type module', () => {
+    const schematicsDir = join(__dirname, '..');
+    const rootDir = join(schematicsDir, '..');
+    const rootPackageJson = join(rootDir, 'package.json');
+    const hadRootPackageJson = existsSync(rootPackageJson);
+    const originalContent = hadRootPackageJson ? readFileSync(rootPackageJson, 'utf8') : undefined;
+
+    try {
+      writeFileSync(rootPackageJson, JSON.stringify({ name: 'ng-zorro-antd', type: 'module' }));
+
+      const requireFromRoot = createRequire(rootPackageJson);
+      const migration = requireFromRoot('./schematics/ng-update/index.js');
+
+      expect(typeof migration.updateToV22).toBe('function');
+      expect(typeof migration.postUpdate).toBe('function');
+    } finally {
+      if (hadRootPackageJson && originalContent !== undefined) {
+        writeFileSync(rootPackageJson, originalContent);
+      } else {
+        rmSync(rootPackageJson, { force: true });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When migrate ng zorro on nx mono repo there is an issue with esModule. The fix is already present. A package json have been added with type common js to avoid this error but not yet released

This PR just complete the fix by adding regression test

Issue Number: #9833


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
