### PR TITLE
fix(module:core): clean up drag event listeners

### DIFF
--- a/components/core/services/drag.spec.ts
+++ b/components/core/services/drag.spec.ts
@@ -3,9 +3,11 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Component, inject } from '@angular/core';
+import { Component, inject, Renderer2 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subject, Subscription } from 'rxjs';
+
+import { vi } from 'vitest';
 
 import {
   createMouseEvent,
@@ -21,12 +23,12 @@ import { NzDragService } from './drag';
   template: ''
 })
 export class NzTestDragServiceComponent {
-  public nzDragService = inject(NzDragService);
+  readonly dragService = inject(NzDragService);
   drag$ = new Subject<void>();
   complete$ = new Subject<void>();
 
   drag(event: MouseEvent | TouchEvent): void {
-    this.nzDragService.requestDraggingSequence(event).subscribe({
+    this.dragService.requestDraggingSequence(event).subscribe({
       next: () => this.drag$.next(),
       complete: () => this.complete$.next()
     });
@@ -46,9 +48,7 @@ describe('drag service', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(NzTestDragServiceComponent);
       component = fixture.debugElement.componentInstance;
-    });
 
-    beforeEach(() => {
       completed = false;
       dragged = false;
 
@@ -99,6 +99,42 @@ describe('drag service', () => {
       expect(dragged).toBeFalsy();
 
       dispatchMouseEvent(document, 'mouseup');
+      expect(completed).toBeTruthy();
+    });
+
+    it('should teardown document listeners after the dragging sequence ends', () => {
+      const service = component.dragService;
+      const renderer = service['renderer'];
+      const originalListen = renderer.listen.bind(renderer);
+      const teardown = vi.fn();
+
+      vi.spyOn(renderer, 'listen').mockImplementation((...args: Parameters<Renderer2['listen']>) => {
+        const removeEventListener = originalListen(...args);
+        return () => {
+          teardown();
+          removeEventListener();
+        };
+      });
+
+      component.drag(createMouseEvent('mousedown', 0, 0));
+      dispatchMouseEvent(document, 'mouseup');
+
+      expect(teardown).toHaveBeenCalledTimes(2);
+      expect(service['handleRegistry'].size).toBe(0);
+    });
+
+    it('should register handlers for a touch drag after a mouse drag ends', async () => {
+      component.drag(createMouseEvent('mousedown', 0, 0));
+      dispatchMouseEvent(document, 'mouseup');
+      completed = false;
+
+      component.drag(createTouchEvent('touchdown') as TouchEvent);
+      dispatchTouchEvent(document, 'touchmove', 100, 0);
+
+      await stabilize(fixture, 20);
+      expect(dragged).toBeTruthy();
+
+      dispatchTouchEvent(document, 'touchend');
       expect(completed).toBeTruthy();
     });
   });

--- a/components/core/services/drag.ts
+++ b/components/core/services/drag.ts
@@ -44,24 +44,20 @@ export class NzDragService {
   private renderer = inject(RendererFactory2).createRenderer(null, null);
 
   requestDraggingSequence(event: MouseEvent | TouchEvent): Observable<Delta> {
-    if (!this.handleRegistry.size) {
-      this.registerDraggingHandler(isTouchEvent(event));
-    }
-
     // Complete last dragging sequence if a new target is dragged.
-    if (this.currentDraggingSequence) {
-      this.currentDraggingSequence.complete();
-    }
+    this.currentDraggingSequence?.complete();
+    this.teardownDraggingHandlers();
+    this.registerDraggingHandler(isTouchEvent(event));
 
     this.currentStartingPoint = getPagePosition(event);
     this.currentDraggingSequence = new Subject<MouseEvent | Touch>();
 
     return this.currentDraggingSequence.pipe(
-      map((e: MouseEvent | Touch) => ({
+      map(e => ({
         x: e.pageX - this.currentStartingPoint!.x,
         y: e.pageY - this.currentStartingPoint!.y
       })),
-      filter((e: Delta) => Math.abs(e.x) > this.draggingThreshold || Math.abs(e.y) > this.draggingThreshold),
+      filter(e => Math.abs(e.x) > this.draggingThreshold || Math.abs(e.y) > this.draggingThreshold),
       finalize(() => this.teardownDraggingSequence())
     );
   }
@@ -70,31 +66,23 @@ export class NzDragService {
     if (isTouch) {
       this.handleRegistry.add({
         teardown: this.renderer.listen('document', 'touchmove', (e: TouchEvent) => {
-          if (this.currentDraggingSequence) {
-            this.currentDraggingSequence.next(e.touches[0] || e.changedTouches[0]);
-          }
+          this.currentDraggingSequence?.next(e.touches[0] || e.changedTouches[0]);
         })
       });
       this.handleRegistry.add({
         teardown: this.renderer.listen('document', 'touchend', () => {
-          if (this.currentDraggingSequence) {
-            this.currentDraggingSequence.complete();
-          }
+          this.currentDraggingSequence?.complete();
         })
       });
     } else {
       this.handleRegistry.add({
         teardown: this.renderer.listen('document', 'mousemove', e => {
-          if (this.currentDraggingSequence) {
-            this.currentDraggingSequence.next(e);
-          }
+          this.currentDraggingSequence?.next(e);
         })
       });
       this.handleRegistry.add({
         teardown: this.renderer.listen('document', 'mouseup', () => {
-          if (this.currentDraggingSequence) {
-            this.currentDraggingSequence.complete();
-          }
+          this.currentDraggingSequence?.complete();
         })
       });
     }
@@ -102,5 +90,13 @@ export class NzDragService {
 
   private teardownDraggingSequence(): void {
     this.currentDraggingSequence = null;
+    this.teardownDraggingHandlers();
+  }
+
+  private teardownDraggingHandlers(): void {
+    for (const { teardown } of this.handleRegistry) {
+      teardown();
+    }
+    this.handleRegistry.clear();
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Document-level drag event listeners remain registered after a drag sequence ends.

Issue Number: #9918

## What is the new behavior?

Drag event listeners are torn down and cleared when a sequence ends or is replaced. A following drag registers handlers for its input type.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Validated with the focused drag-service test suite and the development library build.
