### PR TITLE
fix(module:select): keep dropdown scroll position when loading more options on scroll

### DIFF
--- a/components/select/option-container.component.ts
+++ b/components/select/option-container.component.ts
@@ -156,7 +156,12 @@ export class NzOptionContainerComponent implements OnChanges, AfterViewInit {
 
   ngOnChanges(changes: SimpleChanges): void {
     const { listOfContainerItem, activatedValue } = changes;
-    if (listOfContainerItem || activatedValue) {
+
+    const isInitialLoad =
+      !!listOfContainerItem &&
+      !listOfContainerItem.previousValue?.length &&
+      !!listOfContainerItem.currentValue?.length;
+    if (activatedValue || isInitialLoad) {
       this.scrollToActivatedValue();
     }
   }

--- a/components/select/option-container.component.ts
+++ b/components/select/option-container.component.ts
@@ -154,13 +154,11 @@ export class NzOptionContainerComponent implements OnChanges, AfterViewInit {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+ ngOnChanges(changes: SimpleChanges): void {
     const { listOfContainerItem, activatedValue } = changes;
 
     const isInitialLoad =
-      !!listOfContainerItem &&
-      !listOfContainerItem.previousValue?.length &&
-      !!listOfContainerItem.currentValue?.length;
+      !!listOfContainerItem && !listOfContainerItem.previousValue?.length && !!listOfContainerItem.currentValue?.length;
     if (activatedValue || isInitialLoad) {
       this.scrollToActivatedValue();
     }

--- a/components/select/option-container.component.ts
+++ b/components/select/option-container.component.ts
@@ -154,7 +154,7 @@ export class NzOptionContainerComponent implements OnChanges, AfterViewInit {
     }
   }
 
- ngOnChanges(changes: SimpleChanges): void {
+  ngOnChanges(changes: SimpleChanges): void {
     const { listOfContainerItem, activatedValue } = changes;
 
     const isInitialLoad =

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -5,7 +5,7 @@
 
 import { BACKSPACE, DOWN_ARROW, ENTER, ESCAPE, SPACE, TAB, UP_ARROW } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { ApplicationRef, Component, signal, TemplateRef, ViewChild, WritableSignal } from '@angular/core';
+import { ApplicationRef, Component, signal, SimpleChange, TemplateRef, ViewChild, WritableSignal } from '@angular/core';
 import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -36,6 +36,7 @@ import {
   NzSelectOptionInterface,
   NzSelectPlacementType
 } from './select.types';
+import { NzOptionContainerComponent } from './option-container.component';
 
 describe('select', () => {
   beforeEach(() => {
@@ -1785,6 +1786,35 @@ describe('select finalVariant', () => {
     expect(selectElement.classList).not.toContain('ant-select-filled');
     expect(selectElement.classList).not.toContain('ant-select-borderless');
     expect(selectElement.classList).not.toContain('ant-select-underlined');
+  });
+});
+
+describe('option container scroll', () => {
+  let container: NzOptionContainerComponent;
+  let scrollSpy: ReturnType<typeof vi.spyOn>;
+
+  const change = (previousValue: unknown, currentValue: unknown, firstChange = false): SimpleChange =>
+    ({ previousValue, currentValue, firstChange, isFirstChange: () => firstChange }) as SimpleChange;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [provideNzIconsTesting(), provideNzNoAnimation()] });
+    container = TestBed.createComponent(NzOptionContainerComponent).componentInstance;
+    scrollSpy = vi.spyOn(container, 'scrollToActivatedValue').mockImplementation(() => {});
+  });
+
+  it('should not recenter when more options are appended on scroll', () => {
+    container.ngOnChanges({ listOfContainerItem: change([{ key: 'a' }], [{ key: 'a' }, { key: 'b' }]) });
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it('should recenter when the activated value changes (keyboard/selection)', () => {
+    container.ngOnChanges({ activatedValue: change('a', 'b') });
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should recenter on the initial population of options', () => {
+    container.ngOnChanges({ listOfContainerItem: change([], [{ key: 'a' }], true) });
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -25,6 +25,7 @@ import { NzFormControlStatusType, NzFormModule } from 'ng-zorro-antd/form';
 import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 import { NZ_SPACE_COMPACT_SIZE } from 'ng-zorro-antd/space';
 
+import { NzOptionContainerComponent } from './option-container.component';
 import { NzSelectSearchComponent } from './select-search.component';
 import { NzSelectTopControlComponent } from './select-top-control.component';
 import { NzSelectComponent, NzSelectSizeType } from './select.component';
@@ -36,7 +37,6 @@ import {
   NzSelectOptionInterface,
   NzSelectPlacementType
 } from './select.types';
-import { NzOptionContainerComponent } from './option-container.component';
 
 describe('select', () => {
   beforeEach(() => {
@@ -1500,10 +1500,10 @@ describe('select', () => {
 
     it('should not run change detection when `nz-select-top-control` is clicked and should focus the `nz-select-search`', () => {
       const appRef = TestBed.inject(ApplicationRef);
-      vi.spyOn(appRef, 'tick').mockImplementation(() => {});
+      vi.spyOn(appRef, 'tick').mockImplementation(() => { });
 
       const nzSelectSearch = fixture.debugElement.query(By.directive(NzSelectSearchComponent));
-      vi.spyOn(nzSelectSearch.componentInstance, 'focus').mockImplementation(() => {});
+      vi.spyOn(nzSelectSearch.componentInstance, 'focus').mockImplementation(() => { });
 
       const nzSelectTopControl = fixture.debugElement.query(By.directive(NzSelectTopControlComponent));
       dispatchMouseEvent(nzSelectTopControl.nativeElement, 'click');
@@ -1514,7 +1514,7 @@ describe('select', () => {
 
     it('should not run change detection when non-backspace button is pressed on the `nz-select-top-control`', () => {
       const appRef = TestBed.inject(ApplicationRef);
-      vi.spyOn(appRef, 'tick').mockImplementation(() => {});
+      vi.spyOn(appRef, 'tick').mockImplementation(() => { });
 
       const nzSelectTopControl = fixture.debugElement.query(By.directive(NzSelectTopControlComponent));
       dispatchKeyboardEvent(nzSelectTopControl.nativeElement, 'keydown', TAB, nzSelectTopControl.nativeElement);
@@ -1799,7 +1799,7 @@ describe('option container scroll', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({ providers: [provideNzIconsTesting(), provideNzNoAnimation()] });
     container = TestBed.createComponent(NzOptionContainerComponent).componentInstance;
-    scrollSpy = vi.spyOn(container, 'scrollToActivatedValue').mockImplementation(() => {});
+    scrollSpy = vi.spyOn(container, 'scrollToActivatedValue').mockImplementation(() => { });
   });
 
   it('should not recenter when more options are appended on scroll', () => {

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -1500,10 +1500,10 @@ describe('select', () => {
 
     it('should not run change detection when `nz-select-top-control` is clicked and should focus the `nz-select-search`', () => {
       const appRef = TestBed.inject(ApplicationRef);
-      vi.spyOn(appRef, 'tick').mockImplementation(() => { });
+      vi.spyOn(appRef, 'tick').mockImplementation(() => {});
 
       const nzSelectSearch = fixture.debugElement.query(By.directive(NzSelectSearchComponent));
-      vi.spyOn(nzSelectSearch.componentInstance, 'focus').mockImplementation(() => { });
+      vi.spyOn(nzSelectSearch.componentInstance, 'focus').mockImplementation(() => {});
 
       const nzSelectTopControl = fixture.debugElement.query(By.directive(NzSelectTopControlComponent));
       dispatchMouseEvent(nzSelectTopControl.nativeElement, 'click');
@@ -1514,7 +1514,7 @@ describe('select', () => {
 
     it('should not run change detection when non-backspace button is pressed on the `nz-select-top-control`', () => {
       const appRef = TestBed.inject(ApplicationRef);
-      vi.spyOn(appRef, 'tick').mockImplementation(() => { });
+      vi.spyOn(appRef, 'tick').mockImplementation(() => {});
 
       const nzSelectTopControl = fixture.debugElement.query(By.directive(NzSelectTopControlComponent));
       dispatchKeyboardEvent(nzSelectTopControl.nativeElement, 'keydown', TAB, nzSelectTopControl.nativeElement);
@@ -1799,7 +1799,7 @@ describe('option container scroll', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({ providers: [provideNzIconsTesting(), provideNzNoAnimation()] });
     container = TestBed.createComponent(NzOptionContainerComponent).componentInstance;
-    scrollSpy = vi.spyOn(container, 'scrollToActivatedValue').mockImplementation(() => { });
+    scrollSpy = vi.spyOn(container, 'scrollToActivatedValue').mockImplementation(() => {});
   });
 
   it('should not recenter when more options are appended on scroll', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With load-on-scroll (`(nzScrollToBottom)`), reaching the bottom of the dropdown by
**dragging the scrollbar** (or middle-click autoscroll) makes the option list jump
back to the top / last activated option the moment the newly loaded page is appended.
Mouse-wheel scrolling is unaffected.

Root cause: `NzOptionContainerComponent.ngOnChanges` calls `scrollToActivatedValue()`
on every `listOfContainerItem` change. When a page is appended while the user is
scrolled down with no option hovered, the activated option is the top/selected item,
so the virtual viewport is scrolled back to it. Hovering (wheel scrolling) keeps the
activated option in view, which is why only scrollbar dragging exposes the bug.

Issue Number: #7031


## What is the new behavior?
`ngOnChanges` recenters the viewport only when the **activated option changes**
(keyboard navigation / selection) or on the **initial population** of options.
Appending more options no longer moves the scroll position; keyboard navigation and
open-to-selected still scroll to the active option as before.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
