### PR TITLE
fix(module:i18n): add missing quarter placeholders to ja_JP

### DIFF
--- a/components/i18n/languages/ja_JP.ts
+++ b/components/i18n/languages/ja_JP.ts
@@ -22,10 +22,12 @@ export default {
     lang: {
       placeholder: '日付を選択',
       yearPlaceholder: '年を選択',
+      quarterPlaceholder: '四半期を選択',
       monthPlaceholder: '月を選択',
       weekPlaceholder: '週を選択',
       rangePlaceholder: ['開始日付', '終了日付'],
       rangeYearPlaceholder: ['開始年', '終了年'],
+      rangeQuarterPlaceholder: ['開始四半期', '終了四半期'],
       rangeMonthPlaceholder: ['開始月', '終了月'],
       rangeWeekPlaceholder: ['開始週', '終了週'],
       locale: 'ja_JP',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The Japanese locale is missing `quarterPlaceholder` and `rangeQuarterPlaceholder` under `DatePicker.lang`. A date picker in quarter mode (`nzMode="quarter"`) falls back to the English `Select quarter` / `Start quarter` / `End quarter` in a Japanese app.

`ja_JP` already localizes the year, month and week placeholders (both single and range), so the quarter pair is the only gap in that set. `en_US` and `zh_CN` both already define it.

Issue Number: N/A


## What is the new behavior?

Adds the two missing keys to `ja_JP`, matching the wording used by the official Ant Design `ja_JP` locale:

- `quarterPlaceholder: '四半期を選択'`
- `rangeQuarterPlaceholder: ['開始四半期', '終了四半期']`


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

These are translation strings only, so no tests or docs are affected.
