### PR TITLE
feat(module:border-beam): add animated border beam

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@ components/upload/**                      @cipchk
 components/auto-complete/**               @hsuanxyz
 components/avatar/**                      @hsuanxyz
 components/badge/**                       @hsuanxyz
+components/border-beam/**                 @laffery
 components/comment/**                     @hsuanxyz
 components/drawer/**                      @hsuanxyz
 components/mention/**                     @hsuanxyz

--- a/.github/nz-boot.yml
+++ b/.github/nz-boot.yml
@@ -14,9 +14,7 @@ issue:
     - labels:
         - Upgrade Deps
       replay: |
-        Hello @{user}.
-        - If you use npm, please try `rm -rf node_modules && npm install` to upgrade all your deps.
-        - If you use yarn, you may need `yarn upgrade`.
+        Hello @{user}, please try `rm -rf node_modules && npm install` to upgrade all your deps.
 
         <img src="https://cloud.githubusercontent.com/assets/465125/26667345/4bcc8f10-46d7-11e7-8c72-32a0c68ea7ca.jpg" width="500" height="300">
     - labels:
@@ -67,12 +65,15 @@ issue:
       AutoComplete: hsuanxyz
       Avatar: hsuanxyz
       Badge: hsuanxyz
+      BorderBeam: laffery
+      Cascader: laffery
       Comment: hsuanxyz
       Drawer: hsuanxyz
       Mention: hsuanxyz
       Modal: hsuanxyz
       Steps: hsuanxyz
       Tag: hsuanxyz
+      Tabs: hsuanxyz
       TreeSelect: hsuanxyz
       TreeView: hsuanxyz
       Typography: hsuanxyz
@@ -81,7 +82,6 @@ issue:
       Breadcrumb: simplejason
       Empty: simplejason
       Carousel: simplejason
-      Cascader: simplejason
       Descriptions: simplejason
       Icon: simplejason
       Message: simplejason
@@ -96,6 +96,7 @@ issue:
       Timeline: simplejason
       Tooltip: simplejason
       CodeEditor: simplejason
+      Segmented: simplejason
       Calendar: wenqi73
       DatePicker: wenqi73
       Skeleton: wenqi73
@@ -119,7 +120,6 @@ issue:
       Spin: vthinkxie
       Switch: vthinkxie
       Table: vthinkxie
-      Tabs: NearZXH
       Tree: simplejason
       Form: danranVm
       PageHeader: CK110
@@ -127,3 +127,11 @@ issue:
       Pipes: chensimeng
       Image: stygian-desolator
       Splitter: laffery
+      CheckList: OriginRing
+      ColorPicker: OriginRing
+      CronExpression: OriginRing
+      FloatButton: OriginRing
+      HashCode: OriginRing
+      QRCode: OriginRing
+      Watermark: OriginRing
+      Flex: ParsaArvanehPA

--- a/components/border-beam/border-beam.directive.spec.ts
+++ b/components/border-beam/border-beam.directive.spec.ts
@@ -69,6 +69,32 @@ describe('border-beam', () => {
     expect(beam.style.getPropertyValue('--nz-border-beam-inset-offset')).toBe('-2px -2px -2px -2px');
   });
 
+  it('should update duration, size, line width, and outset', async () => {
+    component.duration.set(12);
+    component.size.set('12em');
+    component.lineWidth.set('0.25rem');
+    component.outset.set(4);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const beam = getHost(fixture).querySelector<HTMLElement>('.ant-border-beam')!;
+    expect(beam.style.getPropertyValue('--nz-border-beam-duration')).toBe('12s');
+    expect(beam.style.getPropertyValue('--nz-border-beam-size')).toBe('12em');
+    expect(beam.style.getPropertyValue('--nz-border-beam-line-width')).toBe('0.25rem');
+    expect(beam.style.getPropertyValue('--nz-border-beam-inset-offset')).toBe('-4px');
+  });
+
+  it('should normalize invalid count and duration values', async () => {
+    component.count.set(0);
+    component.duration.set(0);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const beams = getHost(fixture).querySelectorAll<HTMLElement>('.ant-border-beam');
+    expect(beams).toHaveLength(1);
+    expect(beams[0].style.getPropertyValue('--nz-border-beam-duration')).toBe('6s');
+  });
+
   it('should remove the beam when disabled', async () => {
     component.enabled.set(false);
     fixture.detectChanges();
@@ -91,6 +117,10 @@ function getHost(fixture: ComponentFixture<NzTestBorderBeamComponent>): HTMLElem
       [nzBorderBeam]="enabled()"
       [nzBorderBeamColor]="color()"
       [nzBorderBeamCount]="count()"
+      [nzBorderBeamDuration]="duration()"
+      [nzBorderBeamLineWidth]="lineWidth()"
+      [nzBorderBeamOutset]="outset()"
+      [nzBorderBeamSize]="size()"
       style="position: relative; border: 2px solid; border-radius: 8px"
     >
       content
@@ -101,4 +131,8 @@ class NzTestBorderBeamComponent {
   readonly enabled = signal(true);
   readonly color = signal<NzBorderBeamGradientStop[] | string | undefined>(undefined);
   readonly count = signal(1);
+  readonly duration = signal(6);
+  readonly lineWidth = signal<number | string>(1);
+  readonly outset = signal<number | string | undefined>(undefined);
+  readonly size = signal<number | string>(100);
 }

--- a/components/border-beam/border-beam.directive.spec.ts
+++ b/components/border-beam/border-beam.directive.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NzBorderBeamGradientStop } from './border-beam.directive';
+import { NzBorderBeamModule } from './border-beam.module';
+
+describe('border-beam', () => {
+  let fixture: ComponentFixture<NzTestBorderBeamComponent>;
+  let component: NzTestBorderBeamComponent;
+
+  beforeEach(async () => {
+    fixture = TestBed.createComponent(NzTestBorderBeamComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should append an inaccessible decorative beam to its host', () => {
+    const host = getHost(fixture);
+    const beam = host.querySelector<HTMLElement>('.ant-border-beam');
+
+    expect(beam).toBeTruthy();
+    expect(beam?.getAttribute('aria-hidden')).toBe('true');
+    expect(beam?.parentElement).toBe(host);
+  });
+
+  it('should support multiple beams and distribute their delays evenly', async () => {
+    component.count.set(3);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const beams = getHost(fixture).querySelectorAll<HTMLElement>('.ant-border-beam');
+    expect(beams).toHaveLength(3);
+    expect(beams[0].style.getPropertyValue('--nz-border-beam-delay')).toBe('0s');
+    expect(beams[1].style.getPropertyValue('--nz-border-beam-delay')).toBe('-2s');
+    expect(beams[2].style.getPropertyValue('--nz-border-beam-delay')).toBe('-4s');
+  });
+
+  it('should support solid and gradient colors', async () => {
+    component.color.set('#36cfc9');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const beam = getHost(fixture).querySelector<HTMLElement>('.ant-border-beam')!;
+    expect(beam.style.getPropertyValue('--nz-border-beam-gradient')).toBe(
+      'linear-gradient(to left, #36cfc9 0%, #36cfc9 70%, transparent)'
+    );
+
+    component.color.set([
+      { color: '#1677ff', percent: 0 },
+      { color: '#36cfc9', percent: 55 },
+      { color: '#95de64', percent: 100 }
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(beam.style.getPropertyValue('--nz-border-beam-gradient')).toBe(
+      'linear-gradient(to left, #1677ff 0%, #36cfc9 38.5%, #95de64 70%, transparent)'
+    );
+  });
+
+  it('should use the host border width as the default outset', () => {
+    const beam = getHost(fixture).querySelector<HTMLElement>('.ant-border-beam')!;
+    expect(beam.style.getPropertyValue('--nz-border-beam-inset-offset')).toBe('-2px -2px -2px -2px');
+  });
+
+  it('should remove the beam when disabled', async () => {
+    component.enabled.set(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(getHost(fixture).querySelector('.ant-border-beam')).toBeNull();
+  });
+});
+
+function getHost(fixture: ComponentFixture<NzTestBorderBeamComponent>): HTMLElement {
+  return (fixture.nativeElement as HTMLElement).querySelector<HTMLElement>('.beam-host')!;
+}
+
+@Component({
+  imports: [NzBorderBeamModule],
+  template: `
+    <div
+      class="beam-host"
+      nzBorderBeam
+      [nzBorderBeam]="enabled()"
+      [nzBorderBeamColor]="color()"
+      [nzBorderBeamCount]="count()"
+      style="position: relative; border: 2px solid; border-radius: 8px"
+    >
+      content
+    </div>
+  `
+})
+class NzTestBorderBeamComponent {
+  readonly enabled = signal(true);
+  readonly color = signal<NzBorderBeamGradientStop[] | string | undefined>(undefined);
+  readonly count = signal(1);
+}

--- a/components/border-beam/border-beam.directive.spec.ts
+++ b/components/border-beam/border-beam.directive.spec.ts
@@ -27,6 +27,7 @@ describe('border-beam', () => {
     expect(beam).toBeTruthy();
     expect(beam?.getAttribute('aria-hidden')).toBe('true');
     expect(beam?.parentElement).toBe(host);
+    expect(beam?.querySelector('.ant-border-beam-motion')).toBeTruthy();
   });
 
   it('should support multiple beams and distribute their delays evenly', async () => {
@@ -36,9 +37,9 @@ describe('border-beam', () => {
 
     const beams = getHost(fixture).querySelectorAll<HTMLElement>('.ant-border-beam');
     expect(beams).toHaveLength(3);
-    expect(beams[0].style.getPropertyValue('--nz-border-beam-delay')).toBe('0s');
-    expect(beams[1].style.getPropertyValue('--nz-border-beam-delay')).toBe('-2s');
-    expect(beams[2].style.getPropertyValue('--nz-border-beam-delay')).toBe('-4s');
+    expect(getMotionElement(beams[0]).style.animationDelay).toBe('0s');
+    expect(getMotionElement(beams[1]).style.animationDelay).toBe('-2s');
+    expect(getMotionElement(beams[2]).style.animationDelay).toBe('-4s');
   });
 
   it('should support solid and gradient colors', async () => {
@@ -47,8 +48,8 @@ describe('border-beam', () => {
     await fixture.whenStable();
 
     const beam = getHost(fixture).querySelector<HTMLElement>('.ant-border-beam')!;
-    expect(beam.style.getPropertyValue('--nz-border-beam-gradient')).toBe(
-      'linear-gradient(to left, #36cfc9 0%, #36cfc9 70%, transparent)'
+    expect(getMotionElement(beam).style.backgroundImage).toBe(
+      'linear-gradient(to left, rgb(54, 207, 201) 0%, rgb(54, 207, 201) 70%, transparent)'
     );
 
     component.color.set([
@@ -59,14 +60,14 @@ describe('border-beam', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(beam.style.getPropertyValue('--nz-border-beam-gradient')).toBe(
-      'linear-gradient(to left, #1677ff 0%, #36cfc9 38.5%, #95de64 70%, transparent)'
+    expect(getMotionElement(beam).style.backgroundImage).toBe(
+      'linear-gradient(to left, rgb(22, 119, 255) 0%, rgb(54, 207, 201) 38.5%, rgb(149, 222, 100) 70%, transparent)'
     );
   });
 
   it('should use the host border width as the default outset', () => {
     const beam = getHost(fixture).querySelector<HTMLElement>('.ant-border-beam')!;
-    expect(beam.style.getPropertyValue('--nz-border-beam-inset-offset')).toBe('-2px -2px -2px -2px');
+    expect(beam.style.inset).toBe('-2px');
   });
 
   it('should update duration, size, line width, and outset', async () => {
@@ -78,10 +79,12 @@ describe('border-beam', () => {
     await fixture.whenStable();
 
     const beam = getHost(fixture).querySelector<HTMLElement>('.ant-border-beam')!;
-    expect(beam.style.getPropertyValue('--nz-border-beam-duration')).toBe('12s');
-    expect(beam.style.getPropertyValue('--nz-border-beam-size')).toBe('12em');
-    expect(beam.style.getPropertyValue('--nz-border-beam-line-width')).toBe('0.25rem');
-    expect(beam.style.getPropertyValue('--nz-border-beam-inset-offset')).toBe('-4px');
+    const motionElement = getMotionElement(beam);
+    expect(motionElement.style.animationDuration).toBe('12s');
+    expect(motionElement.style.width).toBe('12em');
+    expect(motionElement.style.offsetPath).toBe('rect(0px auto auto 0px round 12em)');
+    expect(beam.style.padding).toBe('0.25rem');
+    expect(beam.style.inset).toBe('-4px');
   });
 
   it('should normalize invalid count and duration values', async () => {
@@ -92,7 +95,15 @@ describe('border-beam', () => {
 
     const beams = getHost(fixture).querySelectorAll<HTMLElement>('.ant-border-beam');
     expect(beams).toHaveLength(1);
-    expect(beams[0].style.getPropertyValue('--nz-border-beam-duration')).toBe('6s');
+    expect(getMotionElement(beams[0]).style.animationDuration).toBe('');
+  });
+
+  it('should not use CSS custom properties for its runtime styles', () => {
+    const beam = getHost(fixture).querySelector<HTMLElement>('.ant-border-beam')!;
+    const motionElement = getMotionElement(beam);
+
+    expect(beam.style.cssText).not.toContain('--nz-border-beam');
+    expect(motionElement.style.cssText).not.toContain('--nz-border-beam');
   });
 
   it('should remove the beam when disabled', async () => {
@@ -106,6 +117,10 @@ describe('border-beam', () => {
 
 function getHost(fixture: ComponentFixture<NzTestBorderBeamComponent>): HTMLElement {
   return (fixture.nativeElement as HTMLElement).querySelector<HTMLElement>('.beam-host')!;
+}
+
+function getMotionElement(beam: HTMLElement): HTMLElement {
+  return beam.querySelector<HTMLElement>('.ant-border-beam-motion')!;
 }
 
 @Component({

--- a/components/border-beam/border-beam.directive.ts
+++ b/components/border-beam/border-beam.directive.ts
@@ -1,0 +1,158 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { isPlatformBrowser } from '@angular/common';
+import {
+  afterRenderEffect,
+  booleanAttribute,
+  DestroyRef,
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  numberAttribute,
+  PLATFORM_ID
+} from '@angular/core';
+
+export interface NzBorderBeamGradientStop {
+  color: string;
+  percent: number;
+}
+
+export type NzBorderBeamColor = string | NzBorderBeamGradientStop[];
+
+const DEFAULT_DURATION = 6;
+const MAX_COLOR_STOP_PERCENT = 70;
+
+function toCssUnit(value: number | string): string {
+  return typeof value === 'number' ? `${value}px` : value;
+}
+
+function getInset(value: number | string): string {
+  return typeof value === 'number' ? `-${value}px` : `calc(-1 * ${value})`;
+}
+
+function getBorderInset(host: HTMLElement): string {
+  const { borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth } = getComputedStyle(host);
+  return [borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth]
+    .map(borderWidth => {
+      const width = Number.parseFloat(borderWidth);
+      return getInset(Number.isFinite(width) ? width : 0);
+    })
+    .join(' ');
+}
+
+function getGradient(color: NzBorderBeamColor | undefined): string | undefined {
+  if (typeof color === 'string') {
+    return `linear-gradient(to left, ${color} 0%, ${color} ${MAX_COLOR_STOP_PERCENT}%, transparent)`;
+  }
+
+  if (!color?.length) {
+    return undefined;
+  }
+
+  const stops = [...color];
+  const lastStop = stops.at(-1);
+  if (lastStop && lastStop.percent !== 100) {
+    stops.push({ ...lastStop, percent: 100 });
+  }
+
+  return `linear-gradient(to left, ${stops
+    .map(stop => {
+      const percent = Math.min(Math.max(stop.percent, 0), 100);
+      return `${stop.color} ${Number(((percent / 100) * MAX_COLOR_STOP_PERCENT).toFixed(2))}%`;
+    })
+    .join(', ')}, transparent)`;
+}
+
+/**
+ * Adds a decorative animated beam around the host element's border.
+ */
+@Directive({
+  selector: '[nzBorderBeam]',
+  exportAs: 'nzBorderBeam',
+  host: {
+    class: 'ant-border-beam-host'
+  }
+})
+export class NzBorderBeamDirective {
+  private readonly host = inject(ElementRef<HTMLElement>).nativeElement;
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly beamElements: HTMLSpanElement[] = [];
+
+  readonly nzBorderBeam = input(true, { transform: booleanAttribute });
+  readonly nzBorderBeamColor = input<NzBorderBeamColor>();
+  readonly nzBorderBeamCount = input(1, { transform: numberAttribute });
+  readonly nzBorderBeamDuration = input(DEFAULT_DURATION, { transform: numberAttribute });
+  readonly nzBorderBeamLineWidth = input<number | string>(1);
+  readonly nzBorderBeamOutset = input<number | string>();
+  readonly nzBorderBeamSize = input<number | string>(100);
+
+  constructor() {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    afterRenderEffect({
+      mixedReadWrite: () => this.render()
+    });
+
+    this.destroyRef.onDestroy(() => this.removeBeams());
+  }
+
+  private render(): void {
+    if (!this.nzBorderBeam()) {
+      this.removeBeams();
+      return;
+    }
+
+    const count = this.getCount();
+    this.syncBeamCount(count);
+
+    const duration = this.nzBorderBeamDuration();
+    const mergedDuration = Number.isFinite(duration) && duration > 0 ? duration : DEFAULT_DURATION;
+    const outset = this.nzBorderBeamOutset();
+    const inset = outset === undefined ? getBorderInset(this.host) : getInset(outset);
+    const gradient = getGradient(this.nzBorderBeamColor());
+
+    this.beamElements.forEach((beam, index) => {
+      beam.style.setProperty('--nz-border-beam-inset-offset', inset);
+      beam.style.setProperty('--nz-border-beam-duration', `${mergedDuration}s`);
+      beam.style.setProperty('--nz-border-beam-line-width', toCssUnit(this.nzBorderBeamLineWidth()));
+      beam.style.setProperty('--nz-border-beam-size', toCssUnit(this.nzBorderBeamSize()));
+      beam.style.setProperty('--nz-border-beam-delay', `${(-mergedDuration * index) / count}s`);
+
+      if (gradient) {
+        beam.style.setProperty('--nz-border-beam-gradient', gradient);
+      } else {
+        beam.style.removeProperty('--nz-border-beam-gradient');
+      }
+    });
+  }
+
+  private getCount(): number {
+    const count = this.nzBorderBeamCount();
+    return Number.isFinite(count) && count >= 1 ? Math.floor(count) : 1;
+  }
+
+  private syncBeamCount(count: number): void {
+    while (this.beamElements.length > count) {
+      this.beamElements.pop()?.remove();
+    }
+
+    while (this.beamElements.length < count) {
+      const beam = document.createElement('span');
+      beam.className = 'ant-border-beam';
+      beam.setAttribute('aria-hidden', 'true');
+      this.host.append(beam);
+      this.beamElements.push(beam);
+    }
+  }
+
+  private removeBeams(): void {
+    this.beamElements.splice(0).forEach(beam => beam.remove());
+  }
+}

--- a/components/border-beam/border-beam.directive.ts
+++ b/components/border-beam/border-beam.directive.ts
@@ -16,6 +16,8 @@ import {
   PLATFORM_ID
 } from '@angular/core';
 
+import { generateClassName, toCssPixel } from 'ng-zorro-antd/core/util';
+
 export interface NzBorderBeamGradientStop {
   color: string;
   percent: number;
@@ -23,15 +25,17 @@ export interface NzBorderBeamGradientStop {
 
 export type NzBorderBeamColor = string | NzBorderBeamGradientStop[];
 
-const DEFAULT_DURATION = 6;
-const MAX_COLOR_STOP_PERCENT = 70;
-
-function toCssUnit(value: number | string): string {
-  return typeof value === 'number' ? `${value}px` : value;
+interface BeamElement {
+  element: HTMLSpanElement;
+  motionElement: HTMLSpanElement;
 }
 
+const DEFAULT_DURATION = 6;
+const MAX_COLOR_STOP_PERCENT = 70;
+const CLASS_NAME = 'ant-border-beam';
+
 function getInset(value: number | string): string {
-  return typeof value === 'number' ? `-${value}px` : `calc(-1 * ${value})`;
+  return typeof value === 'number' ? toCssPixel(-value) : `calc(-1 * ${value})`;
 }
 
 function getBorderInset(host: HTMLElement): string {
@@ -72,16 +76,15 @@ function getGradient(color: NzBorderBeamColor | undefined): string | undefined {
  */
 @Directive({
   selector: '[nzBorderBeam]',
-  exportAs: 'nzBorderBeam',
   host: {
     class: 'ant-border-beam-host'
   }
 })
 export class NzBorderBeamDirective {
-  private readonly host = inject(ElementRef<HTMLElement>).nativeElement;
+  private readonly host: HTMLElement = inject(ElementRef<HTMLElement>).nativeElement;
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly destroyRef = inject(DestroyRef);
-  private readonly beamElements: HTMLSpanElement[] = [];
+  private readonly beamElements: BeamElement[] = [];
 
   readonly nzBorderBeam = input(true, { transform: booleanAttribute });
   readonly nzBorderBeamColor = input<NzBorderBeamColor>();
@@ -118,18 +121,16 @@ export class NzBorderBeamDirective {
     const inset = outset === undefined ? getBorderInset(this.host) : getInset(outset);
     const gradient = getGradient(this.nzBorderBeamColor());
 
-    this.beamElements.forEach((beam, index) => {
-      beam.style.setProperty('--nz-border-beam-inset-offset', inset);
-      beam.style.setProperty('--nz-border-beam-duration', `${mergedDuration}s`);
-      beam.style.setProperty('--nz-border-beam-line-width', toCssUnit(this.nzBorderBeamLineWidth()));
-      beam.style.setProperty('--nz-border-beam-size', toCssUnit(this.nzBorderBeamSize()));
-      beam.style.setProperty('--nz-border-beam-delay', `${(-mergedDuration * index) / count}s`);
+    this.beamElements.forEach(({ element, motionElement }, index) => {
+      element.style.inset = inset;
+      element.style.padding = this.nzBorderBeamLineWidth() === 1 ? '' : toCssPixel(this.nzBorderBeamLineWidth());
 
-      if (gradient) {
-        beam.style.setProperty('--nz-border-beam-gradient', gradient);
-      } else {
-        beam.style.removeProperty('--nz-border-beam-gradient');
-      }
+      motionElement.style.animationDuration = mergedDuration === DEFAULT_DURATION ? '' : `${mergedDuration}s`;
+      motionElement.style.animationDelay = count === 1 ? '' : `${(-mergedDuration * index) / count}s`;
+      motionElement.style.width = this.nzBorderBeamSize() === 100 ? '' : toCssPixel(this.nzBorderBeamSize());
+      motionElement.style.offsetPath =
+        this.nzBorderBeamSize() === 100 ? '' : `rect(0 auto auto 0 round ${toCssPixel(this.nzBorderBeamSize())})`;
+      motionElement.style.backgroundImage = gradient ?? '';
     });
   }
 
@@ -140,19 +141,22 @@ export class NzBorderBeamDirective {
 
   private syncBeamCount(count: number): void {
     while (this.beamElements.length > count) {
-      this.beamElements.pop()?.remove();
+      this.beamElements.pop()?.element.remove();
     }
 
     while (this.beamElements.length < count) {
       const beam = document.createElement('span');
-      beam.className = 'ant-border-beam';
+      beam.className = CLASS_NAME;
       beam.setAttribute('aria-hidden', 'true');
+      const motionElement = document.createElement('span');
+      motionElement.className = generateClassName(CLASS_NAME, 'motion');
+      beam.append(motionElement);
       this.host.append(beam);
-      this.beamElements.push(beam);
+      this.beamElements.push({ element: beam, motionElement });
     }
   }
 
   private removeBeams(): void {
-    this.beamElements.splice(0).forEach(beam => beam.remove());
+    this.beamElements.splice(0).forEach(({ element }) => element.remove());
   }
 }

--- a/components/border-beam/border-beam.module.ts
+++ b/components/border-beam/border-beam.module.ts
@@ -1,0 +1,14 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+import { NgModule } from '@angular/core';
+
+import { NzBorderBeamDirective } from './border-beam.directive';
+
+@NgModule({
+  imports: [NzBorderBeamDirective],
+  exports: [NzBorderBeamDirective]
+})
+export class NzBorderBeamModule {}

--- a/components/border-beam/demo/basic.md
+++ b/components/border-beam/demo/basic.md
@@ -1,0 +1,14 @@
+---
+order: 0
+title:
+  zh-CN: 基本
+  en-US: Basic
+---
+
+## zh-CN
+
+为容器边缘添加持续移动的流光效果。
+
+## en-US
+
+Add a continuous animated beam around a container border.

--- a/components/border-beam/demo/basic.ts
+++ b/components/border-beam/demo/basic.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+
+import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
+
+@Component({
+  selector: 'nz-demo-border-beam-basic',
+  imports: [NzBorderBeamModule],
+  template: `
+    <section class="beam-card" nzBorderBeam>
+      <h3>Deployments are healthy</h3>
+      <p>All services are running normally.</p>
+    </section>
+  `,
+  styles: `
+    .beam-card {
+      position: relative;
+      width: 320px;
+      padding: 24px;
+      overflow: hidden;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+    }
+
+    h3 {
+      margin: 0 0 8px;
+    }
+
+    p {
+      margin: 0;
+      color: rgba(0, 0, 0, 0.65);
+    }
+  `
+})
+export class NzDemoBorderBeamBasicComponent {}

--- a/components/border-beam/demo/custom.md
+++ b/components/border-beam/demo/custom.md
@@ -1,0 +1,14 @@
+---
+order: 1
+title:
+  zh-CN: 自定义流光
+  en-US: Custom beam
+---
+
+## zh-CN
+
+通过渐变色、多束流光与尺寸相关参数突出重点内容。
+
+## en-US
+
+Emphasize content with a gradient, multiple beams, and custom dimensions.

--- a/components/border-beam/demo/custom.md
+++ b/components/border-beam/demo/custom.md
@@ -1,14 +1,14 @@
 ---
 order: 1
 title:
-  zh-CN: 自定义流光
-  en-US: Custom beam
+  zh-CN: 自定义容器
+  en-US: Custom container
 ---
 
 ## zh-CN
 
-通过渐变色、多束流光与尺寸相关参数突出重点内容。
+自定义容器同样可以承载流光。宿主元素需要提供定位上下文。
 
 ## en-US
 
-Emphasize content with a gradient, multiple beams, and custom dimensions.
+Custom containers can also host a beam. The host element needs a positioning context.

--- a/components/border-beam/demo/custom.ts
+++ b/components/border-beam/demo/custom.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+
+import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
+
+@Component({
+  selector: 'nz-demo-border-beam-custom',
+  imports: [NzBorderBeamModule],
+  template: `
+    <section
+      class="beam-card"
+      nzBorderBeam
+      [nzBorderBeamColor]="gradient"
+      [nzBorderBeamCount]="2"
+      [nzBorderBeamDuration]="4"
+      [nzBorderBeamLineWidth]="2"
+      [nzBorderBeamSize]="140"
+    >
+      <h3>Two gradient beams</h3>
+      <p>Use the inputs to control color, count, pace, line width, and size.</p>
+    </section>
+  `,
+  styles: `
+    .beam-card {
+      position: relative;
+      width: 320px;
+      padding: 24px;
+      overflow: hidden;
+      border: 2px solid #d9d9d9;
+      border-radius: 12px;
+    }
+
+    h3 {
+      margin: 0 0 8px;
+    }
+
+    p {
+      margin: 0;
+      color: rgba(0, 0, 0, 0.65);
+    }
+  `
+})
+export class NzDemoBorderBeamCustomComponent {
+  readonly gradient = [
+    { color: '#1677ff', percent: 0 },
+    { color: '#36cfc9', percent: 55 },
+    { color: '#95de64', percent: 100 }
+  ];
+}

--- a/components/border-beam/demo/custom.ts
+++ b/components/border-beam/demo/custom.ts
@@ -6,43 +6,22 @@ import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
   selector: 'nz-demo-border-beam-custom',
   imports: [NzBorderBeamModule],
   template: `
-    <section
-      class="beam-card"
-      nzBorderBeam
-      [nzBorderBeamColor]="gradient"
-      [nzBorderBeamCount]="2"
-      [nzBorderBeamDuration]="4"
-      [nzBorderBeamLineWidth]="2"
-      [nzBorderBeamSize]="140"
-    >
-      <h3>Two gradient beams</h3>
-      <p>Use the inputs to control color, count, pace, line width, and size.</p>
+    <section class="beam-card" nzBorderBeam>
+      Review task status, deployment health, and recent automation activity in one custom container.
     </section>
   `,
   styles: `
     .beam-card {
       position: relative;
       width: 320px;
+      min-height: 160px;
       padding: 24px;
-      overflow: hidden;
-      border: 2px solid #d9d9d9;
-      border-radius: 12px;
-    }
-
-    h3 {
-      margin: 0 0 8px;
-    }
-
-    p {
-      margin: 0;
       color: rgba(0, 0, 0, 0.65);
+      line-height: 1.5715;
+      background: #fff;
+      border: 1px solid #f0f0f0;
+      border-radius: 8px;
     }
   `
 })
-export class NzDemoBorderBeamCustomComponent {
-  readonly gradient = [
-    { color: '#1677ff', percent: 0 },
-    { color: '#36cfc9', percent: 55 },
-    { color: '#95de64', percent: 100 }
-  ];
-}
+export class NzDemoBorderBeamCustomComponent {}

--- a/components/border-beam/demo/duration.md
+++ b/components/border-beam/demo/duration.md
@@ -1,0 +1,14 @@
+---
+order: 4
+title:
+  zh-CN: 动画时长
+  en-US: Duration
+---
+
+## zh-CN
+
+使用 `nzBorderBeamDuration` 控制流光完成一圈所需的秒数，默认值为 `6`。
+
+## en-US
+
+Use `nzBorderBeamDuration` to control the seconds required to complete one loop. The default is `6`.

--- a/components/border-beam/demo/duration.ts
+++ b/components/border-beam/demo/duration.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+
+import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzTagModule } from 'ng-zorro-antd/tag';
+
+@Component({
+  selector: 'nz-demo-border-beam-duration',
+  imports: [NzBorderBeamModule, NzCardModule, NzTagModule],
+  template: `
+    <div class="card-list">
+      @for (item of durations; track item.name) {
+        <nz-card
+          class="beam-card"
+          nzBorderBeam
+          [nzBorderBeamDuration]="item.seconds"
+          nzTitle="{{ item.name }}"
+          [nzExtra]="extra"
+        >
+          {{ item.description }}
+          <ng-template #extra
+            ><nz-tag>{{ item.seconds }}s</nz-tag></ng-template
+          >
+        </nz-card>
+      }
+    </div>
+  `,
+  styles: `
+    .card-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+    }
+
+    .beam-card {
+      position: relative;
+      width: 220px;
+      overflow: hidden;
+    }
+  `
+})
+export class NzDemoBorderBeamDurationComponent {
+  readonly durations = [
+    { name: 'Fast', seconds: 3, description: 'A quick loop for temporary highlights and active modules.' },
+    { name: 'Default', seconds: 6, description: 'The original pacing for most emphasized containers.' },
+    { name: 'Slow', seconds: 12, description: 'A calmer loop for persistent panels and ambient surfaces.' }
+  ];
+}

--- a/components/border-beam/demo/gradients.md
+++ b/components/border-beam/demo/gradients.md
@@ -1,0 +1,14 @@
+---
+order: 3
+title:
+  zh-CN: 渐变色
+  en-US: Gradients
+---
+
+## zh-CN
+
+使用色标数组定义流光渐变，并在不同配色之间切换。
+
+## en-US
+
+Define a beam gradient with color stops and switch between palettes.

--- a/components/border-beam/demo/gradients.ts
+++ b/components/border-beam/demo/gradients.ts
@@ -1,0 +1,90 @@
+import { Component, signal } from '@angular/core';
+
+import { NzBorderBeamGradientStop, NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzCardModule } from 'ng-zorro-antd/card';
+
+interface GradientPalette {
+  name: string;
+  description: string;
+  stops: NzBorderBeamGradientStop[];
+}
+
+@Component({
+  selector: 'nz-demo-border-beam-gradients',
+  imports: [NzBorderBeamModule, NzButtonModule, NzCardModule],
+  template: `
+    <div class="palette-list">
+      @for (palette of palettes; track palette.name) {
+        <button
+          nz-button
+          [nzType]="selectedPalette().name === palette.name ? 'primary' : 'default'"
+          [attr.aria-pressed]="selectedPalette().name === palette.name"
+          (click)="selectPalette(palette)"
+        >
+          {{ palette.name }}
+        </button>
+      }
+    </div>
+
+    <nz-card
+      class="beam-card"
+      nzBorderBeam
+      [nzBorderBeamColor]="selectedPalette().stops"
+      nzTitle="{{ selectedPalette().name }}"
+    >
+      {{ selectedPalette().description }}
+    </nz-card>
+  `,
+  styles: `
+    .palette-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 16px;
+    }
+
+    .beam-card {
+      position: relative;
+      width: 320px;
+      overflow: hidden;
+    }
+  `
+})
+export class NzDemoBorderBeamGradientsComponent {
+  readonly palettes: GradientPalette[] = [
+    {
+      name: 'Ocean',
+      description: 'A calm blue-green accent that works well for data views and cloud tooling.',
+      stops: [
+        { color: '#1677ff', percent: 0 },
+        { color: '#36cfc9', percent: 52 },
+        { color: '#95de64', percent: 100 }
+      ]
+    },
+    {
+      name: 'Sunset',
+      description: 'A warm orange and pink gradient for announcements and featured content.',
+      stops: [
+        { color: '#fa8c16', percent: 0 },
+        { color: '#ff4d4f', percent: 54 },
+        { color: '#eb2f96', percent: 100 }
+      ]
+    },
+    {
+      name: 'Aurora',
+      description: 'A vivid violet and cyan gradient for AI and creative workflows.',
+      stops: [
+        { color: '#722ed1', percent: 0 },
+        { color: '#13c2c2', percent: 58 },
+        { color: '#52c41a', percent: 100 }
+      ]
+    }
+  ];
+
+  readonly selectedPalette = signal(this.palettes[0]);
+
+  selectPalette(palette: GradientPalette): void {
+    this.selectedPalette.set(palette);
+  }
+}

--- a/components/border-beam/demo/hover.md
+++ b/components/border-beam/demo/hover.md
@@ -1,0 +1,14 @@
+---
+order: 1
+title:
+  zh-CN: 悬停显示
+  en-US: Show on hover
+---
+
+## zh-CN
+
+默认隐藏流光，在鼠标悬停到容器时显示。
+
+## en-US
+
+Hide the beam by default and reveal it when hovering over the container.

--- a/components/border-beam/demo/hover.ts
+++ b/components/border-beam/demo/hover.ts
@@ -1,0 +1,40 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+
+import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
+import { NzCardModule } from 'ng-zorro-antd/card';
+
+@Component({
+  selector: 'nz-demo-border-beam-hover',
+  encapsulation: ViewEncapsulation.None,
+  imports: [NzBorderBeamModule, NzCardModule],
+  template: `
+    <nz-card class="nz-demo-border-beam-hover-card" nzBorderBeam nzTitle="Hover over the card">
+      The border beam appears when the pointer moves over this card.
+    </nz-card>
+  `,
+  styles: `
+    .nz-demo-border-beam-hover-card {
+      position: relative;
+      width: 320px;
+      overflow: hidden;
+    }
+
+    .nz-demo-border-beam-hover-card .ant-border-beam {
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+
+    .nz-demo-border-beam-hover-card .ant-border-beam::before {
+      animation-play-state: paused;
+    }
+
+    .nz-demo-border-beam-hover-card:hover .ant-border-beam {
+      opacity: 1;
+    }
+
+    .nz-demo-border-beam-hover-card:hover .ant-border-beam::before {
+      animation-play-state: running;
+    }
+  `
+})
+export class NzDemoBorderBeamHoverComponent {}

--- a/components/border-beam/demo/line-width.md
+++ b/components/border-beam/demo/line-width.md
@@ -1,0 +1,14 @@
+---
+order: 6
+title:
+  zh-CN: 流光线宽
+  en-US: Line width
+---
+
+## zh-CN
+
+使用 `nzBorderBeamLineWidth` 调整流光线宽，默认值为 `1px`。
+
+## en-US
+
+Use `nzBorderBeamLineWidth` to adjust the beam width. The default is `1px`.

--- a/components/border-beam/demo/line-width.ts
+++ b/components/border-beam/demo/line-width.ts
@@ -4,11 +4,17 @@ import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
 import { NzCardModule } from 'ng-zorro-antd/card';
 
 @Component({
-  selector: 'nz-demo-border-beam-basic',
+  selector: 'nz-demo-border-beam-line-width',
   imports: [NzBorderBeamModule, NzCardModule],
   template: `
-    <nz-card class="beam-card" nzBorderBeam nzTitle="Workspace overview">
-      Review task status, deployment health, and recent automation activity in one panel.
+    <nz-card
+      class="beam-card"
+      nzBorderBeam
+      [nzBorderBeamLineWidth]="2"
+      nzTitle="Custom line width"
+      style="border-width: 2px"
+    >
+      Set nzBorderBeamLineWidth to match the border width of this container.
     </nz-card>
   `,
   styles: `
@@ -19,4 +25,4 @@ import { NzCardModule } from 'ng-zorro-antd/card';
     }
   `
 })
-export class NzDemoBorderBeamBasicComponent {}
+export class NzDemoBorderBeamLineWidthComponent {}

--- a/components/border-beam/demo/multiple.md
+++ b/components/border-beam/demo/multiple.md
@@ -1,0 +1,14 @@
+---
+order: 2
+title:
+  zh-CN: 多束流光
+  en-US: Multiple beams
+---
+
+## zh-CN
+
+通过 `nzBorderBeamCount` 设置多束流光，它们会沿容器边缘均匀分布。
+
+## en-US
+
+Use `nzBorderBeamCount` to distribute multiple beams evenly around the container border.

--- a/components/border-beam/demo/multiple.ts
+++ b/components/border-beam/demo/multiple.ts
@@ -4,11 +4,11 @@ import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
 import { NzCardModule } from 'ng-zorro-antd/card';
 
 @Component({
-  selector: 'nz-demo-border-beam-basic',
+  selector: 'nz-demo-border-beam-multiple',
   imports: [NzBorderBeamModule, NzCardModule],
   template: `
-    <nz-card class="beam-card" nzBorderBeam nzTitle="Workspace overview">
-      Review task status, deployment health, and recent automation activity in one panel.
+    <nz-card class="beam-card" nzBorderBeam [nzBorderBeamCount]="3" nzTitle="Multiple beams">
+      Set count to distribute multiple beams evenly around the container border.
     </nz-card>
   `,
   styles: `
@@ -19,4 +19,4 @@ import { NzCardModule } from 'ng-zorro-antd/card';
     }
   `
 })
-export class NzDemoBorderBeamBasicComponent {}
+export class NzDemoBorderBeamMultipleComponent {}

--- a/components/border-beam/demo/size.md
+++ b/components/border-beam/demo/size.md
@@ -1,0 +1,14 @@
+---
+order: 5
+title:
+  zh-CN: 流光尺寸
+  en-US: Size
+---
+
+## zh-CN
+
+使用 `nzBorderBeamSize` 控制可见流光片段的尺寸，默认值为 `100px`。
+
+## en-US
+
+Use `nzBorderBeamSize` to control the visible beam segment. The default is `100px`.

--- a/components/border-beam/demo/size.ts
+++ b/components/border-beam/demo/size.ts
@@ -1,0 +1,55 @@
+import { Component } from '@angular/core';
+
+import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzTagModule } from 'ng-zorro-antd/tag';
+
+@Component({
+  selector: 'nz-demo-border-beam-size',
+  imports: [NzBorderBeamModule, NzCardModule, NzTagModule],
+  template: `
+    <div class="card-list">
+      @for (item of sizes; track item.name) {
+        <nz-card
+          class="beam-card"
+          [class.beam-card-wide]="item.wide"
+          nzBorderBeam
+          [nzBorderBeamSize]="item.size"
+          nzTitle="{{ item.name }}"
+          [nzExtra]="extra"
+        >
+          {{ item.description }}
+          <ng-template #extra
+            ><nz-tag>{{ item.size }}px</nz-tag></ng-template
+          >
+        </nz-card>
+      }
+    </div>
+  `,
+  styles: `
+    .card-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      max-width: 640px;
+    }
+
+    .beam-card {
+      position: relative;
+      min-height: 136px;
+      overflow: hidden;
+    }
+
+    .beam-card-wide {
+      grid-column: 1 / -1;
+      min-height: 192px;
+    }
+  `
+})
+export class NzDemoBorderBeamSizeComponent {
+  readonly sizes = [
+    { name: 'Default', size: 100, description: 'Uses the default 100px visible beam segment.', wide: false },
+    { name: 'Compact', size: 56, description: 'Keeps the highlight shorter for dense card groups.', wide: false },
+    { name: 'Extended', size: 160, description: 'Creates a longer highlight for wider feature panels.', wide: true }
+  ];
+}

--- a/components/border-beam/doc/index.en-US.md
+++ b/components/border-beam/doc/index.en-US.md
@@ -14,7 +14,7 @@ description: Add a decorative moving beam around a container border.
 
 ## API
 
-Import `NzBorderBeamDirective` or `NzBorderBeamModule`, then apply `nzBorderBeam` to the container to decorate. The host needs `position: relative` (or another positioning context).
+After importing the directive, apply `nzBorderBeam` to the container to decorate. The host needs `position: relative` (or another positioning context).
 
 | Property                | Description                                                                                                                                | Type                                   | Default |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- | ------- |
@@ -39,6 +39,18 @@ Import `NzBorderBeamDirective` or `NzBorderBeamModule`, then apply `nzBorderBeam
 
 The beam is hidden when the browser has `prefers-reduced-motion: reduce` enabled.
 
+### What does `percent` mean in `nzBorderBeamColor`?
+
+`percent` is the authored stop position from `0` to `100`. BorderBeam maps the stops into the visible beam segment and reserves the trailing range for a transparent fade-out.
+
+### Are there size limits?
+
+The beam is a square gradient layer whose side length is `nzBorderBeamSize`. Keep it below twice the shorter side of the decorated element: `size < 2 × min(width, height)`. Otherwise the square can visibly overlap opposite edges.
+
 ### Why is the beam not visible?
 
 The host needs a positioning context because the beam is absolutely positioned. In most cases, add `position: relative` to the element that has `nzBorderBeam`.
+
+### How does the beam follow rounded corners?
+
+The effect inherits the host element's `border-radius`, so changes made through classes, responsive styles, or CSS variables stay aligned automatically.

--- a/components/border-beam/doc/index.en-US.md
+++ b/components/border-beam/doc/index.en-US.md
@@ -3,6 +3,7 @@ category: Components
 type: Other
 title: BorderBeam
 tag: 22.1.0
+cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*uae3QbkNCm8AAAAAAAAAAAAADrJ8AQ/original
 description: Add a decorative moving beam around a container border.
 ---
 

--- a/components/border-beam/doc/index.en-US.md
+++ b/components/border-beam/doc/index.en-US.md
@@ -1,0 +1,44 @@
+---
+category: Components
+type: Other
+title: BorderBeam
+tag: 22.1.0
+description: Add a decorative moving beam around a container border.
+---
+
+## When To Use
+
+- Use to visually emphasize a container without adding business-state meaning.
+- Suitable for login panels, recommendation cards, AI modules, and key call-to-action blocks.
+- This is decorative only. Do not use it as a replacement for focus indicators, validation borders, or status feedback.
+
+## API
+
+Import `NzBorderBeamDirective` or `NzBorderBeamModule`, then apply `nzBorderBeam` to the container to decorate. The host needs `position: relative` (or another positioning context).
+
+| Property                | Description                                                                                                                                | Type                                   | Default |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- | ------- |
+| `nzBorderBeam`          | Whether to show the beam.                                                                                                                  | `boolean`                              | `true`  |
+| `nzBorderBeamColor`     | Beam color. Supports one color or gradient stops. `percent` accepts `0` to `100`; the trailing range is reserved for the transparent fade. | `string \| NzBorderBeamGradientStop[]` | -       |
+| `nzBorderBeamCount`     | Number of evenly distributed beams.                                                                                                        | `number`                               | `1`     |
+| `nzBorderBeamDuration`  | Seconds for one loop.                                                                                                                      | `number`                               | `6`     |
+| `nzBorderBeamLineWidth` | Beam line width; numbers are pixels.                                                                                                       | `number \| string`                     | `1`     |
+| `nzBorderBeamOutset`    | Distance to extend the beam layer from the host edge; omit to follow the host border width.                                                | `number \| string`                     | -       |
+| `nzBorderBeamSize`      | Visible beam segment size; numbers are pixels.                                                                                             | `number \| string`                     | `100`   |
+
+### NzBorderBeamGradientStop
+
+| Property  | Description                      | Type     |
+| --------- | -------------------------------- | -------- |
+| `color`   | Color at this stop.              | `string` |
+| `percent` | Stop position from `0` to `100`. | `number` |
+
+## FAQ
+
+### How does it behave with reduced motion?
+
+The beam is hidden when the browser has `prefers-reduced-motion: reduce` enabled.
+
+### Why is the beam not visible?
+
+The host needs a positioning context because the beam is absolutely positioned. In most cases, add `position: relative` to the element that has `nzBorderBeam`.

--- a/components/border-beam/doc/index.zh-CN.md
+++ b/components/border-beam/doc/index.zh-CN.md
@@ -15,7 +15,7 @@ description: 在容器边缘添加装饰性的移动流光。
 
 ## API
 
-导入 `NzBorderBeamDirective` 或 `NzBorderBeamModule` 后，在容器上添加 `nzBorderBeam`。宿主元素需要设置 `position: relative`（或其他定位上下文）。
+导入指令后，在容器上添加 `nzBorderBeam`。宿主元素需要设置 `position: relative`（或其他定位上下文）。
 
 | 参数                    | 说明                                                                                          | 类型                                   | 默认值 |
 | ----------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------- | ------ |
@@ -40,6 +40,18 @@ description: 在容器边缘添加装饰性的移动流光。
 
 浏览器启用 `prefers-reduced-motion: reduce` 时，流光会被隐藏。
 
+### `nzBorderBeamColor` 中的 `percent` 表示什么？
+
+`percent` 是作者定义的色标位置，范围为 `0` 到 `100`。BorderBeam 会将色标映射到可见流光片段中，并保留末尾区间作为透明渐隐。
+
+### `nzBorderBeamSize` 有限制吗？
+
+流光使用边长为 `nzBorderBeamSize` 的正方形渐变层。建议其小于容器较短边的两倍：`size < 2 × min(width, height)`，否则可能会在对侧边缘产生可见重叠。
+
 ### 为什么没有看到流光？
 
 流光层使用绝对定位，因此宿主元素需要提供定位上下文。通常为添加了 `nzBorderBeam` 的元素设置 `position: relative` 即可。
+
+### 流光如何与圆角保持一致？
+
+效果层继承宿主元素的 `border-radius`，因此通过 class、响应式样式或 CSS 变量修改圆角时，流光会自动保持一致。

--- a/components/border-beam/doc/index.zh-CN.md
+++ b/components/border-beam/doc/index.zh-CN.md
@@ -1,0 +1,45 @@
+---
+category: Components
+type: 其他
+subtitle: 边框流光
+title: BorderBeam
+tag: 22.1.0
+description: 在容器边缘添加装饰性的移动流光。
+---
+
+## 何时使用
+
+- 需要突出容器，但不表达业务状态时使用。
+- 适用于登录面板、推荐卡片、AI 模块和关键操作区域。
+- 本组件仅提供装饰效果，不能替代焦点轮廓、校验边框或状态反馈。
+
+## API
+
+导入 `NzBorderBeamDirective` 或 `NzBorderBeamModule` 后，在容器上添加 `nzBorderBeam`。宿主元素需要设置 `position: relative`（或其他定位上下文）。
+
+| 参数                    | 说明                                                                                          | 类型                                   | 默认值 |
+| ----------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------- | ------ |
+| `nzBorderBeam`          | 是否显示流光。                                                                                | `boolean`                              | `true` |
+| `nzBorderBeamColor`     | 流光颜色。支持单色或渐变色标；`percent` 的取值范围为 `0` 到 `100`，末尾区间会保留给透明渐隐。 | `string \| NzBorderBeamGradientStop[]` | -      |
+| `nzBorderBeamCount`     | 均匀分布的流光数量。                                                                          | `number`                               | `1`    |
+| `nzBorderBeamDuration`  | 完成一次循环所需秒数。                                                                        | `number`                               | `6`    |
+| `nzBorderBeamLineWidth` | 流光线宽；数字按像素处理。                                                                    | `number \| string`                     | `1`    |
+| `nzBorderBeamOutset`    | 流光层相对宿主边缘的外扩距离；省略时跟随宿主边框宽度。                                        | `number \| string`                     | -      |
+| `nzBorderBeamSize`      | 可见流光片段尺寸；数字按像素处理。                                                            | `number \| string`                     | `100`  |
+
+### NzBorderBeamGradientStop
+
+| 参数      | 说明                            | 类型     |
+| --------- | ------------------------------- | -------- |
+| `color`   | 当前色标的颜色。                | `string` |
+| `percent` | 色标位置，范围为 `0` 到 `100`。 | `number` |
+
+## FAQ
+
+### 减少动态效果时如何表现？
+
+浏览器启用 `prefers-reduced-motion: reduce` 时，流光会被隐藏。
+
+### 为什么没有看到流光？
+
+流光层使用绝对定位，因此宿主元素需要提供定位上下文。通常为添加了 `nzBorderBeam` 的元素设置 `position: relative` 即可。

--- a/components/border-beam/doc/index.zh-CN.md
+++ b/components/border-beam/doc/index.zh-CN.md
@@ -4,6 +4,7 @@ type: 其他
 subtitle: 边框流光
 title: BorderBeam
 tag: 22.1.0
+cover: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*uae3QbkNCm8AAAAAAAAAAAAADrJ8AQ/original
 description: 在容器边缘添加装饰性的移动流光。
 ---
 

--- a/components/border-beam/index.ts
+++ b/components/border-beam/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+export * from './public-api';

--- a/components/border-beam/ng-package.json
+++ b/components/border-beam/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/components/border-beam/public-api.ts
+++ b/components/border-beam/public-api.ts
@@ -1,0 +1,7 @@
+/**
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
+ */
+
+export * from './border-beam.directive';
+export * from './border-beam.module';

--- a/components/border-beam/style/entry.less
+++ b/components/border-beam/style/entry.less
@@ -1,0 +1,1 @@
+@import './index.less';

--- a/components/border-beam/style/index.less
+++ b/components/border-beam/style/index.less
@@ -16,8 +16,8 @@
   position: absolute;
   z-index: 1;
   display: none;
-  inset: var(--nz-border-beam-inset-offset, 0);
-  padding: var(--nz-border-beam-line-width, @border-width-base);
+  inset: 0;
+  padding: @border-width-base;
   overflow: hidden;
   border-radius: inherit;
   pointer-events: none;
@@ -36,24 +36,19 @@
     @supports (offset-path: rect(0 auto auto 0 round 1px)) {
       display: block;
 
-      &::before {
+      &-motion {
         position: absolute;
         top: 0;
         left: 0;
-        width: var(--nz-border-beam-size, 100px);
-        background-image: var(
-          --nz-border-beam-gradient,
-          linear-gradient(to left, @primary-color 0%, @primary-color-hover 70%, transparent)
-        );
+        width: 100px;
+        background-image: linear-gradient(to left, @primary-color 0%, @primary-color-hover 70%, transparent);
         opacity: 0.95;
-        animation: ant-border-beam-move var(--nz-border-beam-duration, 6s) linear var(--nz-border-beam-delay, 0s)
-          infinite;
-        content: '';
+        animation: ant-border-beam-move 6s linear 0s infinite;
         will-change: offset-distance;
         aspect-ratio: 1 / 1;
         offset-anchor: 90% 50%;
         offset-distance: 0%;
-        offset-path: rect(0 auto auto 0 round var(--nz-border-beam-size, 100px));
+        offset-path: rect(0 auto auto 0 round 100px);
         offset-rotate: auto;
       }
     }
@@ -62,7 +57,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .@{border-beam-prefix-cls}::before {
+  .@{border-beam-prefix-cls}-motion {
     display: none;
   }
 }

--- a/components/border-beam/style/index.less
+++ b/components/border-beam/style/index.less
@@ -1,0 +1,68 @@
+@import '../../style/themes/index';
+
+@border-beam-prefix-cls: ~'@{ant-prefix}-border-beam';
+
+@keyframes ant-border-beam-move {
+  from {
+    offset-distance: 0%;
+  }
+
+  to {
+    offset-distance: 100%;
+  }
+}
+
+.@{border-beam-prefix-cls} {
+  position: absolute;
+  z-index: 1;
+  display: none;
+  inset: var(--nz-border-beam-inset-offset, 0);
+  padding: var(--nz-border-beam-line-width, @border-width-base);
+  overflow: hidden;
+  border-radius: inherit;
+  pointer-events: none;
+
+  /* stylelint-disable property-no-vendor-prefix */
+  @supports ((mask-composite: exclude) or (-webkit-mask-composite: xor)) {
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+
+    @supports (offset-path: rect(0 auto auto 0 round 1px)) {
+      display: block;
+
+      &::before {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: var(--nz-border-beam-size, 100px);
+        background-image: var(
+          --nz-border-beam-gradient,
+          linear-gradient(to left, @primary-color 0%, @primary-color-hover 70%, transparent)
+        );
+        opacity: 0.95;
+        animation: ant-border-beam-move var(--nz-border-beam-duration, 6s) linear var(--nz-border-beam-delay, 0s)
+          infinite;
+        content: '';
+        will-change: offset-distance;
+        aspect-ratio: 1 / 1;
+        offset-anchor: 90% 50%;
+        offset-distance: 0%;
+        offset-path: rect(0 auto auto 0 round var(--nz-border-beam-size, 100px));
+        offset-rotate: auto;
+      }
+    }
+  }
+  /* stylelint-enable property-no-vendor-prefix */
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .@{border-beam-prefix-cls}::before {
+    display: none;
+  }
+}

--- a/components/components.less
+++ b/components/components.less
@@ -4,6 +4,7 @@
 @import './anchor/style/entry.less';
 @import './avatar/style/entry.less';
 @import './badge/style/entry.less';
+@import './border-beam/style/entry.less';
 @import './breadcrumb/style/entry.less';
 @import './button/style/entry.less';
 @import './card/style/entry.less';

--- a/components/package.json
+++ b/components/package.json
@@ -97,6 +97,10 @@
       "less": "./badge/style/*.less",
       "style": "./badge/style/index.min.css"
     },
+    "./border-beam/style/*": {
+      "less": "./border-beam/style/*.less",
+      "style": "./border-beam/style/index.min.css"
+    },
     "./breadcrumb/style/*": {
       "less": "./breadcrumb/style/*.less",
       "style": "./breadcrumb/style/index.min.css"

--- a/scripts/site/doc/app/components-overview/components-overview.component.html
+++ b/scripts/site/doc/app/components-overview/components-overview.component.html
@@ -46,11 +46,28 @@
           @for (component of group.children; track $index) {
             <div nz-col nzXs="24" nzSm="12" nzMd="12" nzLg="8" nzXl="6" nzXXl="6" class="components-overview-card">
               <a routerLink="/{{ component.path }}">
-                <nz-card nzHoverable nzTitle="{{ component.label }} {{ component.zh }}">
-                  <div class="components-overview-img">
-                    <img [alt]="component.label" [src]="component.cover" />
-                  </div>
-                </nz-card>
+                @if (component.tag) {
+                  <nz-ribbon [nzText]="component.tag" nzColor="green">
+                    <ng-container [ngTemplateOutlet]="componentCard"></ng-container>
+                  </nz-ribbon>
+                } @else {
+                  <ng-container [ngTemplateOutlet]="componentCard"></ng-container>
+                }
+
+                <ng-template #componentCard>
+                  @let isBorderBeam = component.path.includes('border-beam');
+                  <nz-card
+                    nzHoverable
+                    [nzBorderBeam]="isBorderBeam"
+                    [nzBorderBeamOutset]="isBorderBeam ? 0 : undefined"
+                    [class.components-overview-beam-card]="isBorderBeam"
+                    nzTitle="{{ component.label }} {{ component.zh }}"
+                  >
+                    <div class="components-overview-img">
+                      <img [alt]="component.label" [src]="component.cover" />
+                    </div>
+                  </nz-card>
+                </ng-template>
               </a>
             </div>
           }

--- a/scripts/site/doc/app/components-overview/components-overview.component.less
+++ b/scripts/site/doc/app/components-overview/components-overview.component.less
@@ -13,11 +13,26 @@
     align-items: center;
     justify-content: center;
     height: 152px;
+
+    img {
+      max-width: 100%;
+      max-height: 100%;
+    }
   }
 
   &-card {
     padding: 12px;
     cursor: pointer;
+
+    a,
+    nz-ribbon {
+      display: block;
+    }
+  }
+
+  &-beam-card {
+    position: relative;
+    overflow: hidden;
   }
 }
 

--- a/scripts/site/doc/app/components-overview/components-overview.component.ts
+++ b/scripts/site/doc/app/components-overview/components-overview.component.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common';
 import {
   afterNextRender,
   Component,
@@ -15,6 +16,8 @@ import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
 import { NzAffixModule } from 'ng-zorro-antd/affix';
+import { NzBadgeModule } from 'ng-zorro-antd/badge';
+import { NzBorderBeamModule } from 'ng-zorro-antd/border-beam';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzDividerModule } from 'ng-zorro-antd/divider';
@@ -31,7 +34,10 @@ import { ROUTER_LIST } from '../router';
   selector: 'app-components-overview',
   imports: [
     RouterLink,
+    NgTemplateOutlet,
     NzAffixModule,
+    NzBadgeModule,
+    NzBorderBeamModule,
     NzCardModule,
     NzButtonModule,
     NzTagModule,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Feature

## What is the current behavior?

NG-ZORRO does not provide a BorderBeam component for adding a decorative animated beam around a container border.

Issue Number: N/A

## What is the new behavior?

- Add the `nzBorderBeam` directive with color, count, duration, line-width, outset, and size customization.
- Add API documentation and usage examples.
- Add the BorderBeam card to the component overview, including its cover, version tag, and visible beam effect.
- Align component ownership mappings for BorderBeam and existing component names.

## Does this PR introduce a breaking change?

- [x] No

## Other information

Validation performed:

- `npx nx run ng-zorro-antd-lib:test --include=components/border-beam/border-beam.directive.spec.ts --watch=false --coverage=false`
- `npx nx run ng-zorro-antd-doc:build --configuration=development --skip-nx-cache`