### PR TITLE
refactor(module:modal,tabs): remove legacy eager change detection

### DIFF
--- a/components/cascader/cascader.spec.ts
+++ b/components/cascader/cascader.spec.ts
@@ -72,6 +72,7 @@ import {
 } from './typings';
 
 const MOUSE_EVENT_DELAY = 150;
+const LAZY_LOAD_DELAY = 150;
 
 describe('cascader', () => {
   let overlayContainer: OverlayContainer;
@@ -2131,7 +2132,7 @@ describe('cascader', () => {
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(1);
 
-      await sleep(600); // wait for first row to load finish
+      await sleep(LAZY_LOAD_DELAY); // wait for first row to load finish
       fixture.detectChanges();
       expect(getAllColumns().length).toBe(1);
       expect(testComponent.values()).toBeNull(); // not select yet
@@ -2140,7 +2141,7 @@ describe('cascader', () => {
       expect(itemEl1.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl1.click();
-      await sleep(600);
+      await sleep(LAZY_LOAD_DELAY);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(2);
       expect(getAllColumns().length).toBe(2);
@@ -2151,7 +2152,7 @@ describe('cascader', () => {
       expect(itemEl2.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl2.click();
-      await sleep(600);
+      await sleep(LAZY_LOAD_DELAY);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(3);
       expect(getAllColumns().length).toBe(3);
@@ -2163,13 +2164,13 @@ describe('cascader', () => {
       expect(itemEl3.classList).not.toContain('ant-cascader-menu-item-active');
 
       itemEl3.click();
-      await sleep(600);
+      await sleep(LAZY_LOAD_DELAY);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(4);
       expect(testComponent.values()).toBeNull(); // not select yet
 
       itemEl3.click(); // re-click again, this time it is a leaf
-      await sleep(600);
+      await sleep(LAZY_LOAD_DELAY);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(4);
       expect(testComponent.values()).toEqual(['zhejiang', 'hangzhou', 'xihu']);
@@ -2178,7 +2179,7 @@ describe('cascader', () => {
     it('should nzLoadData work when specifies default value', async () => {
       vi.spyOn(testComponent, 'addCallTimes').mockImplementation(() => {});
       testComponent.values.set(['zhejiang', 'hangzhou', 'xihu']);
-      await sleep(3000);
+      await sleep(LAZY_LOAD_DELAY * 3 + 16);
       fixture.detectChanges();
       expect(testComponent.addCallTimes).toHaveBeenCalledTimes(3);
       expect(testComponent.cascader.cascaderService.columns.length).toBe(3);
@@ -2188,26 +2189,26 @@ describe('cascader', () => {
     it('should not emit error after clear search and reopen it', async () => {
       fixture.detectChanges();
       testComponent.cascader.setMenuOpen(true);
-      await sleep(1000); // wait for first row to load finish
+      await sleep(LAZY_LOAD_DELAY); // wait for first row to load finish
       fixture.detectChanges();
       const itemEl1 = getItemAtColumnAndRow(1, 1)!;
 
       itemEl1.click();
-      await sleep(600);
+      await sleep(LAZY_LOAD_DELAY);
       fixture.detectChanges();
       const itemEl2 = getItemAtColumnAndRow(2, 1)!;
 
       itemEl2.click();
-      await sleep(600);
+      await sleep(LAZY_LOAD_DELAY);
       fixture.detectChanges();
       const itemEl3 = getItemAtColumnAndRow(3, 1)!;
 
       itemEl3.click();
-      await sleep(600);
+      await sleep(LAZY_LOAD_DELAY);
       fixture.detectChanges();
 
       itemEl3.click(); // re-click again, this time it is a leaf
-      await sleep(600);
+      await sleep(LAZY_LOAD_DELAY);
       fixture.detectChanges();
       cascader.nativeElement.querySelector('.ant-select-clear .anticon').click();
       testComponent.cascader.setMenuOpen(true);
@@ -2857,7 +2858,7 @@ export class NzDemoCascaderLoadDataComponent {
         } else {
           reject();
         }
-      }, 500);
+      }, LAZY_LOAD_DELAY);
     });
   };
 

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -156,7 +156,7 @@ export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extend
 {
   private readonly renderer = inject(Renderer2);
   private readonly injector = inject(Injector);
-  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly cdr = inject(ChangeDetectorRef);
   private readonly focusTrapFactory = inject(FocusTrapFactory);
   private readonly viewContainerRef = inject(ViewContainerRef);
   private readonly overlayKeyboardDispatcher = inject(OverlayKeyboardDispatcher);
@@ -312,7 +312,7 @@ export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extend
     this.updateOverlayStyle();
     this.updateBodyOverflow();
     this.templateContext = { $implicit: this.nzData || this.nzContentParams, drawerRef: this as NzDrawerRef<R> };
-    this.changeDetectorRef.detectChanges();
+    this.cdr.detectChanges();
   }
 
   ngAfterViewInit(): void {
@@ -349,11 +349,11 @@ export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extend
   private triggerPlacementChangeCycleOnce(): void {
     if (!this.nzNoAnimation) {
       this.placementChanging = true;
-      this.changeDetectorRef.markForCheck();
+      this.cdr.markForCheck();
       clearTimeout(this.placementChangeTimeoutId);
       this.placementChangeTimeoutId = setTimeout(() => {
         this.placementChanging = false;
-        this.changeDetectorRef.markForCheck();
+        this.cdr.markForCheck();
       }, this.getAnimationDuration());
     }
   }
@@ -364,7 +364,7 @@ export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extend
     this.nzVisibleChange.emit(false);
     this.updateOverlayStyle();
     this.overlayKeyboardDispatcher.remove(this.overlayRef!);
-    this.changeDetectorRef.detectChanges();
+    this.cdr.detectChanges();
     setTimeout(() => {
       this.updateBodyOverflow();
       this.restoreFocus();
@@ -386,10 +386,10 @@ export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extend
     this.updateBodyOverflow();
     this.savePreviouslyFocusedElement();
     this.trapFocus();
-    this.changeDetectorRef.detectChanges();
+    this.cdr.detectChanges();
     setTimeout(() => {
       this.inAnimation = false;
-      this.changeDetectorRef.detectChanges();
+      this.cdr.detectChanges();
       this.nzAfterOpen.next();
     }, this.getAnimationDuration());
   }

--- a/components/drawer/drawer.spec.ts
+++ b/components/drawer/drawer.spec.ts
@@ -7,7 +7,7 @@ import { Directionality } from '@angular/cdk/bidi';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component, Input, signal, TemplateRef, ViewChild, inject } from '@angular/core';
-import { ComponentFixture, TestBed, inject as testingInject } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { vi } from 'vitest';
 
@@ -42,19 +42,27 @@ describe('NzDrawerComponent', () => {
       fixture = TestBed.createComponent(NzTestDrawerComponent);
       component = fixture.componentInstance;
       fixture.detectChanges();
+      initialize();
     });
 
-    beforeEach(
-      testingInject([OverlayContainer], (oc: OverlayContainer) => {
-        overlayContainer = oc;
-        overlayContainerElement = oc.getContainerElement();
-        forceScrollElement = document.createElement('div');
-        document.body.appendChild(forceScrollElement);
-        forceScrollElement.style.width = '100px';
-        forceScrollElement.style.height = '3000px';
-        forceScrollElement.style.background = 'rebeccapurple';
-      })
-    );
+    function initialize(): void {
+      const oc = TestBed.inject(OverlayContainer);
+      overlayContainer = oc;
+      overlayContainerElement = oc.getContainerElement();
+      forceScrollElement = document.createElement('div');
+      document.body.appendChild(forceScrollElement);
+      forceScrollElement.style.width = '100px';
+      forceScrollElement.style.height = '3000px';
+      forceScrollElement.style.background = 'rebeccapurple';
+    }
+
+    function getDrawerElement(): HTMLElement {
+      return overlayContainerElement.querySelector('.ant-drawer') as HTMLElement;
+    }
+
+    function getDrawerCloseButton(): HTMLElement | null {
+      return overlayContainerElement.querySelector('.ant-drawer .ant-drawer-close') as HTMLElement | null;
+    }
 
     afterEach(() => {
       component.close();
@@ -67,7 +75,7 @@ describe('NzDrawerComponent', () => {
       expect(component.triggerVisible).toHaveBeenCalledTimes(1);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(true);
       expect(component.drawerComponent.nzVisible).toBe(true);
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
@@ -77,12 +85,12 @@ describe('NzDrawerComponent', () => {
       expect(component.triggerVisible).toHaveBeenCalledTimes(1);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(true);
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
       component.close();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(false);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(false);
       expect(component.drawerComponent.nzVisible).toBe(false);
       expect(component.triggerVisible).toHaveBeenCalledTimes(3);
       expect(component.triggerVisible).toHaveBeenCalledWith(false);
@@ -102,15 +110,16 @@ describe('NzDrawerComponent', () => {
       component.closable.set(false);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer .ant-drawer-close')).toBe(null);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.querySelector('.ant-drawer-close')).toBe(null);
     });
 
     it('should open work', () => {
       expect(component.triggerVisible).toHaveBeenCalledTimes(1);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(true);
       expect(component.drawerComponent.nzVisible).toBe(true);
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
@@ -120,12 +129,12 @@ describe('NzDrawerComponent', () => {
       expect(component.triggerVisible).toHaveBeenCalledTimes(1);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(true);
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
       component.close();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(false);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(false);
       expect(component.drawerComponent.nzVisible).toBe(false);
       expect(component.triggerVisible).toHaveBeenCalledTimes(3);
       expect(component.triggerVisible).toHaveBeenCalledWith(false);
@@ -138,10 +147,11 @@ describe('NzDrawerComponent', () => {
       fixture.detectChanges();
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      (overlayContainerElement.querySelector('.ant-drawer .ant-drawer-close') as HTMLElement).click();
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      getDrawerCloseButton()!.click();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(false);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(false);
       expect(component.triggerVisible).toHaveBeenCalledTimes(3);
       expect(component.triggerVisible).toHaveBeenCalledWith(false);
     });
@@ -171,10 +181,11 @@ describe('NzDrawerComponent', () => {
       fixture.detectChanges();
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      (overlayContainerElement.querySelector('.ant-drawer .ant-drawer-mask') as HTMLElement).click();
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      (drawerElement.querySelector('.ant-drawer-mask') as HTMLElement).click();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
     });
 
@@ -182,12 +193,12 @@ describe('NzDrawerComponent', () => {
       expect(component.triggerVisible).toHaveBeenCalledTimes(1);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(true);
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
       dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(false);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(false);
       expect(component.triggerVisible).toHaveBeenCalledTimes(3);
       expect(component.triggerVisible).toHaveBeenCalledWith(false);
     });
@@ -199,13 +210,11 @@ describe('NzDrawerComponent', () => {
       fixture.detectChanges();
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(true);
       dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(getDrawerElement().classList.contains('ant-drawer-open')).toBe(true);
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
-      component.close();
-      fixture.detectChanges();
     });
 
     it('should close when click mask', () => {
@@ -215,10 +224,11 @@ describe('NzDrawerComponent', () => {
       fixture.detectChanges();
       expect(component.triggerVisible).toHaveBeenCalledTimes(2);
       expect(component.triggerVisible).toHaveBeenCalledWith(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      (overlayContainerElement.querySelector('.ant-drawer .ant-drawer-mask') as HTMLElement).click();
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      (drawerElement.querySelector('.ant-drawer-mask') as HTMLElement).click();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(false);
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(false);
       expect(component.triggerVisible).toHaveBeenCalledTimes(3);
       expect(component.triggerVisible).toHaveBeenCalledWith(false);
     });
@@ -227,49 +237,49 @@ describe('NzDrawerComponent', () => {
       component.showMask.set(false);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('no-mask')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer .ant-drawer-mask')).toBe(null);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.classList.contains('no-mask')).toBe(true);
+      expect(drawerElement.querySelector('.ant-drawer-mask')).toBe(null);
       component.showMask.set(true);
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('no-mask')).toBe(false);
+      expect(drawerElement.classList.contains('no-mask')).toBe(false);
     });
 
     it('should set nzMaskStyle & nzBodyStyle', () => {
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect((overlayContainerElement.querySelector('.ant-drawer .ant-drawer-mask') as HTMLElement).style.color).toBe(
-        'gray'
-      );
-      expect((overlayContainerElement.querySelector('.ant-drawer .ant-drawer-body') as HTMLElement).style.color).toBe(
-        'gray'
-      );
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect((drawerElement.querySelector('.ant-drawer-mask') as HTMLElement).style.color).toBe('gray');
+      expect((drawerElement.querySelector('.ant-drawer-body') as HTMLElement).style.color).toBe('gray');
     });
 
     it('should not render title', () => {
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer .ant-drawer-title')).toBe(null);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.querySelector('.ant-drawer-title')).toBe(null);
     });
 
     it('should render header when is no title but is closeable', () => {
       component.closable.set(true);
       component.open();
       fixture.detectChanges();
-
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer-header-close-only')).toBeTruthy();
-      expect(overlayContainerElement.querySelector('.ant-drawer .ant-drawer-title')).toBe(null);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.querySelector('.ant-drawer-header-close-only')).toBeTruthy();
+      expect(drawerElement.querySelector('.ant-drawer-title')).toBe(null);
     });
 
     it('should not render title even with nzExtra', () => {
       component.extra.set('test');
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer .ant-drawer-title')).toBe(null);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.querySelector('.ant-drawer-title')).toBe(null);
     });
 
     it('should support string extra', () => {
@@ -277,10 +287,9 @@ describe('NzDrawerComponent', () => {
       component.extra.set(component.stringTitle);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer .ant-drawer-extra') as HTMLElement).innerText.trim()
-      ).toBe('test');
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect((drawerElement.querySelector('.ant-drawer-extra') as HTMLElement).innerText.trim()).toBe('test');
     });
 
     it('should support TemplateRef extra', () => {
@@ -288,68 +297,67 @@ describe('NzDrawerComponent', () => {
       component.extra.set(component.titleTemplateRef);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer .ant-drawer-extra .custom-title')).not.toBe(null);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.querySelector('.ant-drawer-extra .custom-title')).not.toBeNull();
     });
 
     it('should support string title', () => {
       component.title.set(component.stringTitle);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer .ant-drawer-title') as HTMLElement).innerText.trim()
-      ).toBe('test');
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect((drawerElement.querySelector('.ant-drawer-title') as HTMLElement).innerText.trim()).toBe('test');
     });
 
     it('should support TemplateRef title', () => {
       component.title.set(component.titleTemplateRef);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer .ant-drawer-title .custom-title')).not.toBe(null);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.querySelector('.ant-drawer-title .custom-title')).not.toBe(null);
     });
 
     it('should support string footer', () => {
       component.footer.set('test');
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer .ant-drawer-footer') as HTMLElement).innerText.trim()
-      ).toBe('test');
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect((drawerElement.querySelector('.ant-drawer-footer') as HTMLElement).innerText.trim()).toBe('test');
     });
 
     it('should support TemplateRef footer', () => {
       component.footer.set(component.templateFooter);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(overlayContainerElement.querySelector('.ant-drawer .ant-drawer-footer .custom-footer')).not.toBe(null);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.querySelector('.ant-drawer-footer .custom-footer')).not.toBe(null);
     });
 
     it('should support custom width', () => {
       component.width.set('500px');
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(
-        (
-          overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content') as HTMLElement
-        ).getBoundingClientRect().width
-      ).toBe(500);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect((drawerElement.querySelector('.ant-drawer-content') as HTMLElement).getBoundingClientRect().width).toBe(
+        500
+      );
     });
 
     it('should support custom number type width', () => {
       component.width.set(520);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(
-        (
-          overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content') as HTMLElement
-        ).getBoundingClientRect().width
-      ).toBe(520);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect((drawerElement.querySelector('.ant-drawer-content') as HTMLElement).getBoundingClientRect().width).toBe(
+        520
+      );
     });
 
     it('should support custom height', () => {
@@ -357,14 +365,11 @@ describe('NzDrawerComponent', () => {
       component.placement.set('top');
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
       expect(
-        (
-          overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content-wrapper') as HTMLElement
-        ).getBoundingClientRect().height
+        (drawerElement.querySelector('.ant-drawer-content-wrapper') as HTMLElement).getBoundingClientRect().height
       ).toBe(500);
-      component.placement.set('left');
-      fixture.detectChanges();
     });
 
     it('should support custom number type height', () => {
@@ -372,26 +377,22 @@ describe('NzDrawerComponent', () => {
       component.placement.set('top');
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
       expect(
-        (
-          overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content-wrapper') as HTMLElement
-        ).getBoundingClientRect().height
+        (drawerElement.querySelector('.ant-drawer-content-wrapper') as HTMLElement).getBoundingClientRect().height
       ).toBe(520);
-      component.placement.set('left');
-      fixture.detectChanges();
     });
 
     it('should support large size width', () => {
       component.size.set('large');
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(
-        (
-          overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content') as HTMLElement
-        ).getBoundingClientRect().width
-      ).toBe(736);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect((drawerElement.querySelector('.ant-drawer-content') as HTMLElement).getBoundingClientRect().width).toBe(
+        736
+      );
     });
 
     it('should custom width priority higher than size', () => {
@@ -399,11 +400,10 @@ describe('NzDrawerComponent', () => {
       component.width.set(520);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
       expect(
-        (
-          overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content') as HTMLElement
-        ).getBoundingClientRect().width
+        (drawerElement.querySelector('.ant-drawer .ant-drawer-content') as HTMLElement).getBoundingClientRect().width
       ).toBe(520);
     });
 
@@ -412,14 +412,11 @@ describe('NzDrawerComponent', () => {
       component.placement.set('top');
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
       expect(
-        (
-          overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content-wrapper') as HTMLElement
-        ).getBoundingClientRect().height
+        (drawerElement.querySelector('.ant-drawer-content-wrapper') as HTMLElement).getBoundingClientRect().height
       ).toBe(736);
-      component.placement.set('left');
-      fixture.detectChanges();
     });
 
     it('should custom height priority higher than size', () => {
@@ -428,20 +425,18 @@ describe('NzDrawerComponent', () => {
       component.placement.set('top');
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
       expect(
-        (
-          overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content-wrapper') as HTMLElement
-        ).getBoundingClientRect().height
+        (drawerElement.querySelector('.ant-drawer-content-wrapper') as HTMLElement).getBoundingClientRect().height
       ).toBe(520);
-      component.placement.set('left');
-      fixture.detectChanges();
     });
 
     it('should nzWrapClassName work', () => {
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
       expect(
         (
           overlayContainerElement.querySelector('.ant-drawer .ant-drawer-content-wrapper') as HTMLElement
@@ -452,110 +447,46 @@ describe('NzDrawerComponent', () => {
     it('should nzZIndex work', () => {
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.zIndex).toBe('1001');
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.style.zIndex).toBe('1001');
     });
 
-    it('should nzPlacement work', () => {
-      component.open();
-      fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-left')
-      ).toBe(true);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-bottom')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-top')
-      ).toBe(false);
-      component.placement.set('right');
-      fixture.detectChanges();
-      component.close();
-      fixture.detectChanges();
-      component.open();
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-left')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-right')
-      ).toBe(true);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-bottom')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-top')
-      ).toBe(false);
-      component.placement.set('top');
-      fixture.detectChanges();
-      component.close();
-      fixture.detectChanges();
-      component.open();
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-left')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-right')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-bottom')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-top')
-      ).toBe(true);
-      component.placement.set('bottom');
-      fixture.detectChanges();
-      component.close();
-      fixture.detectChanges();
-      component.open();
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-left')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-right')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-bottom')
-      ).toBe(true);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-top')
-      ).toBe(false);
-      component.close();
-      fixture.detectChanges();
-      component.placement.set('Invalid' as unknown as NzDrawerPlacement);
-      fixture.detectChanges();
-      component.open();
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-left')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-right')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-bottom')
-      ).toBe(false);
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).classList.contains('ant-drawer-top')
-      ).toBe(false);
-      component.close();
-      fixture.detectChanges();
+    describe('placement', () => {
+      const placements: NzDrawerPlacement[] = ['left', 'right', 'top', 'bottom'];
+      placements.forEach(placement => {
+        it(`should nzPlacement work (${placement})`, () => {
+          component.placement.set(placement as NzDrawerPlacement);
+          component.open();
+          fixture.detectChanges();
+          const drawerElement = overlayContainerElement.querySelector('.ant-drawer') as HTMLElement;
+          expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+          expect(drawerElement.classList.contains(`ant-drawer-${placement}`)).toBe(true);
+          placements.forEach(p => {
+            if (p !== placement) {
+              expect(drawerElement.classList.contains(`ant-drawer-${p}`)).toBe(false);
+            }
+          });
+        });
+      });
     });
 
     it('should disable the transition when the placement changing', async () => {
       component.open();
       await stabilize(fixture, 300);
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transition).toBe('');
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.style.transition).toBe('');
+
       component.placement.set('top');
       fixture.detectChanges();
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transition).toBe('none');
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer-content-wrapper') as HTMLElement).style.transition
-      ).toBe('none');
+      expect(drawerElement.style.transition).toBe('none');
+      expect((drawerElement.querySelector('.ant-drawer-content-wrapper') as HTMLElement).style.transition).toBe('none');
+
       component.placement.set('right');
       fixture.detectChanges();
       component.close();
       await stabilize(fixture, 300);
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transition).toBe('');
+      expect(getDrawerElement().style.transition).toBe('');
     });
 
     it('should ignore set transition when `noAnimation` is `true` ', async () => {
@@ -563,18 +494,13 @@ describe('NzDrawerComponent', () => {
       fixture.detectChanges();
       component.open();
       await stabilize(fixture, 300);
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transition).toBe('');
+
+      const drawerElement = getDrawerElement();
+      expect(drawerElement.style.transition).toBe('');
       component.placement.set('top');
       fixture.detectChanges();
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transition).toBe('');
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer-content-wrapper') as HTMLElement).style.transition
-      ).toBe('');
-      fixture.detectChanges();
-      component.close();
-      component.placement.set('right');
-      component.noAnimation.set(false);
-      await stabilize(fixture, 300);
+      expect(drawerElement.style.transition).toBe('');
+      expect((drawerElement.querySelector('.ant-drawer-content-wrapper') as HTMLElement).style.transition).toBe('');
     });
 
     it('should nzOffsetX work', () => {
@@ -583,19 +509,15 @@ describe('NzDrawerComponent', () => {
       component.width.set('300px');
       component.offsetX.set(100);
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transform).toBe(
-        'translateX(100px)'
-      );
+
+      const drawerElement = getDrawerElement();
+      expect(drawerElement!.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.style.transform).toBe('translateX(100px)');
       fixture.detectChanges();
       component.placement.set('right');
       component.offsetX.set(100);
       fixture.detectChanges();
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transform).toBe(
-        'translateX(-100px)'
-      );
-      component.close();
-      fixture.detectChanges();
+      expect(drawerElement.style.transform).toBe('translateX(-100px)');
     });
 
     it('should nzOffsetY work', () => {
@@ -604,30 +526,25 @@ describe('NzDrawerComponent', () => {
       component.height.set('300px');
       component.offsetY.set(100);
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-open')).toBe(true);
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transform).toBe(
-        'translateY(100px)'
-      );
+      const drawerElement = getDrawerElement();
+
+      expect(drawerElement.classList.contains('ant-drawer-open')).toBe(true);
+      expect(drawerElement.style.transform).toBe('translateY(100px)');
       fixture.detectChanges();
       component.placement.set('bottom');
       component.offsetY.set(100);
       fixture.detectChanges();
-      expect((overlayContainerElement.querySelector('.ant-drawer') as HTMLElement).style.transform).toBe(
-        'translateY(-100px)'
-      );
-      component.close();
-      fixture.detectChanges();
+      expect(drawerElement.style.transform).toBe('translateY(-100px)');
     });
 
     it('should allow scroll', () => {
       component.placement.set('right');
       component.open();
       fixture.detectChanges();
-      expect(
-        (overlayContainerElement.querySelector('.ant-drawer .ant-drawer-wrapper-body') as HTMLElement).style.height
-      ).toBe('100%');
+      expect((getDrawerElement().querySelector('.ant-drawer-wrapper-body') as HTMLElement).style.height).toBe('100%');
     });
   });
+
   describe('RTL', () => {
     let component: NzTestDrawerComponent;
     let fixture: ComponentFixture<NzTestDrawerComponent>;
@@ -642,14 +559,9 @@ describe('NzDrawerComponent', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(NzTestDrawerComponent);
       component = fixture.componentInstance;
+      overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
       fixture.detectChanges();
     });
-
-    beforeEach(
-      testingInject([OverlayContainer], (oc: OverlayContainer) => {
-        overlayContainerElement = oc.getContainerElement();
-      })
-    );
 
     afterEach(() => {
       component.close();
@@ -660,17 +572,19 @@ describe('NzDrawerComponent', () => {
       const dir = TestBed.inject(Directionality);
       component.open();
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-rtl')).toBe(false);
+      const drawerElement = overlayContainerElement.querySelector('.ant-drawer')!;
+      expect(drawerElement.classList.contains('ant-drawer-rtl')).toBe(false);
 
       dir.valueSignal.set('rtl');
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-rtl')).toBe(true);
+      expect(drawerElement.classList.contains('ant-drawer-rtl')).toBe(true);
 
       dir.valueSignal.set('ltr');
       fixture.detectChanges();
-      expect(overlayContainerElement.querySelector('.ant-drawer')!.classList.contains('ant-drawer-rtl')).toBe(false);
+      expect(drawerElement.classList.contains('ant-drawer-rtl')).toBe(false);
     });
   });
+
   describe('animation', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
@@ -697,29 +611,21 @@ describe('NzDrawerService', () => {
     TestBed.configureTestingModule({
       providers: [NzDrawerService, provideNzNoAnimation()]
     });
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(NzTestDrawerWithServiceComponent);
     component = fixture.componentInstance;
+    overlayContainer = TestBed.inject(OverlayContainer);
+    overlayContainerElement = overlayContainer.getContainerElement();
+    drawerService = TestBed.inject(NzDrawerService);
     fixture.detectChanges();
   });
 
   beforeEach(() => vi.useFakeTimers());
-
-  beforeEach(
-    testingInject([OverlayContainer, NzDrawerService], (oc: OverlayContainer, ds: NzDrawerService) => {
-      overlayContainer = oc;
-      drawerService = ds;
-      overlayContainerElement = oc.getContainerElement();
-    })
-  );
+  afterEach(() => vi.useRealTimers());
 
   afterEach(() => {
     overlayContainer.ngOnDestroy();
   });
-
-  afterEach(() => vi.useRealTimers());
 
   it('should create template content drawer', async () => {
     component.openTemplate();
@@ -732,7 +638,6 @@ describe('NzDrawerService', () => {
     (overlayContainerElement.querySelector('.ant-drawer .ant-drawer-mask') as HTMLElement).click();
     await flushDrawerAnimation(fixture);
     expect(component.templateCloseSpy).toHaveBeenCalled();
-    fixture.detectChanges();
   });
 
   it('should create component content drawer', async () => {

--- a/components/icon/icon.spec.ts
+++ b/components/icon/icon.spec.ts
@@ -270,6 +270,7 @@ export class NzTestIconIconfontComponent {
 class ChildModule {}
 
 @Component({
+  selector: 'nz-test-icon-multi-injection',
   imports: [NzIconModule, ChildModule],
   template: `
     <nz-icon nzType="home" />
@@ -279,6 +280,7 @@ class ChildModule {}
 class NzTestIconMultiInjectionComponent {}
 
 @Component({
+  selector: 'nz-test-icon-multi-injection-standalone',
   imports: [NzIconModule],
   providers: [provideNzIconsPatch([QuestionOutline])],
   template: `

--- a/components/modal/modal-config.ts
+++ b/components/modal/modal-config.ts
@@ -5,7 +5,6 @@
 
 import { InjectionToken } from '@angular/core';
 
-import { NzConfigKey } from 'ng-zorro-antd/core/config';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 export const ZOOM_CLASS_NAME_MAP = {
@@ -23,7 +22,7 @@ export const FADE_CLASS_NAME_MAP = {
 };
 
 export const MODAL_MASK_CLASS_NAME = 'ant-modal-mask';
-export const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'modal';
+export const NZ_CONFIG_MODULE_NAME = 'modal';
 export const NZ_MODAL_DATA = new InjectionToken<NzSafeAny>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'nz-modal-data' : ''
 );

--- a/components/modal/modal-confirm-container.component.ts
+++ b/components/modal/modal-confirm-container.component.ts
@@ -5,21 +5,11 @@
 
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { CdkPortalOutlet, PortalModule } from '@angular/cdk/portal';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  EventEmitter,
-  OnInit,
-  Output,
-  ViewChild,
-  inject
-} from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, ElementRef, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
-import { NzI18nService, NzModalI18nInterface } from 'ng-zorro-antd/i18n';
+import { NzI18nPipe } from 'ng-zorro-antd/i18n';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzPipesModule } from 'ng-zorro-antd/pipes';
 
@@ -29,6 +19,15 @@ import { BaseModalContainerComponent } from './modal-container.directive';
 @Component({
   selector: 'nz-modal-confirm-container',
   exportAs: 'nzModalConfirmContainer',
+  imports: [
+    NzPipesModule,
+    NzI18nPipe,
+    NzIconModule,
+    NzModalCloseComponent,
+    NzOutletModule,
+    PortalModule,
+    NzButtonModule
+  ],
   template: `
     <div
       #modalElement
@@ -68,7 +67,7 @@ import { BaseModalContainerComponent } from './modal-container.directive';
                   [nzLoading]="config.nzCancelLoading"
                   [disabled]="config.nzCancelDisabled"
                 >
-                  {{ config.nzCancelText || locale.cancelText }}
+                  {{ config.nzCancelText || ('Modal.cancelText' | nzI18n) }}
                 </button>
               }
               @if (config.nzOkText !== null) {
@@ -81,7 +80,7 @@ import { BaseModalContainerComponent } from './modal-container.directive';
                   [disabled]="config.nzOkDisabled"
                   [nzDanger]="config.nzOkDanger"
                 >
-                  {{ config.nzOkText || locale.okText }}
+                  {{ config.nzOkText || ('Modal.okText' | nzI18n) }}
                 </button>
               }
             </div>
@@ -91,8 +90,6 @@ import { BaseModalContainerComponent } from './modal-container.directive';
     </div>
   `,
   hostDirectives: [CdkScrollable],
-  // Using OnPush for modal caused footer can not to detect changes. we can fix it when 8.x.
-  changeDetection: ChangeDetectionStrategy.Eager,
   host: {
     tabindex: '-1',
     role: 'dialog',
@@ -101,12 +98,9 @@ import { BaseModalContainerComponent } from './modal-container.directive';
     '[class.ant-modal-centered]': 'config.nzCentered',
     '[style.zIndex]': 'config.nzZIndex',
     '(click)': 'onContainerClick($event)'
-  },
-  imports: [NzPipesModule, NzIconModule, NzModalCloseComponent, NzOutletModule, PortalModule, NzButtonModule]
+  }
 })
 export class NzModalConfirmContainerComponent extends BaseModalContainerComponent implements OnInit {
-  private i18n = inject(NzI18nService);
-
   @ViewChild(CdkPortalOutlet, { static: true }) set _portalOutlet(portalOutlet: CdkPortalOutlet) {
     this.portalOutlet = portalOutlet;
   }
@@ -115,15 +109,6 @@ export class NzModalConfirmContainerComponent extends BaseModalContainerComponen
   }
   @Output() override readonly cancelTriggered = new EventEmitter<void>();
   @Output() override readonly okTriggered = new EventEmitter<void>();
-  locale!: NzModalI18nInterface;
-
-  constructor() {
-    super();
-
-    this.i18n.localeChange.pipe(takeUntilDestroyed()).subscribe(() => {
-      this.locale = this.i18n.getLocaleData('Modal');
-    });
-  }
 
   ngOnInit(): void {
     this.setupMouseListeners(this.modalElementRef);

--- a/components/modal/modal-container.component.ts
+++ b/components/modal/modal-container.component.ts
@@ -6,7 +6,7 @@
 import { CdkDrag, CdkDragHandle } from '@angular/cdk/drag-drop';
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { CdkPortalOutlet, PortalModule } from '@angular/cdk/portal';
-import { ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 
 import { NzPipesModule } from 'ng-zorro-antd/pipes';
 
@@ -18,6 +18,15 @@ import { NzModalTitleComponent } from './modal-title.component';
 @Component({
   selector: 'nz-modal-container',
   exportAs: 'nzModalContainer',
+  imports: [
+    NzModalCloseComponent,
+    NzModalTitleComponent,
+    PortalModule,
+    NzModalFooterComponent,
+    NzPipesModule,
+    CdkDrag,
+    CdkDragHandle
+  ],
   hostDirectives: [CdkScrollable],
   template: `
     <div
@@ -56,8 +65,6 @@ import { NzModalTitleComponent } from './modal-title.component';
       </div>
     </div>
   `,
-  // Using OnPush for modal caused footer can not to detect changes. we can fix it when 8.x.
-  changeDetection: ChangeDetectionStrategy.Eager,
   host: {
     tabindex: '-1',
     role: 'dialog',
@@ -66,16 +73,7 @@ import { NzModalTitleComponent } from './modal-title.component';
     '[class.ant-modal-centered]': 'config.nzCentered',
     '[style.zIndex]': 'config.nzZIndex',
     '(click)': 'onContainerClick($event)'
-  },
-  imports: [
-    NzModalCloseComponent,
-    NzModalTitleComponent,
-    PortalModule,
-    NzModalFooterComponent,
-    NzPipesModule,
-    CdkDrag,
-    CdkDragHandle
-  ]
+  }
 })
 export class NzModalContainerComponent extends BaseModalContainerComponent implements OnInit {
   @ViewChild(CdkPortalOutlet, { static: true }) set _portalOutlet(portalOutlet: CdkPortalOutlet) {
@@ -83,6 +81,12 @@ export class NzModalContainerComponent extends BaseModalContainerComponent imple
   }
   @ViewChild('modalElement', { static: true }) set _modalElementRef(elementRef: ElementRef<HTMLDivElement>) {
     this.modalElementRef = elementRef;
+  }
+  @ViewChild(NzModalFooterComponent) private modalFooter?: NzModalFooterComponent;
+
+  override markForCheck(): void {
+    super.markForCheck();
+    this.modalFooter?.markForCheck();
   }
 
   ngOnInit(): void {

--- a/components/modal/modal-container.directive.ts
+++ b/components/modal/modal-container.directive.ts
@@ -25,7 +25,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { NzConfigService, onConfigChangeEventForComponent } from 'ng-zorro-antd/core/config';
 import { requestAnimationFrame } from 'ng-zorro-antd/core/polyfill';
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
 import { fromEventOutsideAngular, getElementOffset, isNotNil } from 'ng-zorro-antd/core/util';
 
 import { FADE_CLASS_NAME_MAP, MODAL_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME, ZOOM_CLASS_NAME_MAP } from './modal-config';
@@ -41,17 +40,17 @@ type AnimationState = 'enter-start' | 'enter-active' | 'leave-start' | 'leave-ac
 
 @Directive()
 export class BaseModalContainerComponent extends BasePortalOutlet {
-  readonly document: Document = inject(DOCUMENT);
-  readonly cdr: ChangeDetectorRef = inject(ChangeDetectorRef);
-  readonly config: ModalOptions = inject(ModalOptions);
-  protected ngZone: NgZone = inject(NgZone);
-  protected host: ElementRef<HTMLElement> = inject(ElementRef);
-  protected focusTrapFactory: FocusTrapFactory = inject(FocusTrapFactory);
-  protected render: Renderer2 = inject(Renderer2);
-  protected overlayRef: OverlayRef = inject(OverlayRef);
-  protected nzConfigService: NzConfigService = inject(NzConfigService);
-  protected animationType = inject(ANIMATION_MODULE_TYPE, { optional: true });
-  protected destroyRef = inject(DestroyRef);
+  readonly document = inject(DOCUMENT);
+  readonly cdr = inject(ChangeDetectorRef);
+  readonly config = inject(ModalOptions);
+  protected readonly ngZone = inject(NgZone);
+  protected readonly host: ElementRef<HTMLElement> = inject(ElementRef);
+  protected readonly focusTrapFactory = inject(FocusTrapFactory);
+  protected readonly renderer = inject(Renderer2);
+  protected readonly overlayRef = inject(OverlayRef);
+  protected readonly nzConfigService = inject(NzConfigService);
+  protected readonly animationType = inject(ANIMATION_MODULE_TYPE, { optional: true });
+  protected readonly destroyRef = inject(DestroyRef);
 
   portalOutlet!: CdkPortalOutlet;
   modalElementRef!: ElementRef<HTMLDivElement>;
@@ -70,14 +69,12 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
   private oldMaskStyle: Record<string, string> | null = null;
 
   get showMask(): boolean {
-    const defaultConfig: NzSafeAny = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
-
+    const defaultConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
     return !!getValueWithConfig<boolean>(this.config.nzMask, defaultConfig.nzMask, true);
   }
 
   get maskClosable(): boolean {
-    const defaultConfig: NzSafeAny = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
-
+    const defaultConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
     return !!getValueWithConfig<boolean>(this.config.nzMaskClosable, defaultConfig.nzMaskClosable, true);
   }
 
@@ -105,6 +102,10 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
 
   onOkClick(): void {
     this.okTriggered.emit();
+  }
+
+  markForCheck(): void {
+    this.cdr.markForCheck();
   }
 
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
@@ -154,7 +155,7 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
       const x = lastPosition.left + previouslyDOMRect.width / 2;
       const y = lastPosition.top + previouslyDOMRect.height / 2;
       const transformOrigin = `${x - modalElement.offsetLeft}px ${y - modalElement.offsetTop}px 0px`;
-      this.render.setStyle(modalElement, 'transform-origin', transformOrigin);
+      this.renderer.setStyle(modalElement, 'transform-origin', transformOrigin);
     }
   }
 
@@ -260,7 +261,7 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
     const backdropElement = this.overlayRef.backdropElement;
     if (backdropElement) {
       if (isNotNil(this.config.nzZIndex)) {
-        this.render.setStyle(backdropElement, 'z-index', this.config.nzZIndex);
+        this.renderer.setStyle(backdropElement, 'z-index', this.config.nzZIndex);
       }
     }
   }
@@ -271,7 +272,7 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
       if (this.oldMaskStyle) {
         const styles = this.oldMaskStyle as Record<string, string>;
         Object.keys(styles).forEach(key => {
-          this.render.removeStyle(backdropElement, key);
+          this.renderer.removeStyle(backdropElement, key);
         });
         this.oldMaskStyle = null;
       }
@@ -281,7 +282,7 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
       if (typeof this.config.nzMaskStyle === 'object' && Object.keys(this.config.nzMaskStyle).length) {
         const styles: Record<string, string> = { ...this.config.nzMaskStyle };
         Object.keys(styles).forEach(key => {
-          this.render.setStyle(backdropElement, key, styles[key]);
+          this.renderer.setStyle(backdropElement, key, styles[key]);
         });
         this.oldMaskStyle = styles;
       }

--- a/components/modal/modal-footer.component.ts
+++ b/components/modal/modal-footer.component.ts
@@ -3,13 +3,12 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { ChangeDetectionStrategy, Component, EventEmitter, inject, Input, Output } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ChangeDetectorRef, Component, inject, input, output } from '@angular/core';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { isPromise } from 'ng-zorro-antd/core/util';
-import { NzI18nService, NzModalI18nInterface } from 'ng-zorro-antd/i18n';
+import { NzI18nPipe } from 'ng-zorro-antd/i18n';
 
 import { NzModalRef } from './modal-ref';
 import { ModalButtonOptions, ModalOptions } from './modal-types';
@@ -17,12 +16,13 @@ import { ModalButtonOptions, ModalOptions } from './modal-types';
 @Component({
   selector: 'div[nz-modal-footer]',
   exportAs: 'nzModalFooterBuiltin',
+  imports: [NzOutletModule, NzButtonModule, NzI18nPipe],
   template: `
     @if (config.nzFooter) {
       <ng-container
-        *nzStringTemplateOutlet="config.nzFooter; context: { $implicit: config.nzData, modalRef: modalRef }"
+        *nzStringTemplateOutlet="config.nzFooter; context: { $implicit: config.nzData, modalRef: modalRef() }"
       >
-        @if (buttonsFooter) {
+        @if (buttons) {
           @for (button of buttons; track button) {
             <button
               nz-button
@@ -52,7 +52,7 @@ import { ModalButtonOptions, ModalOptions } from './modal-types';
           [nzLoading]="config.nzCancelLoading"
           [disabled]="config.nzCancelDisabled"
         >
-          {{ config.nzCancelText || locale.cancelText }}
+          {{ config.nzCancelText || ('Modal.cancelText' | nzI18n) }}
         </button>
       }
       @if (config.nzOkText !== null) {
@@ -65,37 +65,26 @@ import { ModalButtonOptions, ModalOptions } from './modal-types';
           [nzLoading]="config.nzOkLoading"
           [disabled]="config.nzOkDisabled"
         >
-          {{ config.nzOkText || locale.okText }}
+          {{ config.nzOkText || ('Modal.okText' | nzI18n) }}
         </button>
       }
     }
   `,
   host: {
     class: 'ant-modal-footer'
-  },
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [NzOutletModule, NzButtonModule]
+  }
 })
 export class NzModalFooterComponent {
-  private i18n = inject(NzI18nService);
+  private readonly cdr = inject(ChangeDetectorRef);
   public readonly config = inject(ModalOptions);
 
-  buttonsFooter = false;
-  buttons: ModalButtonOptions[] = [];
-  locale!: NzModalI18nInterface;
-  @Output() readonly cancelTriggered = new EventEmitter<void>();
-  @Output() readonly okTriggered = new EventEmitter<void>();
-  @Input() modalRef!: NzModalRef;
+  readonly modalRef = input.required<NzModalRef>();
+  readonly cancelTriggered = output();
+  readonly okTriggered = output();
 
-  constructor() {
-    if (Array.isArray(this.config.nzFooter)) {
-      this.buttonsFooter = true;
-      this.buttons = (this.config.nzFooter as ModalButtonOptions[]).map(mergeDefaultOption);
-    }
-    this.i18n.localeChange.pipe(takeUntilDestroyed()).subscribe(() => {
-      this.locale = this.i18n.getLocaleData('Modal');
-    });
-  }
+  protected buttons = Array.isArray(this.config.nzFooter)
+    ? (this.config.nzFooter as ModalButtonOptions[]).map(mergeDefaultOption)
+    : null;
 
   onCancel(): void {
     this.cancelTriggered.emit();
@@ -105,13 +94,17 @@ export class NzModalFooterComponent {
     this.okTriggered.emit();
   }
 
+  markForCheck(): void {
+    this.cdr.markForCheck();
+  }
+
   /**
    * Returns the value of the specified key.
    * If it is a function, run and return the return value of the function.
    */
   getButtonCallableProp(options: ModalButtonOptions, prop: keyof ModalButtonOptions): boolean {
     const value = options[prop];
-    const componentInstance = this.modalRef.getContentComponent();
+    const componentInstance = this.modalRef().getContentComponent();
     return typeof value === 'function' ? value.apply(options, componentInstance && [componentInstance]) : value;
   }
 

--- a/components/modal/modal-ref.ts
+++ b/components/modal/modal-ref.ts
@@ -141,7 +141,7 @@ export class NzModalRef<T = NzSafeAny, R = NzSafeAny> implements NzModalLegacyAP
   updateConfig(config: ModalOptions): void {
     Object.assign(this.config, config);
     this.containerInstance.bindBackdropStyle();
-    this.containerInstance.cdr.markForCheck();
+    this.containerInstance.markForCheck();
   }
 
   getState(): NzModalState {

--- a/components/modal/modal.service.ts
+++ b/components/modal/modal.service.ts
@@ -20,7 +20,7 @@ import { NzConfigService } from 'ng-zorro-antd/core/config';
 import { warn } from 'ng-zorro-antd/core/logger';
 import { overlayZIndexSetter } from 'ng-zorro-antd/core/overlay';
 import { IndexableObject, NzSafeAny } from 'ng-zorro-antd/core/types';
-import { isNotNil } from 'ng-zorro-antd/core/util';
+import { isNotNil, isTemplateRef } from 'ng-zorro-antd/core/util';
 
 import { MODAL_MASK_CLASS_NAME, NZ_CONFIG_MODULE_NAME, NZ_MODAL_DATA } from './modal-config';
 import { NzModalConfirmContainerComponent } from './modal-confirm-container.component';
@@ -34,10 +34,10 @@ type ContentType<T> = ComponentType<T> | TemplateRef<T> | string;
 
 @Injectable()
 export class NzModalService implements OnDestroy {
-  private injector = inject(Injector);
-  private nzConfigService = inject(NzConfigService);
-  private directionality = inject(Directionality);
-  private parentModal = inject(NzModalService, { skipSelf: true, optional: true });
+  private readonly injector = inject(Injector);
+  private readonly nzConfigService = inject(NzConfigService);
+  private readonly directionality = inject(Directionality);
+  private readonly parentModal = inject(NzModalService, { skipSelf: true, optional: true });
 
   private openModalsAtThisLevel: NzModalRef[] = [];
   private readonly afterAllClosedAtThisLevel = new Subject<void>();
@@ -53,7 +53,7 @@ export class NzModalService implements OnDestroy {
 
   readonly afterAllClose: Observable<void> = defer(() =>
     this.openModals.length ? this._afterAllClosed : this._afterAllClosed.pipe(startWith(undefined))
-  ) as Observable<void>;
+  );
 
   create<T, D = NzSafeAny, R = NzSafeAny>(config: ModalOptions<T, D, R>): NzModalRef<T, R> {
     return this.open<T, D, R>(config.nzContent as ComponentType<T>, config);
@@ -132,7 +132,7 @@ export class NzModalService implements OnDestroy {
   }
 
   private createOverlay(config: ModalOptions): OverlayRef {
-    const globalConfig: NzSafeAny = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
+    const globalConfig = this.nzConfigService.getConfigForComponent(NZ_CONFIG_MODULE_NAME) || {};
 
     return createOverlayRef(this.injector, {
       hasBackdrop: true,
@@ -179,12 +179,12 @@ export class NzModalService implements OnDestroy {
   ): NzModalRef<T, R> {
     const modalRef = new NzModalRef<T, R>(overlayRef, config, modalContainer);
 
-    if (componentOrTemplateRef instanceof TemplateRef) {
+    if (isTemplateRef(componentOrTemplateRef)) {
       modalContainer.attachTemplatePortal(
         new TemplatePortal<T>(componentOrTemplateRef, null!, {
           $implicit: config.nzData,
           modalRef
-        } as NzSafeAny)
+        } as T)
       );
     } else if (isNotNil(componentOrTemplateRef) && typeof componentOrTemplateRef !== 'string') {
       const injector = this.createInjector<T, D, R>(modalRef, config);

--- a/components/pagination/pagination-item.component.ts
+++ b/components/pagination/pagination-item.component.ts
@@ -6,7 +6,6 @@
 
 import { NgTemplateOutlet } from '@angular/common';
 import {
-  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -1821,7 +1821,7 @@ describe('select finalVariant', () => {
       [nzMaxMultipleCount]="nzMaxMultipleCount()"
       (nzOnSearch)="searchValueChange($event)"
     >
-      @for (o of listOfOption(); track o) {
+      @for (o of listOfOption(); track o.nzValue) {
         <nz-option
           [nzValue]="o.nzValue"
           [nzLabel]="o.nzLabel"
@@ -1830,7 +1830,7 @@ describe('select finalVariant', () => {
           [nzHide]="o.nzHide"
         />
       }
-      @for (group of listOfGroup(); track group) {
+      @for (group of listOfGroup(); track group.nzLabel) {
         <nz-option-group [nzLabel]="group.nzLabel">
           @for (o of group.children; track o) {
             <nz-option
@@ -1908,7 +1908,7 @@ export class TestSelectTemplateDefaultComponent {
       [(nzOpen)]="nzOpen"
       (nzOpenChange)="valueChange($event)"
     >
-      @for (o of listOfOption(); track o) {
+      @for (o of listOfOption(); track o.nzValue) {
         <nz-option [nzValue]="o.nzValue" [nzLabel]="o.nzLabel" [nzDisabled]="o.nzDisabled" [nzHide]="o.nzHide" />
       }
     </nz-select>
@@ -1942,7 +1942,7 @@ export class TestSelectTemplateMultipleComponent {
       [nzTokenSeparators]="nzTokenSeparators()"
       [nzMaxTagPlaceholder]="nzMaxTagPlaceholder() ?? null"
     >
-      @for (o of listOfOption(); track o) {
+      @for (o of listOfOption(); track o.nzValue) {
         <nz-option [nzValue]="o.nzValue" [nzLabel]="o.nzLabel" [nzDisabled]="o.nzDisabled" [nzHide]="o.nzHide" />
       }
     </nz-select>

--- a/components/slider/slider.spec.ts
+++ b/components/slider/slider.spec.ts
@@ -1031,6 +1031,7 @@ class SliderWithStepComponent {
 }
 
 @Component({
+  selector: 'nz-test-slider-with-value-smaller-than-min',
   imports: [FormsModule, NzSliderModule],
   template: `<nz-slider [ngModel]="3" [nzMin]="4" [nzMax]="6" />`,
   styles: [styles]
@@ -1038,6 +1039,7 @@ class SliderWithStepComponent {
 class SliderWithValueSmallerThanMinComponent {}
 
 @Component({
+  selector: 'nz-test-slider-with-value-zero',
   imports: [FormsModule, NzSliderModule],
   template: `<nz-slider [ngModel]="0" [nzMin]="-5" [nzMax]="5" />`,
   styles: [styles]
@@ -1045,6 +1047,7 @@ class SliderWithValueSmallerThanMinComponent {}
 class SliderWithValueZeroComponent {}
 
 @Component({
+  selector: 'nz-test-slider-with-value-greater-than-max',
   imports: [FormsModule, NzSliderModule],
   template: `<nz-slider [ngModel]="7" [nzMin]="4" [nzMax]="6" />`,
   styles: [styles]
@@ -1052,6 +1055,7 @@ class SliderWithValueZeroComponent {}
 class SliderWithValueGreaterThanMaxComponent {}
 
 @Component({
+  selector: 'nz-test-vertical-slider',
   imports: [NzSliderModule],
   template: `<nz-slider nzVertical />`,
   styles: [styles]
@@ -1059,6 +1063,7 @@ class SliderWithValueGreaterThanMaxComponent {}
 class VerticalSliderComponent {}
 
 @Component({
+  selector: 'nz-test-reverse-slider',
   imports: [NzSliderModule],
   template: `
     <nz-slider nzReverse [nzMarks]="marks" />
@@ -1071,6 +1076,7 @@ class ReverseSliderComponent {
 }
 
 @Component({
+  selector: 'nz-test-reverse-slider-with-min-and-max',
   imports: [NzSliderModule],
   template: `<nz-slider [nzMin]="4" [nzMax]="6" nzReverse />`,
   styles: [styles]
@@ -1078,6 +1084,7 @@ class ReverseSliderComponent {
 class ReverseSliderWithMinAndMaxComponent {}
 
 @Component({
+  selector: 'nz-test-mixed-slider',
   imports: [NzSliderModule],
   template: `
     <nz-slider
@@ -1108,6 +1115,7 @@ class MixedSliderComponent {
 }
 
 @Component({
+  selector: 'nz-test-slider-with-form-control',
   imports: [ReactiveFormsModule, NzSliderModule],
   template: `
     <form>
@@ -1131,6 +1139,7 @@ class SliderWithFormControlComponent {
 }
 
 @Component({
+  selector: 'nz-test-slider-show-tooltip',
   imports: [FormsModule, NzSliderModule],
   template: `<nz-slider [nzTooltipVisible]="show()" [ngModel]="value" />`,
   styles: [styles]
@@ -1142,6 +1151,7 @@ class SliderShowTooltipComponent {
 }
 
 @Component({
+  selector: 'nz-test-slider-keyboard',
   imports: [NzSliderModule],
   template: `<nz-slider [nzRange]="range()" [nzDisabled]="disabled()" />`
 })
@@ -1151,6 +1161,7 @@ class NzTestSliderKeyboardComponent {
 }
 
 @Component({
+  selector: 'nz-test-slider-show-template-tooltip',
   imports: [FormsModule, NzSliderModule],
   template: `
     <nz-slider [nzTooltipVisible]="show()" [ngModel]="value" [nzTipFormatter]="titleTemplate" />
@@ -1236,7 +1247,6 @@ function dispatchSlideStartEvent(sliderElement: HTMLElement, percent: number): v
   const y = dimensions.top + dimensions.height * percent;
 
   dispatchMouseenterEvent(sliderElement);
-
   dispatchMouseEvent(sliderElement, 'mousedown', x, y);
 }
 

--- a/components/table/src/testing/tbody.spec.ts
+++ b/components/table/src/testing/tbody.spec.ts
@@ -3,46 +3,36 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Component, DebugElement } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { NzTableModule, NzTbodyComponent } from 'ng-zorro-antd/table';
 
 describe('nz-tbody', () => {
-  describe('nz-tbody in table', () => {
-    let fixture: ComponentFixture<NzTbodyTestTableComponent>;
-    let tbody: DebugElement;
-
-    beforeEach(() => {
-      fixture = TestBed.createComponent(NzTbodyTestTableComponent);
+  [
+    {
+      component: NzTbodyTestTableComponent,
+      case: 'should not add class to tbody in table',
+      expected: false
+    },
+    {
+      component: NzTbodyTestNzTableComponent,
+      case: 'should add class to tbody in nz-table',
+      expected: true
+    }
+  ].forEach(({ component, case: testCase, expected }) => {
+    it(testCase, () => {
+      const fixture = TestBed.createComponent(component);
       fixture.detectChanges();
-      tbody = fixture.debugElement.query(By.directive(NzTbodyComponent));
-    });
-
-    it('should not add class', () => {
-      fixture.detectChanges();
-      expect(tbody.nativeElement.classList).not.toContain('ant-table-tbody');
-    });
-  });
-
-  describe('nz-tbody in nz-table', () => {
-    let fixture: ComponentFixture<NzTbodyTestNzTableComponent>;
-    let tbody: DebugElement;
-
-    beforeEach(() => {
-      fixture = TestBed.createComponent(NzTbodyTestNzTableComponent);
-      fixture.detectChanges();
-      tbody = fixture.debugElement.query(By.directive(NzTbodyComponent));
-    });
-    it('should not add class', () => {
-      fixture.detectChanges();
-      expect(tbody.nativeElement.classList).toContain('ant-table-tbody');
+      const tbody = fixture.debugElement.query(By.directive(NzTbodyComponent));
+      expect(tbody.nativeElement.classList.contains('ant-table-tbody')).toBe(expected);
     });
   });
 });
 
 @Component({
+  selector: 'nz-test-tbody-in-table',
   imports: [NzTableModule],
   template: `
     <table>
@@ -53,6 +43,7 @@ describe('nz-tbody', () => {
 export class NzTbodyTestTableComponent {}
 
 @Component({
+  selector: 'nz-test-tbody-in-nz-table',
   imports: [NzTableModule],
   template: `
     <nz-table>
@@ -60,6 +51,4 @@ export class NzTbodyTestTableComponent {}
     </nz-table>
   `
 })
-export class NzTbodyTestNzTableComponent {
-  expand = false;
-}
+export class NzTbodyTestNzTableComponent {}

--- a/components/tabs/tab-close-button.component.ts
+++ b/components/tabs/tab-close-button.component.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Component, Input, TemplateRef } from '@angular/core';
+import { Component, input, TemplateRef } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
@@ -12,7 +12,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 @Component({
   selector: 'nz-tab-close-button, button[nz-tab-close-button]',
   template: `
-    <ng-container *nzStringTemplateOutlet="closeIcon; let icon">
+    <ng-container *nzStringTemplateOutlet="closeIcon(); let icon">
       <nz-icon [nzType]="icon" nzTheme="outline" />
     </ng-container>
   `,
@@ -24,5 +24,5 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
   imports: [NzOutletModule, NzIconModule]
 })
 export class NzTabCloseButtonComponent {
-  @Input() closeIcon: string | TemplateRef<NzSafeAny> = 'close';
+  readonly closeIcon = input<string | TemplateRef<NzSafeAny>>('close');
 }

--- a/components/tabs/tab-nav-bar.component.ts
+++ b/components/tabs/tab-nav-bar.component.ts
@@ -62,9 +62,9 @@ const CSS_TRANSFORM_TIME = 150;
     NgTemplateOutlet
   ],
   template: `
-    @if (startExtraContent()) {
+    @if (startExtraContent(); as extraContent) {
       <div class="ant-tabs-extra-content">
-        <ng-template [ngTemplateOutlet]="startExtraContent()!.templateRef" />
+        <ng-template [ngTemplateOutlet]="extraContent.templateRef" />
       </div>
     }
     <div
@@ -109,9 +109,9 @@ const CSS_TRANSFORM_TIME = 150;
       [addable]="addable"
       [items]="hiddenItems"
     />
-    @if (endExtraContent()) {
+    @if (endExtraContent(); as extraContent) {
       <div class="ant-tabs-extra-content">
-        <ng-template [ngTemplateOutlet]="endExtraContent()!.templateRef" />
+        <ng-template [ngTemplateOutlet]="extraContent.templateRef" />
       </div>
     } @else if (extraTemplate) {
       <div class="ant-tabs-extra-content">
@@ -223,9 +223,6 @@ export class NzTabNavBarComponent implements AfterViewInit, AfterContentChecked,
   }
 
   ngAfterViewInit(): void {
-    const dirChange = this.directionality.change.asObservable();
-    const resize = this.viewportRuler.change(150);
-
     const realign = (): void => {
       this.updateScrollListPosition();
       this.alignInkBarToSelectedTab();
@@ -239,10 +236,8 @@ export class NzTabNavBarComponent implements AfterViewInit, AfterContentChecked,
 
     merge(this.nzResizeObserver.observe(this.navWrapRef), this.nzResizeObserver.observe(this.navListRef))
       .pipe(takeUntilDestroyed(this.destroyRef), auditTime(16, RESIZE_SCHEDULER))
-      .subscribe(() => {
-        realign();
-      });
-    merge(dirChange, resize, this.items.changes)
+      .subscribe(() => realign());
+    merge(this.directionality.change, this.viewportRuler.change(150), this.items.changes)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         Promise.resolve().then(realign);
@@ -308,8 +303,7 @@ export class NzTabNavBarComponent implements AfterViewInit, AfterContentChecked,
   }
 
   handleKeydown(event: KeyboardEvent): void {
-    const inNavigationList = this.navWrapRef.nativeElement.contains(event.target as HTMLElement);
-    if (hasModifierKey(event) || !inNavigationList) {
+    if (hasModifierKey(event) || !this.navWrapRef.nativeElement.contains(event.target as HTMLElement)) {
       return;
     }
 
@@ -337,7 +331,7 @@ export class NzTabNavBarComponent implements AfterViewInit, AfterContentChecked,
       return true;
     }
 
-    const tab = this.items ? this.items.toArray()[index] : null;
+    const tab = this.items.toArray()[index];
     return !!tab && !tab.disabled;
   }
 
@@ -428,8 +422,8 @@ export class NzTabNavBarComponent implements AfterViewInit, AfterContentChecked,
   }
 
   private resetSizes(): void {
-    this.addButtonWidth = this.addBtnRef ? this.addBtnRef.getElementWidth() : 0;
-    this.addButtonHeight = this.addBtnRef ? this.addBtnRef.getElementHeight() : 0;
+    this.addButtonWidth = this.addBtnRef?.getElementWidth() || 0;
+    this.addButtonHeight = this.addBtnRef?.getElementHeight() || 0;
     this.operationWidth = this.operationRef.getElementWidth();
     this.operationHeight = this.operationRef.getElementHeight();
     this.wrapperWidth = this.navWrapRef.nativeElement.offsetWidth || 0;

--- a/components/tabs/tab-nav-item.directive.ts
+++ b/components/tabs/tab-nav-item.directive.ts
@@ -12,13 +12,13 @@ import { NzTabComponent } from './tab.component';
   selector: '[nzTabNavItem]'
 })
 export class NzTabNavItemDirective implements FocusableOption {
-  @Input({ transform: booleanAttribute }) disabled: boolean = false;
-  @Input() tab!: NzTabComponent;
-  @Input({ transform: booleanAttribute }) active: boolean = false;
+  public readonly elementRef: ElementRef<HTMLElement> = inject(ElementRef<HTMLElement>);
+  private el = this.elementRef.nativeElement;
+  private parentElement = this.el.parentElement!;
 
-  public elementRef: ElementRef<HTMLElement> = inject(ElementRef<HTMLElement>);
-  private el: HTMLElement = this.elementRef.nativeElement;
-  private parentElement: HTMLElement = this.el.parentElement!;
+  @Input() tab!: NzTabComponent;
+  @Input({ transform: booleanAttribute }) disabled = false;
+  @Input({ transform: booleanAttribute }) active = false;
 
   focus(): void {
     this.el.focus({ preventScroll: true });

--- a/components/tabs/tab-nav-operation.component.ts
+++ b/components/tabs/tab-nav-operation.component.ts
@@ -4,17 +4,17 @@
  */
 
 import {
-  ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
   Input,
-  OnDestroy,
   Output,
   TemplateRef,
   ViewEncapsulation,
   booleanAttribute,
-  inject
+  inject,
+  signal
 } from '@angular/core';
 
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
@@ -42,13 +42,13 @@ import { NzTabNavItemDirective } from './tab-nav-item.directive';
       [nzDropdownMenu]="menu"
       [nzOverlayStyle]="{ minWidth: '46px' }"
       [nzMatchWidthElement]="null"
-      (nzVisibleChange)="menuVisChange($event)"
+      (nzVisibleChange)="menuVisibleChange($event)"
       (mouseenter)="showItems()"
     >
       <nz-icon nzType="ellipsis" />
     </button>
     <nz-dropdown-menu #menu="nzDropdownMenu">
-      @if (menuOpened) {
+      @if (menuOpened()) {
         <ul nz-menu>
           @for (item of items; track item) {
             <li
@@ -78,18 +78,24 @@ import { NzTabNavItemDirective } from './tab-nav-item.directive';
   },
   imports: [NzDropdownModule, NzIconModule, NzOutletModule, NzTabAddButtonComponent, NzMenuModule]
 })
-export class NzTabNavOperationComponent implements OnDestroy {
+export class NzTabNavOperationComponent {
+  private readonly element: HTMLElement = inject(ElementRef<HTMLElement>).nativeElement;
+
   @Input() items: NzTabNavItemDirective[] = [];
   @Input({ transform: booleanAttribute }) addable: boolean = false;
   @Input() addIcon: string | TemplateRef<NzSafeAny> = 'plus';
 
   @Output() readonly addClicked = new EventEmitter<void>();
   @Output() readonly selected = new EventEmitter<NzTabNavItemDirective>();
-  closeAnimationWaitTimeoutId?: ReturnType<typeof setTimeout>;
-  menuOpened = false;
 
-  private cdr = inject(ChangeDetectorRef);
-  private readonly element: HTMLElement = inject(ElementRef<HTMLElement>).nativeElement;
+  private closeAnimationWaitTimeoutId?: ReturnType<typeof setTimeout>;
+  protected readonly menuOpened = signal(false);
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => {
+      clearTimeout(this.closeAnimationWaitTimeoutId);
+    });
+  }
 
   onSelect(item: NzTabNavItemDirective): void {
     if (!item.disabled) {
@@ -104,30 +110,23 @@ export class NzTabNavOperationComponent implements OnDestroy {
       item.tab.nzContextmenu.emit(e);
     }
   }
+
   showItems(): void {
     clearTimeout(this.closeAnimationWaitTimeoutId);
-    this.menuOpened = true;
-    this.cdr.markForCheck();
+    this.menuOpened.set(true);
   }
 
-  menuVisChange(visible: boolean): void {
+  protected menuVisibleChange(visible: boolean): void {
     if (!visible) {
-      this.closeAnimationWaitTimeoutId = setTimeout(() => {
-        this.menuOpened = false;
-        this.cdr.markForCheck();
-      }, 150);
+      this.closeAnimationWaitTimeoutId = setTimeout(() => this.menuOpened.set(false), 150);
     }
   }
 
   getElementWidth(): number {
-    return this.element?.offsetWidth || 0;
+    return this.element.offsetWidth || 0;
   }
 
   getElementHeight(): number {
-    return this.element?.offsetHeight || 0;
-  }
-
-  ngOnDestroy(): void {
-    clearTimeout(this.closeAnimationWaitTimeoutId);
+    return this.element.offsetHeight || 0;
   }
 }

--- a/components/tabs/tab-scroll-list.directive.ts
+++ b/components/tabs/tab-scroll-list.directive.ts
@@ -3,7 +3,7 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { DestroyRef, Directive, ElementRef, EventEmitter, inject, NgZone, OnInit, Output } from '@angular/core';
+import { DestroyRef, Directive, ElementRef, EventEmitter, inject, NgZone, Output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Observable, Subscription } from 'rxjs';
 
@@ -24,7 +24,7 @@ const SPEED_OFF_MULTIPLE = 0.995 ** REFRESH_INTERVAL;
 @Directive({
   selector: '[nzTabScrollList]'
 })
-export class NzTabScrollListDirective implements OnInit {
+export class NzTabScrollListDirective {
   private ngZone = inject(NgZone);
   private destroyRef = inject(DestroyRef);
   private el: HTMLElement = inject(ElementRef<HTMLElement>).nativeElement;
@@ -42,7 +42,7 @@ export class NzTabScrollListDirective implements OnInit {
   @Output() readonly offsetChange = new EventEmitter<NzTabScrollListOffsetEvent>();
   @Output() readonly tabScroll = new EventEmitter<NzTabScrollEvent>();
 
-  ngOnInit(): void {
+  constructor() {
     const wheel$ = fromEventOutsideAngular<WheelEvent>(this.el, 'wheel');
     const touchstart$ = fromEventOutsideAngular<TouchEvent>(this.el, 'touchstart');
     const touchmove$ = fromEventOutsideAngular<TouchEvent>(this.el, 'touchmove');

--- a/components/tabs/tab.component.ts
+++ b/components/tabs/tab.component.ts
@@ -46,6 +46,8 @@ export const NZ_TAB_SET = new InjectionToken<NzSafeAny>(typeof ngDevMode !== 'un
   `
 })
 export class NzTabComponent implements OnChanges, OnDestroy {
+  readonly closestTabSet = inject(NZ_TAB_SET);
+
   @Input() nzTitle: string | TemplateRef<TabTemplateContext> = '';
   @Input({ transform: booleanAttribute }) nzClosable = false;
   @Input() nzCloseIcon: string | TemplateRef<NzSafeAny> = 'close';
@@ -59,13 +61,12 @@ export class NzTabComponent implements OnChanges, OnDestroy {
   @ContentChild(NzTabLinkTemplateDirective, { static: false }) nzTabLinkTemplateDirective!: NzTabLinkTemplateDirective;
   @ContentChild(NzTabDirective, { static: false, read: TemplateRef }) template: TemplateRef<void> | null = null;
   @ContentChild(NzTabLinkDirective, { static: false }) linkDirective!: NzTabLinkDirective;
-  @ViewChild('contentTemplate', { static: true }) contentTemplate!: TemplateRef<NzSafeAny>;
+  @ViewChild('contentTemplate', { static: true }) contentTemplate!: TemplateRef<void>;
 
-  isActive: boolean = false;
+  isActive = false;
   hasBeenActive = false;
   position: number | null = null;
   origin: number | null = null;
-  closestTabSet = inject(NZ_TAB_SET);
 
   readonly stateChanges = new Subject<void>();
 

--- a/components/tabs/tabs.component.spec.ts
+++ b/components/tabs/tabs.component.spec.ts
@@ -44,11 +44,9 @@ describe('tabs', () => {
 
   describe('basic', () => {
     let fixture: ComponentFixture<SimpleTabsTestComponent>;
-    let element: HTMLElement;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(SimpleTabsTestComponent);
-      element = fixture.nativeElement;
     });
 
     it('should default to the first tab', () => {
@@ -57,7 +55,9 @@ describe('tabs', () => {
 
     it('should load content on first change detection pass', () => {
       fixture.detectChanges();
-      expect(element.querySelectorAll('.ant-tabs-tabpane')[0]!.textContent).toContain(`Content of Tab Pane 1`);
+      expect(fixture.nativeElement.querySelectorAll('.ant-tabs-tabpane')[0]!.textContent).toContain(
+        `Content of Tab Pane 1`
+      );
     });
 
     it('should change selected index on click', async () => {
@@ -94,7 +94,7 @@ describe('tabs', () => {
     it('should update tab positions when selected index is changed', async () => {
       fixture.detectChanges();
       const component: NzTabsComponent = fixture.debugElement.query(By.css('nz-tabs'))!.componentInstance;
-      const tabs: NzTabComponent[] = component.tabs.toArray();
+      const tabs = component.tabs.toArray();
 
       expect(tabs[0].position).toBeLessThan(0);
       expect(tabs[1].position).toBe(0);
@@ -208,14 +208,12 @@ describe('tabs', () => {
       await stabilize(fixture);
 
       expect(component.handleSelection).toHaveBeenCalledTimes(0);
-      await stabilize(fixture, 300);
     });
 
     it('should clean up the tabs QueryList on destroy', () => {
       const component: NzTabsComponent = fixture.debugElement.query(By.css('nz-tabs'))!.componentInstance;
       const spy = vi.fn();
       const subscription = component.tabs.changes.subscribe({ complete: spy });
-
       fixture.destroy();
 
       expect(spy).toHaveBeenCalled();
@@ -285,14 +283,13 @@ describe('tabs', () => {
     });
 
     it('should set the correct tabBarStyle', async () => {
-      await stabilize(fixture, 200);
+      await stabilize(fixture, 32);
 
       const component = fixture.debugElement.componentInstance;
       const tabsNav = fixture.debugElement.query(By.css('nz-tabs-nav'))!.nativeElement;
       component.tabBarStyle.set({ color: 'rgb(255, 0, 0)' });
 
-      await stabilize(fixture, 200);
-
+      await stabilize(fixture, 32);
       expect(tabsNav.style.color).toBe('rgb(255, 0, 0)');
     });
 
@@ -305,7 +302,6 @@ describe('tabs', () => {
 
       component.centered.set(true);
       fixture.detectChanges();
-
       expect(tabSet.classList).toContain('ant-tabs-centered');
     });
 
@@ -313,7 +309,6 @@ describe('tabs', () => {
       const component = fixture.debugElement.componentInstance;
       component.selectedIndex.set(0);
       component.canDeactivate.set((_: number, next: number) => next !== 2);
-
       fixture.detectChanges();
 
       let tabLabel = fixture.debugElement.queryAll(By.css('.ant-tabs-tab'))[1];
@@ -462,15 +457,15 @@ describe('tabs', () => {
 
   describe('dynamic tabs', () => {
     let fixture: ComponentFixture<DynamicTabsTestComponent>;
+    let component: NzTabsComponent;
 
     beforeEach(async () => {
       fixture = TestBed.createComponent(DynamicTabsTestComponent);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
+      component = fixture.debugElement.query(By.css('nz-tabs'))!.componentInstance as NzTabsComponent;
     });
 
     it('should be able to add a new tab, select it, and have correct origin position', async () => {
-      const component: NzTabsComponent = fixture.debugElement.query(By.css('nz-tabs'))!.componentInstance;
-
       let tabs: NzTabComponent[] = component.tabs.toArray();
       expect(tabs[0].origin).toBe(null);
       expect(tabs[1].origin).toBe(0);
@@ -479,14 +474,14 @@ describe('tabs', () => {
       // Add a new tab on the right and select it, expect an origin >= than 0 (animate right)
       fixture.componentInstance.tabs.update(tabs => [...tabs, { title: 'New tab', content: 'to right of index' }]);
       fixture.componentInstance.selectedIndex.set(4);
-      await stabilize(fixture);
+      fixture.detectChanges();
 
       tabs = component.tabs.toArray();
       expect(tabs[3].origin).toBeGreaterThanOrEqual(0);
 
       // Add a new tab in the beginning and select it, expect an origin < than 0 (animate left)
       fixture.componentInstance.selectedIndex.set(0);
-      await stabilize(fixture);
+      fixture.detectChanges();
 
       fixture.componentInstance.tabs.update(tabs => [...tabs, { title: 'New tab', content: 'to left of index' }]);
       await stabilize(fixture);
@@ -496,11 +491,9 @@ describe('tabs', () => {
     });
 
     it('should update selected index if the last tab removed while selected', async () => {
-      const component: NzTabsComponent = fixture.debugElement.query(By.css('nz-tabs'))!.componentInstance;
-
       const numberOfTabs = component.tabs.length;
       fixture.componentInstance.selectedIndex.set(numberOfTabs - 1);
-      await stabilize(fixture);
+      fixture.detectChanges();
 
       // Remove last tab while last tab is selected, expect the next tab over to be selected
       fixture.componentInstance.tabs.update(tabs => tabs.slice(0, -1));
@@ -510,31 +503,25 @@ describe('tabs', () => {
       expect(fixture.componentInstance.selectedIndex()).toBe(numberOfTabs - 2);
     });
 
-    it('should maintain the selected tab if a new tab is added', () => {
-      fixture.detectChanges();
-      const component: NzTabsComponent = fixture.debugElement.query(By.css('nz-tabs'))!.componentInstance;
-
+    it('should maintain the selected tab if a new tab is added', async () => {
       fixture.componentInstance.selectedIndex.set(1);
       fixture.detectChanges();
 
       // Add a new tab at the beginning.
       fixture.componentInstance.tabs.update(tabs => [{ title: 'New tab', content: 'at the start' }, ...tabs]);
-      fixture.detectChanges();
+      await stabilize(fixture);
 
       expect(component.nzSelectedIndex).toBe(2);
       expect(component.tabs.toArray()[2].isActive).toBe(true);
     });
 
-    it('should maintain the selected tab if a tab is removed', () => {
+    it('should maintain the selected tab if a tab is removed', async () => {
       // Select the second tab.
       fixture.componentInstance.selectedIndex.set(1);
-      fixture.detectChanges();
-
-      const component: NzTabsComponent = fixture.debugElement.query(By.css('nz-tabs'))!.componentInstance;
 
       // Remove the first tab that is right before the selected one.
       fixture.componentInstance.tabs.update(tabs => tabs.slice(1));
-      fixture.detectChanges();
+      await stabilize(fixture);
 
       // Since the first tab has been removed and the second one was selected before, the selected
       // tab moved one position to the right. Meaning that the tab is now the first tab.
@@ -543,12 +530,8 @@ describe('tabs', () => {
     });
 
     it('should be able to select a new tab after creation', async () => {
-      fixture.detectChanges();
-      const component: NzTabsComponent = fixture.debugElement.query(By.css('nz-tabs'))!.componentInstance;
-
       fixture.componentInstance.tabs.update(tabs => [...tabs, { title: 'Last tab', content: 'at the end' }]);
       fixture.componentInstance.selectedIndex.set(3);
-
       await stabilize(fixture);
 
       expect(component.nzSelectedIndex).toBe(3);
@@ -556,7 +539,6 @@ describe('tabs', () => {
     });
 
     it('should not fire `selectedTabChange` when the amount of tabs changes', async () => {
-      fixture.detectChanges();
       fixture.componentInstance.selectedIndex.set(1);
       fixture.detectChanges();
 
@@ -569,7 +551,6 @@ describe('tabs', () => {
     });
 
     it('should show add btn after all tabs are removed', () => {
-      fixture.detectChanges();
       fixture.componentInstance.tabs.set([]);
       fixture.detectChanges();
       const btnCount = fixture.debugElement.queryAll(By.css('.ant-tabs-nav-add')).length;
@@ -583,9 +564,7 @@ describe('tabs', () => {
 
       expect(fixture.debugElement.queryAll(By.css('.ant-tabs-tab')).length).toBe(0);
 
-      await stabilize(fixture, 200);
-      await stabilize(fixture, 200);
-
+      await stabilize(fixture, 32);
       expect(fixture.debugElement.queryAll(By.css('.ant-tabs-tab')).length).toBe(3);
     });
   });
@@ -598,8 +577,8 @@ describe('tabs', () => {
       const groups = fixture.componentInstance.tabSets.toArray();
 
       expect(groups.length).toBe(2);
-      expect(groups[0].tabs.map((tab: NzTabComponent) => tab.nzTitle)).toEqual(['Tab 0', 'Tab 1']);
-      expect(groups[1].tabs.map((tab: NzTabComponent) => tab.nzTitle)).toEqual(['Inner Tab 0', 'Inner Tab 1']);
+      expect(groups[0].tabs.map(tab => tab.nzTitle)).toEqual(['Tab 0', 'Tab 1']);
+      expect(groups[1].tabs.map(tab => tab.nzTitle)).toEqual(['Inner Tab 0', 'Inner Tab 1']);
     });
 
     it('should pick up indirect descendant tabs', () => {
@@ -607,7 +586,7 @@ describe('tabs', () => {
       fixture.detectChanges();
 
       const tabs = fixture.componentInstance.tabSet.tabs;
-      expect(tabs.map((tab: NzTabComponent) => tab.nzTitle)).toEqual(['Tab 0', 'Tab 1']);
+      expect(tabs.map(tab => tab.nzTitle)).toEqual(['Tab 0', 'Tab 1']);
     });
   });
 
@@ -620,10 +599,10 @@ describe('tabs', () => {
       fixture = TestBed.createComponent(ScrollableTabsTestComponent);
       element = fixture.nativeElement;
       overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
     });
 
-    it('should hide the overflow tabs', () => {
+    it('should hide the overflow tabs', async () => {
       const tabSetComponent = fixture.componentInstance.tabSet;
       expect(tabSetComponent.tabNavBarRef.hiddenItems.length).toBeGreaterThan(0);
       expect(element.querySelector('nz-tab-nav-operation')).not.toBeNull();
@@ -636,10 +615,10 @@ describe('tabs', () => {
       });
 
       dispatchFakeEvent(element.querySelector('nz-tab-nav-operation')!, 'mouseenter');
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       const inMenu = overlayContainerElement.querySelectorAll<HTMLLIElement>('.ant-tabs-dropdown-menu-item');
-      inMenu.forEach((tab: HTMLLIElement) => {
+      inMenu.forEach(tab => {
         expect(tab.textContent!.trim()).toBe('Title in menu');
       });
     });
@@ -648,7 +627,7 @@ describe('tabs', () => {
       const tabsList = element.querySelector('.ant-tabs-nav-list')! as HTMLElement;
       const translateX = getTranslate(tabsList.style.transform).x;
       fixture.componentInstance.selectedIndex.set(10);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       const newTranslateX = getTranslate(tabsList.style.transform).x;
       expect(translateX).toBeGreaterThan(newTranslateX);
@@ -656,7 +635,7 @@ describe('tabs', () => {
 
     it('should handle the positions correctly', async () => {
       fixture.componentInstance.position.set('left');
-      fixture.detectChanges();
+      await stabilize(fixture, 32);
 
       const tabsList = element.querySelector('.ant-tabs-nav-list')! as HTMLElement;
       const translateY = getTranslate(tabsList.style.transform).y;
@@ -666,7 +645,7 @@ describe('tabs', () => {
       expect(translateY).toBe(0);
 
       fixture.componentInstance.selectedIndex.set(15);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       const newTranslateX = getTranslate(tabsList.style.transform).x;
       const newTranslateY = getTranslate(tabsList.style.transform).y;
@@ -676,7 +655,6 @@ describe('tabs', () => {
 
     it('should set transform to visible and select when selected on nav-operation', async () => {
       vi.spyOn(fixture.componentInstance, 'handleSelection');
-      fixture.detectChanges();
       expect(fixture.componentInstance.handleSelection).toHaveBeenCalledTimes(0);
 
       const tabsList = element.querySelector('.ant-tabs-nav-list')! as HTMLElement;
@@ -685,8 +663,7 @@ describe('tabs', () => {
         .componentInstance as NzTabNavOperationComponent;
 
       navOperation.onSelect(navOperation.items[5]);
-
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       const newTranslateX = getTranslate(tabsList.style.transform).x;
       expect(translateX).toBeGreaterThan(newTranslateX);
@@ -709,8 +686,7 @@ describe('tabs', () => {
       };
 
       tabNavBarComponent.onOffsetChange(event);
-
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       translateX = getTranslate(tabsList.style.transform).x;
       expect(translateX).toBe(-200);
@@ -718,7 +694,7 @@ describe('tabs', () => {
 
     it('should set transformY when scroll(mock)', async () => {
       fixture.componentInstance.position.set('left');
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       const tabNavBarComponent = fixture.debugElement.query(By.directive(NzTabNavBarComponent))!
         .componentInstance as NzTabNavBarComponent;
@@ -734,8 +710,7 @@ describe('tabs', () => {
       };
 
       tabNavBarComponent.onOffsetChange(event);
-
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       translateY = getTranslate(tabsList.style.transform).y;
       expect(translateY).toBe(-200);
@@ -773,7 +748,6 @@ describe('tabs', () => {
   describe('router', () => {
     let fixture: ComponentFixture<RouterTabsTestComponent>;
     let tabs: DebugElement;
-    let router: Router;
 
     beforeEach(() => {
       TestBed.configureTestingModule({
@@ -786,10 +760,11 @@ describe('tabs', () => {
     });
 
     it('should change router and emit handleSelection once when click', async () => {
+      const router = TestBed.inject(Router);
+      const component = fixture.componentInstance;
+
       await fixture.ngZone!.run(async () => {
-        router = TestBed.inject(Router);
         await router.navigateByUrl('/');
-        const component = fixture.componentInstance;
         await stabilize(fixture);
 
         expect((tabs.componentInstance as NzTabsComponent).nzSelectedIndex).toBe(0);
@@ -799,12 +774,12 @@ describe('tabs', () => {
         // select the second tab
         const tabLabel = fixture.debugElement.queryAll(By.css('.ant-tabs-tab'))[1];
         tabLabel.nativeElement.click();
-        await stabilize(fixture, 300);
+        await stabilize(fixture, 32);
 
         expect(component.handleSelection).toHaveBeenCalled();
 
         await router.navigateByUrl('/two');
-        await stabilize(fixture, 300);
+        await stabilize(fixture, 32);
         expect(router.url).toBe('/two');
       });
     });
@@ -814,39 +789,39 @@ describe('tabs', () => {
     let fixture: ComponentFixture<SimpleTabsRenderingComponent>;
     let element: HTMLElement;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(SimpleTabsRenderingComponent);
       element = fixture.nativeElement;
-      await stabilize(fixture, 0);
     });
 
     it('should delay rendering and preserve DOM of tabpane', async () => {
+      await stabilize(fixture, 32);
       expect(element.querySelectorAll('.ant-tabs-tabpane').length).toBe(1);
       fixture.componentInstance.selectedIndex.set(1);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
       expect(element.querySelectorAll('.ant-tabs-tabpane').length).toBe(2);
       fixture.componentInstance.selectedIndex.set(2);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
       expect(element.querySelectorAll('.ant-tabs-tabpane').length).toBe(3);
     });
 
     it('should render inactive tab when forceRender is true', async () => {
       fixture.componentInstance.forceRender.set(true);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
       expect(element.querySelectorAll('.ant-tabs-tabpane').length).toBe(3);
     });
 
     it('should destroy inactive tab when destroyInactiveTabPane is true', async () => {
       fixture.componentInstance.destroyInactiveTabPane.set(true);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
       expect(element.querySelectorAll('.ant-tabs-tabpane').length).toBe(1);
 
       fixture.componentInstance.selectedIndex.set(1);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
       expect(element.querySelectorAll('.ant-tabs-tabpane').length).toBe(1);
 
       fixture.componentInstance.selectedIndex.set(2);
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
       expect(element.querySelectorAll('.ant-tabs-tabpane').length).toBe(1);
     });
   });
@@ -885,26 +860,24 @@ describe('tabs', () => {
     });
 
     it('should update active tab when tabs changed', async () => {
-      await stabilize(fixture, 0);
+      await stabilize(fixture);
 
       await router.navigateByUrl('/one');
-      await stabilize(fixture, 0);
+      await stabilize(fixture);
 
       const comp = fixture.componentInstance;
 
       await router.navigateByUrl('/three');
-      await stabilize(fixture, 0);
+      await stabilize(fixture);
 
       comp.tabs.set(comp.lazyTabs);
-      await stabilize(fixture, 0);
+      await stabilize(fixture);
       await router.navigateByUrl('/three');
-      await stabilize(fixture, 0);
-      await stabilize(fixture, 0);
+      await stabilize(fixture);
 
       comp.selectedIdx.set(2);
-      await stabilize(fixture, 0);
+      await stabilize(fixture);
       expect(comp.selectedIdx()).toBe(2);
-      await stabilize(fixture, 300);
     });
   });
 
@@ -924,10 +897,9 @@ describe('tabs', () => {
     let fixture: ComponentFixture<IndicatorTabsTestComponent>;
     let element: HTMLElement;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       fixture = TestBed.createComponent(IndicatorTabsTestComponent);
       element = fixture.nativeElement;
-      await stabilize(fixture, 300);
     });
 
     it('should set indicator width and horizontal alignment', async () => {
@@ -935,8 +907,7 @@ describe('tabs', () => {
         size: 20,
         align: 'end'
       });
-
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       const activeTab = element.querySelector('.ant-tabs-tab-active') as HTMLElement;
       const inkBar = element.querySelector('.ant-tabs-ink-bar') as HTMLElement;
@@ -951,7 +922,7 @@ describe('tabs', () => {
         size: 10,
         align: 'start'
       });
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       const inkBar = element.querySelector('.ant-tabs-ink-bar') as HTMLElement;
       const previousWidth = inkBar.style.width;
@@ -961,7 +932,7 @@ describe('tabs', () => {
         size: 30,
         align: 'end'
       });
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       expect(inkBar.style.width).toBe('30px');
       expect(inkBar.style.width).not.toBe(previousWidth);
@@ -974,8 +945,7 @@ describe('tabs', () => {
         size: origin => origin / 2,
         align: 'center'
       });
-
-      await stabilize(fixture, 300);
+      await stabilize(fixture, 32);
 
       const activeTab = element.querySelector('.ant-tabs-tab-active') as HTMLElement;
       const inkBar = element.querySelector('.ant-tabs-ink-bar') as HTMLElement;
@@ -1024,9 +994,9 @@ class SimpleTabsTestComponent {
   readonly centered = signal(false);
   readonly canDeactivate = signal<NzSafeAny>(null);
 
-  handleSelection(_event: number): void {}
-  handleClose(_event: { index: number }): void {}
-  handleAdd(): void {}
+  handleSelection = vi.fn();
+  handleClose = vi.fn();
+  handleAdd = vi.fn();
 }
 
 @Component({
@@ -1091,7 +1061,7 @@ class DisableTabsTestComponent {
   readonly disabled = signal(false);
   @ViewChildren(NzTabComponent) tabs!: QueryList<NzTabComponent>;
 
-  handleSelection(_event: number): void {}
+  handleSelection = vi.fn();
 }
 
 @Component({
@@ -1118,7 +1088,7 @@ class DynamicTabsTestComponent {
     { title: 'Tab 2', content: 'Content of Tab Pane 2' }
   ]);
 
-  handleSelection(_event: number): void {}
+  handleSelection = vi.fn();
 }
 
 @Component({
@@ -1151,7 +1121,7 @@ class ScrollableTabsTestComponent {
   tabs: NzSafeAny[] = Array(30).fill(null);
   @ViewChild(NzTabsComponent, { static: true }) tabSet!: NzTabsComponent;
 
-  handleSelection(_event: number): void {}
+  handleSelection = vi.fn();
 }
 
 @Component({
@@ -1239,7 +1209,7 @@ class TabSetWithIndirectDescendantTabsTestComponent {
   `
 })
 export class RouterTabsTestComponent {
-  handleSelection(_event: number): void {}
+  handleSelection = vi.fn();
 }
 
 @Component({

--- a/components/tabs/tabs.component.ts
+++ b/components/tabs/tabs.component.ts
@@ -11,19 +11,17 @@ import {
   AfterContentChecked,
   AfterContentInit,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   contentChildren,
   ContentChildren,
   DestroyRef,
-  EventEmitter,
   forwardRef,
   inject,
   input,
   Input,
   NgZone,
-  Output,
+  output,
   QueryList,
   TemplateRef,
   ViewChild,
@@ -34,7 +32,7 @@ import { NavigationEnd, Router, RouterLink } from '@angular/router';
 import { merge, Observable, of, Subscription } from 'rxjs';
 import { delay, filter, first, startWith } from 'rxjs/operators';
 
-import { NzConfigKey, NzConfigService, WithConfig } from 'ng-zorro-antd/core/config';
+import { NzConfigKey, WithConfig } from 'ng-zorro-antd/core/config';
 import { PREFIX } from 'ng-zorro-antd/core/logger';
 import { NzOutletModule } from 'ng-zorro-antd/core/outlet';
 import { NzSafeAny, NzSizeLDSType } from 'ng-zorro-antd/core/types';
@@ -58,15 +56,12 @@ import { NzTabNavBarComponent } from './tab-nav-bar.component';
 import { NzTabNavItemDirective } from './tab-nav-item.directive';
 import { NZ_TAB_SET, NzTabComponent } from './tab.component';
 
-const NZ_CONFIG_MODULE_NAME: NzConfigKey = 'tabs';
-
 let nextId = 0;
 
 @Component({
   selector: 'nz-tabs',
   exportAs: 'nzTabs',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     {
       provide: NZ_TAB_SET,
@@ -195,13 +190,13 @@ let nextId = 0;
   ]
 })
 export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
-  readonly _nzModuleName: NzConfigKey = NZ_CONFIG_MODULE_NAME;
+  readonly _nzModuleName: NzConfigKey = 'tabs';
 
-  public nzConfigService = inject(NzConfigService);
-  private ngZone = inject(NgZone);
-  private cdr = inject(ChangeDetectorRef);
   protected readonly dir = inject(Directionality).valueSignal;
-  private destroyRef = inject(DestroyRef);
+  private readonly ngZone = inject(NgZone);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly router = inject(Router, { optional: true });
 
   @Input()
   get nzSelectedIndex(): number | null {
@@ -227,12 +222,11 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
   @Input({ transform: booleanAttribute }) nzDestroyInactiveTabPane = false;
 
   readonly nzIndicator = input<NzIndicator>();
-
-  @Output() readonly nzSelectChange: EventEmitter<NzTabChangeEvent> = new EventEmitter<NzTabChangeEvent>(true);
-  @Output() readonly nzSelectedIndexChange: EventEmitter<number> = new EventEmitter<number>();
-  @Output() readonly nzTabListScroll = new EventEmitter<NzTabScrollEvent>();
-  @Output() readonly nzClose = new EventEmitter<{ index: number }>();
-  @Output() readonly nzAdd = new EventEmitter<void>();
+  readonly nzSelectChange = output<NzTabChangeEvent>();
+  readonly nzSelectedIndexChange = output<number>();
+  readonly nzTabListScroll = output<NzTabScrollEvent>();
+  readonly nzClose = output<{ index: number }>();
+  readonly nzAdd = output();
 
   get position(): NzTabPositionMode {
     return ['top', 'bottom'].indexOf(this.nzTabPosition) === -1 ? 'vertical' : 'horizontal';
@@ -246,12 +240,8 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
     return this.nzType === 'editable-card';
   }
 
-  get line(): boolean {
-    return this.nzType === 'line';
-  }
-
   get inkBarAnimated(): boolean {
-    return this.line && (typeof this.nzAnimated === 'boolean' ? this.nzAnimated : this.nzAnimated.inkBar);
+    return this.nzType === 'line' && (typeof this.nzAnimated === 'boolean' ? this.nzAnimated : this.nzAnimated.inkBar);
   }
 
   get tabPaneAnimated(): boolean {
@@ -276,7 +266,6 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
   private selectedIndex: number | null = null;
   private tabLabelSubscription = Subscription.EMPTY;
   private canDeactivateSubscription = Subscription.EMPTY;
-  private router = inject(Router, { optional: true });
 
   constructor() {
     this.tabSetId = nextId++;
@@ -292,9 +281,6 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
     this.ngZone.runOutsideAngular(() => {
       Promise.resolve().then(() => this.setUpRouter());
     });
-
-    this.subscribeToTabLabels();
-    this.subscribeToAllTabChanges();
 
     // Subscribe to changes of the number of tabs, to be
     // able to re-render the content as new tabs are added or removed.
@@ -319,6 +305,8 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
       this.subscribeToTabLabels();
       this.cdr.markForCheck();
     });
+
+    this.subscribeToAllTabChanges();
   }
 
   ngAfterContentChecked(): void {
@@ -393,10 +381,7 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
   }
 
   private subscribeToTabLabels(): void {
-    if (this.tabLabelSubscription) {
-      this.tabLabelSubscription.unsubscribe();
-    }
-
+    this.tabLabelSubscription.unsubscribe();
     this.tabLabelSubscription = merge(...this.tabs.map(tab => tab.stateChanges)).subscribe(() =>
       this.cdr.markForCheck()
     );
@@ -411,8 +396,7 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
 
   canDeactivateFun(pre: number, next: number): Observable<boolean> {
     if (typeof this.nzCanDeactivate === 'function') {
-      const observable = wrapIntoObservable(this.nzCanDeactivate(pre, next));
-      return observable.pipe(first(), takeUntilDestroyed(this.destroyRef));
+      return wrapIntoObservable(this.nzCanDeactivate(pre, next)).pipe(first(), takeUntilDestroyed(this.destroyRef));
     } else {
       return of(true);
     }
@@ -473,10 +457,7 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
       }
       merge(this.router.events.pipe(filter(e => e instanceof NavigationEnd)), this.tabLinks.changes)
         .pipe(startWith(true), delay(0), takeUntilDestroyed(this.destroyRef))
-        .subscribe(() => {
-          this.updateRouterActive();
-          this.cdr.markForCheck();
-        });
+        .subscribe(() => this.updateRouterActive());
     }
   }
 
@@ -486,7 +467,10 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
       if (index !== this.selectedIndex) {
         this.setSelectedIndex(index);
       }
-      Promise.resolve().then(() => (this.nzHideAll = index === -1));
+      Promise.resolve().then(() => {
+        this.nzHideAll = index === -1;
+        this.cdr.markForCheck();
+      });
     }
   }
 
@@ -501,14 +485,16 @@ export class NzTabsComponent implements AfterContentChecked, AfterContentInit {
   }
 
   private isLinkActive(router: Router | null): (link?: RouterLink | null) => boolean {
-    return (link?: RouterLink | null) =>
-      link
-        ? !!router?.isActive(link.urlTree || '', {
-            paths: this.nzLinkExact ? 'exact' : 'subset',
-            queryParams: this.nzLinkExact ? 'exact' : 'subset',
-            fragment: 'ignored',
-            matrixParams: 'ignored'
-          })
-        : false;
+    return (link?: RouterLink | null): boolean => {
+      if (!router || !link) {
+        return false;
+      }
+      return router.isActive(link.urlTree || '', {
+        paths: this.nzLinkExact ? 'exact' : 'subset',
+        queryParams: this.nzLinkExact ? 'exact' : 'subset',
+        fragment: 'ignored',
+        matrixParams: 'ignored'
+      });
+    };
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Some components still relied on the legacy `ChangeDetectionStrategy.Eager` change detection mode.

Issue Number: N/A


## What is the new behavior?

Remove legacy eager change detection usage and update affected components/tests to work with the default change detection behavior.

Also updates related tests for zoneless/default change detection compatibility and removes stale `ChangeDetectionStrategy` imports.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Verified with:

- `npx tsc -p components/tsconfig.json --noEmit`
- `npx ng test --watch=false --progress=false --coverage=false --include=components/tabs/tabs.component.spec.ts`
- `npm t`
