### PR TITLE
fix(module:select): scroll to initial selected option

### DIFF
--- a/components/select/select.component.ts
+++ b/components/select/select.component.ts
@@ -666,6 +666,9 @@ export class NzSelectComponent implements ControlValueAccessor, OnInit, AfterCon
       };
       const listOfValue = covertModelToList(modelValue, this.nzMode);
       this.listOfValue = listOfValue;
+      if (!this.nzOpen) {
+        this.activatedValue = listOfValue[0] ?? null;
+      }
       this.listOfValue$.next(listOfValue);
       this.cdr.markForCheck();
     }

--- a/components/select/select.spec.ts
+++ b/components/select/select.spec.ts
@@ -113,6 +113,23 @@ describe('select', () => {
       expect(component.valueChange).not.toHaveBeenCalled();
     });
 
+    it('should scroll to the initially selected option when opened', async () => {
+      component.listOfOption.set(
+        Array.from({ length: 30 }, (_, index) => ({ nzValue: index + 1, nzLabel: `Option ${index + 1}` }))
+      );
+      component.value.set(15);
+      await flushChanges();
+
+      component.nzOpen.set(true);
+      await flushChanges();
+
+      const viewport = overlayContainerElement.querySelector<HTMLElement>('.cdk-virtual-scroll-viewport');
+      expect(viewport!.scrollTop).toBeGreaterThan(0);
+      expect(overlayContainerElement.querySelector('.ant-select-item-option-active')!.textContent?.trim()).toBe(
+        'Option 15'
+      );
+    });
+
     it('should ngModelChange trigger when click option', async () => {
       component.listOfOption.set([
         { nzValue: 'test_01', nzLabel: 'test_01' },
@@ -636,6 +653,28 @@ describe('select', () => {
       expect(listOfSelectItem[0].textContent?.trim()).toBe('label_01');
       expect(listOfSelectItem[1].textContent?.trim()).toBe('label_02');
       expect(component.valueChange).not.toHaveBeenCalled();
+    });
+
+    it('should preserve the activated option when the value changes while opened', async () => {
+      component.listOfOption.set([
+        { nzValue: 'value_01', nzLabel: 'label_01' },
+        { nzValue: 'value_02', nzLabel: 'label_02' },
+        { nzValue: 'value_03', nzLabel: 'label_03' }
+      ]);
+      component.value.set(['value_01']);
+      await flushChanges();
+
+      component.nzOpen.set(true);
+      await flushChanges();
+      dispatchFakeEvent(overlayContainerElement.querySelectorAll('nz-option-item')[1], 'mouseenter');
+      await flushChanges();
+
+      component.value.set(['value_01', 'value_03']);
+      await flushChanges();
+
+      expect(overlayContainerElement.querySelectorAll('nz-option-item')[1].classList).toContain(
+        'ant-select-item-option-active'
+      );
     });
 
     it('should click option work', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The initially selected value does not update the active option. On the first dropdown open, the virtual scroll viewport remains at the beginning of the option list.

Issue Number: #9886


## What is the new behavior?
The first selected value initializes the active option, so the dropdown scrolls to it when it is opened for the first time. A regression test covers this behavior.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Validated with:

- `npx nx run ng-zorro-antd-lib:test --include=components/select/select.spec.ts --watch=false --coverage=false`
- `npx nx run ng-zorro-antd-lib:build`