### PR TITLE
fix(module:input): support Signal Forms state

### DIFF
--- a/components/input/input.directive.ts
+++ b/components/input/input.directive.ts
@@ -22,6 +22,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
+import { FormField } from '@angular/forms/signals';
 import { EMPTY } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
@@ -56,6 +57,7 @@ const PREFIX_CLS = 'ant-input';
     '[class.ant-input-sm]': `finalSize() === 'small'`,
     '[attr.disabled]': 'finalDisabled() || null',
     '[attr.readonly]': 'readonly() || null',
+    '(input)': 'onInput($event)',
     '[class.ant-input-rtl]': `dir() === 'rtl'`,
     '[class.ant-input-focused]': 'focused()'
   },
@@ -72,9 +74,16 @@ export class NzInputDirective implements OnInit {
   private hostView = inject(ViewContainerRef);
   private readonly inputPasswordDir = inject(NzInputPasswordDirective, { host: true, optional: true });
   private readonly inputSearchDir = inject(NZ_INPUT_SEARCH, { host: true, optional: true });
+  private readonly formField = inject(FormField, { self: true, optional: true });
 
   readonly ngControl = inject(NgControl, { self: true, optional: true });
-  readonly value = signal<string>(this.elementRef.nativeElement.value);
+  private readonly nativeValue = signal(this.elementRef.nativeElement.value);
+  readonly value = computed(() => {
+    if (this.formField) {
+      return String(this.formField.state().value() ?? '');
+    }
+    return this.nativeValue();
+  });
 
   readonly nzVariant = input<NzVariant>();
   readonly nzSize = input<NzSizeLDSType>('default');
@@ -83,7 +92,12 @@ export class NzInputDirective implements OnInit {
   readonly readonly = input(false, { transform: booleanAttribute });
 
   readonly controlDisabled = signal(false);
-  readonly finalDisabled = this.ngControl ? this.controlDisabled : this.disabled;
+  readonly finalDisabled = computed(() => {
+    if (this.formField) {
+      return this.formField.state().disabled();
+    }
+    return this.ngControl ? this.controlDisabled() : this.disabled();
+  });
   readonly dir = inject(Directionality).valueSignal;
   // TODO: When the input group is removed, we can remove this.
   readonly size = linkedSignal(this.nzSize);
@@ -150,8 +164,12 @@ export class NzInputDirective implements OnInit {
     this.ngControl?.valueChanges
       ?.pipe(startWith(this.ngControl?.control?.value), takeUntilDestroyed(this.destroyRef))
       .subscribe(value => {
-        this.value.set(value ?? '');
+        this.nativeValue.set(value ?? '');
       });
+  }
+
+  onInput(event: Event): void {
+    this.nativeValue.set((event.target as HTMLInputElement | HTMLTextAreaElement).value);
   }
 
   private renderFeedbackIcon(): void {

--- a/components/input/input.directive.ts
+++ b/components/input/input.directive.ts
@@ -22,7 +22,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
-import { FormField } from '@angular/forms/signals';
+import { FORM_FIELD } from '@angular/forms/signals';
 import { EMPTY } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
@@ -74,7 +74,7 @@ export class NzInputDirective implements OnInit {
   private hostView = inject(ViewContainerRef);
   private readonly inputPasswordDir = inject(NzInputPasswordDirective, { host: true, optional: true });
   private readonly inputSearchDir = inject(NZ_INPUT_SEARCH, { host: true, optional: true });
-  private readonly formField = inject(FormField, { self: true, optional: true });
+  private readonly formField = inject(FORM_FIELD, { self: true, optional: true });
 
   readonly ngControl = inject(NgControl, { self: true, optional: true });
   private readonly nativeValue = signal(this.elementRef.nativeElement.value);

--- a/components/input/input.spec.ts
+++ b/components/input/input.spec.ts
@@ -6,6 +6,7 @@
 import { Component, DebugElement, signal, viewChild, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { disabled, form, FormField } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 
 import { NZ_FORM_SIZE, NZ_FORM_VARIANT } from 'ng-zorro-antd/core/form';
@@ -155,6 +156,24 @@ describe('input', () => {
         expect(inputElement.nativeElement.classList).toContain('ant-input-disabled');
         expect(inputElement.nativeElement.getAttribute('disabled')).toBe('true');
       });
+    });
+  });
+
+  describe('input with Signal Forms', () => {
+    it('should reflect the disabled field state', async () => {
+      const fixture = TestBed.createComponent(NzTestInputSignalFormComponent);
+      fixture.autoDetectChanges();
+      await fixture.whenStable();
+
+      const input = fixture.debugElement.query(By.directive(NzInputDirective)).nativeElement as HTMLInputElement;
+      expect(input.disabled).toBe(false);
+      expect(input.classList).not.toContain('ant-input-disabled');
+
+      fixture.componentInstance.isDisabled.set(true);
+      await fixture.whenStable();
+
+      expect(input.disabled).toBe(true);
+      expect(input.classList).toContain('ant-input-disabled');
     });
   });
 
@@ -421,6 +440,18 @@ export class NzTestInputFormComponent {
   disable(): void {
     this.formControl.disable();
   }
+}
+
+@Component({
+  imports: [FormField, NzInputModule],
+  template: `<input nz-input [formField]="form.name" />`
+})
+export class NzTestInputSignalFormComponent {
+  readonly model = signal({ name: '' });
+  readonly isDisabled = signal(false);
+  readonly form = form(this.model, path => {
+    disabled(path.name, () => this.isDisabled());
+  });
 }
 
 // status

--- a/components/input/textarea-count.component.ts
+++ b/components/input/textarea-count.component.ts
@@ -7,17 +7,15 @@ import {
   AfterContentInit,
   Component,
   ContentChild,
-  DestroyRef,
   ElementRef,
+  effect,
   inject,
+  Injector,
   Input,
   isDevMode,
   numberAttribute,
   Renderer2
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { EMPTY } from 'rxjs';
-import { map, startWith } from 'rxjs/operators';
 
 import { isNotNil } from 'ng-zorro-antd/core/util';
 
@@ -32,7 +30,7 @@ import { NzInputDirective } from './input.directive';
 })
 export class NzTextareaCountComponent implements AfterContentInit {
   private renderer = inject(Renderer2);
-  private destroyRef = inject(DestroyRef);
+  private injector = inject(Injector);
   private elementRef: ElementRef<HTMLElement> = inject(ElementRef);
 
   @ContentChild(NzInputDirective, { static: true }) nzInputDirective!: NzInputDirective;
@@ -45,18 +43,7 @@ export class NzTextareaCountComponent implements AfterContentInit {
       throw new Error('[nz-textarea-count]: Could not find matching textarea[nz-input] child.');
     }
 
-    if (this.nzInputDirective.ngControl) {
-      const valueChanges = this.nzInputDirective.ngControl.valueChanges || EMPTY;
-      valueChanges
-        .pipe(
-          takeUntilDestroyed(this.destroyRef),
-          map(() => this.nzInputDirective.ngControl!.value),
-          startWith(this.nzInputDirective.ngControl.value as string)
-        )
-        .subscribe(value => {
-          this.setDataCount(value);
-        });
-    }
+    effect(() => this.setDataCount(this.nzInputDirective.value()), { injector: this.injector });
   }
 
   setDataCount(value: string): void {

--- a/components/input/textarea-count.spec.ts
+++ b/components/input/textarea-count.spec.ts
@@ -6,9 +6,10 @@
 import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { form, FormField } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 
-import { updateNonSignalsInput } from 'ng-zorro-antd/core/testing';
+import { dispatchFakeEvent, updateNonSignalsInput } from 'ng-zorro-antd/core/testing';
 import { NzInputModule } from 'ng-zorro-antd/input/input.module';
 import { NzTextareaCountComponent } from 'ng-zorro-antd/input/textarea-count.component';
 
@@ -62,6 +63,22 @@ describe('textarea-count', () => {
       expect(textareaCountElement.getAttribute('data-count')).toBe('4/100');
     });
   });
+
+  describe('with Signal Forms', () => {
+    it('should update the count when the field value changes', async () => {
+      const fixture = TestBed.createComponent(NzTestInputTextareaCountWithSignalFormComponent);
+      fixture.autoDetectChanges();
+      await fixture.whenStable();
+
+      const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+      const textareaCountElement = fixture.debugElement.query(By.directive(NzTextareaCountComponent)).nativeElement;
+      textarea.value = 'Signal Forms';
+      dispatchFakeEvent(textarea, 'input');
+      await fixture.whenStable();
+
+      expect(textareaCountElement.getAttribute('data-count')).toBe('12/50');
+    });
+  });
 });
 
 @Component({
@@ -86,4 +103,17 @@ export class NzTestInputTextareaCountWithoutMaxComponent {
 })
 export class NzTestInputTextareaCountWithMaxComponent {
   readonly inputValue = signal('');
+}
+
+@Component({
+  imports: [FormField, NzInputModule],
+  template: `
+    <nz-textarea-count [nzMaxCharacterCount]="50">
+      <textarea rows="4" nz-input [formField]="form.bio"></textarea>
+    </nz-textarea-count>
+  `
+})
+export class NzTestInputTextareaCountWithSignalFormComponent {
+  readonly model = signal({ bio: '' });
+  readonly form = form(this.model);
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (not needed for this internal integration fix)

## PR Type

- [x] Bugfix

## What is the current behavior?

Signal Forms bindings are not exposed through `NgControl`. As a result, `nz-textarea-count` does not observe field-value changes, and `nz-input` overwrites the disabled state applied by `[formField]`.

Closes #9880
Closes #9887

## What is the new behavior?

`NzInputDirective` reads the Signal Forms `FormField` state when present. `nz-textarea-count` now derives its count from the directive value signal, so it works with both Angular form APIs.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Validation: focused Input tests, TypeScript check, and production library build.