### PR TITLE
fix(module:i18n): add missing sections to en_GB, en_AU and default

### DIFF
--- a/components/i18n/languages/default.ts
+++ b/components/i18n/languages/default.ts
@@ -181,5 +181,29 @@ export default {
   },
   Image: {
     preview: 'Preview'
+  },
+  CronExpression: {
+    cronError: 'Invalid cron expression',
+    second: 'second',
+    minute: 'minute',
+    hour: 'hour',
+    day: 'day',
+    month: 'month',
+    week: 'week'
+  },
+  QRCode: {
+    expired: 'QR code expired',
+    refresh: 'Refresh',
+    scanned: 'Scanned'
+  },
+  CheckList: {
+    checkList: 'Check List',
+    checkListFinish: 'You have successfully completed the list!',
+    checkListClose: 'Close',
+    checkListFooter: 'Check list is no longer required',
+    checkListCheck: 'Do you want to close the list?',
+    ok: 'OK',
+    cancel: 'Cancel',
+    checkListCheckOther: 'No longer required to show'
   }
 };

--- a/components/i18n/languages/en_AU.ts
+++ b/components/i18n/languages/en_AU.ts
@@ -194,5 +194,15 @@ export default {
     expired: 'QR code expired',
     refresh: 'Refresh',
     scanned: 'Scanned'
+  },
+  CheckList: {
+    checkList: 'Check List',
+    checkListFinish: 'You have successfully completed the list!',
+    checkListClose: 'Close',
+    checkListFooter: 'Check list is no longer required',
+    checkListCheck: 'Do you want to close the list?',
+    ok: 'OK',
+    cancel: 'Cancel',
+    checkListCheckOther: 'No longer required to show'
   }
 };

--- a/components/i18n/languages/en_GB.ts
+++ b/components/i18n/languages/en_GB.ts
@@ -175,5 +175,32 @@ export default {
   },
   PageHeader: {
     back: 'Back'
+  },
+  Image: {
+    preview: 'Preview'
+  },
+  CronExpression: {
+    cronError: 'Invalid cron expression',
+    second: 'second',
+    minute: 'minute',
+    hour: 'hour',
+    day: 'day',
+    month: 'month',
+    week: 'week'
+  },
+  QRCode: {
+    expired: 'QR code expired',
+    refresh: 'Refresh',
+    scanned: 'Scanned'
+  },
+  CheckList: {
+    checkList: 'Check List',
+    checkListFinish: 'You have successfully completed the list!',
+    checkListClose: 'Close',
+    checkListFooter: 'Check list is no longer required',
+    checkListCheck: 'Do you want to close the list?',
+    ok: 'OK',
+    cancel: 'Cancel',
+    checkListCheckOther: 'No longer required to show'
   }
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Three English locale files are missing sections that exist in `en_US`:

| locale | missing |
|---|---|
| `en_GB` | `Image`, `CronExpression`, `QRCode`, `CheckList` |
| `en_AU` | `CheckList` |
| `default` | `CronExpression`, `QRCode`, `CheckList` |

Issue Number: N/A


## What is the new behavior?

Each file now has the same 20 top-level sections as `en_US`, in the same order.

Since these are English locales, the added strings are copied verbatim from `en_US` rather than
translated, which is how the sections already present in `en_AU` and `default` are worded today.
No wording decisions were made in this PR.

Verified locally: `npm run lint:script` passes, the `i18n` specs pass (15 tests), and Prettier
reports no formatting differences.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Split out from #9912 (`ar_EG`) so that each PR stays reviewable on its own: that one involves
translation, this one does not.

A further 58 locale files are still missing one or more of these four sections. Those need
native-speaker translations, so they are intentionally left out here.
