### PR TITLE
fix(module:drawer): avoid overwriting signal inputs with data

### DIFF
--- a/components/drawer/drawer-options.ts
+++ b/components/drawer/drawer-options.ts
@@ -27,7 +27,9 @@ export interface NzDrawerOptionsOfComponent<T = NzSafeAny, D = NzSafeAny> {
   nzExtra?: string | TemplateRef<{}>;
   nzFooter?: string | TemplateRef<{}>;
   nzContent?: TemplateRef<{ $implicit: D; drawerRef: NzDrawerRef }> | Type<T>;
-  /**@Deprecated**/
+  /**
+   * @deprecated will be removed in v23, please use `nzData` instead
+   */
   nzContentParams?: Partial<T & D>;
   nzData?: D;
   nzMaskStyle?: object;

--- a/components/drawer/drawer.component.ts
+++ b/components/drawer/drawer.component.ts
@@ -33,6 +33,7 @@ import {
   OnChanges,
   OnInit,
   Output,
+  reflectComponentType,
   Renderer2,
   SimpleChanges,
   TemplateRef,
@@ -425,12 +426,25 @@ export class NzDrawerComponent<T extends {} = NzSafeAny, R = NzSafeAny, D extend
       });
       const componentPortal = new ComponentPortal<T>(this.nzContent, null, childInjector);
       this.componentRef = this.bodyPortalOutlet!.attachComponentPortal(componentPortal);
-
       this.componentInstance = this.componentRef.instance;
-      /**TODO
-       * When nzContentParam will be remove in the next major version, we have to remove the following line
-       * **/
-      Object.assign(this.componentRef.instance!, this.nzData || this.nzContentParams);
+
+      /**
+       * @todo `nzContentParams` will be removed in v23, we have to remove the following logics
+       */
+      const contentParams = this.nzData || this.nzContentParams;
+      const signalInputNames = new Set(
+        reflectComponentType(this.nzContent)
+          ?.inputs.filter(input => input.isSignal)
+          .map(input => input.propName)
+      );
+
+      for (const [key, value] of Object.entries(contentParams ?? {})) {
+        // skip signal inputs
+        if (!signalInputNames.has(key)) {
+          const instance = this.componentRef.instance as Record<string, unknown>;
+          instance[key] = value;
+        }
+      }
       this.componentRef.changeDetectorRef.detectChanges();
     }
   }

--- a/components/drawer/drawer.spec.ts
+++ b/components/drawer/drawer.spec.ts
@@ -6,7 +6,7 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Component, Input, signal, TemplateRef, ViewChild, inject } from '@angular/core';
+import { Component, Input, input, signal, TemplateRef, ViewChild, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { vi } from 'vitest';
@@ -693,6 +693,19 @@ describe('NzDrawerService', () => {
     expect(drawerRef.getContentComponentRef()).toBeNull();
   });
 
+  it('should not replace an input signal with nzData', () => {
+    const drawerRef = drawerService.create({
+      nzContent: NzDrawerContentWithInputSignalComponent,
+      nzData: { text: 'Drawer data' }
+    });
+
+    fixture.detectChanges();
+
+    const contentComponent = drawerRef.getContentComponent();
+    expect(contentComponent?.text()).toBe('Default input');
+    expect(contentComponent?.nzData.text).toBe('Drawer data');
+  });
+
   it('should `nzOnCancel` work', async () => {
     let canClose = false;
     const openSpy = vi.fn();
@@ -860,4 +873,12 @@ export class NzDrawerCustomComponent {
   close(): void {
     this.drawerRef.close(this.value);
   }
+}
+
+@Component({
+  template: ''
+})
+class NzDrawerContentWithInputSignalComponent {
+  readonly nzData = inject<{ text: string }>(NZ_DRAWER_DATA);
+  readonly text = input('Default input');
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Creating a Drawer through the service directly assigns `nzData` to the content component. When a data key matches an `input()` signal, the signal function is replaced and invoking it throws an error.

Issue Number: #9888


## What is the new behavior?

Drawer skips fields that match signal inputs when assigning content parameters. The data remains available through `NZ_DRAWER_DATA`, and the signal input is preserved. The deprecated `nzContentParams` documentation now states its v23 removal.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Validation:

- `npx nx run ng-zorro-antd-lib:test --watch=false --coverage=false --include=components/drawer/drawer.spec.ts`
- `npx nx run ng-zorro-antd-lib:build-lib`