### PR TITLE
fix(module:tooltip,popover,popconfirm): skip hover on touch devices

### DIFF
--- a/components/popconfirm/popconfirm.spec.ts
+++ b/components/popconfirm/popconfirm.spec.ts
@@ -12,10 +12,11 @@ import { delay, of, Observable } from 'rxjs';
 import { vi } from 'vitest';
 
 import { provideNzNoAnimation } from 'ng-zorro-antd/core/animation';
-import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
+import { dispatchMouseEvent, dispatchTouchEvent } from 'ng-zorro-antd/core/testing';
 import { provideNzIconsTesting } from 'ng-zorro-antd/icon/testing';
 import { NzAutoFocusType } from 'ng-zorro-antd/popconfirm/popconfirm';
 import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm/popconfirm.module';
+import { NzTooltipTrigger } from 'ng-zorro-antd/tooltip';
 
 import { NzPopConfirmButtonProps } from './popconfirm-option';
 
@@ -310,6 +311,31 @@ describe('popconfirm', () => {
 
     expect(overlayContainerElement.querySelector('.testClass1.testClass2')).not.toBeNull();
   });
+
+  describe('touch devices', () => {
+    it('should not show popconfirm on a tap when trigger is hover', () => {
+      component.popconfirmTrigger.set('hover');
+      fixture.detectChanges();
+      const triggerElement = component.stringTemplate.nativeElement;
+
+      dispatchTouchEvent(triggerElement, 'touchend');
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(getTitleText()).toBeNull();
+    });
+
+    it('should still show popconfirm on genuine mouseenter when trigger is hover', () => {
+      component.popconfirmTrigger.set('hover');
+      fixture.detectChanges();
+      const triggerElement = component.stringTemplate.nativeElement;
+
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(getTitleText()!.textContent).toContain('title-string');
+    });
+  });
 });
 
 @Component({
@@ -319,6 +345,7 @@ describe('popconfirm', () => {
       nz-popconfirm
       #stringTemplate
       nzPopconfirmTitle="title-string"
+      [nzPopconfirmTrigger]="popconfirmTrigger()"
       nzOkText="ok-text"
       [nzOkType]="nzOkType()"
       [nzOkDisabled]="nzOkDisabled()"
@@ -358,6 +385,7 @@ export class NzPopconfirmTestNewComponent {
   readonly condition = signal(false);
   readonly nzOkType = signal<string>('default');
   readonly nzOkDisabled = signal<boolean>(false);
+  readonly popconfirmTrigger = signal<NzTooltipTrigger>('click');
   nzCancelText = 'Cancel';
   nzOkText = 'Ok';
   nzOkButtonProps = signal<NzPopConfirmButtonProps>({ nzDisabled: false });

--- a/components/popover/popover.spec.ts
+++ b/components/popover/popover.spec.ts
@@ -10,7 +10,7 @@ import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { vi } from 'vitest';
 
 import { provideNzNoAnimation } from 'ng-zorro-antd/core/animation';
-import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
+import { dispatchMouseEvent, dispatchTouchEvent } from 'ng-zorro-antd/core/testing';
 
 import { NzPopoverDirective } from './popover';
 import { NzPopoverModule } from './popover.module';
@@ -160,6 +160,27 @@ describe('popover', () => {
     waitingForTooltipToggling();
     expect(getTitleTextContent()).toContain('titleContextTest');
     expect(getInnerTextContent()).toContain('contentContextTest');
+  });
+
+  describe('touch devices', () => {
+    it('should not show popover on a tap (touchend immediately before mouseenter)', () => {
+      const triggerElement = component.stringPopover.nativeElement;
+
+      dispatchTouchEvent(triggerElement, 'touchend');
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(getTitleTextContent()).toBeNull();
+    });
+
+    it('should still show popover on a genuine mouseenter with no preceding touch', () => {
+      const triggerElement = component.stringPopover.nativeElement;
+
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(getTitleTextContent()).toContain('title-string');
+    });
   });
 });
 

--- a/components/tooltip/base.ts
+++ b/components/tooltip/base.ts
@@ -132,6 +132,14 @@ export abstract class NzTooltipBaseDirective implements AfterViewInit, OnChanges
   protected readonly triggerDisposables: VoidFunction[] = [];
 
   private delayTimer?: ReturnType<typeof setTimeout>;
+  /**
+   * Timer used to update the value of {@link isTouchTriggered}.
+   */
+  private touchResetTimer?: ReturnType<typeof setTimeout>;
+  /**
+   * Tracks whether the most recent pointer interaction was a touch.
+   */
+  private isTouchTriggered: boolean = false;
 
   // componentType is supplied by subclasses, not Angular DI.
   // eslint-disable-next-line @angular-eslint/prefer-inject
@@ -139,6 +147,7 @@ export abstract class NzTooltipBaseDirective implements AfterViewInit, OnChanges
     this.destroyRef.onDestroy(() => {
       // Clear toggling timer. Issue #3875 #4317 #4386
       this.clearTogglingTimer();
+      this.clearTouchResetTimer();
       this.removeTriggerListeners();
     });
   }
@@ -228,13 +237,27 @@ export abstract class NzTooltipBaseDirective implements AfterViewInit, OnChanges
 
     if (trigger === 'hover') {
       let overlayElement: HTMLElement;
+
+      // Because of Hybrid devices, rather than disabling hover we flag a short window after `touchend` event.
+      // Following W3C Touch Events documented sequence `touchend` should fire before the mouse events.
+      this.triggerDisposables.push(
+        this.renderer.listen(el, 'touchend', () => {
+          this.isTouchTriggered = true;
+          this.clearTouchResetTimer();
+          this.touchResetTimer = setTimeout(() => {
+            this.isTouchTriggered = false;
+          }, 500);
+        })
+      );
       this.triggerDisposables.push(
         this.renderer.listen(el, 'mouseenter', () => {
+          if (this.isTouchTriggered) return;
           this.delayEnterLeave(true, true, this._mouseEnterDelay);
         })
       );
       this.triggerDisposables.push(
         this.renderer.listen(el, 'mouseleave', () => {
+          if (this.isTouchTriggered) return;
           this.delayEnterLeave(true, false, this._mouseLeaveDelay);
           if (this.component?.overlay.overlayRef && !overlayElement) {
             overlayElement = this.component.overlay.overlayRef.overlayElement;
@@ -335,6 +358,13 @@ export abstract class NzTooltipBaseDirective implements AfterViewInit, OnChanges
     if (this.delayTimer) {
       clearTimeout(this.delayTimer);
       this.delayTimer = undefined;
+    }
+  }
+
+  private clearTouchResetTimer(): void {
+    if (this.touchResetTimer) {
+      clearTimeout(this.touchResetTimer);
+      this.touchResetTimer = undefined;
     }
   }
 }

--- a/components/tooltip/tooltip.spec.ts
+++ b/components/tooltip/tooltip.spec.ts
@@ -11,7 +11,7 @@ import { vi } from 'vitest';
 
 import { provideNzNoAnimation } from 'ng-zorro-antd/core/animation';
 import { NzElementPatchDirective } from 'ng-zorro-antd/core/element-patch';
-import { dispatchMouseEvent } from 'ng-zorro-antd/core/testing';
+import { dispatchMouseEvent, dispatchTouchEvent } from 'ng-zorro-antd/core/testing';
 
 import { NzTooltipBaseDirective, NzTooltipTrigger } from './base';
 import { NzTooltipDirective } from './tooltip';
@@ -323,6 +323,79 @@ describe('tooltip', () => {
       const triggerElement = component.inBtnGroup.nativeElement;
       // There's a <!--container--> element created by Ivy.
       expect(triggerElement.nextSibling.nextSibling.tagName).toBe('BUTTON');
+    });
+  });
+
+  describe('touch devices', () => {
+    it('should not show tooltip when a tap fires touchend immediately before mouseenter', () => {
+      const title = 'title-string';
+      const triggerElement = component.titleString.nativeElement;
+
+      dispatchTouchEvent(triggerElement, 'touchend');
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(overlayContainerElement.textContent).not.toContain(title);
+    });
+
+    it('should not show tooltip after a long press (touchstart held before touchend)', () => {
+      const title = 'title-string';
+      const triggerElement = component.titleString.nativeElement;
+
+      dispatchTouchEvent(triggerElement, 'touchstart');
+      vi.advanceTimersByTime(700); // Hold well past the old touchstart-anchored window.
+      dispatchTouchEvent(triggerElement, 'touchend');
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(overlayContainerElement.textContent).not.toContain(title);
+    });
+
+    it('should still show tooltip on a genuine mouseenter with no preceding touch', () => {
+      const title = 'title-string';
+      const triggerElement = component.titleString.nativeElement;
+
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(overlayContainerElement.textContent).toContain(title);
+    });
+
+    it('should show tooltip on mouseenter once the touch-suppression window has elapsed (hybrid device)', () => {
+      const title = 'title-string';
+      const triggerElement = component.titleString.nativeElement;
+
+      dispatchTouchEvent(triggerElement, 'touchend');
+      vi.advanceTimersByTime(600); // Past the 500ms suppression window.
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(overlayContainerElement.textContent).toContain(title);
+    });
+
+    it('should reset the suppression timer on repeated taps rather than stacking timers', () => {
+      const title = 'title-string';
+      const triggerElement = component.titleString.nativeElement;
+
+      dispatchTouchEvent(triggerElement, 'touchend');
+      vi.advanceTimersByTime(300);
+      dispatchTouchEvent(triggerElement, 'touchend'); // Second tap resets the window.
+      vi.advanceTimersByTime(300); // 300+300=600 total, but only 300 since the reset.
+      dispatchMouseEvent(triggerElement, 'mouseenter');
+      waitingForTooltipToggling();
+
+      expect(overlayContainerElement.textContent).not.toContain(title);
+    });
+
+    it('should leave click trigger unaffected by touch suppression', () => {
+      const featureKey = 'title-template';
+      const triggerElement = component.titleTemplate.nativeElement;
+
+      dispatchTouchEvent(triggerElement, 'touchend');
+      dispatchMouseEvent(triggerElement, 'click');
+      waitingForTooltipToggling();
+
+      expect(overlayContainerElement.textContent).toContain(featureKey);
     });
   });
 });


### PR DESCRIPTION
…ver trigger.


Add check for touch devices before handling hover trigger.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `nzTooltipTrigger` hover behavior on devices that use touch as primary input leads to anomalies.
eg: having a button with `nz-tooltip` with `hover` trigger leads to the activation of both button action and tooltip visualization.

Issue Number: N/A


## What is the new behavior?
The new behavior avoids the activation of tooltip when a user press a component with a `nz-tooltip` on it (that use `hover` as trigger), leaving `click` trigger as it is, that is because, in my humble opinion, a touch is intended to be a click, not a hover.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
If this behavior was intended this PR can lead to breaking changes, impacting the behavior of a lot of web apps.
However, as a developer, I have to disable the tooltip that exploit `hover` trigger on touch devices because of this annoying behavior.

## Other information
Example to reproduce:
Imagine having something like:

```ts
<button
  nz-col
  nz-tooltip
  [nzTooltipMouseEnterDelay]="0.75"
  [nzTooltipTitle]="'search' | translate"
  nz-button
  (click)="openSearchModal = true">
  <nz-icon nzType="search" nzTheme="outline" />
</button>
```

Just press the button for enough time to satisfy the delay time and you will have (the search button is under the searchbar that has been opened):
<img width="436" height="939" alt="image" src="https://github.com/user-attachments/assets/769873c3-f478-4a42-9249-513beae2a16d" />

To be clear, the `nzTooltipMouseEnterDelay` is what, in the example listed above, leads to the bug, but that is due to the action that I make once the searchModal is open.
There are cases in which, without any enterDelay, the tooltip fires after click and remain open as showed in the screenshot.