### PR TITLE
fix(module:date-picker): support range picker with signal forms

### DIFF
--- a/components/date-picker/date-picker.component.ts
+++ b/components/date-picker/date-picker.component.ts
@@ -359,7 +359,7 @@ export class NzDatePickerComponent implements OnInit, OnChanges, AfterViewInit, 
   inputSize: number = 12;
   inputWidth?: number;
   prefixCls = PREFIX_CLASS;
-  inputValue!: NzSafeAny;
+  inputValue: NzSafeAny = this.isRange ? ['', ''] : '';
   activeBarStyle: object = {};
   overlayOpen: boolean = false; // Available when "nzOpen" = undefined
   overlayPositions: ConnectionPositionPair[] = [...DEFAULT_DATE_PICKER_POSITIONS];
@@ -730,7 +730,6 @@ export class NzDatePickerComponent implements OnInit, OnChanges, AfterViewInit, 
       this.close();
     });
 
-    this.inputValue = this.isRange ? ['', ''] : '';
     this.setModeAndFormat();
 
     this.datePickerService.valueChange$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {

--- a/components/date-picker/range-picker.component.spec.ts
+++ b/components/date-picker/range-picker.component.spec.ts
@@ -9,7 +9,8 @@ import { registerLocaleData } from '@angular/common';
 import zh from '@angular/common/locales/zh';
 import { Component, DebugElement, TemplateRef, ViewChild, signal } from '@angular/core';
 import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { form, FormField } from '@angular/forms/signals';
 import { By } from '@angular/platform-browser';
 
 import { differenceInDays, isSameDay } from 'date-fns';
@@ -1308,6 +1309,55 @@ describe('range-picker', () => {
   }
 });
 
+describe('Reactive Forms', () => {
+  it('should display the initial range value', async () => {
+    const fixture = TestBed.createComponent(NzTestRangePickerInReactiveFormComponent);
+
+    await fixture.whenStable();
+
+    expect(getRangeInputValues(fixture)).toEqual(['2020-04-08', '2020-04-09']);
+  });
+
+  it('should display an updated range value', async () => {
+    const fixture = TestBed.createComponent(NzTestRangePickerInReactiveFormComponent);
+    const range = [new Date('2020-04-10'), new Date('2020-04-11')];
+
+    fixture.componentInstance.range.setValue(range);
+    await fixture.whenStable();
+
+    expect(getRangeInputValues(fixture)).toEqual(['2020-04-10', '2020-04-11']);
+  });
+});
+
+describe('Signal Forms', () => {
+  it('should initialize an empty range', async () => {
+    const fixture = TestBed.createComponent(NzTestRangePickerInSignalFormComponent);
+    fixture.componentInstance.model.set({ range: [] });
+
+    await fixture.whenStable();
+
+    expect(getRangeInputValues(fixture)).toEqual(['', '']);
+  });
+
+  it('should display the initial range value', async () => {
+    const fixture = TestBed.createComponent(NzTestRangePickerInSignalFormComponent);
+
+    await fixture.whenStable();
+
+    expect(getRangeInputValues(fixture)).toEqual(['2020-04-08', '2020-04-09']);
+  });
+
+  it('should display an updated range value', async () => {
+    const fixture = TestBed.createComponent(NzTestRangePickerInSignalFormComponent);
+    const range = [new Date('2020-04-10'), new Date('2020-04-11')];
+
+    fixture.componentInstance.model.set({ range });
+    await fixture.whenStable();
+
+    expect(getRangeInputValues(fixture)).toEqual(['2020-04-10', '2020-04-11']);
+  });
+});
+
 @Component({
   imports: [FormsModule, NzDatePickerModule],
   template: `
@@ -1422,4 +1472,29 @@ class NzTestRangePickerComponent {
 })
 class NzTestRangePickerStatusComponent {
   readonly status = signal<NzStatus>('error');
+}
+
+@Component({
+  imports: [ReactiveFormsModule, NzDatePickerModule],
+  template: `<nz-range-picker [formControl]="range" />`
+})
+class NzTestRangePickerInReactiveFormComponent {
+  readonly range = new FormControl([new Date('2020-04-08'), new Date('2020-04-09')], { nonNullable: true });
+}
+
+@Component({
+  selector: 'nz-test-range-picker-in-signal-form',
+  imports: [FormField, NzDatePickerModule],
+  template: `<nz-range-picker [formField]="myForm.range" />`
+})
+class NzTestRangePickerInSignalFormComponent {
+  readonly model = signal({ range: [new Date('2020-04-08'), new Date('2020-04-09')] });
+  readonly myForm = form(this.model);
+}
+
+function getRangeInputValues(fixture: ComponentFixture<unknown>): [string, string] {
+  return [
+    getPickerInput(fixture.debugElement).value!.trim(),
+    getRangePickerRightInput(fixture.debugElement).value!.trim()
+  ];
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Using `nz-range-picker` with Signal Forms (`[formField]`) throws `Cannot read properties of undefined (reading '0')` during initialization. Signal Forms calls the value accessor before `ngOnInit`, but the component initializes `inputValue` only in `ngOnInit`.

Issue Number: #9906

## What is the new behavior?

The component initializes `inputValue` when it is constructed. The range-picker template can safely access both input values during the first Signal Forms update. A regression test covers Signal Forms initialization.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation:
 - `npx nx run ng-zorro-antd-lib:test --include=components/date-picker/range-picker.component.spec.ts --watch=false --coverage=false`
 - `npx nx run ng-zorro-antd-lib:build-lib`