### PR TITLE
fix(module:date-picker): preserve range selection behavior

### DIFF
--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -108,7 +108,7 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
           [hoverValue]="$any(hoverValue)"
           [format]="format"
           (cellHover)="onCellHover($event)"
-          (selectDate)="changeValueFromSelect($event, !showTime)"
+          (selectDate)="changeValueFromSelect($event, !showTime, true)"
           (selectTime)="onSelectTime($event, partType)"
           (headerChange)="onActiveDateChange($event, partType)"
         />
@@ -312,11 +312,18 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
     this.buildTimeOptions();
   }
 
-  changeValueFromSelect(value: CandyDate, emitValue: boolean = true): void {
+  changeValueFromSelect(value: CandyDate, emitValue: boolean = true, isDateCellClick: boolean = false): void {
     if (this.isRange) {
       const selectedValue: SingleValue[] = cloneDate(this.datePickerService.value) as CandyDate[];
       const checkedPart: RangePartType = this.datePickerService.activeInput;
       let nextPart: RangePartType = checkedPart;
+      const hasCompleteRange = !!selectedValue[0] && !!selectedValue[1];
+      const isFreshSelection = !this.checkedPartArr[0] && !this.checkedPartArr[1];
+
+      // A new cell click should start a fresh range even when reopening with a complete existing value.
+      if (isDateCellClick && hasCompleteRange && isFreshSelection) {
+        selectedValue[this.datePickerService.getActiveIndex(this.reversedPart(checkedPart))] = null;
+      }
 
       selectedValue[this.datePickerService.getActiveIndex(checkedPart)] = value;
       this.checkedPartArr[this.datePickerService.getActiveIndex(checkedPart)] = true;
@@ -334,6 +341,8 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
           this.calendarChange.emit(selectedValue);
           if (this.isBothAllowed(selectedValue) && this.checkedPartArr[0] && this.checkedPartArr[1]) {
             this.clearHoverValue();
+            // The next user click should begin a new selection cycle.
+            this.resetCheckedPart();
             this.datePickerService.emitValue$.next();
           }
         } else {
@@ -351,6 +360,8 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
           if (this.isBothAllowed(selectedValue) && this.checkedPartArr[0] && this.checkedPartArr[1]) {
             this.calendarChange.emit(selectedValue);
             this.clearHoverValue();
+            // The next user click should begin a new selection cycle.
+            this.resetCheckedPart();
             this.datePickerService.emitValue$.next();
           } else if (this.isAllowed(selectedValue)) {
             nextPart = this.reversedPart(checkedPart);
@@ -465,6 +476,10 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
 
   private clearHoverValue(): void {
     this.hoverValue = [];
+  }
+
+  private resetCheckedPart(): void {
+    this.checkedPartArr = [false, false];
   }
 
   private buildTimeOptions(): void {

--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -108,7 +108,7 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
           [hoverValue]="$any(hoverValue)"
           [format]="format"
           (cellHover)="onCellHover($event)"
-          (selectDate)="changeValueFromSelect($event, !showTime, true)"
+          (selectDate)="changeValueFromSelect($event, !showTime, true, partType)"
           (selectTime)="onSelectTime($event, partType)"
           (headerChange)="onActiveDateChange($event, partType)"
         />
@@ -312,7 +312,12 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
     this.buildTimeOptions();
   }
 
-  changeValueFromSelect(value: CandyDate, emitValue: boolean = true, isDateCellClick: boolean = false): void {
+  changeValueFromSelect(
+    value: CandyDate,
+    emitValue: boolean = true,
+    isDateCellClick: boolean = false,
+    selectionPanel?: RangePartType
+  ): void {
     if (this.isRange) {
       const selectedValue: SingleValue[] = cloneDate(this.datePickerService.value) as CandyDate[];
       const checkedPart: RangePartType = this.datePickerService.activeInput;
@@ -372,6 +377,10 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
         this.datePickerService.setValue(selectedValue);
       }
       this.datePickerService.inputPartChange$.next(nextPart);
+      if (selectionPanel && !!selectedValue[0] !== !!selectedValue[1]) {
+        // Keep an incomplete range anchored to the panel where its value was selected.
+        this.onActiveDateChange(value, selectionPanel);
+      }
     } else {
       this.datePickerService.setValue(value);
       this.datePickerService.inputPartChange$.next(null);

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -1100,6 +1100,25 @@ describe('range-picker', () => {
       fixture.detectChanges();
       expect(rightThirdRowCell.classList.contains('ant-picker-cell-range-hover-end')).toBeTruthy();
     }));
+
+    it('should start a fresh range when reselecting months from an existing range', fakeAsync(() => {
+      fixtureInstance.modelValue = [new Date('2026-01-01'), new Date('2026-05-01')];
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+
+      dispatchMouseEvent(getMonthCell('left', 7), 'click');
+      fixture.detectChanges();
+      dispatchMouseEvent(getMonthCell('left', 3), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+
+      const [start, end] = fixtureInstance.modelValue as Date[];
+      expect(start.getFullYear()).toBe(2026);
+      expect(start.getMonth()).toBe(2);
+      expect(end.getFullYear()).toBe(2026);
+      expect(end.getMonth()).toBe(6);
+    }));
   });
 
   describe('year mode', () => {
@@ -1193,6 +1212,13 @@ describe('range-picker', () => {
   function getFirstCell(partial: 'left' | 'right'): HTMLElement {
     const flg = partial === 'left' ? 'first' : 'last';
     return queryFromOverlay(`.ant-picker-panel:${flg}-child td:first-child .ant-picker-cell-inner`) as HTMLElement;
+  }
+
+  function getMonthCell(partial: 'left' | 'right', month: number): HTMLElement {
+    const flg = partial === 'left' ? 'first' : 'last';
+    return queryFromOverlay(`.ant-picker-panel:${flg}-child .ant-picker-month-panel`)!.querySelectorAll(
+      'td.ant-picker-cell .ant-picker-cell-inner'
+    )[month - 1] as HTMLElement;
   }
 
   function queryFromOverlay(selector: string): HTMLElement {

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -1119,6 +1119,29 @@ describe('range-picker', () => {
       expect(end.getFullYear()).toBe(2026);
       expect(end.getMonth()).toBe(6);
     }));
+
+    it('should keep a typed start month when selecting the end month from the panel', fakeAsync(() => {
+      fixtureInstance.modelValue = [new Date('2026-01-01'), new Date('2026-05-01')];
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+
+      const leftInput = getPickerInput(fixture.debugElement);
+      typeInElement('2026-02', leftInput);
+      fixture.detectChanges();
+      leftInput.dispatchEvent(ENTER_EVENT);
+      fixture.detectChanges();
+
+      dispatchMouseEvent(getMonthCell('left', 6), 'click');
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+
+      const [start, end] = fixtureInstance.modelValue as Date[];
+      expect(start.getFullYear()).toBe(2026);
+      expect(start.getMonth()).toBe(1);
+      expect(end.getFullYear()).toBe(2026);
+      expect(end.getMonth()).toBe(5);
+    }));
   });
 
   describe('year mode', () => {

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -1101,6 +1101,17 @@ describe('range-picker', () => {
       expect(rightThirdRowCell.classList.contains('ant-picker-cell-range-hover-end')).toBeTruthy();
     }));
 
+    it('should keep a selected start month in the right panel', fakeAsync(() => {
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+
+      const selectedMonth = getMonthCell('right', 6);
+      dispatchMouseEvent(selectedMonth, 'click');
+      fixture.detectChanges();
+
+      expect(queryFromOverlay('.ant-picker-panel:last-child .ant-picker-cell-selected')).not.toBeNull();
+    }));
+
     it('should start a fresh range when reselecting months from an existing range', fakeAsync(() => {
       fixtureInstance.modelValue = [new Date('2026-01-01'), new Date('2026-05-01')];
       fixture.detectChanges();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9856, #9752

When an nz-range-picker in nzMode="month" is reopened with an existing complete range, the first new cell click can still be combined with the stale opposite endpoint. This is related to #9518: that change correctly preserves reversed range selections by reversing the selected value, but it also made the stale endpoint visible when a new selection cycle was not reset.

When the left input is active, selecting a month in the right panel can re-anchor the panels around the start value and move the selected cell to the left panel.


## What is the new behavior?

A fresh cell click after a complete range starts a new range selection cycle, so the stale opposite endpoint is cleared before the new endpoint is applied. The existing reverse-order behavior from #9518 is preserved.

An incomplete range remains anchored to the panel where its value was selected, while the selected value continues to belong to the active start or end input.

Regression tests cover reopening a month range picker with Jan 2026 - May 2026, then selecting Jul 2026 and Mar 2026; the resulting range is now Mar 2026 - Jul 2026. They also cover typing a start month before selecting the end month, and selecting a start month from the right panel.


## 中文说明

本 PR 同时修复范围选择器的两类状态问题：

- #9856：已有完整月份范围时重新选择，首个新月份会与旧的另一端组合。现在首次点击会开启新的选择周期，先清除旧端点，再完成新的范围选择。
- #9752：左侧输入框处于焦点时，点击右侧月份面板会导致已选月份跳到左侧面板。现在未完成范围会以实际点击的面板为展示锚点，同时保留起止输入框对应的值语义。

回归测试覆盖重新选择月份范围、输入起始月份后点选结束月份，以及从右侧面板选择起始月份。


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Validated with:

npx ng test --watch=false --progress=false --browsers=ChromeHeadless --include=components/date-picker/range-picker.component.spec.ts

Result: TOTAL: 63 SUCCESS.
