### PR TITLE
fix(module:select): prevent dropdown option overflow

### DIFF
--- a/components/select/style/patch.less
+++ b/components/select/style/patch.less
@@ -5,6 +5,10 @@
   display: block;
   width: 100%;
 
+  .cdk-virtual-scroll-content-wrapper {
+    right: 0;
+  }
+
   .full-width {
     contain: initial;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

When an `nz-select` dropdown matches the trigger width and contains long option labels, the CDK virtual scroll content wrapper can expand past the dropdown viewport, causing horizontal overflow and a scrollbar.

Issue Number: #9843

## What is the new behavior?

The select dropdown virtual scroll content wrapper is constrained to the right edge again, so long option labels are clipped by the dropdown width and continue to use ellipsis.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified with:

- `npx stylelint components/select/style/patch.less`
- `npx ng test --watch=false --progress=false --browsers=ChromeHeadlessCI --include=components/select/select.spec.ts`