### PR TITLE
fix(module:icon): guard handleRotate against non-Element firstChild

### DIFF
--- a/components/icon/icon.directive.ts
+++ b/components/icon/icon.directive.ts
@@ -167,7 +167,7 @@ export class NzIconDirective extends IconBase implements AfterContentChecked {
   }
 
   private handleRotate(svg: SVGElement | null): void {
-    if (!svg) {
+    if (!svg || svg.nodeType !== Node.ELEMENT_NODE) {
       return;
     }
 

--- a/components/icon/icon.spec.ts
+++ b/components/icon/icon.spec.ts
@@ -106,6 +106,23 @@ describe('nz-icon', () => {
       fixture.detectChanges();
       expect(icons[0].nativeElement.firstChild.style.transform).toBeFalsy();
     });
+
+    it('should not throw when firstChild is not an Element', async () => {
+      fixture.detectChanges();
+      await updateNonSignalsInput(fixture);
+      fixture.detectChanges();
+
+      const hostEl = icons[0].nativeElement as HTMLElement;
+      const svg = hostEl.firstChild!;
+      // Simulate the icon's firstChild being a non-Element node, which can
+      // happen before the SVG has been created or during rapid teardown/recreate.
+      hostEl.replaceChild(document.createComment(''), svg);
+
+      expect(() => {
+        testComponent.rotate.set(180);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
   });
 
   describe('custom', () => {


### PR DESCRIPTION
nzRotate's effect calls handleRotate(this.el.firstChild), typed as SVGElement via an unchecked assertion. firstChild can be a Text or Comment node (e.g. before the icon's SVG has been created, or during rapid component teardown/recreate), and Renderer2.removeAttribute internally calls el.removeAttribute(), which doesn't exist on non-Element nodes:

  TypeError: el.removeAttribute is not a function
    at NzIconDirective.handleRotate

This throws inside the effect, aborting the current change detection pass and leaving unrelated host bindings elsewhere in the tree unflushed. Guard against non-Element nodes before touching attributes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`NzIconDirective.handleRotate` throws when `this.el.firstChild` is not
an `Element` (e.g. a Text or Comment node), which can happen before the
icon's SVG has been created, or during rapid component teardown/recreate.
The method's only guard is a null check, but the parameter is force-cast
to `SVGElement` (`this.el.firstChild as SVGElement | null`) without a
runtime check, so a non-Element node reaches
`this.renderer.removeAttribute(svg, 'style')`, whose underlying
implementation calls `el.removeAttribute()` directly — a method that
doesn't exist on non-Element nodes:

TypeError: el.removeAttribute is not a function
    at NzIconDirective.handleRotate

This throws inside a reactive `effect()`, aborting the current change
detection pass and leaving unrelated host bindings elsewhere in the
component tree unflushed (e.g. we hit this as an intermittent layout
bug in an unrelated `nz-col` grid inside the same view, which only
manifested after several rapid open/close cycles of a modal containing
a rotating icon).

Issue Number: N/A


## What is the new behavior?

`handleRotate` now checks `svg.nodeType !== Node.ELEMENT_NODE` alongside
the existing null check, and returns early for non-Element nodes instead
of throwing. No change to rotate behavior for the normal (Element) case —
verified against the existing `icon.spec.ts` suite, including the
"should rotate work" test (10/10 passing).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Root cause is a stale type assertion: `firstChild` is typed as
`ChildNode | null` by the DOM lib, but the call site casts it to
`SVGElement | null` without validation. The fix keeps the existing
public API/behavior unchanged and only adds a defensive runtime check.