### PR TITLE
fix(module:input-number): prevent keyboard step when readonly

### DIFF
--- a/components/input-number/input-number.component.spec.ts
+++ b/components/input-number/input-number.component.spec.ts
@@ -436,6 +436,18 @@ describe('input-number', () => {
     expect(component.value).toBe(0);
   });
 
+  it('should not step by keyboard when readonly', () => {
+    component.value = 5;
+    component.readonly.set(true);
+    fixture.detectChanges();
+
+    upStepByKeyboard();
+    expect(component.value).toBe(5);
+
+    downStepByKeyboard();
+    expect(component.value).toBe(5);
+  });
+
   it('should be set mouse wheel', () => {
     const input = hostElement.querySelector('input')!;
     component.value = 0;

--- a/components/input-number/input-number.component.ts
+++ b/components/input-number/input-number.component.ts
@@ -408,6 +408,11 @@ export class NzInputNumberComponent implements OnInit, ControlValueAccessor {
   }
 
   private step(event: MouseEvent | KeyboardEvent, up: boolean, emitter: NzInputNumberStepEmitter): void {
+    // Ignore step since field is readonly
+    if (this.nzReadOnly()) {
+      return;
+    }
+
     // Ignore step since out of range
     if ((up && this.upDisabled()) || (!up && this.downDisabled())) {
       return;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
- [x] Bugfix

## What is the current behavior?
When `nz-input-number` has `nzReadOnly` set, typing is blocked and the up/down control buttons are hidden, but pressing the ArrowUp / ArrowDown keys still changes the value. A read-only control should not be mutable through any input.

Issue Number: Fixes #9924

## What is the new behavior?
Stepping is now blocked while `nzReadOnly` is set. The guard is placed in the shared `step()` method, so it covers keyboard, handler buttons, and mouse wheel consistently.

## Does this PR introduce a breaking change?
- [x] No

## Other information
Added a unit test asserting ArrowUp / ArrowDown do not change the value when `nzReadOnly` is set.