### PR TITLE
fix(module:mention): trigger behavior aligned with antd

### DIFF
--- a/components/mention/mention.component.ts
+++ b/components/mention/mention.component.ts
@@ -445,12 +445,7 @@ export class NzMentionComponent implements OnInit, AfterViewInit, OnChanges {
           ? value.indexOf(NZ_MENTION_CONFIG.split, selectionStart)
           : value.length;
       const mention = value.substring(startPos, endPos);
-      if (
-        (startPos > 0 && value[startPos - 1] !== NZ_MENTION_CONFIG.split) ||
-        startPos < 0 ||
-        mention.includes(prefix[i], 1) ||
-        mention.includes(NZ_MENTION_CONFIG.split)
-      ) {
+      if (startPos < 0 || mention.includes(prefix[i], 1) || mention.includes(NZ_MENTION_CONFIG.split)) {
         this.cursorMention = null;
         this.cursorMentionStart = -1;
         this.cursorMentionEnd = -1;

--- a/components/mention/mention.spec.ts
+++ b/components/mention/mention.spec.ts
@@ -449,6 +449,16 @@ describe('mention', () => {
       expect(mention.isOpen).toBe(true);
     });
 
+    it('should open the dropdown when the prefix follows a non-space character', () => {
+      dispatchFakeEvent(textarea, 'click');
+      fixture.detectChanges();
+      typeInElement('hello@', textarea);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.mention.isOpen).toBe(true);
+      expect(spyNzOnSearch).toHaveBeenCalledTimes(1);
+    });
+
     it('should emit nzOnSearchChange when type in @ prefix', () => {
       dispatchFakeEvent(textarea, 'click');
       fixture.detectChanges();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

<img width="296" height="164" alt="image" src="https://github.com/user-attachments/assets/6095c958-db85-4c2d-b5ce-e9a76dd2e9b1" />

当 `@` 前面不是空格时，无法唤起下拉框，这与 antd 的行为不符。

Issue Number: N/A


## What is the new behavior?

<img width="472" height="514" alt="image" src="https://github.com/user-attachments/assets/00fd2710-025a-41b1-89a3-0b8e539d898f" />

现在当 `@` 前面不是空格时，仍然可以唤起下拉框

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
