### PR TITLE
fix(module:modal): animate mask when closing

### DIFF
--- a/components/modal/modal-container.directive.ts
+++ b/components/modal/modal-container.directive.ts
@@ -327,12 +327,11 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
     }
   }
 
-  _startLeaveAnimation(callback?: () => void): void {
+  _startLeaveAnimation(): void {
     this.animationStateChanged.emit('leave-start');
 
     if (this.animationDisabled()) {
       this.restoreFocus();
-      callback?.();
       this.animationStateChanged.emit('leave-active');
     } else {
       this.setExitAnimationClass();
@@ -341,7 +340,6 @@ export class BaseModalContainerComponent extends BasePortalOutlet {
         element.removeEventListener('animationend', onAnimationEnd);
         this.restoreFocus();
         this.cleanAnimationClass();
-        callback?.();
         this.animationStateChanged.emit('leave-active');
       };
 

--- a/components/modal/modal-ref.ts
+++ b/components/modal/modal-ref.ts
@@ -132,10 +132,8 @@ export class NzModalRef<T = NzSafeAny, R = NzSafeAny> implements NzModalLegacyAP
     }
     this.result = result;
     this.state = NzModalState.CLOSING;
-    this.containerInstance._startLeaveAnimation(() => {
-      this.overlayRef.detachBackdrop();
-      this._finishDialogClose();
-    });
+    this.overlayRef.detachBackdrop();
+    this.containerInstance._startLeaveAnimation();
   }
 
   updateConfig(config: ModalOptions): void {

--- a/components/modal/modal.spec.ts
+++ b/components/modal/modal.spec.ts
@@ -99,10 +99,13 @@ describe('modal with animation', () => {
 
     animationDone(modalContentElement!, 'enter');
     await fixture.whenStable();
+
+    const backdropElement = modalRef.getBackdropElement()!;
     modalRef.close();
 
     expect(modalContentElement!.classList).toContain('ant-zoom-leave');
     expect(modalContentElement!.classList).toContain('ant-zoom-leave-active');
+    expect(backdropElement.classList).not.toContain('cdk-overlay-backdrop-showing');
   });
 
   it('should emit when modal opening animation is complete', async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: #9916

The modal backdrop starts detaching only after the dialog leave animation finishes, then the overlay is immediately disposed. This prevents the backdrop fade-out from being rendered.

## What is the new behavior?

The backdrop begins its leave transition when the modal starts closing. The existing leave lifecycle event completes overlay disposal after the dialog animation. The unused leave-animation callback was removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Added a regression test for starting the backdrop transition when closing.

Verified with:

- npx nx run ng-zorro-antd-lib:test --watch=false --coverage=false --include=modal/modal.spec.ts
- npx nx run ng-zorro-antd-lib:build-lib

## 中文说明

修复 Modal 关闭时遮罩动画未生效的问题：在面板退出动画开始时同步触发遮罩淡出，避免 Overlay 被立即销毁而跳过动画。