### PR TITLE
fix(module:select): restore virtual scroll spacer width

### DIFF
--- a/components/select/style/patch.less
+++ b/components/select/style/patch.less
@@ -19,6 +19,8 @@
     .cdk-virtual-scroll-spacer {
       position: absolute;
       top: 0;
+      // Keep the spacer in the viewport's scrollable overflow area.
+      width: 1px;
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

This is a regression introduced in `21.3.1` by #9808. The refactor removed the `width: 1px` declaration from the virtual-scroll spacer while retaining the `full-width` layout overrides used by `nzDropdownMatchSelectWidth=false`:

```less
.cdk-virtual-scroll-content-wrapper { position: static; }
.cdk-virtual-scroll-spacer { position: absolute; top: 0; }
```

CDK writes the spacer's full data-set height. With no width, that empty absolutely positioned spacer no longer contributes to the viewport's scrollable overflow. The viewport therefore has only the initial 16 rendered options (`8` visible options plus an `8`-item buffer) to scroll through. Reopening a Select whose selected option is beyond that range cannot position it correctly.

Issue Number: #9863

## What is the new behavior?

Restore the 1px spacer width so the CDK virtual viewport includes the complete option list in its scrollable overflow and can position selected options beyond the initial render buffer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated manually with the Select large-data demo and with `npx stylelint components/select/style/patch.less` and `npm run build`.
