### PR TITLE
fix(module:i18n): add missing translations to `ar_EG`

### DIFF
--- a/components/i18n/languages/ar_EG.ts
+++ b/components/i18n/languages/ar_EG.ts
@@ -170,5 +170,32 @@ export default {
   },
   PageHeader: {
     back: 'عودة'
+  },
+  Image: {
+    preview: 'معاينة'
+  },
+  CronExpression: {
+    cronError: 'تعبير Cron غير صالح',
+    second: 'ثانية',
+    minute: 'دقيقة',
+    hour: 'ساعة',
+    day: 'يوم',
+    month: 'شهر',
+    week: 'أسبوع'
+  },
+  QRCode: {
+    expired: 'انتهت صلاحية رمز الاستجابة السريعة',
+    refresh: 'تحديث',
+    scanned: 'تم المسح'
+  },
+  CheckList: {
+    checkList: 'قائمة التحقق',
+    checkListFinish: 'لقد أكملت القائمة بنجاح!',
+    checkListClose: 'إغلاق',
+    checkListFooter: 'لم تعد قائمة التحقق مطلوبة',
+    checkListCheck: 'هل تريد إغلاق القائمة؟',
+    ok: 'تأكيد',
+    cancel: 'إلغاء',
+    checkListCheckOther: 'لا حاجة لعرضها مرة أخرى'
   }
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`ar_EG` is missing four of the twenty top-level sections present in `en_US`: `Image`,
`CronExpression`, `QRCode` and `CheckList`. Applications running under the `ar_EG` locale fall
back to English for those components.

Issue Number: N/A


## What is the new behavior?

Adds the four missing sections to `components/i18n/languages/ar_EG.ts`, 19 strings in total.
`ar_EG` now has the same 20 sections as `en_US`, in the same order, with identical key names.

`CheckList.ok` and `CheckList.cancel` reuse the wording already used elsewhere in this file
(`Modal.okText` / `Popconfirm.okText` and `cancelText`) so the locale stays internally consistent.

Verified locally: `npm run lint:script` passes, the `i18n` specs pass (15 tests), and Prettier
reports no formatting differences.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Follows the same pattern as the recent locale completions, for example #9864 (`ko_KR`),
#9658 (`he_IL`) and #9615 (`fa_IR`).
