### PR TITLE
fix(module:dropdown,menu): add deprecated aliases for renamed exports

### DIFF
--- a/components/dropdown/dropdown-a.directive.ts
+++ b/components/dropdown/dropdown-a.directive.ts
@@ -12,3 +12,6 @@ import { Directive } from '@angular/core';
   }
 })
 export class NzDropdownADirective {}
+
+/** @deprecated Use {@link NzDropdownADirective} instead. */
+export { NzDropdownADirective as NzDropDownADirective };

--- a/components/dropdown/dropdown.directive.ts
+++ b/components/dropdown/dropdown.directive.ts
@@ -267,3 +267,6 @@ export class NzDropdownDirective implements AfterViewInit, OnChanges {
     }
   }
 }
+
+/** @deprecated Use {@link NzDropdownDirective} instead. */
+export { NzDropdownDirective as NzDropDownDirective };

--- a/components/menu/menu.token.ts
+++ b/components/menu/menu.token.ts
@@ -15,6 +15,9 @@ export const NzIsMenuInsideDropdownToken = new InjectionToken<boolean>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'nz-is-in-dropdown-menu' : ''
 );
 
+/** @deprecated Use {@link NzIsMenuInsideDropdownToken} instead. Removed in v22. */
+export { NzIsMenuInsideDropdownToken as NzIsMenuInsideDropDownToken };
+
 /**
  * A token to hold the local {@link MenuService} instance. This is used for nested menu.
  * @note Internally used only, please do not use it.


### PR DESCRIPTION
PR #9527 renamed `NzDropDownDirective` → `NzDropdownDirective`, `NzDropDownADirective` → `NzDropdownADirective`, and `NzIsMenuInsideDropDownToken` → `NzIsMenuInsideDropdownToken`, but only added a deprecated alias for `NzDropDownModule`.

Angular libraries compiled with partial-Ivy against ng-zorro-antd <=19 bake the old export names into their compiled output. When consumed by an app using ng-zorro-antd 21, these names resolve to `undefined` at runtime, causing `NG0919: Cannot read @Component metadata`.

This PR adds the missing deprecated re-export aliases for the renamed directives and token.

Closes #9859

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Partial-Ivy libraries compiled against ng-zorro-antd <=19 that use `NzDropDownModule` crash with `NG0919: Cannot read @Component metadata` when consumed by an Angular 21 app with ng-zorro-antd 21. The old export names (`NzDropDownDirective`, `NzDropDownADirective`, `NzIsMenuInsideDropDownToken`) resolve to `undefined` at runtime.

Issue Number: #9859

## What is the new behavior?

Deprecated re-export aliases are added for the renamed identifiers, so partial-Ivy libraries compiled against older versions continue to work at runtime.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Minimal reproduction: https://github.com/delbertooo/ng-zorro-dropdown-issue
