### PR TITLE
fix(module:date-picker): preserve range selection behavior

### DIFF
--- a/components/date-picker/date-range-popup.component.ts
+++ b/components/date-picker/date-range-popup.component.ts
@@ -106,7 +106,7 @@ import { getTimeConfig, isAllowedDate, PREFIX_CLASS } from './util';
           [hoverValue]="$any(hoverValue)"
           [format]="format"
           (cellHover)="onCellHover($event)"
-          (selectDate)="changeValueFromSelect($event, !showTime)"
+          (selectDate)="changeValueFromSelect($event, !showTime, true, partType)"
           (selectTime)="onSelectTime($event, partType)"
           (headerChange)="onActiveDateChange($event, partType)"
         />
@@ -310,11 +310,23 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
     this.buildTimeOptions();
   }
 
-  changeValueFromSelect(value: CandyDate, emitValue: boolean = true): void {
+  changeValueFromSelect(
+    value: CandyDate,
+    emitValue: boolean = true,
+    isDateCellClick: boolean = false,
+    selectionPanel?: RangePartType
+  ): void {
     if (this.isRange) {
       const selectedValue: SingleValue[] = cloneDate(this.datePickerService.value) as CandyDate[];
       const checkedPart: RangePartType = this.datePickerService.activeInput;
       let nextPart: RangePartType = checkedPart;
+      const hasCompleteRange = !!selectedValue[0] && !!selectedValue[1];
+      const isFreshSelection = !this.checkedPartArr[0] && !this.checkedPartArr[1];
+
+      // A new cell click should start a fresh range even when reopening with a complete existing value.
+      if (isDateCellClick && hasCompleteRange && isFreshSelection) {
+        selectedValue[this.datePickerService.getActiveIndex(this.reversedPart(checkedPart))] = null;
+      }
 
       selectedValue[this.datePickerService.getActiveIndex(checkedPart)] = value;
       this.checkedPartArr[this.datePickerService.getActiveIndex(checkedPart)] = true;
@@ -332,6 +344,8 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
           this.calendarChange.emit(selectedValue);
           if (this.isBothAllowed(selectedValue) && this.checkedPartArr[0] && this.checkedPartArr[1]) {
             this.clearHoverValue();
+            // The next user click should begin a new selection cycle.
+            this.resetCheckedPart();
             this.datePickerService.emitValue$.next();
           }
         } else {
@@ -349,6 +363,8 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
           if (this.isBothAllowed(selectedValue) && this.checkedPartArr[0] && this.checkedPartArr[1]) {
             this.calendarChange.emit(selectedValue);
             this.clearHoverValue();
+            // The next user click should begin a new selection cycle.
+            this.resetCheckedPart();
             this.datePickerService.emitValue$.next();
           } else if (this.isAllowed(selectedValue)) {
             nextPart = this.reversedPart(checkedPart);
@@ -359,6 +375,10 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
         this.datePickerService.setValue(selectedValue);
       }
       this.datePickerService.inputPartChange$.next(nextPart);
+      if (selectionPanel && !!selectedValue[0] !== !!selectedValue[1]) {
+        // Keep an incomplete range anchored to the panel where its value was selected.
+        this.onActiveDateChange(value, selectionPanel);
+      }
     } else {
       this.datePickerService.setValue(value);
       this.datePickerService.inputPartChange$.next(null);
@@ -463,6 +483,10 @@ export class DateRangePopupComponent implements OnInit, OnChanges {
 
   private clearHoverValue(): void {
     this.hoverValue = [];
+  }
+
+  private resetCheckedPart(): void {
+    this.checkedPartArr = [false, false];
   }
 
   private buildTimeOptions(): void {

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -1098,6 +1098,59 @@ describe('range-picker', () => {
       fixture.detectChanges();
       expect(rightThirdRowCell.classList.contains('ant-picker-cell-range-hover-end')).toBeTruthy();
     });
+
+    it('should keep a selected start month in the right panel', () => {
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+
+      const selectedMonth = getMonthCell('right', 6);
+      dispatchMouseEvent(selectedMonth, 'click');
+      fixture.detectChanges();
+
+      expect(queryFromOverlay('.ant-picker-panel:last-child .ant-picker-cell-selected')).not.toBeNull();
+    });
+
+    it('should start a fresh range when reselecting months from an existing range', () => {
+      fixtureInstance.modelValue.set([new Date('2026-01-01'), new Date('2026-05-01')]);
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+
+      dispatchMouseEvent(getMonthCell('left', 7), 'click');
+      fixture.detectChanges();
+      dispatchMouseEvent(getMonthCell('left', 3), 'click');
+      fixture.detectChanges();
+      vi.advanceTimersByTime(500);
+      fixture.detectChanges();
+
+      const [start, end] = fixtureInstance.modelValue() as Date[];
+      expect(start.getFullYear()).toBe(2026);
+      expect(start.getMonth()).toBe(2);
+      expect(end.getFullYear()).toBe(2026);
+      expect(end.getMonth()).toBe(6);
+    });
+
+    it('should keep a typed start month when selecting the end month from the panel', () => {
+      fixtureInstance.modelValue.set([new Date('2026-01-01'), new Date('2026-05-01')]);
+      fixture.detectChanges();
+      openPickerByClickTrigger();
+
+      const leftInput = getPickerInput(fixture.debugElement);
+      typeInElement('2026-02', leftInput);
+      fixture.detectChanges();
+      leftInput.dispatchEvent(ENTER_EVENT);
+      fixture.detectChanges();
+
+      dispatchMouseEvent(getMonthCell('left', 6), 'click');
+      fixture.detectChanges();
+      vi.advanceTimersByTime(500);
+      fixture.detectChanges();
+
+      const [start, end] = fixtureInstance.modelValue() as Date[];
+      expect(start.getFullYear()).toBe(2026);
+      expect(start.getMonth()).toBe(1);
+      expect(end.getFullYear()).toBe(2026);
+      expect(end.getMonth()).toBe(5);
+    });
   });
 
   describe('year mode', () => {
@@ -1198,6 +1251,13 @@ describe('range-picker', () => {
   function getFirstCell(partial: 'left' | 'right'): HTMLElement {
     const flg = partial === 'left' ? 'first' : 'last';
     return queryFromOverlay(`.ant-picker-panel:${flg}-child td:first-child .ant-picker-cell-inner`) as HTMLElement;
+  }
+
+  function getMonthCell(partial: 'left' | 'right', month: number): HTMLElement {
+    const flg = partial === 'left' ? 'first' : 'last';
+    return queryFromOverlay(`.ant-picker-panel:${flg}-child .ant-picker-month-panel`)!.querySelectorAll(
+      'td.ant-picker-cell .ant-picker-cell-inner'
+    )[month - 1] as HTMLElement;
   }
 
   function queryFromOverlay(selector: string): HTMLElement {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #9856, #9752

This ports the behavior fixed by #9873 from `v21` to `master`, which has since migrated the range-picker test setup to signals and Vitest.

When a month range picker is reopened with an existing complete range, the first new cell click can still combine with the stale opposite endpoint. The reversed-range handling introduced by #9518 preserves the reverse order correctly, but the selection-cycle state was not reset after completing a range.

Also, when the left input is active, selecting a month from the right panel can re-anchor the panels around the start value and move the selected cell to the left panel.

## What is the new behavior?

- A cell click after a complete range begins a fresh selection cycle and clears the stale opposite endpoint before applying the new value. Existing reversed-range behavior remains intact.
- An incomplete range remains anchored to the panel where its value was selected, while the start/end input value semantics remain unchanged.
- Adds master-compatible Vitest regression coverage for reselecting a month range, typing a start month before selecting an end month, and selecting a start month from the right panel.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated with:

- `npm run build` (passed)
- `npx ng test --watch=false --progress=false --include=components/date-picker/range-picker.component.spec.ts` could not run locally because the required Playwright Chromium executable is not installed; no test cases were executed.
