### PR TITLE
feat(module:cron-expression): support nzStatus and form status sync

### DIFF
--- a/components/cron-expression/cron-expression.component.ts
+++ b/components/cron-expression/cron-expression.component.ts
@@ -8,9 +8,11 @@ import {
   booleanAttribute,
   ChangeDetectorRef,
   Component,
+  computed,
   DestroyRef,
   forwardRef,
   inject,
+  input,
   Input,
   OnChanges,
   OnInit,
@@ -18,7 +20,7 @@ import {
   TemplateRef,
   ViewEncapsulation
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -30,10 +32,13 @@ import {
   ValidatorFn,
   Validators
 } from '@angular/forms';
+import { map } from 'rxjs/operators';
 
 import { CronExpressionParser } from 'cron-parser';
 
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
+import { NzFormStatusService } from 'ng-zorro-antd/core/form';
+import { NzSafeAny, NzStatus } from 'ng-zorro-antd/core/types';
+import { getStatusClassNames } from 'ng-zorro-antd/core/util';
 import { NzCronExpressionI18nInterface, NzI18nService } from 'ng-zorro-antd/i18n';
 
 import { NzCronExpressionInputComponent } from './cron-expression-input.component';
@@ -57,12 +62,11 @@ function labelsOfType(type: NzCronExpressionType): TimeType[] {
       <div class="ant-cron-expression-content">
         <div
           class="ant-input ant-cron-expression-input-group"
+          [class]="statusClasses()"
           [class.ant-input-lg]="nzSize === 'large'"
           [class.ant-input-sm]="nzSize === 'small'"
           [class.ant-input-borderless]="nzBorderless"
-          [class.ant-cron-expression-input-group-focus]="focus && !nzBorderless"
-          [class.ant-input-status-error]="form.invalid && !nzBorderless"
-          [class.ant-cron-expression-input-group-error-focus]="form.invalid && focus && !nzBorderless"
+          [class.ant-input-focused]="focus"
           [class.ant-input-disabled]="nzDisabled"
         >
           @for (label of labels; track label) {
@@ -127,7 +131,9 @@ export class NzCronExpressionComponent implements OnInit, OnChanges, ControlValu
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly i18n = inject(NzI18nService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly nzFormStatusService = inject(NzFormStatusService, { optional: true });
 
+  readonly nzStatus = input<NzStatus>('');
   @Input() nzSize: NzCronExpressionSize = 'default';
   @Input() nzType: NzCronExpressionType = 'linux';
   @Input({ transform: booleanAttribute }) nzCollapseDisable: boolean = false;
@@ -167,6 +173,16 @@ export class NzCronExpressionComponent implements OnInit, OnChanges, ControlValu
     },
     { validators: this.cronValidatorFn }
   );
+  private readonly inheritedStatus = this.nzFormStatusService
+    ? toSignal(this.nzFormStatusService.formStatusChanges.pipe(map(({ status }) => status)), {
+        initialValue: ''
+      })
+    : this.nzStatus;
+  private readonly internalFormStatus = toSignal(this.form.statusChanges, { initialValue: this.form.status });
+  private readonly finalStatus = computed(() =>
+    this.internalFormStatus() === 'INVALID' ? 'error' : this.inheritedStatus()
+  );
+  protected readonly statusClasses = computed(() => getStatusClassNames('ant-input', this.finalStatus()));
 
   onChange: NzSafeAny = () => {};
   onTouch: () => void = () => null;

--- a/components/cron-expression/cron-expression.spec.ts
+++ b/components/cron-expression/cron-expression.spec.ts
@@ -9,9 +9,11 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzStatus } from 'ng-zorro-antd/core/types';
 import { NzCronExpressionComponent } from 'ng-zorro-antd/cron-expression/cron-expression.component';
 import { NzCronExpressionModule } from 'ng-zorro-antd/cron-expression/cron-expression.module';
 import { NzCronExpressionSize } from 'ng-zorro-antd/cron-expression/typings';
+import { NzFormControlStatusType, NzFormModule } from 'ng-zorro-antd/form';
 
 describe('cron-expression', () => {
   describe('basic', () => {
@@ -56,6 +58,44 @@ describe('cron-expression', () => {
       fixture.detectChanges();
       expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).toContain(
         'ant-input-borderless'
+      );
+    });
+
+    it('should nzStatus work', () => {
+      testComponent.nzStatus.set('error');
+      fixture.detectChanges();
+      expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).toContain(
+        'ant-input-status-error'
+      );
+
+      testComponent.nzStatus.set('warning');
+      fixture.detectChanges();
+      expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).toContain(
+        'ant-input-status-warning'
+      );
+      expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).not.toContain(
+        'ant-input-status-error'
+      );
+
+      testComponent.nzStatus.set('');
+      fixture.detectChanges();
+      expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).not.toContain(
+        'ant-input-status-warning'
+      );
+    });
+
+    it('should use standard input focus class', () => {
+      fixture.detectChanges();
+      resultEl.componentInstance.focusEffect('minute');
+      fixture.detectChanges();
+      expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).toContain(
+        'ant-input-focused'
+      );
+
+      resultEl.componentInstance.blurEffect();
+      fixture.detectChanges();
+      expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).not.toContain(
+        'ant-input-focused'
       );
     });
 
@@ -116,6 +156,54 @@ describe('cron-expression', () => {
         'ant-input-disabled'
       );
     });
+
+    it('should reflect parent FormControl validation status', () => {
+      fixture.detectChanges();
+      testComponent.formControl.markAsTouched();
+      testComponent.formControl.setErrors({ external: true });
+      fixture.detectChanges();
+      expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).toContain(
+        'ant-input-status-error'
+      );
+
+      testComponent.formControl.setErrors(null);
+      fixture.detectChanges();
+      expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).not.toContain(
+        'ant-input-status-error'
+      );
+    });
+  });
+
+  describe('form status', () => {
+    let fixture: ComponentFixture<NzTestCronExpressionStatusInFormComponent>;
+    let resultEl: DebugElement;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(NzTestCronExpressionStatusInFormComponent);
+      resultEl = fixture.debugElement.query(By.directive(NzCronExpressionComponent));
+    });
+
+    it.each(['error', 'warning', 'success', 'validating'] as const)(
+      'should reflect %s status from nz-form-control',
+      status => {
+        fixture.componentInstance.status.set(status);
+        fixture.detectChanges();
+        expect(resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList).toContain(
+          `ant-input-status-${status}`
+        );
+      }
+    );
+
+    it('should prioritize internal validation error', () => {
+      fixture.componentInstance.status.set('warning');
+      fixture.detectChanges();
+      resultEl.componentInstance.getValue({ label: 'minute', value: 'invalid' });
+      fixture.detectChanges();
+
+      const classList = resultEl.nativeElement.querySelector('.ant-cron-expression-input-group').classList;
+      expect(classList).toContain('ant-input-status-error');
+      expect(classList).not.toContain('ant-input-status-warning');
+    });
   });
 });
 
@@ -127,6 +215,7 @@ describe('cron-expression', () => {
       [nzCollapseDisable]="nzCollapseDisable()"
       [nzDisabled]="nzDisabled()"
       [nzBorderless]="nzBorderless()"
+      [nzStatus]="nzStatus()"
       [nzExtra]="shortcuts"
       [nzSemantic]="semanticTemplate"
     />
@@ -141,11 +230,16 @@ export class NzTestCronExpressionComponent {
   readonly nzDisabled = signal(false);
   readonly nzBorderless = signal(false);
   readonly nzCollapseDisable = signal(false);
+  readonly nzStatus = signal<NzStatus>('');
 }
 
 @Component({
-  imports: [ReactiveFormsModule, NzCronExpressionModule],
-  template: `<nz-cron-expression [formControl]="formControl" />`
+  imports: [ReactiveFormsModule, NzCronExpressionModule, NzFormModule],
+  template: `
+    <nz-form-control>
+      <nz-cron-expression [formControl]="formControl" />
+    </nz-form-control>
+  `
 })
 export class NzTestCronExpressionFormComponent {
   formControl = new FormControl('1 1 1 * *');
@@ -153,4 +247,16 @@ export class NzTestCronExpressionFormComponent {
   disable(): void {
     this.formControl.disable();
   }
+}
+
+@Component({
+  imports: [NzCronExpressionModule, NzFormModule],
+  template: `
+    <nz-form-control [nzValidateStatus]="status()">
+      <nz-cron-expression />
+    </nz-form-control>
+  `
+})
+export class NzTestCronExpressionStatusInFormComponent {
+  readonly status = signal<NzFormControlStatusType>('');
 }

--- a/components/cron-expression/demo/form.ts
+++ b/components/cron-expression/demo/form.ts
@@ -1,10 +1,14 @@
 import { Component, inject } from '@angular/core';
-import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
+
+import { CronExpressionParser } from 'cron-parser';
 
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzCronExpressionModule } from 'ng-zorro-antd/cron-expression';
 import { NzFormModule } from 'ng-zorro-antd/form';
 import { NzInputModule } from 'ng-zorro-antd/input';
+
+const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 
 @Component({
   selector: 'nz-demo-cron-expression-form',
@@ -30,6 +34,18 @@ import { NzInputModule } from 'ng-zorro-antd/input';
         </nz-form-control>
       </nz-form-item>
       <nz-form-item>
+        <nz-form-label [nzSpan]="6">minimum interval: 1 day</nz-form-label>
+        <nz-form-control [nzSpan]="14">
+          <nz-cron-expression
+            formControlName="cronMinInterval"
+            [nzSemantic]="form.controls.cronMinInterval.hasError('minInterval') ? minIntervalError : null"
+          />
+          <ng-template #minIntervalError>
+            <span class="ant-cron-expression-error">The interval cannot be less than 1 day.</span>
+          </ng-template>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
         <nz-form-control>
           <button nz-button nzType="primary" [disabled]="!form.valid">submit</button>
         </nz-form-control>
@@ -39,15 +55,38 @@ import { NzInputModule } from 'ng-zorro-antd/input';
 })
 export class NzDemoCronExpressionFormComponent {
   private readonly fb = inject(FormBuilder);
+  private readonly minIntervalValidator: ValidatorFn = control => {
+    if (typeof control.value !== 'string' || !control.value) {
+      return null;
+    }
+
+    try {
+      const interval = CronExpressionParser.parse(control.value);
+      const firstExecution = interval.next().toDate();
+      const secondExecution = interval.next().toDate();
+      return secondExecution.getTime() - firstExecution.getTime() < ONE_DAY_IN_MILLISECONDS
+        ? { minInterval: true }
+        : null;
+    } catch {
+      return null;
+    }
+  };
+
   readonly form: FormGroup<{
     username: FormControl<string | null>;
     cronLinux: FormControl<string | null>;
+    cronMinInterval: FormControl<string | null>;
     cronSpring: FormControl<string | null>;
   }> = this.fb.group({
     username: ['cron-expression', [Validators.required]],
     cronLinux: ['* 1 * * *', [Validators.required]],
-    cronSpring: ['0 * 1 * * *', [Validators.required]]
+    cronSpring: ['0 * 1 * * *', [Validators.required]],
+    cronMinInterval: ['0 */12 * * *', [Validators.required, this.minIntervalValidator]]
   });
+
+  constructor() {
+    this.form.controls.cronMinInterval.markAsTouched();
+  }
 
   submit(): void {
     console.log(this.form.value);

--- a/components/cron-expression/demo/status.md
+++ b/components/cron-expression/demo/status.md
@@ -1,0 +1,14 @@
+---
+order: 8
+title:
+  zh-CN: 自定义状态
+  en-US: Status
+---
+
+## zh-CN
+
+使用 `nzStatus` 为 Cron Expression 添加状态，可选 `error` 或者 `warning`。
+
+## en-US
+
+Add status to Cron Expression with `nzStatus`, which could be `error` or `warning`.

--- a/components/cron-expression/demo/status.ts
+++ b/components/cron-expression/demo/status.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+
+import { NzCronExpressionModule } from 'ng-zorro-antd/cron-expression';
+
+@Component({
+  selector: 'nz-demo-cron-expression-status',
+  imports: [NzCronExpressionModule],
+  template: `
+    <div class="example-cron-expression">
+      <nz-cron-expression nzStatus="error" />
+      <nz-cron-expression nzStatus="warning" />
+    </div>
+  `,
+  styles: `
+    .example-cron-expression nz-cron-expression {
+      display: block;
+      margin-bottom: 8px;
+    }
+  `
+})
+export class NzDemoCronExpressionStatusComponent {}

--- a/components/cron-expression/doc/index.en-US.md
+++ b/components/cron-expression/doc/index.en-US.md
@@ -28,6 +28,7 @@ npm install cron-parser@^5.5.0
 | `[nzDisabled]`        | Disable                              | `boolean`                     | `false`   |
 | `[nzBorderless]`      | Whether to hide the border           | `boolean`                     | `false`   |
 | `[nzSize]`            | The size of the input box.           | `'large'｜'small'｜'default'` | `default` |
+| `[nzStatus]`          | Set validation status                | `'error'｜'warning'`          | -         |
 | `[nzCollapseDisable]` | Hide collapse                        | `boolean`                     | `false`   |
 | `[nzExtra]`           | Render the content on the right      | `TemplateRef<void>`           | -         |
 | `[nzSemantic]`        | Custom rendering next execution time | `TemplateRef<void>`           | -         |

--- a/components/cron-expression/doc/index.zh-CN.md
+++ b/components/cron-expression/doc/index.zh-CN.md
@@ -28,6 +28,7 @@ npm install cron-parser@^5.5.0
 | `[nzSize]`            | 设置输入框大小         | `'large'｜'small'｜'default'` | `default` |
 | `[nzDisabled]`        | 禁用                   | `boolean`                     | `false`   |
 | `[nzBorderless]`      | 是否隐藏边框           | `boolean`                     | `false`   |
+| `[nzStatus]`          | 设置校验状态           | `'error'｜'warning'`          | -         |
 | `[nzCollapseDisable]` | 隐藏折叠面板           | `boolean`                     | `false`   |
 | `[nzExtra]`           | 自定义渲染右侧的内容   | `TemplateRef<void>`           | -         |
 | `[nzSemantic]`        | 自定义渲染下次执行时间 | `TemplateRef<void>`           | -         |

--- a/components/cron-expression/style/index.less
+++ b/components/cron-expression/style/index.less
@@ -7,15 +7,11 @@
   display: flex;
   flex-wrap: nowrap;
 
-  &-content{
+  &-content {
     width: 100%;
-
-    .@{cron-expression-prefix-cls}-input-group-error-focus {
-      box-shadow: 0 0 0 @outline-width @error-color-outline;
-    }
   }
 
-  nz-cron-expression-input{
+  nz-cron-expression-input {
     width: 20%;
   }
 
@@ -32,12 +28,6 @@
       outline: none;
       box-shadow: none !important;
     }
-  }
-
-  &-input-group-focus {
-    border-color: @primary-color;
-    outline: 0;
-    box-shadow: 0 0 0 @outline-width @primary-color-outline;
   }
 
   nz-cron-expression-label {
@@ -86,7 +76,8 @@
       padding-left: @padding-md;
     }
 
-    &-list, &-icon {
+    &-list,
+    &-icon {
       margin: 0;
       padding: 0;
       list-style: none;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`nz-cron-expression` only displays errors from its internal form and does not reflect `nzStatus` or its parent form control status.

## What is the new behavior?

- Support `nzStatus`
- Synchronizes validation status from `nz-form-control,` consistent with other input components (such as `nz-input`, `nz-select`, and so on). Internal Cron validation errors take precedence.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
