### PR TITLE
fix(module:cdk): react to resize observer disabled changes

### DIFF
--- a/components/cdk/resize-observer/resize-observer.directive.ts
+++ b/components/cdk/resize-observer/resize-observer.directive.ts
@@ -18,24 +18,24 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { NzResizeObserver, NzResizeObserverFactory } from './resize-observer.service';
+import { NzResizeObserver } from './resize-observer.service';
 
 @Directive({
-  selector: '[nzResizeObserver]',
-  providers: [NzResizeObserverFactory]
+  selector: '[nzResizeObserver]'
 })
 export class NzResizeObserverDirective implements AfterContentInit, OnChanges {
-  private nzResizeObserver = inject(NzResizeObserver);
-  private elementRef = inject(ElementRef<HTMLElement>);
-  private destroyRef = inject(DestroyRef);
+  private readonly resizeObserver = inject(NzResizeObserver);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private readonly destroyRef = inject(DestroyRef);
 
-  @Output() readonly nzResizeObserve = new EventEmitter<ResizeObserverEntry[]>();
   @Input({ transform: booleanAttribute }) nzResizeObserverDisabled = false;
+  @Output() readonly nzResizeObserve = new EventEmitter<ResizeObserverEntry[]>();
+
   private currentSubscription: Subscription | null = null;
 
   private subscribe(): void {
     this.unsubscribe();
-    this.currentSubscription = this.nzResizeObserver.observe(this.elementRef).subscribe(this.nzResizeObserve);
+    this.currentSubscription = this.resizeObserver.observe(this.elementRef).subscribe(this.nzResizeObserve);
   }
 
   private unsubscribe(): void {
@@ -51,9 +51,10 @@ export class NzResizeObserverDirective implements AfterContentInit, OnChanges {
       this.subscribe();
     }
   }
+
   ngOnChanges(changes: SimpleChanges): void {
-    const { nzResizeObserve } = changes;
-    if (nzResizeObserve) {
+    const { nzResizeObserverDisabled } = changes;
+    if (nzResizeObserverDisabled) {
       if (this.nzResizeObserverDisabled) {
         this.unsubscribe();
       } else {

--- a/components/cdk/resize-observer/resize-observer.spec.ts
+++ b/components/cdk/resize-observer/resize-observer.spec.ts
@@ -9,12 +9,16 @@ import { Subscription } from 'rxjs';
 
 import { vi } from 'vitest';
 
-import { NzResizeObserverDirective } from 'ng-zorro-antd/cdk/resize-observer/resize-observer.directive';
+import { NzResizeObserverDirective, NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
 import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 describe('resize observer', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let directive: NzResizeObserverDirective;
+
+  function getResizeObserver(): NzResizeObserver {
+    return directive['resizeObserver'];
+  }
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestHostComponent);
@@ -54,9 +58,9 @@ describe('resize observer', () => {
     expect(directive['subscribe']).not.toHaveBeenCalled();
   });
 
-  it('should call unsubscribe when nzResizeObserve is changed and nzResizeObserverDisabled is true', () => {
+  it('should call unsubscribe when nzResizeObserverDisabled changes to true', () => {
     const change = {
-      nzResizeObserve: {}
+      nzResizeObserverDisabled: {}
     };
     vi.spyOn(directive as NzSafeAny, 'unsubscribe');
     directive.nzResizeObserverDisabled = true;
@@ -64,9 +68,9 @@ describe('resize observer', () => {
     expect(directive['unsubscribe']).toHaveBeenCalled();
   });
 
-  it('should call subscribe when nzResizeObserve is changed and nzResizeObserverDisabled is false', () => {
+  it('should call subscribe when nzResizeObserverDisabled changes to false', () => {
     const change = {
-      nzResizeObserve: {}
+      nzResizeObserverDisabled: {}
     };
     vi.spyOn(directive as NzSafeAny, 'subscribe');
     directive.nzResizeObserverDisabled = false;
@@ -82,17 +86,18 @@ describe('resize observer', () => {
 
   it('should destroy the observedElements', () => {
     const element = document.createElement('div');
-    directive['nzResizeObserver'].observe(element);
+    const resizeObserver = getResizeObserver();
+    resizeObserver.observe(element);
     fixture.detectChanges();
-    vi.spyOn(directive['nzResizeObserver'] as NzSafeAny, 'cleanupObserver');
+    vi.spyOn(resizeObserver as NzSafeAny, 'cleanupObserver');
     fixture.destroy();
-    expect(directive['nzResizeObserver']['cleanupObserver']).toHaveBeenCalled();
+    expect(resizeObserver['cleanupObserver']).toHaveBeenCalled();
   });
 
   it('should return correct resizeObserver if it is supported', () => {
     // eslint-disable-next-line no-global-assign
     ResizeObserver = undefined as NzSafeAny;
-    const result = directive['nzResizeObserver']['nzResizeObserverFactory'].create(vi.fn());
+    const result = directive['resizeObserver']['nzResizeObserverFactory'].create(vi.fn());
     expect(result).toEqual(null);
   });
 });

--- a/components/cdk/resize-observer/resize-observer.spec.ts
+++ b/components/cdk/resize-observer/resize-observer.spec.ts
@@ -3,107 +3,65 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Component, EventEmitter, SimpleChanges } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Subscription } from 'rxjs';
-
-import { vi } from 'vitest';
+import { Subject } from 'rxjs';
 
 import { NzResizeObserverDirective, NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
-import { NzSafeAny } from 'ng-zorro-antd/core/types';
 
 describe('resize observer', () => {
   let fixture: ComponentFixture<TestHostComponent>;
-  let directive: NzResizeObserverDirective;
-
-  function getResizeObserver(): NzResizeObserver {
-    return directive['resizeObserver'];
-  }
+  let component: TestHostComponent;
+  let resizeEntries$: Subject<ResizeObserverEntry[]>;
 
   beforeEach(() => {
+    resizeEntries$ = new Subject<ResizeObserverEntry[]>();
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: NzResizeObserver,
+          useValue: { observe: () => resizeEntries$ }
+        }
+      ]
+    });
     fixture = TestBed.createComponent(TestHostComponent);
-    directive = fixture.debugElement.children[0].injector.get(NzResizeObserverDirective);
+    component = fixture.componentInstance;
+    fixture.autoDetectChanges();
   });
 
-  it('should have correct initial values', () => {
-    expect(directive.nzResizeObserve).toBeDefined();
-    expect(directive.nzResizeObserve).toBeInstanceOf(EventEmitter);
+  it('should stop and resume resize events when disabled changes', async () => {
+    await fixture.whenStable();
 
-    expect(directive.nzResizeObserverDisabled).toEqual(false);
+    const initialEntries = [{} as ResizeObserverEntry];
+    resizeEntries$.next(initialEntries);
+    expect(component.resizeEntries()).toEqual([initialEntries]);
 
-    expect(directive['currentSubscription']).toEqual(null);
-  });
+    component.disabled.set(true);
+    await fixture.whenStable();
 
-  it('should call subscribe when all the conditions are met', () => {
-    directive['currentSubscription'] = null;
-    directive.nzResizeObserverDisabled = false;
-    vi.spyOn(directive as NzSafeAny, 'subscribe');
-    directive.ngAfterContentInit();
-    expect(directive['subscribe']).toHaveBeenCalled();
-  });
+    resizeEntries$.next([{} as ResizeObserverEntry]);
+    expect(component.resizeEntries()).toEqual([initialEntries]);
 
-  it('should not call subscribe when nzResizeObserverDisabled is true', () => {
-    directive['currentSubscription'] = null;
-    directive.nzResizeObserverDisabled = true;
-    vi.spyOn(directive as NzSafeAny, 'subscribe');
-    directive.ngAfterContentInit();
-    expect(directive['subscribe']).not.toHaveBeenCalled();
-  });
+    component.disabled.set(false);
+    await fixture.whenStable();
 
-  it('should not call subscribe when currentSubscription is truthy', () => {
-    directive['currentSubscription'] = new Subscription();
-    directive.nzResizeObserverDisabled = false;
-    vi.spyOn(directive as NzSafeAny, 'subscribe');
-    directive.ngAfterContentInit();
-    expect(directive['subscribe']).not.toHaveBeenCalled();
-  });
-
-  it('should call unsubscribe when nzResizeObserverDisabled changes to true', () => {
-    const change = {
-      nzResizeObserverDisabled: {}
-    };
-    vi.spyOn(directive as NzSafeAny, 'unsubscribe');
-    directive.nzResizeObserverDisabled = true;
-    directive.ngOnChanges(change as unknown as SimpleChanges);
-    expect(directive['unsubscribe']).toHaveBeenCalled();
-  });
-
-  it('should call subscribe when nzResizeObserverDisabled changes to false', () => {
-    const change = {
-      nzResizeObserverDisabled: {}
-    };
-    vi.spyOn(directive as NzSafeAny, 'subscribe');
-    directive.nzResizeObserverDisabled = false;
-    directive.ngOnChanges(change as unknown as SimpleChanges);
-    expect(directive['subscribe']).toHaveBeenCalled();
-  });
-
-  it('should call correct methods when calling subscribe', () => {
-    vi.spyOn(directive as NzSafeAny, 'unsubscribe');
-    directive['subscribe']();
-    expect(directive['unsubscribe']).toHaveBeenCalled();
-  });
-
-  it('should destroy the observedElements', () => {
-    const element = document.createElement('div');
-    const resizeObserver = getResizeObserver();
-    resizeObserver.observe(element);
-    fixture.detectChanges();
-    vi.spyOn(resizeObserver as NzSafeAny, 'cleanupObserver');
-    fixture.destroy();
-    expect(resizeObserver['cleanupObserver']).toHaveBeenCalled();
-  });
-
-  it('should return correct resizeObserver if it is supported', () => {
-    // eslint-disable-next-line no-global-assign
-    ResizeObserver = undefined as NzSafeAny;
-    const result = directive['resizeObserver']['nzResizeObserverFactory'].create(vi.fn());
-    expect(result).toEqual(null);
+    const resumedEntries = [{} as ResizeObserverEntry];
+    resizeEntries$.next(resumedEntries);
+    expect(component.resizeEntries()).toEqual([initialEntries, resumedEntries]);
   });
 });
 
 @Component({
-  template: `<div nzResizeObserver></div>`,
+  template: `
+    <div nzResizeObserver [nzResizeObserverDisabled]="disabled()" (nzResizeObserve)="onResize($event)"></div>
+  `,
   imports: [NzResizeObserverDirective]
 })
-class TestHostComponent {}
+class TestHostComponent {
+  readonly disabled = signal(false);
+  readonly resizeEntries = signal<ResizeObserverEntry[][]>([]);
+
+  onResize(entries: ResizeObserverEntry[]): void {
+    this.resizeEntries.update(currentEntries => [...currentEntries, entries]);
+  }
+}

--- a/components/cdk/resize-observer/resize-observer.spec.ts
+++ b/components/cdk/resize-observer/resize-observer.spec.ts
@@ -3,11 +3,17 @@
  * found in the LICENSE file at https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/LICENSE
  */
 
-import { Component, signal } from '@angular/core';
+import { Component, ElementRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 
-import { NzResizeObserverDirective, NzResizeObserver } from 'ng-zorro-antd/cdk/resize-observer';
+import { vi } from 'vitest';
+
+import {
+  NzResizeObserver,
+  NzResizeObserverDirective,
+  NzResizeObserverFactory
+} from 'ng-zorro-antd/cdk/resize-observer';
 
 describe('resize observer', () => {
   let fixture: ComponentFixture<TestHostComponent>;
@@ -63,5 +69,71 @@ class TestHostComponent {
 
   onResize(entries: ResizeObserverEntry[]): void {
     this.resizeEntries.update(currentEntries => [...currentEntries, entries]);
+  }
+}
+
+describe('resize observer service', () => {
+  let service: NzResizeObserver;
+  let observer: TestResizeObserver;
+  let callbacks: ResizeObserverCallback[];
+  let create: ReturnType<typeof vi.fn<(callback: ResizeObserverCallback) => ResizeObserver>>;
+
+  beforeEach(() => {
+    observer = new TestResizeObserver();
+    callbacks = [];
+    create = vi.fn(callback => {
+      callbacks.push(callback);
+      return observer;
+    });
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: NzResizeObserverFactory,
+          useValue: { create }
+        }
+      ]
+    });
+    service = TestBed.inject(NzResizeObserver);
+  });
+
+  it('should share an observer and disconnect it after the last subscription ends', () => {
+    const element = document.createElement('div');
+    const firstEntries: ResizeObserverEntry[][] = [];
+    const secondEntries: ResizeObserverEntry[][] = [];
+    const firstSubscription = service.observe(element).subscribe(entries => firstEntries.push(entries));
+    const secondSubscription = service.observe(element).subscribe(entries => secondEntries.push(entries));
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(observer.observe).toHaveBeenCalledWith(element);
+
+    const entries = [{} as ResizeObserverEntry];
+    callbacks[0](entries, observer);
+    expect(firstEntries).toEqual([entries]);
+    expect(secondEntries).toEqual([entries]);
+
+    firstSubscription.unsubscribe();
+    expect(observer.disconnect).not.toHaveBeenCalled();
+
+    secondSubscription.unsubscribe();
+    expect(observer.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should accept an ElementRef', () => {
+    const element = document.createElement('div');
+    const subscription = service.observe(new ElementRef(element)).subscribe();
+
+    expect(observer.observe).toHaveBeenCalledWith(element);
+
+    subscription.unsubscribe();
+  });
+});
+
+class TestResizeObserver implements ResizeObserver {
+  readonly disconnect = vi.fn();
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+
+  takeRecords(): ResizeObserverEntry[] {
+    return [];
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Application (the showcase website) / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Dynamic changes to `nzResizeObserverDisabled` are ignored because the directive checks the output property in `ngOnChanges`.

Issue Number: #9919

## What is the new behavior?

The directive now reacts to changes to `nzResizeObserverDisabled` and updates its subscription accordingly. The redundant local `NzResizeObserverFactory` provider has also been removed. The consolidated spec covers the directive's emitted-event behavior and the service's observer sharing, cleanup, and `ElementRef` support.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Validated with the spec TypeScript check, Prettier, and the development library build.
